### PR TITLE
🛡️ Sentinel: Fix Path Traversal in Storage Service

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Path Traversal in Storage Service
+**Vulnerability:** The `storage` service used `filepath.Join(baseDir, id)` without validating the `id`. This allowed an attacker to use `../` to read or write files outside the intended storage directory.
+**Learning:** `filepath.Join` on its own does not prevent path traversal if one of the components is an absolute path or contains traversal elements that are not resolved relative to the base directory in a safe way.
+**Prevention:** Always validate user-provided file identifiers. A robust pattern in Go is to ensure that `filepath.Base(id) == id` and that the ID is not empty or equal to `.` or `..`. This ensures the ID is a simple filename and cannot escape the base directory.

--- a/backend/internal/service/storage/path_traversal_test.go
+++ b/backend/internal/service/storage/path_traversal_test.go
@@ -1,0 +1,56 @@
+package storage
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStorage_PathTraversal(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "storage_traversal_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	s, err := New(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to create storage: %v", err)
+	}
+
+	// Create a canary file outside the storage directory
+	canaryFile := filepath.Join(filepath.Dir(tmpDir), "canary.txt")
+	canaryContent := "secret canary content"
+	err = os.WriteFile(canaryFile, []byte(canaryContent), 0644)
+	if err != nil {
+		t.Fatalf("failed to create canary file: %v", err)
+	}
+	defer os.Remove(canaryFile)
+
+	t.Run("PathTraversal_LoadRaw", func(t *testing.T) {
+		// Attempt to read the canary file using path traversal
+		traversalID := "../canary.txt"
+		_, err := s.LoadRaw(traversalID)
+
+		if err == nil {
+			t.Errorf("Security vulnerability: successfully loaded file via path traversal!")
+		} else {
+			t.Logf("Successfully blocked traversal: %v", err)
+		}
+	})
+
+	t.Run("PathTraversal_Save", func(t *testing.T) {
+		// Attempt to write a file outside using path traversal
+		traversalID := "../pwned.txt"
+		contentB64 := base64.StdEncoding.EncodeToString([]byte("pwned"))
+		err := s.Save(traversalID, contentB64)
+
+		if err == nil {
+			t.Errorf("Security vulnerability: successfully saved file via path traversal!")
+			os.Remove(filepath.Join(filepath.Dir(tmpDir), "pwned.txt"))
+		} else {
+			t.Logf("Successfully blocked traversal: %v", err)
+		}
+	})
+}

--- a/backend/internal/service/storage/storage.go
+++ b/backend/internal/service/storage/storage.go
@@ -31,24 +31,51 @@ func (s *service) Save(id string, dataBase64 string) error {
 		return fmt.Errorf("decode base64: %w", err)
 	}
 
-	path := filepath.Join(s.baseDir, id)
+	path, err := s.fullPath(id)
+	if err != nil {
+		return err
+	}
 	return os.WriteFile(path, data, 0644)
 }
 
 func (s *service) Load(id string) (string, error) {
-	path := filepath.Join(s.baseDir, id)
+	path, err := s.fullPath(id)
+	if err != nil {
+		return "", err
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}
 	return base64.StdEncoding.EncodeToString(data), nil
 }
+
 func (s *service) LoadRaw(id string) ([]byte, error) {
-	path := filepath.Join(s.baseDir, id)
+	path, err := s.fullPath(id)
+	if err != nil {
+		return nil, err
+	}
 	return os.ReadFile(path)
 }
 
 func (s *service) Delete(id string) error {
-	path := filepath.Join(s.baseDir, id)
+	path, err := s.fullPath(id)
+	if err != nil {
+		return err
+	}
 	return os.Remove(path)
+}
+
+// fullPath validates the ID and returns the absolute path within the base directory.
+// It prevents path traversal by ensuring the ID is a simple filename.
+func (s *service) fullPath(id string) (string, error) {
+	if id == "" || id == "." || id == ".." {
+		return "", fmt.Errorf("invalid storage id")
+	}
+	// filepath.Base returns the last element of path.
+	// If ID contains any path separators or traversal sequences, Base(id) will not equal id.
+	if filepath.Base(id) != id {
+		return "", fmt.Errorf("invalid storage id: path traversal detected or invalid format")
+	}
+	return filepath.Join(s.baseDir, id), nil
 }


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix path traversal in storage service

🚨 Severity: CRITICAL
💡 Vulnerability: Path Traversal
🎯 Impact: An attacker could read or overwrite any file on the filesystem that the application process has access to, by providing a crafted attachment ID with `../` sequences.
🔧 Fix: Implemented a `fullPath` helper in the storage service to validate that the provided ID is a simple filename and does not contain traversal sequences.
✅ Verification: Created a new test file `backend/internal/service/storage/path_traversal_test.go` that specifically attempts to exploit the vulnerability and verifies it is now blocked. All backend tests passed.


---
*PR created automatically by Jules for task [12972120268595116298](https://jules.google.com/task/12972120268595116298) started by @mustafaturan*