### PR TITLE
🛡️ Sentinel: Fix open redirect in OAuth callback

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The `storage` service used `filepath.Join(baseDir, id)` without validating the `id`. This allowed an attacker to use `../` to read or write files outside the intended storage directory.
 **Learning:** `filepath.Join` on its own does not prevent path traversal if one of the components is an absolute path or contains traversal elements that are not resolved relative to the base directory in a safe way.
 **Prevention:** Always validate user-provided file identifiers. A robust pattern in Go is to ensure that `filepath.Base(id) == id` and that the ID is not empty or equal to `.` or `..`. This ensures the ID is a simple filename and cannot escape the base directory.
+
+## 2025-05-14 - Open Redirect in OAuth Callback
+**Vulnerability:** The Google OAuth callback handler used the `state` parameter as a redirect destination without validating the host. This allowed an attacker to redirect users to a malicious site after successful authentication.
+**Learning:** Redirect destinations from user input (like OAuth `state` or `next` parameters) must be strictly validated. Checking only for `http` prefix is insufficient. Protocol-relative URLs (starting with `//`) can bypass simple path checks and are interpreted by browsers as absolute URLs using the current protocol.
+**Prevention:** Use a whitelist of allowed domains for absolute redirects. For internal redirects, ensure the path starts with a single `/` and specifically check that it does NOT start with `//`. Using `url.Parse` to verify the host matches the expected application domain is a robust defense for absolute redirects.

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -322,8 +323,18 @@ func (h *handler) googleCallback() fiber.Handler {
 
 		state := c.Query("state")
 		redirectURL := "/"
-		if state != "" && state != "state" && strings.HasPrefix(state, "http") {
-			redirectURL = state
+		if state != "" && state != "state" {
+			// Only allow relative redirects (starts with / but not //) or redirects to the same domain
+			if strings.HasPrefix(state, "/") && !strings.HasPrefix(state, "//") {
+				redirectURL = state
+			} else if strings.HasPrefix(state, "http") {
+				if u, err := url.Parse(state); err == nil {
+					// In production, validate against the configured domain. In dev, allow localhost.
+					if u.Host == h.domain || (h.domain == "" && (u.Host == "localhost" || strings.HasPrefix(u.Host, "localhost:"))) {
+						redirectURL = state
+					}
+				}
+			}
 		}
 
 		return c.Redirect(redirectURL)


### PR DESCRIPTION
This PR fixes a high-priority open redirect vulnerability in the Google OAuth callback handler. The application now strictly validates the `state` parameter before using it for redirection, ensuring it either points to a relative internal path (preventing protocol-relative bypasses) or matches the configured application domain.

---
*PR created automatically by Jules for task [10401772133757357597](https://jules.google.com/task/10401772133757357597) started by @mustafaturan*