### PR TITLE
fix: prevent flashing empty tasks state when loading workspace

### DIFF
--- a/frontend/src/views/WorkspaceDetailView.vue
+++ b/frontend/src/views/WorkspaceDetailView.vue
@@ -231,11 +231,13 @@ watch(isConnected, (val, old) => {
 
 async function load() {
   try {
-    const pRes = await getWorkspace(workspaceId);
+    const [pRes, tRes] = await Promise.all([
+      getWorkspace(workspaceId),
+      fetchTasks(workspaceId)
+    ]);
+    tasks.value = tRes.tasks || [];
     workspace.value = pRes.workspace;
     isAgentConnected.value = workspace.value.agentConnected;
-    const tRes = await fetchTasks(workspaceId);
-    tasks.value = tRes.tasks || [];
     // Fetch token for display
     fetchToken();
     // Start SSE stream


### PR DESCRIPTION
This new fetching action prevents displaying no task found on slow responses.