### PR TITLE
feat: allow minute-granularity for one-time scheduled tasks

### DIFF
--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -97,7 +97,7 @@ type CreateTaskParams struct {
 	Body         string `json:"body" jsonschema:"Detailed description of the task or action needed"`
 	Assignee     string `json:"assignee,omitempty" jsonschema:"Who should complete the task: 'human' or 'agent'. Default is 'agent'."`
 	Attachments  []any  `json:"attachments,omitempty" jsonschema:"Optional attachments"`
-	CronSchedule string `json:"cron_schedule,omitempty" jsonschema:"Optional cron schedule (5-field format: minute hour dom month dow). When set, creates a recurring cron task. Minimum granularity is hourly (e.g. '30 * * * *'). Sub-hourly schedules are not allowed."`
+	CronSchedule string `json:"cron_schedule,omitempty" jsonschema:"Optional cron schedule (5-field format: minute hour dom month dow). For RECURRING tasks (dom and month use wildcards) the minimum granularity is hourly — the minute field must be a single integer 0-59, not a wildcard or step (e.g. '30 * * * *'). For ONE-TIME tasks (fixed dom and month, e.g. '30 14 25 4 *') any fixed minute value 0-59 is accepted, enabling minute-level precision."`
 }
 
 // UpdateTaskStatusParams is the input to the update_task_status tool.
@@ -1229,11 +1229,12 @@ func formatModelAttachments(raw []byte) string {
 	return "Attachments:\n" + strings.Join(parts, "\n")
 }
 
-// validateCronGranularity validates that the cron schedule is syntactically valid
-// and has a minimum repeat interval of one hour (no sub-hourly schedules).
-// The minute field must be a single fixed value (0-59); wildcards, steps, ranges,
-// and comma-lists in the minute field are all rejected because they would cause
-// the job to fire more than once per hour.
+// validateCronGranularity validates that the cron schedule is syntactically valid.
+// For RECURRING schedules (dom or month field is "*"), the minimum granularity is
+// hourly: the minute field must be a single fixed integer 0-59 (no wildcards, steps,
+// ranges, or comma-lists), because sub-hourly recurring tasks are not supported.
+// For ONE-TIME schedules (both dom and month are fixed integers, e.g. "30 14 25 4 *"),
+// any fixed minute value 0-59 is accepted — enabling minute-level precision.
 func validateCronGranularity(schedule string) error {
 	fields := strings.Fields(schedule)
 	if len(fields) != 5 {

--- a/backend/internal/controller/mcp/server_test.go
+++ b/backend/internal/controller/mcp/server_test.go
@@ -580,14 +580,19 @@ func TestWorkspaceServer_HandleCreateTask_InvalidCron(t *testing.T) {
 
 func TestValidateCronGranularity(t *testing.T) {
 	validCases := []string{
-		"0 * * * *",   // every hour at :00
-		"30 * * * *",  // every hour at :30
-		"0 9 * * *",   // daily at 9am
-		"0 9 * * 1",   // weekly Monday at 9am
-		"0 9 1 * *",   // monthly on the 1st at 9am
-		"59 23 * * *", // daily at 23:59
-		"0 */2 * * *", // every 2 hours at :00
-		"30 9 * * 1-5",// weekdays at 9:30
+		"0 * * * *",    // every hour at :00
+		"30 * * * *",   // every hour at :30
+		"0 9 * * *",    // daily at 9am
+		"0 9 * * 1",    // weekly Monday at 9am
+		"0 9 1 * *",    // monthly on the 1st at 9am
+		"59 23 * * *",  // daily at 23:59
+		"0 */2 * * *",  // every 2 hours at :00
+		"30 9 * * 1-5", // weekdays at 9:30
+		// One-time tasks (fixed dom+month): minute-precision is allowed
+		"30 14 25 4 *",  // one-time: April 25 at 14:30
+		"5 9 1 1 *",     // one-time: Jan 1 at 09:05
+		"59 23 31 12 *", // one-time: Dec 31 at 23:59
+		"1 0 15 6 *",    // one-time: June 15 at 00:01
 	}
 
 	for _, s := range validCases {


### PR DESCRIPTION
Update CreateTaskParams.CronSchedule schema description to clarify that one-time tasks (fixed dom+month fields) support minute-level precision, while recurring tasks remain hourly-minimum.

Also update validateCronGranularity comment to document the one-time vs recurring distinction, and add explicit test cases for minute-precision one-time cron expressions.

No logic changes required — the validator already accepted valid one-time expressions like '30 14 25 4 *'.