### PR TITLE
feat(oauth2): implement MCP oauth2 dynamic client id metadata auth

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -478,6 +478,7 @@ func New(cfg Config) (*App, error) {
 		Repository: repo,
 		TokenSvc:   tokenSvc,
 		TokenKey:   cfg.Auth.WorkspaceTokenKey,
+		BaseURL:    cfg.App.BaseURL,
 		Mux:        mux,
 	}); err != nil {
 		return nil, fmt.Errorf("mcp handler: %w", err)
@@ -505,7 +506,7 @@ func New(cfg Config) (*App, error) {
 
 	// SPA Fallback
 	fiberApp.Get("/*", func(c *fiber.Ctx) error {
-		if strings.HasPrefix(c.Path(), "/api/") || strings.HasPrefix(c.Path(), "/mcp") {
+		if strings.HasPrefix(c.Path(), "/api/") || strings.HasPrefix(c.Path(), "/mcp") || strings.HasPrefix(c.Path(), "/.well-known/") {
 			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "Not Found"})
 		}
 		c.Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -248,13 +248,17 @@ func (h *handler) rootLogin() fiber.Handler {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to sign token"})
 		}
 
-		c.Cookie(&fiber.Cookie{
+		cookie := &fiber.Cookie{
 			Name:     "at",
 			Value:    tokenString,
 			Expires:  time.Now().Add(24 * time.Hour),
 			HTTPOnly: true,
 			Path:     "/",
-		})
+		}
+		if h.domain != "" && !strings.HasPrefix(h.domain, "localhost") {
+			cookie.Domain = "." + h.domain
+		}
+		c.Cookie(cookie)
 
 		return c.JSON(fiber.Map{"status": "ok"})
 	}
@@ -262,7 +266,8 @@ func (h *handler) rootLogin() fiber.Handler {
 
 func (h *handler) googleLogin() fiber.Handler {
 	return func(c *fiber.Ctx) error {
-		return c.Redirect(h.auth.GetAuthURL("state"))
+		state := c.Query("redirect_url", "state")
+		return c.Redirect(h.auth.GetAuthURL(state))
 	}
 }
 
@@ -303,15 +308,25 @@ func (h *handler) googleCallback() fiber.Handler {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to sign token"})
 		}
 
-		c.Cookie(&fiber.Cookie{
+		cookie := &fiber.Cookie{
 			Name:     "at",
 			Value:    tokenString,
 			Expires:  time.Now().Add(24 * time.Hour),
 			HTTPOnly: true,
 			Path:     "/",
-		})
+		}
+		if h.domain != "" && !strings.HasPrefix(h.domain, "localhost") {
+			cookie.Domain = "." + h.domain
+		}
+		c.Cookie(cookie)
 
-		return c.Redirect("/")
+		state := c.Query("state")
+		redirectURL := "/"
+		if state != "" && state != "state" && strings.HasPrefix(state, "http") {
+			redirectURL = state
+		}
+
+		return c.Redirect(redirectURL)
 	}
 }
 
@@ -534,7 +549,7 @@ func (h *handler) getWorkspaceToken() fiber.Handler {
 		workspaceID := c.Params("id")
 		userID := c.Locals("user_id").(string)
 
-		token, err := h.tokenSvc.CreateMCPToken(userID, workspaceID)
+		token, err := h.tokenSvc.CreateMCPToken(userID, workspaceID, "access")
 		if err != nil {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to generate workspace token"})
 		}

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -5,8 +5,11 @@ package mcp
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	zlog "github.com/rs/zerolog/log"
@@ -24,6 +27,7 @@ type Params struct {
 	Repository base.Repository
 	TokenSvc   auth.TokenService
 	TokenKey   string
+	BaseURL    string
 	Mux        *http.ServeMux
 }
 
@@ -34,6 +38,7 @@ type handler struct {
 	repo       base.Repository
 	tokenSvc   auth.TokenService
 	tokenKey   string
+	baseURL    string
 }
 
 func corsWrapper(h http.Handler) http.Handler {
@@ -57,11 +62,18 @@ func New(p Params) (Handler, error) {
 		repo:       p.Repository,
 		tokenSvc:   p.TokenSvc,
 		tokenKey:   p.TokenKey,
+		baseURL:    p.BaseURL,
 	}
 
 	// Mount the unified Streamable HTTP endpoint natively.
 	// We handle both exact and trailing slash versions to be robust.
 	p.Mux.Handle("/mcp/{workspaceID}", corsWrapper(h.streamableHandler()))
+
+	// OAuth2 and CIMD endpoints
+	p.Mux.Handle("/mcp/{workspaceID}/.well-known/oauth-authorization-server", corsWrapper(h.oauthMetadataHandler()))
+	p.Mux.Handle("/.well-known/oauth-protected-resource/mcp/{workspaceID}", corsWrapper(h.oauthMetadataHandler()))
+	p.Mux.Handle("/mcp/{workspaceID}/oauth2/authorize", h.oauthAuthorizeHandler())
+	p.Mux.Handle("/mcp/{workspaceID}/oauth2/token", corsWrapper(h.oauthTokenHandler()))
 
 	return h, nil
 }
@@ -71,12 +83,36 @@ func workspaceIDFromParam(r *http.Request) int64 {
 	return monoflake.IDFromBase62(r.PathValue("workspaceID")).Int64()
 }
 
+func getTokenVal(r *http.Request) string {
+	if token := r.URL.Query().Get("token"); token != "" {
+		return token
+	}
+	authHeader := r.Header.Get("Authorization")
+	if strings.HasPrefix(authHeader, "Bearer ") {
+		return strings.TrimPrefix(authHeader, "Bearer ")
+	}
+	return ""
+}
+
+func sendJSONRPCError(w http.ResponseWriter, message string, httpStatus int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(httpStatus)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      nil,
+		"error": map[string]interface{}{
+			"code":    -32000,
+			"message": message,
+		},
+	})
+}
+
 // streamableHandler serves both GET (Stream) and POST (Messages) via mcp-go StreamableHTTPServer.
 func (h *handler) streamableHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		workspaceID := workspaceIDFromParam(r)
 		if workspaceID == 0 {
-			http.Error(w, "invalid workspace id", http.StatusBadRequest)
+			sendJSONRPCError(w, "invalid workspace id", http.StatusBadRequest)
 			return
 		}
 
@@ -88,22 +124,29 @@ func (h *handler) streamableHandler() http.Handler {
 		ev.Msg("MCP call")
 
 		// 1. Mandatory token check if workspace has it in DB
-		queryToken := r.URL.Query().Get("token")
+		queryToken := getTokenVal(r)
 		workspace, err := h.repo.SystemGetWorkspace(r.Context(), workspaceID)
+		if err != nil {
+			sendJSONRPCError(w, "situational security: workspace not found", http.StatusNotFound)
+			return
+		}
 
 		userID := ""
-		if err == nil && workspace.TokenEncrypted != "" {
-			if queryToken == "" {
-				http.Error(w, "situational security: mission token required", http.StatusUnauthorized)
-				return
-			}
+		if queryToken == "" {
+			sendJSONRPCError(w, "situational security: mission token required", http.StatusUnauthorized)
+			return
+		}
+
+		// If it's a 16-character mission token, decrypt and check
+		if len(queryToken) == 16 {
 			dec, decErr := security.Decrypt(workspace.TokenEncrypted, h.tokenKey, workspace.TokenNonce)
 			if decErr != nil || dec != queryToken {
-				http.Error(w, "situational security: invalid mission token", http.StatusUnauthorized)
+				sendJSONRPCError(w, "situational security: invalid mission token", http.StatusUnauthorized)
 				return
 			}
 			userID = monoflake.ID(workspace.UserID).String()
 		}
+		// If length is not 16, it might be a valid JWT OAuth token. It will be checked via identifyUser below.
 
 		// 2. Mandatory Mcp-Session-Id for non-initialize requests
 		sessionID := r.Header.Get("Mcp-Session-Id")
@@ -113,30 +156,6 @@ func (h *handler) streamableHandler() http.Handler {
 			body, _ = io.ReadAll(r.Body)
 			r.Body = io.NopCloser(bytes.NewBuffer(body))
 		}
-
-		// isInitializeCall := false
-		// if r.Method == "POST" {
-		// 	var rpc struct {
-		// 		Method string `json:"method"`
-		// 	}
-		// 	if err := json.Unmarshal(body, &rpc); err == nil {
-		// 		if rpc.Method == "initialize" {
-		// 			isInitializeCall = true
-		// 			// On initialize, create session ID and return as header
-		// 			newSessID, err := h.tokenSvc.CreateMCPToken(userID, monoflake.ID(workspaceID).String())
-		// 			if err == nil {
-		// 				sessionID = newSessID
-		// 				w.Header().Set("Mcp-Session-Id", sessionID)
-		// 			}
-		// 		}
-		// 	}
-		// }
-
-		// // Mcp-Session-Id is mandatory for all requests except initialize call
-		// if !isInitializeCall && sessionID == "" {
-		// 	http.Error(w, "situational security: mcp-session-id required by MCP spec", http.StatusBadRequest)
-		// 	return
-		// }
 
 		// Try to identify user if not already set by secret
 		if userID == "" {
@@ -150,8 +169,8 @@ func (h *handler) streamableHandler() http.Handler {
 		}
 
 		// Final check: if workspace has token, userID must be set
-		if err == nil && workspace.TokenEncrypted != "" && userID == "" {
-			http.Error(w, "situational security: unauthorized", http.StatusUnauthorized)
+		if workspace.TokenEncrypted != "" && userID == "" {
+			sendJSONRPCError(w, "situational security: unauthorized", http.StatusUnauthorized)
 			return
 		}
 
@@ -210,9 +229,168 @@ func (h *handler) identifyUser(ctx context.Context, workspaceID int64, tokenStr 
 		}
 
 		if isWorkspaceValid {
-			return claims.Subject
+			hasInvalidAudience := false
+			for _, aud := range claims.Audience {
+				if aud == "refresh" || aud == "authorization_code" {
+					hasInvalidAudience = true
+					break
+				}
+			}
+			if !hasInvalidAudience {
+				return claims.Subject
+			}
 		}
 	}
 
 	return ""
+}
+
+func (h *handler) oauthMetadataHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		proto := "https://"
+		if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" && !strings.Contains(r.Host, "mcp.") {
+			proto = "http://"
+		}
+
+		baseURL := proto + r.Host
+
+		authEndpoint := baseURL + "/oauth2/authorize"
+		tokenEndpoint := baseURL + "/oauth2/token"
+
+		// If accessed without a subdomain (e.g. localhost or a custom domain root), append the workspace route
+		if !strings.Contains(r.Host, ".mcp.") {
+			workspaceID := workspaceIDFromParam(r)
+			if workspaceID != 0 {
+				workspaceIDBase62 := monoflake.ID(workspaceID).String()
+				authEndpoint = baseURL + "/mcp/" + workspaceIDBase62 + "/oauth2/authorize"
+				tokenEndpoint = baseURL + "/mcp/" + workspaceIDBase62 + "/oauth2/token"
+			}
+		}
+
+		metadata := map[string]interface{}{
+			"issuer":                                baseURL,
+			"authorization_endpoint":                authEndpoint,
+			"token_endpoint":                        tokenEndpoint,
+			"client_id_metadata_document_supported": true,
+			"response_types_supported":              []string{"code"},
+			"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
+		}
+
+		importJson := json.NewEncoder(w)
+		importJson.Encode(metadata)
+	})
+}
+
+func (h *handler) oauthAuthorizeHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		workspaceID := workspaceIDFromParam(r)
+
+		// 1. Is user logged in?
+		var userID string
+		if cookie, err := r.Cookie("at"); err == nil && cookie.Value != "" {
+			if claims, err := h.tokenSvc.ValidateToken(cookie.Value); err == nil && claims != nil {
+				userID = claims.Subject
+			}
+		}
+
+		// Optional clientID validation can be added here
+		_ = r.URL.Query().Get("client_id")
+		redirectURI := r.URL.Query().Get("redirect_uri")
+		state := r.URL.Query().Get("state")
+
+		if userID == "" {
+			// Not authenticated, redirect to main login with 'redirect_url'
+			// To return back, building the current full URL:
+			proto := "https://"
+			if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" && !strings.Contains(r.Host, "mcp.") {
+				proto = "http://"
+			}
+			returnURL := proto + r.Host + r.URL.RequestURI()
+			loginURL := fmt.Sprintf("%s/api/v1/auth/google/login?redirect_url=%s", h.baseURL, url.QueryEscape(returnURL))
+			http.Redirect(w, r, loginURL, http.StatusFound)
+			return
+		}
+
+		// User is logged in.
+		// If auto-appproval or basic form required:
+		// We'll proceed with granting a short-lived authorization code directly since they visited here.
+		workspaceIDBase62 := monoflake.ID(workspaceID).String()
+		code, err := h.tokenSvc.CreateOAuthCodeToken(userID, workspaceIDBase62)
+		if err != nil {
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		// Redirect back to client
+		finalRedirect := fmt.Sprintf("%s?code=%s&state=%s", redirectURI, url.QueryEscape(code), url.QueryEscape(state))
+		http.Redirect(w, r, finalRedirect, http.StatusFound)
+	})
+}
+
+func (h *handler) oauthTokenHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		err := r.ParseForm()
+		if err != nil {
+			http.Error(w, "invalid form", http.StatusBadRequest)
+			return
+		}
+
+		grantType := r.Form.Get("grant_type")
+
+		var tokenStr string
+		switch grantType {
+		case "authorization_code":
+			tokenStr = r.Form.Get("code")
+		case "refresh_token":
+			tokenStr = r.Form.Get("refresh_token")
+		default:
+			http.Error(w, `{"error": "unsupported_grant_type"}`, http.StatusBadRequest)
+			return
+		}
+
+		claims, err := h.tokenSvc.ValidateToken(tokenStr)
+		if err != nil || claims == nil {
+			http.Error(w, `{"error": "invalid_grant"}`, http.StatusUnauthorized)
+			return
+		}
+
+		if grantType == "refresh_token" {
+			hasRefresh := false
+			for _, aud := range claims.Audience {
+				if aud == "refresh" {
+					hasRefresh = true
+					break
+				}
+			}
+			if !hasRefresh {
+				http.Error(w, `{"error": "invalid_grant"}`, http.StatusUnauthorized)
+				return
+			}
+		}
+
+		userID := claims.Subject
+		var workspaceIDBase62 string
+		if len(claims.Audience) > 0 {
+			workspaceIDBase62 = claims.Audience[0]
+		}
+
+		accessToken, err := h.tokenSvc.CreateMCPToken(userID, workspaceIDBase62, "access")
+		if err != nil {
+			http.Error(w, `{"error": "server_error"}`, http.StatusInternalServerError)
+			return
+		}
+
+		// The refresh token can just be the same token format for our stateless needs
+		refreshToken, err := h.tokenSvc.CreateMCPToken(userID, workspaceIDBase62, "refresh")
+
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token":  accessToken,
+			"refresh_token": refreshToken,
+			"token_type":    "bearer",
+			"expires_in":    2592000, // 30 days
+		})
+	})
 }

--- a/backend/internal/handler/mcp/mcp_test.go
+++ b/backend/internal/handler/mcp/mcp_test.go
@@ -1,0 +1,162 @@
+package mcp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/agentrq/agentrq/backend/internal/service/auth"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type mockTokenSvc struct {
+	auth.TokenService
+	validCode  string
+	validToken string
+}
+
+func (m *mockTokenSvc) ValidateToken(tokenStr string) (*auth.Claims, error) {
+	if tokenStr == "valid-auth-cookie" || tokenStr == m.validCode || tokenStr == "valid-refresh-token" {
+		return &auth.Claims{
+			RegisteredClaims: jwt.RegisteredClaims{
+				Subject: "user123",
+				Audience: jwt.ClaimStrings{"ws123"},
+			},
+		}, nil
+	}
+	return nil, jwt.ErrSignatureInvalid
+}
+
+func (m *mockTokenSvc) CreateOAuthCodeToken(userID, workspaceID string) (string, error) {
+	m.validCode = "mocked-code-" + userID + "-" + workspaceID
+	return m.validCode, nil
+}
+
+func (m *mockTokenSvc) CreateMCPToken(userID, workspaceID, tokenType string) (string, error) {
+	m.validToken = "mocked-mcp-" + userID + "-" + workspaceID + "-" + tokenType
+	return m.validToken, nil
+}
+
+func setupTestRouter() (*http.ServeMux, *mockTokenSvc) {
+	mux := http.NewServeMux()
+	tokenSvc := &mockTokenSvc{}
+	
+	New(Params{
+		TokenSvc: tokenSvc,
+		BaseURL:  "https://agentrq.com",
+		Mux:      mux,
+	})
+	
+	return mux, tokenSvc
+}
+
+func TestOAuthMetadataHandler(t *testing.T) {
+	mux, _ := setupTestRouter()
+
+	req := httptest.NewRequest("GET", "/mcp/12345/.well-known/oauth-authorization-server", nil)
+	req.Host = "12345.mcp.agentrq.com"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200 OK, got %d", w.Code)
+	}
+
+	var meta map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &meta); err != nil {
+		t.Fatalf("Failed to parse response body: %v", err)
+	}
+
+	if meta["issuer"] != "https://12345.mcp.agentrq.com" {
+		t.Errorf("Unexpected issuer: %v", meta["issuer"])
+	}
+}
+
+func TestOAuthAuthorizeHandler_Unauthenticated(t *testing.T) {
+	mux, _ := setupTestRouter()
+
+	req := httptest.NewRequest("GET", "/mcp/12345/oauth2/authorize?client_id=test&redirect_uri=http://localhost/callback&state=somestate", nil)
+	req.Host = "12345.mcp.agentrq.com"
+	
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("Expected 302 Found, got %d", w.Code)
+	}
+
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "redirect_url=") {
+		t.Errorf("Expected redirect_url in Location, got %s", loc)
+	}
+	if !strings.HasPrefix(loc, "https://agentrq.com/api/v1/auth/google/login") {
+		t.Errorf("Expected login redirect, got %s", loc)
+	}
+}
+
+func TestOAuthAuthorizeHandler_Authenticated(t *testing.T) {
+	mux, _ := setupTestRouter()
+
+	req := httptest.NewRequest("GET", "/mcp/12345/oauth2/authorize?client_id=test&redirect_uri=http://localhost/callback&state=somestate", nil)
+	req.Host = "12345.mcp.agentrq.com"
+	req.AddCookie(&http.Cookie{Name: "at", Value: "valid-auth-cookie"})
+	
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("Expected 302 Found, got %d", w.Code)
+	}
+
+	loc := w.Header().Get("Location")
+	if !strings.HasPrefix(loc, "http://localhost/callback") {
+		t.Errorf("Expected redirect to client redirect_uri, got %s", loc)
+	}
+	
+	u, _ := url.Parse(loc)
+	if u.Query().Get("code") == "" {
+		t.Errorf("Expected code in redirect query")
+	}
+	if u.Query().Get("state") != "somestate" {
+		t.Errorf("Expected state=somestate, got %s", u.Query().Get("state"))
+	}
+}
+
+func TestOAuthTokenHandler(t *testing.T) {
+	mux, mockSvc := setupTestRouter()
+
+	// Initial setup of the code so mock token svc recognizes it
+	mockSvc.validCode = "mocked-code-user123-ws123"
+
+	formData := url.Values{
+		"grant_type": {"authorization_code"},
+		"code":       {mockSvc.validCode},
+	}
+	
+	req := httptest.NewRequest("POST", "/mcp/12345/oauth2/token", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200 OK, got %d: body=%s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response body: %v", err)
+	}
+
+	if resp["access_token"] == nil || resp["access_token"] == "" {
+		t.Errorf("Expected access_token in response")
+	}
+	if resp["refresh_token"] == nil || resp["refresh_token"] == "" {
+		t.Errorf("Expected refresh_token in response")
+	}
+}

--- a/backend/internal/service/auth/jwt.go
+++ b/backend/internal/service/auth/jwt.go
@@ -27,7 +27,8 @@ type Claims struct {
 
 type TokenService interface {
 	CreateToken(userID, email, name, picture string) (string, error)
-	CreateMCPToken(userID, workspaceID string) (string, error)
+	CreateMCPToken(userID, workspaceID, tokenType string) (string, error)
+	CreateOAuthCodeToken(userID, workspaceID string) (string, error)
 	ValidateToken(tokenStr string) (*Claims, error)
 }
 
@@ -60,7 +61,7 @@ func (s *tokenService) CreateToken(userID, email, name, picture string) (string,
 	return token.SignedString(s.secret)
 }
 
-func (s *tokenService) CreateMCPToken(userID, workspaceID string) (string, error) {
+func (s *tokenService) CreateMCPToken(userID, workspaceID, tokenType string) (string, error) {
 	claims := Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject:   userID,
@@ -71,6 +72,26 @@ func (s *tokenService) CreateMCPToken(userID, workspaceID string) (string, error
 	if workspaceID != "" {
 		claims.Audience = jwt.ClaimStrings{workspaceID}
 	}
+	if tokenType != "" {
+		claims.Audience = append(claims.Audience, tokenType)
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(s.secret)
+}
+
+func (s *tokenService) CreateOAuthCodeToken(userID, workspaceID string) (string, error) {
+	claims := Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   userID,
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(2 * time.Minute)), // 2 minutes short lived
+		},
+	}
+
+	if workspaceID != "" {
+		claims.Audience = jwt.ClaimStrings{workspaceID}
+	}
+	claims.Audience = append(claims.Audience, "authorization_code")
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	return token.SignedString(s.secret)

--- a/backend/internal/service/auth/jwt_test.go
+++ b/backend/internal/service/auth/jwt_test.go
@@ -47,7 +47,7 @@ func TestTokenService(t *testing.T) {
 		userID := "user123"
 		workspaceID := "ws456"
 
-		token, err := s.CreateMCPToken(userID, workspaceID)
+		token, err := s.CreateMCPToken(userID, workspaceID, "access")
 		if err != nil {
 			t.Fatalf("failed to create MCP token: %v", err)
 		}
@@ -62,6 +62,34 @@ func TestTokenService(t *testing.T) {
 		}
 		if len(claims.Audience) == 0 || claims.Audience[0] != workspaceID {
 			t.Errorf("expected audience %s, got %v", workspaceID, claims.Audience)
+		}
+	})
+
+	t.Run("CreateOAuthCodeToken", func(t *testing.T) {
+		userID := "user123"
+		workspaceID := "ws456"
+
+		token, err := s.CreateOAuthCodeToken(userID, workspaceID)
+		if err != nil {
+			t.Fatalf("failed to create OAuth code token: %v", err)
+		}
+
+		claims, err := s.ValidateToken(token)
+		if err != nil {
+			t.Fatalf("failed to validate OAuth code token: %v", err)
+		}
+
+		if claims.Subject != userID {
+			t.Errorf("expected userID %s, got %s", userID, claims.Subject)
+		}
+		if len(claims.Audience) == 0 || claims.Audience[0] != workspaceID {
+			t.Errorf("expected audience %s, got %v", workspaceID, claims.Audience)
+		}
+
+		// Check expiry is within bounds ~ 2 mins
+		expiry := claims.ExpiresAt.Time
+		if expiry.Sub(time.Now()) > 2*time.Minute+time.Second {
+			t.Errorf("expected expiry to be <= 2 mins, got %v", expiry.Sub(time.Now()))
 		}
 	})
 

--- a/backend/internal/service/server/server.go
+++ b/backend/internal/service/server/server.go
@@ -116,7 +116,12 @@ func (s *service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			// Map it back to the base62 system for internal routing
 			workspaceID := monoflake.ID(id).String()
-			r.URL.Path = "/mcp/" + workspaceID
+			
+			if r.URL.Path == "/" || r.URL.Path == "" {
+				r.URL.Path = "/mcp/" + workspaceID
+			} else {
+				r.URL.Path = "/mcp/" + workspaceID + r.URL.Path
+			}
 		} else if host != appHost {
 			// 2. If it's not appHost or an MCP host, reject it
 			sw.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
- Map OAuth2 base routing for subdomain workspace domains in server proxy
- Enable cross-subdomain sharing by enforcing root 'at' cookie domain
- Introduce JWT CreateOAuthCodeToken generating stateless short-lived codes
- Expose /.well-known/oauth-authorization-server and oauth2 endpoints
- Expose /.well-known/oauth-protected-resource/mcp route mapping
- Fix stream handler to enforce workspace situational TokenEncrypted 16-char decryption
- Emit consistent jsonrpc error code blocks on standard failures