### PR TITLE
Standardize API naming to camelCase across backend and frontend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,3 +22,7 @@ Mock packages are **generated** (gitignored). Run `make mocks` before testing if
 
 ## Commit convention
 Include `Task: <taskID>` in the commit body for traceability.
+
+## Coding Standards
+- **API Naming**: All JSON fields in API requests and responses MUST use `camelCase` (e.g., `workspaceId`, `createdAt`). Never use `snake_case` in the API surface.
+- **Backend Layers**: Follow view-entity-model separation; only `view` structs define the API schema.

--- a/backend/GEMINI.md
+++ b/backend/GEMINI.md
@@ -61,7 +61,8 @@ Entities are standard Go structs that specify the data passing between the contr
 
 ### Views (`internal/data/view/`)
 Views define the external structures, like JSON inputs/outputs.
-- Structs use `json:"fieldName"` struct tags for serialization properties.
+- Structs use `json:"fieldName"` struct tags with **camelCase** naming (e.g., `workspaceId`, `createdAt`).
+- **CRITICAL**: No `snake_case` is allowed in the JSON API surface.
 - Do not contain behavior/business logic or persistence details here.
 
 ## 3. General Best Practices

--- a/backend/internal/controller/mcp/event.go
+++ b/backend/internal/controller/mcp/event.go
@@ -26,10 +26,10 @@ func (a Action) String() string {
 
 type MCPEvent struct {
 	Action      Action `json:"action"`
-	WorkspaceID int64  `json:"workspace_id"`
-	UserID      int64  `json:"user_id"`
+	WorkspaceID int64  `json:"workspaceId"`
+	UserID      int64  `json:"userId"`
 	Method      string `json:"method,omitempty"`
-	ToolName    string `json:"tool_name,omitempty"`
+	ToolName    string `json:"toolName,omitempty"`
 	Actor       uint8  `json:"actor"` // 1: Human, 2: Agent
 }
 

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -44,10 +44,10 @@ type UpdateMessageMetadataFunc func(ctx context.Context, taskID int64, messageID
 type UpdateWorkspaceAutoAllowedToolsFunc func(ctx context.Context, tools []string) error
 
 type PermissionRequestParams struct {
-	RequestID    string `json:"request_id"`
-	ToolName     string `json:"tool_name"`
+	RequestID    string `json:"requestId"`
+	ToolName     string `json:"toolName"`
 	Description  string `json:"description"`
-	InputPreview string `json:"input_preview"`
+	InputPreview string `json:"inputPreview"`
 }
 
 // WorkspaceServer is a per-workspace MCP server that exposes the Claude Channels protocol.
@@ -97,30 +97,30 @@ type CreateTaskParams struct {
 	Body         string `json:"body" jsonschema:"Detailed description of the task or action needed"`
 	Assignee     string `json:"assignee,omitempty" jsonschema:"Who should complete the task: 'human' or 'agent'. Default is 'agent'."`
 	Attachments  []any  `json:"attachments,omitempty" jsonschema:"Optional attachments"`
-	CronSchedule string `json:"cron_schedule,omitempty" jsonschema:"Optional cron schedule (5-field format: minute hour dom month dow). For RECURRING tasks (dom and month use wildcards) the minimum granularity is hourly — the minute field must be a single integer 0-59, not a wildcard or step (e.g. '30 * * * *'). For ONE-TIME tasks (fixed dom and month, e.g. '30 14 25 4 *') any fixed minute value 0-59 is accepted, enabling minute-level precision."`
+	CronSchedule string `json:"cronSchedule,omitempty" jsonschema:"Optional cron schedule (5-field format: minute hour dom month dow). For RECURRING tasks (dom and month use wildcards) the minimum granularity is hourly — the minute field must be a single integer 0-59, not a wildcard or step (e.g. '30 * * * *'). For ONE-TIME tasks (fixed dom and month, e.g. '30 14 25 4 *') any fixed minute value 0-59 is accepted, enabling minute-level precision."`
 }
 
 // UpdateTaskStatusParams is the input to the update_task_status tool.
 type UpdateTaskStatusParams struct {
-	TaskID string `json:"task_id" jsonschema:"The ID of the task to update"`
+	TaskID string `json:"taskId" jsonschema:"The ID of the task to update"`
 	Status string `json:"status" jsonschema:"New status: 'ongoing', 'completed', 'blocked', 'rejected', or 'notstarted'"`
 }
 
 // ReplyParams is the input to the reply tool.
 type ReplyParams struct {
-	ChatID      string              `json:"chat_id" jsonschema:"The conversation to reply in (from the chat_id tag field)"`
+	ChatID      string              `json:"chatId" jsonschema:"The conversation to reply in (from the chat_id tag field)"`
 	Text        string              `json:"text" jsonschema:"The message text to send"`
 	Attachments []entity.Attachment `json:"attachments,omitempty" jsonschema:"Optional attachments to include in the reply"`
 }
 
 // DownloadAttachmentParams is the input to the download_attachment tool.
 type DownloadAttachmentParams struct {
-	AttachmentID string `json:"attachment_id" jsonschema:"The ID of the attachment to download"`
+	AttachmentID string `json:"attachmentId" jsonschema:"The ID of the attachment to download"`
 }
 
 // GetTaskMessagesParams is the input to the getTaskMessages tool.
 type GetTaskMessagesParams struct {
-	TaskID string `json:"task_id" jsonschema:"The ID of the task to get messages for"`
+	TaskID string `json:"taskId" jsonschema:"The ID of the task to get messages for"`
 	Cursor int    `json:"cursor,omitempty" jsonschema:"The offset cursor. Default is 0."`
 	Limit  int    `json:"limit,omitempty" jsonschema:"The maximum items to return. Default is 5."`
 }

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -290,7 +290,7 @@ type (
 
 	GetWorkspaceStatsRequest struct {
 		ID     int64  `json:"id"`
-		UserID string `json:"user_id"`
+		UserID string `json:"userId"`
 		Range  string `json:"range"` // 1d, 7d, week, 30d, month, custom
 		From   int64  `json:"from"`  // unix timestamp for custom range
 		To     int64  `json:"to"`    // unix timestamp for custom range
@@ -302,16 +302,16 @@ type (
 	}
 
 	WorkspaceStatsSummary struct {
-		TasksCompleted  int64 `json:"tasks_completed"`
-		TasksScheduled  int64 `json:"tasks_scheduled"`
+		TasksCompleted  int64 `json:"tasksCompleted"`
+		TasksScheduled  int64 `json:"tasksScheduled"`
 		Messages        int64 `json:"messages"`
-		ManualApprovals int64 `json:"manual_approvals"`
-		AutoApprovals   int64 `json:"auto_approvals"`
+		ManualApprovals int64 `json:"manualApprovals"`
+		AutoApprovals   int64 `json:"autoApprovals"`
 		Denies          int64 `json:"denies"`
 	}
 
 	WorkspaceStatsTimeseries struct {
-		TasksCompleted []DailyStat `json:"tasks_completed"`
+		TasksCompleted []DailyStat `json:"tasksCompleted"`
 		Messages       []DailyStat `json:"messages"`
 	}
 
@@ -337,10 +337,10 @@ type (
 	// CRUDEvent is the central structure for all CRUD events published via PubSub
 	CRUDEvent struct {
 		Action       Action       `json:"action"`
-		WorkspaceID  int64        `json:"workspace_id"`
-		UserID       int64        `json:"user_id"`
-		ResourceType ResourceType `json:"resource_type"`
-		ResourceID   int64        `json:"resource_id"`
+		WorkspaceID  int64        `json:"workspaceId"`
+		UserID       int64        `json:"userId"`
+		ResourceType ResourceType `json:"resourceType"`
+		ResourceID   int64        `json:"resourceId"`
 		Actor        Actor        `json:"actor"` // 1: Human, 2: Agent
 	}
 )

--- a/backend/internal/data/view/api/view.go
+++ b/backend/internal/data/view/api/view.go
@@ -7,26 +7,26 @@ type (
 
 	Workspace struct {
 		ID          string `json:"id"`
-		CreatedAt   time.Time `json:"created_at"`
-		UpdatedAt   time.Time `json:"updated_at"`
+		CreatedAt   time.Time `json:"createdAt"`
+		UpdatedAt   time.Time `json:"updatedAt"`
 		Name        string    `json:"name"`
 		Description string    `json:"description"`
-		ArchivedAt           *time.Time            `json:"archived_at,omitempty"`
+		ArchivedAt           *time.Time            `json:"archivedAt,omitempty"`
 		Icon                 string                `json:"icon,omitempty"`
-		NotificationSettings *NotificationSettings `json:"notification_settings,omitempty"`
-		AgentConnected       bool                  `json:"agent_connected"`
-		MCPURL               string                `json:"mcp_url"`
-		MCPToken             string                `json:"mcp_token,omitempty"`
-		AutoAllowedTools     []string              `json:"auto_allowed_tools,omitempty"`
-		AllowAllCommands     bool                  `json:"allow_all_commands"`
+		NotificationSettings *NotificationSettings `json:"notificationSettings,omitempty"`
+		AgentConnected       bool                  `json:"agentConnected"`
+		MCPURL               string                `json:"mcpUrl"`
+		MCPToken             string                `json:"mcpToken,omitempty"`
+		AutoAllowedTools     []string              `json:"autoAllowedTools,omitempty"`
+		AllowAllCommands     bool                  `json:"allowAllCommands"`
 	}
 
 	NotificationSettings struct {
-		TaskCreated         bool     `json:"task_created"`
-		TaskStatusUpdated   bool     `json:"task_status_updated"`
-		TaskReceivedMessage bool     `json:"task_received_message"`
-		WorkspaceArchived   bool     `json:"workspace_archived"`
-		WorkspaceUnarchived bool     `json:"workspace_unarchived"`
+		TaskCreated         bool     `json:"taskCreated"`
+		TaskStatusUpdated   bool     `json:"taskStatusUpdated"`
+		TaskReceivedMessage bool     `json:"taskReceivedMessage"`
+		WorkspaceArchived   bool     `json:"workspaceArchived"`
+		WorkspaceUnarchived bool     `json:"workspaceUnarchived"`
 		Channels            []string `json:"channels"` // e.g. ["email"]
 	}
 
@@ -61,9 +61,9 @@ type (
 
 	Message struct {
 		ID          string       `json:"id"`
-		CreatedAt   time.Time    `json:"created_at"`
-		TaskID      string       `json:"task_id"`
-		UserID      string       `json:"user_id"`
+		CreatedAt   time.Time    `json:"createdAt"`
+		TaskID      string       `json:"taskId"`
+		UserID      string       `json:"userId"`
 		Sender      string       `json:"sender"`
 		Text        string       `json:"text"`
 		Attachments []Attachment `json:"attachments,omitempty"`
@@ -74,24 +74,24 @@ type (
 	// Status:    "notstarted" | "ongoing" | "completed" | "rejected" | "cron" | "blocked"
 	Task struct {
 		ID        string    `json:"id"`
-		CreatedAt time.Time `json:"created_at"`
-		UpdatedAt time.Time `json:"updated_at"`
+		CreatedAt time.Time `json:"createdAt"`
+		UpdatedAt time.Time `json:"updatedAt"`
 
-		WorkspaceID   string       `json:"workspace_id"`
-		CreatedBy     string       `json:"created_by"`
+		WorkspaceID   string       `json:"workspaceId"`
+		CreatedBy     string       `json:"createdBy"`
 		Assignee      string       `json:"assignee"`
 		Status        string       `json:"status"`
 		Title       string       `json:"title"`
 		Body        string       `json:"body"`
 		Response    string       `json:"response,omitempty"`
-		ReplyText   string       `json:"reply_text,omitempty"`
+		ReplyText   string       `json:"replyText,omitempty"`
 		Attachments []Attachment `json:"attachments,omitempty"`
 		Metadata    any          `json:"metadata,omitempty"`
 		Messages    []Message    `json:"messages,omitempty"`
-		CronSchedule string      `json:"cron_schedule,omitempty"`
-		ParentID     string      `json:"parent_id,omitempty"`
-		SortOrder    float64     `json:"sort_order"`
-		AllowAllCommands bool    `json:"allow_all_commands"`
+		CronSchedule string      `json:"cronSchedule,omitempty"`
+		ParentID     string      `json:"parentId,omitempty"`
+		SortOrder    float64     `json:"sortOrder"`
+		AllowAllCommands bool    `json:"allowAllCommands"`
 	}
 
 	CreateTaskRequest struct {
@@ -146,7 +146,7 @@ type (
 	}
 
 	UpdateTaskAllowAllCommandsRequest struct {
-		AllowAll TaskAllowAllUpdate `json:"allow_all"`
+		AllowAll TaskAllowAllUpdate `json:"allowAll"`
 	}
 
 	TaskAllowAllUpdate struct {
@@ -188,7 +188,7 @@ type (
 	}
 
 	SendPermissionVerdictRequest struct {
-		RequestID string `json:"request_id"`
+		RequestID string `json:"requestId"`
 		Behavior  string `json:"behavior"` // "allow" | "deny"
 	}
 

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -221,7 +221,7 @@ func (h *handler) rootLogin() fiber.Handler {
 		}
 
 		type RootLoginRequest struct {
-			RootToken string `json:"root_token"`
+			RootToken string `json:"rootToken"`
 		}
 		var req RootLoginRequest
 		if err := c.BodyParser(&req); err != nil {

--- a/frontend/GEMINI.md
+++ b/frontend/GEMINI.md
@@ -35,3 +35,6 @@ This document outlines the core design principles and UI patterns to ensure cons
 - **No Native Modals**: Never use browser `confirm()` or `alert()`.
 - **Custom Deletion Flow**: Always use the branded `DeleteModal.vue` component for destructive actions like purging workspaces or deleting tasks.
 - **Toast Notifications**: Use the global `useToasts` system for all mission-critical feedback (Success/Error/Info).
+## 6. API Data Conventions
+- **Naming**: All API data properties must use `camelCase` (e.g., `workspaceId`, `createdAt`).
+- **Standard**: Strictly avoid using `snake_case` for any data received from or sent to the backend.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -268,7 +268,7 @@ watch(events, (newEvents) => {
   if (newEvents.length === 0) return
   const event = newEvents[newEvents.length - 1]
   
-  if (event.type === 'task.created' && event.payload.created_by === 'agent') {
+  if (event.type === 'task.created' && event.payload.createdBy === 'agent') {
     notifySuccess(`Agent started a new task: ${event.payload.title}`)
   } else if (event.type === 'task.updated') {
     const task = event.payload

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -88,12 +88,12 @@ export async function createTask(workspaceId, title, body, assignee = 'agent', a
       task: { 
         title, 
         body, 
-        created_by: 'human', 
+        createdBy: 'human', 
         assignee, 
         attachments, 
         status, 
-        cron_schedule: cronSchedule,
-        allow_all_commands: allowAllCommands
+        cronSchedule,
+        allowAllCommands: allowAllCommands
       } 
     })
   });
@@ -145,7 +145,7 @@ export async function updateTaskAllowAllCommands(workspaceId, taskId, value) {
   const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/allow_all`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ allow_all: { value } })
+    body: JSON.stringify({ allowAll: { value } })
   });
   if (!res.ok) throw new Error('Failed to update task allow all commands flag');
   return res.json();
@@ -205,7 +205,7 @@ export async function sendPermissionVerdict(workspaceId, taskId, requestId, beha
   const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/permission`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ request_id: requestId, behavior })
+    body: JSON.stringify({ requestId, behavior })
   });
   if (!res.ok) throw new Error('Failed to send verdict');
   return res;
@@ -219,8 +219,8 @@ export async function updateScheduledTask(workspaceId, taskId, title, body, assi
         title,
         body,
         assignee,
-        cron_schedule: cronSchedule,
-        allow_all_commands: allowAllCommands
+        cronSchedule,
+        allowAllCommands
       }
     })
   });

--- a/frontend/src/components/EditWorkspaceModal.vue
+++ b/frontend/src/components/EditWorkspaceModal.vue
@@ -49,15 +49,15 @@
               <div class="space-y-4">
                 <div class="flex items-center justify-between">
                   <label class="block text-[10px] font-black text-gray-400 uppercase tracking-widest ml-1">Auto-Allow List</label>
-                  <span class="text-[9px] font-bold text-gray-300 uppercase tracking-wider bg-gray-50 px-2 py-0.5 rounded border border-gray-100">{{ form.auto_allowed_tools.length }} Tools</span>
+                  <span class="text-[9px] font-bold text-gray-300 uppercase tracking-wider bg-gray-50 px-2 py-0.5 rounded border border-gray-100">{{ form.autoAllowedTools.length }} Tools</span>
                 </div>
                 
                 <p class="text-[11px] text-gray-500 leading-relaxed px-1">
                   These tools will execute autonomously without requiring manual confirmation. Auto-approving trusted tools speeds up agent execution.
                 </p>
 
-                <div v-if="form.auto_allowed_tools.length > 0" class="grid grid-cols-1 gap-2 mt-4">
-                  <div v-for="tool in form.auto_allowed_tools" :key="tool" class="flex items-center justify-between p-3.5 bg-gray-50 rounded-xl border border-gray-100 group hover:bg-white hover:border-gray-200 transition-all">
+                <div v-if="form.autoAllowedTools.length > 0" class="grid grid-cols-1 gap-2 mt-4">
+                  <div v-for="tool in form.autoAllowedTools" :key="tool" class="flex items-center justify-between p-3.5 bg-gray-50 rounded-xl border border-gray-100 group hover:bg-white hover:border-gray-200 transition-all">
                     <div class="flex items-center gap-3">
                       <div class="p-2 bg-white rounded-lg shadow-sm border border-gray-100">
                         <svg class="w-3.5 h-3.5 text-indigo-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path d="M13 10V3L4 14h7v7l9-11h-7z" /></svg>
@@ -72,7 +72,7 @@
                       </div>
                       <span v-else class="text-xs font-bold text-gray-800">{{ tool }}</span>
                     </div>
-                    <button type="button" @click="form.auto_allowed_tools = form.auto_allowed_tools.filter(t => t !== tool)" class="text-gray-300 hover:text-red-500 transition-colors p-1.5 opacity-0 group-hover:opacity-100">
+                    <button type="button" @click="form.autoAllowedTools = form.autoAllowedTools.filter(t => t !== tool)" class="text-gray-300 hover:text-red-500 transition-colors p-1.5 opacity-0 group-hover:opacity-100">
                       <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg>
                     </button>
                   </div>
@@ -100,7 +100,7 @@
                     </div>
                   </div>
                   <div class="relative inline-flex items-center cursor-pointer">
-                    <input type="checkbox" v-model="form.allow_all_commands" class="sr-only peer" />
+                    <input type="checkbox" v-model="form.allowAllCommands" class="sr-only peer" />
                     <div class="w-9 h-5 bg-gray-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-red-500"></div>
                   </div>
                 </label>
@@ -211,8 +211,8 @@ const form = ref({
     workspace_unarchived: false,
     channels: ['email']
   },
-  auto_allowed_tools: [],
-  allow_all_commands: false
+  autoAllowedTools: [],
+  allowAllCommands: false
 });
 
 const eventTypes = [
@@ -224,7 +224,7 @@ const eventTypes = [
 ];
 
 const yoloEvent = [
-  { key: 'allow_all_commands', label: 'Allow All Commands (YOLO)', icon: '<path d="M13 10V3L4 14h7v7l9-11h-7z" />' }
+  { key: 'allowAllCommands', label: 'Allow All Commands (YOLO)', icon: '<path d="M13 10V3L4 14h7v7l9-11h-7z" />' }
 ];
 
 watch(() => props.workspace, (newVal) => {
@@ -241,8 +241,8 @@ watch(() => props.workspace, (newVal) => {
         workspace_unarchived: newVal.notification_settings?.workspace_unarchived || false,
         channels: newVal.notification_settings?.channels || ['email']
       },
-      auto_allowed_tools: newVal.auto_allowed_tools || [],
-      allow_all_commands: newVal.allow_all_commands || false
+      autoAllowedTools: newVal.autoAllowedTools || [],
+      allowAllCommands: newVal.allowAllCommands || false
     };
   }
 }, { immediate: true });

--- a/frontend/src/components/TaskFeed.vue
+++ b/frontend/src/components/TaskFeed.vue
@@ -69,15 +69,15 @@
                    
                    <div class="flex flex-wrap items-center gap-2 md:gap-3 text-[9px] font-black uppercase tracking-widest mt-0.5">
                      <template v-if="t.status === 'cron'">
-                       <span class="text-sky-600 font-bold" v-if="getNextRunDateTime(t.cron_schedule)">
-                         {{ getNextRunDateTime(t.cron_schedule).toUpperCase() }}
+                       <span class="text-sky-600 font-bold" v-if="getNextRunDateTime(t.cronSchedule)">
+                         {{ getNextRunDateTime(t.cronSchedule).toUpperCase() }}
                        </span>
                      </template>
-                     <span class="text-gray-500" v-else>{{ formatTime(t.created_at) }}</span>
+                     <span class="text-gray-500" v-else>{{ formatTime(t.createdAt) }}</span>
                      
                      <span class="flex items-center gap-1">
                        <span class="text-gray-400">BY</span>
-                       <span :class="t.created_by === 'human' ? 'text-black' : 'text-indigo-600'">{{ t.created_by === 'human' ? 'YOU' : 'AGENT' }}</span>
+                       <span :class="t.createdBy === 'human' ? 'text-black' : 'text-indigo-600'">{{ t.createdBy === 'human' ? 'YOU' : 'AGENT' }}</span>
                      </span>
                      
                      <span class="flex items-center gap-1" v-if="t.assignee">
@@ -86,15 +86,15 @@
                      </span>
 
                      <span v-if="t.status === 'cron'" class="text-sky-800 bg-sky-100 border border-sky-300 px-1 py-0.5">
-                       ⏰ {{ formatCron(t.cron_schedule) }}
+                       ⏰ {{ formatCron(t.cronSchedule) }}
                      </span>
-                     <span v-if="t.status === 'cron' && getNextRunLabel(t.cron_schedule)" class="text-sky-600 font-bold">
-                       • {{ getNextRunLabel(t.cron_schedule) }}
+                     <span v-if="t.status === 'cron' && getNextRunLabel(t.cronSchedule)" class="text-sky-600 font-bold">
+                       • {{ getNextRunLabel(t.cronSchedule) }}
                      </span>
 
-                     <span class="flex items-center gap-1 bg-white border border-gray-200 px-1 text-gray-600" v-if="t.Messages && t.Messages.length > 0">
+                     <span class="flex items-center gap-1 bg-white border border-gray-200 px-1 text-gray-600" v-if="t.messages && t.messages.length > 0">
                        <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" /></svg>
-                       {{ t.Messages.length }}
+                       {{ t.messages.length }}
                      </span>
                      
                      <div v-if="t.attachments && t.attachments.length > 0" class="flex items-center gap-1 bg-white border border-gray-200 px-1 text-gray-600">
@@ -271,7 +271,7 @@ watch(() => props.liveEvents.length, (newLen, oldLen) => {
         } else {
           localTasks.value.push(t);
           // Trigger notification if it's an agent task
-          if (t.created_by === 'agent') {
+          if (t.createdBy === 'agent') {
             notifyInfo(`Agent defined a new task: ${t.title}`, 'New Task');
           }
         }
@@ -357,9 +357,9 @@ function formatRelativeTime(date) {
 }
 
 function getTaskOrder(t) {
-  if (t.sort_order) return t.sort_order;
-  if (!t.created_at) return Date.now();
-  return new Date(t.created_at).getTime() / 1000.0;
+  if (t.sortOrder) return t.sortOrder;
+  if (!t.createdAt) return Date.now();
+  return new Date(t.createdAt).getTime() / 1000.0;
 }
 
 const allTasks = computed(() => {
@@ -386,7 +386,7 @@ const displayGroups = computed(() => {
     const handledIds = new Set();
 
     categories.forEach(cat => {
-      const matched = cronTasks.filter(t => cat.values.includes(t.cron_schedule));
+      const matched = cronTasks.filter(t => cat.values.includes(t.cronSchedule));
       if (matched.length > 0) {
         grps.push({ title: cat.label, tasks: matched });
         matched.forEach(t => handledIds.add(t.id));
@@ -422,7 +422,7 @@ const displayGroups = computed(() => {
 });
 
 const pendingInputCount = computed(() => {
-  return localTasks.value.filter(t => t.created_by === 'agent' && (t.status === 'notstarted')).length;
+  return localTasks.value.filter(t => t.createdBy === 'agent' && (t.status === 'notstarted')).length;
 });
 
 const scheduledCount = computed(() => {

--- a/frontend/src/views/ScheduledTaskInstancesView.vue
+++ b/frontend/src/views/ScheduledTaskInstancesView.vue
@@ -35,7 +35,7 @@
           </div>
           <div class="flex items-center gap-2">
             <span class="text-[9px] font-black text-sky-300 uppercase tracking-widest bg-sky-800 px-2 py-0.5">
-              ⏰ {{ formatCron(scheduledTask.cron_schedule) }}
+              ⏰ {{ formatCron(scheduledTask.cronSchedule) }}
             </span>
             <span v-if="nextRunLabel" class="text-[9px] font-black text-sky-200 uppercase tracking-widest">
               NEXT: {{ nextRunLabel }}
@@ -46,7 +46,7 @@
           <p class="font-black text-sm text-sky-900 leading-snug">{{ scheduledTask.title }}</p>
           <p v-if="scheduledTask.body" class="text-xs text-sky-700 mt-1 leading-relaxed line-clamp-2">{{ scheduledTask.body }}</p>
           <div class="flex flex-wrap items-center gap-3 mt-2 text-[9px] font-black uppercase tracking-widest text-sky-500">
-            <span>Created {{ formatDate(scheduledTask.created_at) }}</span>
+            <span>Created {{ formatDate(scheduledTask.createdAt) }}</span>
             <span class="border-l border-sky-300 pl-3">{{ instances.length }} instance{{ instances.length !== 1 ? 's' : '' }} found</span>
           </div>
         </div>
@@ -81,10 +81,10 @@
                   {{ instance.title }}
                 </span>
                 <div class="flex flex-wrap items-center gap-2 md:gap-3 text-[9px] font-black uppercase tracking-widest mt-0.5">
-                  <span class="text-gray-500">{{ formatDate(instance.created_at) }}</span>
-                  <span class="flex items-center gap-1 bg-white border border-gray-200 px-1 text-gray-600" v-if="instance.Messages && instance.Messages.length > 0">
+                  <span class="text-gray-500">{{ formatDate(instance.createdAt) }}</span>
+                  <span class="flex items-center gap-1 bg-white border border-gray-200 px-1 text-gray-600" v-if="instance.messages && instance.messages.length > 0">
                     <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" /></svg>
-                    {{ instance.Messages.length }}
+                    {{ instance.messages.length }}
                   </span>
                 </div>
               </div>
@@ -140,10 +140,10 @@ onMounted(async () => {
 
     scheduledTask.value = allTasks.find(t => t.id === taskId) || null;
 
-    // Find instances: tasks whose parent_id matches this task's id, sorted newest first, limit 5
+    // Find instances: tasks whose parentId matches this task's id, sorted newest first, limit 5
     instances.value = allTasks
-      .filter(t => t.parent_id === taskId)
-      .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
+      .filter(t => t.parentId === taskId)
+      .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
       .slice(0, 5);
   } catch (err) {
     error.value = err.message || 'Failed to load instances';
@@ -153,8 +153,8 @@ onMounted(async () => {
 });
 
 const nextRunLabel = computed(() => {
-  if (!scheduledTask.value?.cron_schedule) return '';
-  return getNextRunLabel(scheduledTask.value.cron_schedule);
+  if (!scheduledTask.value?.cronSchedule) return '';
+  return getNextRunLabel(scheduledTask.value.cronSchedule);
 });
 
 function formatDate(dateStr) {

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -54,7 +54,7 @@
         </div>
       </div>
       <div class="flex items-center gap-2 shrink-0">
-        <span v-if="workspace.archived_at" class="border-2 border-yellow-500 bg-yellow-300 text-black px-2 py-0.5 text-[10px] font-black uppercase tracking-widest">Archived</span>
+        <span v-if="workspace.archivedAt" class="border-2 border-yellow-500 bg-yellow-300 text-black px-2 py-0.5 text-[10px] font-black uppercase tracking-widest">Archived</span>
         <span class="hidden md:inline text-[9px] font-black text-gray-300 uppercase tracking-widest">{{ task.id }}</span>
         <button @click="router.push('/workspaces/' + workspaceId)" class="p-1.5 text-gray-400 hover:text-black border-2 border-transparent hover:border-black transition-all">
           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" /></svg>
@@ -74,8 +74,8 @@
           <div class="bg-black px-4 py-2 flex items-center justify-between">
             <div class="flex items-center gap-2">
               <div class="w-5 h-5 flex items-center justify-center text-[9px] font-black"
-                   :class="task.created_by === 'human' ? 'bg-[#00FF88] text-black' : 'bg-gray-600 text-[#00FF88]'">
-                {{ task.created_by === 'human' ? 'H' : 'A' }}
+                   :class="task.createdBy === 'human' ? 'bg-[#00FF88] text-black' : 'bg-gray-600 text-[#00FF88]'">
+                {{ task.createdBy === 'human' ? 'H' : 'A' }}
               </div>
               <span class="text-[10px] font-black text-white uppercase tracking-widest">Task Definition</span>
               <span class="text-[9px] font-black text-gray-400 uppercase tracking-widest">→ {{ task.assignee }}</span>
@@ -83,12 +83,12 @@
                       @click="toggleAllowAllCommands"
                       @mouseenter="showTooltip($event, 'Toggle auto-allow all tool executions for this task')" @mouseleave="hideTooltip"
                       class="ml-1.5 md:ml-2 px-1.5 md:px-2 py-0.5 border text-[8px] font-black uppercase tracking-widest transition-all active:translate-y-0.5 flex items-center gap-1 shrink-0"
-                      :class="task.allow_all_commands ? 'bg-[#00FF88] text-black border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]' : 'bg-gray-800 text-gray-400 border-gray-600 hover:border-[#00FF88] hover:text-[#00FF88] shadow-none'">
-                <svg v-if="task.allow_all_commands" class="w-3 h-3 md:w-2.5 md:h-2.5 text-black" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
+                      :class="task.allowAllCommands ? 'bg-[#00FF88] text-black border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]' : 'bg-gray-800 text-gray-400 border-gray-600 hover:border-[#00FF88] hover:text-[#00FF88] shadow-none'">
+                <svg v-if="task.allowAllCommands" class="w-3 h-3 md:w-2.5 md:h-2.5 text-black" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
                 <div v-else class="w-2.5 h-2.5 border border-gray-500 bg-transparent rounded-sm"></div>
                 <span class="hidden md:inline">YOLO</span>
               </button>
-              <span v-else-if="task.allow_all_commands" 
+              <span v-else-if="task.allowAllCommands" 
                     @mouseenter="showTooltip($event, 'This task automatically approves all tool calls')" @mouseleave="hideTooltip"
                     class="hidden sm:inline-block ml-1.5 md:ml-2 px-1.5 py-0.5 bg-[#00FF88] text-black text-[8px] font-black uppercase tracking-widest border border-[#00FF88]/50 shadow-[1px_1px_0px_0px_rgba(255,255,255,0.4)] truncate">
                 YOLO
@@ -104,7 +104,7 @@
               </button>
             </div>
             <div class="flex items-center gap-3">
-              <span class="text-[9px] font-bold text-gray-500 uppercase tracking-widest">{{ formatDateTime(task.created_at) }}</span>
+              <span class="text-[9px] font-bold text-gray-500 uppercase tracking-widest">{{ formatDateTime(task.createdAt) }}</span>
               <button @click="descExpanded = !descExpanded" class="text-[9px] font-black text-gray-400 hover:text-[#00FF88] uppercase tracking-widest flex items-center gap-1 transition-colors">
                 {{ descExpanded ? 'Collapse' : 'Expand' }}
                 <svg class="w-3 h-3 transition-transform duration-200" :class="descExpanded ? 'rotate-180' : ''" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M19 9l-7 7-7-7" /></svg>
@@ -153,7 +153,7 @@
             </div>
             <div class="bg-gray-50 border-2 border-black flex-1 p-3 shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] min-w-0">
               <span class="text-[10px] font-black text-gray-700 block mb-1.5 uppercase tracking-widest">
-                Claude Agent · {{ formatDateTime(m.created_at) }}
+                Claude Agent · {{ formatDateTime(m.createdAt) }}
               </span>
               <div class="text-xs font-medium text-gray-800 leading-relaxed whitespace-pre-wrap break-all">{{ m.text }}</div>
 
@@ -164,15 +164,15 @@
                     <svg class="w-3.5 h-3.5 text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" /></svg>
                     <span class="text-[10px] font-black text-white uppercase tracking-widest">Agent Authorization Required</span>
                   </div>
-                  <span class="text-[9px] font-bold text-gray-400 uppercase tracking-tight">{{ m.metadata.request_id }}</span>
+                  <span class="text-[9px] font-bold text-gray-400 uppercase tracking-tight">{{ m.metadata.requestId }}</span>
                 </div>
                 <div class="p-3 flex flex-col gap-3">
                   <div>
                     <span class="text-[9px] font-black text-gray-400 uppercase tracking-widest">Tool / Action</span>
-                    <p class="text-xs font-black text-gray-900 mt-0.5 break-all">{{ m.metadata.tool_name }}</p>
+                    <p class="text-xs font-black text-gray-900 mt-0.5 break-all">{{ m.metadata.toolName }}</p>
                   </div>
                   <p v-if="m.metadata.description" class="text-xs text-gray-600 font-medium italic border-l-2 border-black pl-3">"{{ m.metadata.description }}"</p>
-                  <pre v-if="m.metadata.input_preview" class="text-[10px] font-mono bg-gray-950 text-[#00FF88] p-3 overflow-x-auto whitespace-pre-wrap break-all border border-gray-700 custom-scrollbar">{{ m.metadata.input_preview }}</pre>
+                  <pre v-if="m.metadata.inputPreview" class="text-[10px] font-mono bg-gray-950 text-[#00FF88] p-3 overflow-x-auto whitespace-pre-wrap break-all border border-gray-700 custom-scrollbar">{{ m.metadata.inputPreview }}</pre>
 
                   <!-- Pending verdict buttons -->
                   <div v-if="m.metadata.status === 'pending'" class="flex flex-wrap gap-2 pt-2">
@@ -203,7 +203,7 @@
                       <svg v-else class="w-3.5 h-3.5 text-red-600 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M6 18L18 6M6 6l12 12" /></svg>
                       <span class="text-[10px] font-black uppercase tracking-widest flex-1 truncate break-all"
                             :class="m.metadata.status === 'allow' || m.metadata.status === 'allow_always' ? 'text-green-800' : 'text-red-700'">
-                        {{ m.metadata.tool_name }}
+                        {{ m.metadata.toolName }}
                       </span>
                       <span v-if="m.metadata.status === 'allow_always'" class="text-[8px] font-black text-green-700 bg-[#00FF88] border border-green-700 px-1.5 py-0.5 uppercase tracking-widest shrink-0">Auto</span>
                       <span class="text-[9px] font-black uppercase tracking-widest shrink-0"
@@ -215,8 +215,8 @@
                     <div v-if="m._detailsExpanded" class="px-3 pb-3 pt-1 border-t-2 border-dashed"
                          :class="m.metadata.status === 'allow' || m.metadata.status === 'allow_always' ? 'border-[#00FF88]' : 'border-red-300'">
                       <p v-if="m.metadata.description" class="text-[11px] text-gray-600 italic mb-2">"{{ m.metadata.description }}"</p>
-                      <pre v-if="m.metadata.input_preview" class="text-[9px] font-mono bg-gray-950 text-[#00FF88] p-2 overflow-x-auto whitespace-pre-wrap break-all border border-gray-700 mb-2">{{ m.metadata.input_preview }}</pre>
-                      <span class="text-[8px] font-bold text-gray-400 uppercase tracking-tighter">ID: {{ m.metadata.request_id }}</span>
+                      <pre v-if="m.metadata.inputPreview" class="text-[9px] font-mono bg-gray-950 text-[#00FF88] p-2 overflow-x-auto whitespace-pre-wrap break-all border border-gray-700 mb-2">{{ m.metadata.inputPreview }}</pre>
+                      <span class="text-[8px] font-bold text-gray-400 uppercase tracking-tighter">ID: {{ m.metadata.requestId }}</span>
                     </div>
                   </div>
                 </div>
@@ -241,7 +241,7 @@
             </div>
             <div class="bg-[#00FF88] border-2 border-black flex-1 p-3 shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] min-w-0">
               <span class="text-[10px] font-black text-black block mb-1.5 uppercase tracking-widest text-right">
-                You · {{ formatDateTime(m.created_at) }}
+                You · {{ formatDateTime(m.createdAt) }}
               </span>
               <div class="text-xs font-medium text-black leading-relaxed whitespace-pre-wrap text-right break-all">{{ m.text }}</div>
               <!-- Attachments on human message -->
@@ -261,7 +261,7 @@
     </div>
 
     <!-- Reply Box -->
-    <footer v-if="!workspace.archived_at" class="border-t-2 border-dashed border-gray-200 pt-4 shrink-0 z-20">
+    <footer v-if="!workspace.archivedAt" class="border-t-2 border-dashed border-gray-200 pt-4 shrink-0 z-20">
 
       <!-- Attachment previews -->
       <div v-if="replyAttachments.length > 0" class="flex flex-wrap gap-2 mb-3">
@@ -284,18 +284,18 @@
               v-model="replyText"
               @input="adjustTextareaHeight"
               rows="1"
-              :disabled="(!workspace.agent_connected && task.assignee !== 'human' && task.status !== 'pending')"
-              :placeholder="(!workspace.agent_connected && task.assignee !== 'human' && task.status !== 'pending') ? 'Waiting for agent...' : 'Type instructions or response...'"
+              :disabled="(!workspace.agentConnected && task.assignee !== 'human' && task.status !== 'pending')"
+              :placeholder="(!workspace.agentConnected && task.assignee !== 'human' && task.status !== 'pending') ? 'Waiting for agent...' : 'Type instructions or response...'"
               class="flex-1 px-3 py-2 md:px-4 md:py-3 text-xs md:text-sm font-medium text-gray-900 bg-transparent outline-none placeholder-gray-400 disabled:opacity-50 resize-none min-h-[38px] md:min-h-[46px] max-h-[150px] custom-scrollbar"
             ></textarea>
             <button type="button" @click="$refs.fileInput.click()"
-                    :disabled="(!workspace.agent_connected && task.assignee !== 'human' && task.status !== 'pending')"
+                    :disabled="(!workspace.agentConnected && task.assignee !== 'human' && task.status !== 'pending')"
                     class="h-[38px] md:h-[46px] px-2.5 md:px-3 text-gray-400 hover:text-black transition-colors flex items-center justify-center disabled:opacity-30 self-end">
               <svg class="w-4 h-4 md:w-5 md:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"></path></svg>
             </button>
           </div>
            <button type="submit"
-                   :disabled="(!replyText.trim() && replyAttachments.length === 0) || (task.assignee !== 'human' && (!workspace.agent_connected || task.status === 'notstarted' || task.status === 'pending'))"
+                   :disabled="(!replyText.trim() && replyAttachments.length === 0) || (task.assignee !== 'human' && (!workspace.agentConnected || task.status === 'notstarted' || task.status === 'pending'))"
                    class="h-[42px] w-[32px] md:h-[50px] md:w-[46px] bg-transparent md:bg-black text-black md:text-white border-0 md:border-2 md:border-black hover:text-[#00FF88] md:hover:bg-[#00FF88] md:hover:text-black shadow-none md:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] disabled:opacity-30 transition-all shrink-0 flex items-center justify-center"
                    title="Send Instruction">
              <svg class="w-5 h-5 md:w-5 md:h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
@@ -305,7 +305,7 @@
         </div>
 
         <!-- Status Warning Messages -->
-        <div v-if="!workspace.agent_connected && task.assignee !== 'human'" class="flex flex-col items-center gap-2 mt-4 px-4 py-3 bg-red-50 border-2 border-red-200 border-dashed">
+        <div v-if="!workspace.agentConnected && task.assignee !== 'human'" class="flex flex-col items-center gap-2 mt-4 px-4 py-3 bg-red-50 border-2 border-red-200 border-dashed">
            <div class="flex items-center gap-2">
              <span class="w-2.5 h-2.5 rounded-full bg-red-500 animate-pulse border border-black/10"></span>
              <span class="text-[10px] font-black text-red-700 uppercase tracking-[0.2em]">Agent Offline</span>
@@ -321,7 +321,7 @@
            <p class="text-[9px] text-yellow-600 font-bold uppercase tracking-tight text-center italic">Please wait for the task to start or be accepted before sending messages.</p>
         </div>
 
-        <div v-if="(workspace.agent_connected || task.assignee === 'human') && task.status !== 'notstarted' && task.status !== 'pending'" class="hidden md:flex items-center justify-center gap-2 mt-3">
+        <div v-if="(workspace.agentConnected || task.assignee === 'human') && task.status !== 'notstarted' && task.status !== 'pending'" class="hidden md:flex items-center justify-center gap-2 mt-3">
           <div class="h-px bg-gray-200 grow"></div>
           <span class="text-[9px] font-black text-gray-300 uppercase tracking-[0.2em] whitespace-nowrap">Shift+Enter for newline · Secure Agent Sync</span>
           <div class="h-px bg-gray-200 grow"></div>
@@ -452,7 +452,7 @@ const { connect, disconnect, events } = useEventBus(workspaceId);
 
 const sortedMessages = computed(() => {
   if (!task.value || !task.value.messages) return [];
-  return [...task.value.messages].sort((a,b) => new Date(a.created_at) - new Date(b.created_at));
+  return [...task.value.messages].sort((a,b) => new Date(a.createdAt) - new Date(b.createdAt));
 });
 
 function scrollToBottom() {
@@ -531,7 +531,7 @@ async function updateStatus(newStatus) {
 
 async function toggleAllowAllCommands() {
   if (!task.value) return;
-  const newValue = !task.value.allow_all_commands;
+  const newValue = !task.value.allowAllCommands;
   try {
     const res = await updateTaskAllowAllCommands(workspaceId, taskId, newValue);
     task.value = res.task;

--- a/frontend/src/views/TaskFormView.vue
+++ b/frontend/src/views/TaskFormView.vue
@@ -77,12 +77,12 @@
                     <!-- Allow all commands toggle -->
                     <div v-if="newTask.assignee === 'agent'" class="mt-4 flex items-center gap-3">
                         <label class="relative inline-flex items-center cursor-pointer">
-                          <input type="checkbox" v-model="newTask.allow_all_commands" class="sr-only peer">
+                          <input type="checkbox" v-model="newTask.allowAllCommands" class="sr-only peer">
                           <div class="w-9 h-5 bg-gray-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-[#00FF88] border-2 border-black border-transparent"></div>
                         </label>
                         <span class="text-[10px] font-black text-gray-700 uppercase tracking-widest">Allow All Commands</span>
                     </div>
-                    <p v-if="newTask.assignee === 'agent' && newTask.allow_all_commands" class="text-[9px] font-bold text-gray-500 mt-1 max-w-xs">Warning: the agent will execute commands without asking for permission.</p>
+                    <p v-if="newTask.assignee === 'agent' && newTask.allowAllCommands" class="text-[9px] font-bold text-gray-500 mt-1 max-w-xs">Warning: the agent will execute commands without asking for permission.</p>
                  </div>
 
                  <!-- Schedule Type -->
@@ -219,7 +219,7 @@ const workspace = ref(null);
 const sending = ref(false);
 const fileInput = ref(null);
 
-const newTask = ref({ title: '', body: '', assignee: 'agent', cronSchedule: '', allow_all_commands: false });
+const newTask = ref({ title: '', body: '', assignee: 'agent', cronSchedule: '', allowAllCommands: false });
 const newTaskAttachments = ref([]);
 
 // Scheduling state
@@ -246,16 +246,16 @@ onMounted(async () => {
         title: t.title, 
         body: t.body, 
         assignee: t.assignee, 
-        cronSchedule: t.cron_schedule,
-        allow_all_commands: t.allow_all_commands || false
+        cronSchedule: t.cronSchedule,
+        allowAllCommands: t.allowAllCommands || false
       };
       
-      if (t.cron_schedule) {
-        parseCronToUI(t.cron_schedule);
+      if (t.cronSchedule) {
+        parseCronToUI(t.cronSchedule);
       }
     } else {
       // Default to workspace setting for new tasks
-      newTask.value.allow_all_commands = res.workspace.allow_all_commands || false;
+      newTask.value.allowAllCommands = res.workspace.allowAllCommands || false;
     }
   } catch (err) {
     notifyError("Access Error: " + err.message);
@@ -428,7 +428,7 @@ async function submitHumanTask() {
     await createTask(
       workspaceId, newTask.value.title, newTask.value.body, 
       newTask.value.assignee, newTaskAttachments.value,
-      status, newTask.value.cronSchedule, newTask.value.allow_all_commands
+      status, newTask.value.cronSchedule, newTask.value.allowAllCommands
     );
     notifySuccess('Mission Protocol Initialized');
     goBack(status === 'cron');
@@ -443,7 +443,7 @@ async function submitEditProtocol() {
     await updateScheduledTask(
       workspaceId, taskId, newTask.value.title, newTask.value.body,
       newTask.value.assignee, newTask.value.cronSchedule,
-      newTask.value.allow_all_commands
+      newTask.value.allowAllCommands
     );
     notifySuccess('Scheduled Protocol Updated');
     goBack(newTask.value.cronSchedule !== '');

--- a/frontend/src/views/TaskListView.vue
+++ b/frontend/src/views/TaskListView.vue
@@ -29,20 +29,20 @@
               <div class="flex flex-col gap-1.5 min-w-0 flex-1">
                 <div class="flex items-center gap-2 flex-wrap">
                   <span class="text-[9px] font-black px-2 py-0.5 border-2 border-black bg-black text-white uppercase tracking-widest">
-                    {{ getWorkspaceName(task.workspace_id) }}
+                    {{ getWorkspaceName(task.workspaceId) }}
                   </span>
                   <span class="text-xs font-bold bg-yellow-200 border border-black px-2 py-0.5 mr-2 uppercase shrink-0">Pending</span>
                 </div>
                 <h3 class="font-black text-sm text-black truncate">{{ task.title }}</h3>
               </div>
-              <span class="text-xs text-gray-400 shrink-0 font-bold uppercase">{{ formatTime(task.created_at) }}</span>
+              <span class="text-xs text-gray-400 shrink-0 font-bold uppercase">{{ formatTime(task.createdAt) }}</span>
             </div>
             
             <p class="text-xs text-gray-600 mb-3 line-clamp-2">
               {{ getLastMessageText(task) }}
             </p>
             
-            <div class="flex gap-2" @click.stop v-if="isAgentConnected(task.workspace_id)">
+            <div class="flex gap-2" @click.stop v-if="isAgentConnected(task.workspaceId)">
               <button @click="handleAction(task, 'allow')"
                       class="px-3 py-1 bg-[#00FF88] border-2 border-black text-xs font-bold hover:bg-[#00e07a] shadow-[1px_1px_0px_0px_rgba(0,0,0,1)] active:shadow-none active:translate-y-[1px] transition-all">
                 Allow
@@ -70,17 +70,17 @@
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 mb-2 flex-wrap">
                 <span class="text-[9px] font-black px-2 py-0.5 border-2 border-black bg-black text-white uppercase tracking-widest">
-                  {{ getWorkspaceName(task.workspace_id) }}
+                  {{ getWorkspaceName(task.workspaceId) }}
                 </span>
                 <span class="text-[9px] font-black px-2 py-0.5 border-2 border-black uppercase tracking-widest shrink-0" :class="getTaskBadgeStyle(task.status)">
                   {{ task.status }}
                 </span>
-                <span v-if="task.cron_schedule" class="text-[9px] font-black px-2 py-0.5 bg-sky-50 border-2 border-sky-200 text-sky-700 uppercase tracking-widest shrink-0">Scheduled</span>
+                <span v-if="task.cronSchedule" class="text-[9px] font-black px-2 py-0.5 bg-sky-50 border-2 border-sky-200 text-sky-700 uppercase tracking-widest shrink-0">Scheduled</span>
               </div>
               
               <h3 class="text-sm font-black text-black group-hover:text-indigo-600 transition-colors uppercase truncate mb-1">{{ task.title }}</h3>
               <p class="text-[10px] text-gray-500 font-bold uppercase tracking-widest">
-                {{ formatTime(task.created_at) }} • BY {{ task.created_by.toUpperCase() }}
+                {{ formatTime(task.createdAt) }} • BY {{ task.createdBy.toUpperCase() }}
               </p>
             </div>
 
@@ -180,7 +180,7 @@ const title = computed(() => {
 
 const activeTaskCount = computed(() => tasks.value.filter(t => t.status !== 'cron').length);
 const scheduledCount = computed(() => tasks.value.filter(t => t.status === 'cron').length);
-const pendingInputCount = computed(() => tasks.value.filter(t => t.created_by === 'agent' && (t.status === 'notstarted')).length);
+const pendingInputCount = computed(() => tasks.value.filter(t => t.createdBy === 'agent' && (t.status === 'notstarted')).length);
 
 const getWorkspaceName = (workspaceId) => {
   const ws = workspaces.value.find(w => w.id === workspaceId);
@@ -189,7 +189,7 @@ const getWorkspaceName = (workspaceId) => {
 
 const isAgentConnected = (workspaceId) => {
   const ws = workspaces.value.find(w => w.id === workspaceId);
-  return ws ? ws.agent_connected : false;
+  return ws ? ws.agentConnected : false;
 };
 
 const getLastMessageText = (task) => {
@@ -207,11 +207,11 @@ const handleAction = async (task, action) => {
       m.metadata?.status !== 'deny'
     );
     
-    const requestId = pendingMsg?.metadata?.request_id;
+    const requestId = pendingMsg?.metadata?.requestId;
     if (!requestId) throw new Error('No pending permission request found');
     
     const behavior = action === 'allow' ? 'allow' : 'deny';
-    await sendPermissionVerdict(task.workspace_id, task.id, requestId, behavior);
+    await sendPermissionVerdict(task.workspaceId, task.id, requestId, behavior);
     notifySuccess(`Permission ${action === 'allow' ? 'allowed' : 'denied'}`);
     // Refresh the list to remove the acted task
     await fetchInitial();
@@ -274,7 +274,7 @@ const getBackendParams = (filter) => {
 };
 
 const openTask = (task) => {
-  router.push(`/workspaces/${task.workspace_id}/tasks/${task.id}`);
+  router.push(`/workspaces/${task.workspaceId}/tasks/${task.id}`);
 };
 
 const formatTime = (dateStr) => {

--- a/frontend/src/views/WorkspaceDetailView.vue
+++ b/frontend/src/views/WorkspaceDetailView.vue
@@ -155,7 +155,7 @@
 
   <SetupModal
     :show="showSetupModal"
-    :mcpUrl="workspace?.mcp_url"
+    :mcpUrl="workspace?.mcpUrl"
     :workspaceId="workspace?.id"
     @close="showSetupModal = false"
   />
@@ -200,9 +200,9 @@ const isAgentConnected = ref(false);
 const token = ref('');
 
 const authenticatedUrl = computed(() => {
-  if (!workspace.value || !workspace.value.mcp_url) return '';
-  if (!token.value) return workspace.value.mcp_url;
-  return `${workspace.value.mcp_url}?token=${token.value}`;
+  if (!workspace.value || !workspace.value.mcpUrl) return '';
+  if (!token.value) return workspace.value.mcpUrl;
+  return `${workspace.value.mcpUrl}?token=${token.value}`;
 });
 
 async function fetchToken() {
@@ -233,7 +233,7 @@ async function load() {
   try {
     const pRes = await getWorkspace(workspaceId);
     workspace.value = pRes.workspace;
-    isAgentConnected.value = workspace.value.agent_connected;
+    isAgentConnected.value = workspace.value.agentConnected;
     const tRes = await fetchTasks(workspaceId);
     tasks.value = tRes.tasks || [];
     // Fetch token for display
@@ -304,11 +304,11 @@ async function handleUpdate(updatedForm) {
 }
 
 async function copyUrl() {
-  if (workspace.value && workspace.value.mcp_url) {
+  if (workspace.value && workspace.value.mcpUrl) {
     try {
       const res = await getWorkspaceToken(workspaceId);
       const token = res.token;
-      let url = workspace.value.mcp_url;
+      let url = workspace.value.mcpUrl;
       if (token) {
         url += `?token=${token}`;
       }

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -122,7 +122,7 @@
               <div class="flex items-center gap-3 min-w-0">
                 <!-- Status dot -->
                 <div class="w-3 h-3 rounded-full border border-black shrink-0"
-                     :class="p.agent_connected ? 'bg-green-500 animate-pulse' : 'bg-gray-300'"></div>
+                     :class="p.agentConnected ? 'bg-green-500 animate-pulse' : 'bg-gray-300'"></div>
                 <!-- Icon -->
                 <div class="w-6 h-6 bg-white flex items-center justify-center overflow-hidden shrink-0">
                   <template v-if="p.icon">
@@ -180,7 +180,7 @@
               </div>
               <div class="min-w-0">
                 <div class="font-black text-sm text-gray-600 group-hover:text-black uppercase tracking-tight transition-colors truncate">{{ p.name }}</div>
-                <div class="text-[9px] font-black text-red-400 uppercase tracking-widest truncate">Archived {{ new Date(p.archived_at).toLocaleDateString() }}</div>
+                <div class="text-[9px] font-black text-red-400 uppercase tracking-widest truncate">Archived {{ new Date(p.archivedAt).toLocaleDateString() }}</div>
               </div>
             </div>
             <div class="flex items-center gap-1">
@@ -219,11 +219,11 @@ const error = ref(null);
 const form = ref({ name: '', description: '', icon: '' });
 
 const activeWorkspaces = computed(() => {
-  return workspaces.value.filter(p => !p.archived_at);
+  return workspaces.value.filter(p => !p.archivedAt);
 });
 
 const archivedWorkspaces = computed(() => {
-  return workspaces.value.filter(p => !!p.archived_at);
+  return workspaces.value.filter(p => !!p.archivedAt);
 });
 
 const filteredActiveWorkspaces = computed(() => {
@@ -310,7 +310,7 @@ async function submit() {
 
 async function toggleArchive(p) {
   try {
-    if (p.archived_at) {
+    if (p.archivedAt) {
       await unarchiveWorkspace(p.id);
       notifySuccess('Workspace protocol restored');
     }


### PR DESCRIPTION
This commit migrates all JSON API annotations and corresponding property access patterns from snake_case to camelCase to ensure consistency with standard JavaScript/TypeScript conventions.

Modified files:
- Backend: view structs, handlers, MCP controllers
- Frontend: api.js, all major views (TaskFeed, TaskDetail, etc.)
- Docs: GEMINI.md, CLAUDE.md