### PR TITLE
🛡️ Sentinel: [HIGH] Fix Open Redirect vulnerabilities

### DIFF
--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -328,10 +329,17 @@ func (h *handler) googleCallback() fiber.Handler {
 		redirectURL := "/"
 		// Situational security: validate redirect URL to prevent open redirect
 		if state != "" && state != "state" {
-			if strings.HasPrefix(state, "/") && !strings.HasPrefix(state, "//") {
+			if strings.HasPrefix(state, "/") && !strings.HasPrefix(state, "//") && !strings.HasPrefix(state, "/\\") {
 				redirectURL = state
-			} else if strings.HasPrefix(state, h.baseURL) {
-				redirectURL = state
+			} else {
+				// Parse absolute URL and validate against baseURL
+				if pRedirect, err := url.Parse(state); err == nil && pRedirect.IsAbs() {
+					if pBase, err := url.Parse(h.baseURL); err == nil {
+						if pRedirect.Host == pBase.Host && pRedirect.Scheme == pBase.Scheme {
+							redirectURL = state
+						}
+					}
+				}
 			}
 		}
 

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/agentrq/agentrq/backend/internal/controller/crud"
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/agentrq/agentrq/backend/internal/service/auth"
+	"github.com/gofiber/fiber/v2"
+)
+
+type mockAuthService struct {
+	auth.Service
+	exchangeFunc func(ctx context.Context, code string) (*auth.User, error)
+}
+
+func (m *mockAuthService) GetAuthURL(state string) string {
+	return "https://google.com/auth?state=" + state
+}
+
+func (m *mockAuthService) Exchange(ctx context.Context, code string) (*auth.User, error) {
+	return m.exchangeFunc(ctx, code)
+}
+
+type mockTokenSvc struct {
+	auth.TokenService
+	createTokenFunc func(userID, email, name, picture string) (string, error)
+}
+
+func (m *mockTokenSvc) CreateToken(userID, email, name, picture string) (string, error) {
+	return m.createTokenFunc(userID, email, name, picture)
+}
+
+type mockCrudController struct {
+	crud.Controller
+	findOrCreateUserFunc func(ctx context.Context, req entity.FindOrCreateUserRequest) (*entity.FindOrCreateUserResponse, error)
+}
+
+func (m *mockCrudController) FindOrCreateUser(ctx context.Context, req entity.FindOrCreateUserRequest) (*entity.FindOrCreateUserResponse, error) {
+	return m.findOrCreateUserFunc(ctx, req)
+}
+
+func TestGoogleCallback_OpenRedirectPrevention(t *testing.T) {
+	app := fiber.New()
+	authSvc := &mockAuthService{}
+	tokenSvc := &mockTokenSvc{}
+	crudCtrl := &mockCrudController{}
+
+	h := &handler{
+		auth:     authSvc,
+		tokenSvc: tokenSvc,
+		crud:     crudCtrl,
+		baseURL:  "http://localhost:3000",
+	}
+
+	app.Get("/google/callback", h.googleCallback())
+
+	authSvc.exchangeFunc = func(ctx context.Context, code string) (*auth.User, error) {
+		return &auth.User{ID: "123", Email: "test@example.com", Name: "Test"}, nil
+	}
+
+	crudCtrl.findOrCreateUserFunc = func(ctx context.Context, req entity.FindOrCreateUserRequest) (*entity.FindOrCreateUserResponse, error) {
+		return &entity.FindOrCreateUserResponse{User: entity.User{ID: 1}}, nil
+	}
+
+	tokenSvc.createTokenFunc = func(userID, email, name, picture string) (string, error) {
+		return "valid-jwt", nil
+	}
+
+	tests := []struct {
+		name        string
+		state       string
+		expectedLoc string
+	}{
+		{
+			name:        "Safe local redirect",
+			state:       "/workspaces",
+			expectedLoc: "/workspaces",
+		},
+		{
+			name:        "Malicious absolute redirect",
+			state:       "http://localhost:3000.evil.com",
+			expectedLoc: "/",
+		},
+		{
+			name:        "Malicious relative redirect //",
+			state:       "//evil.com",
+			expectedLoc: "/",
+		},
+		{
+			name:        "Malicious relative redirect /\\",
+			state:       "/\\evil.com",
+			expectedLoc: "/",
+		},
+		{
+			name:        "Safe absolute redirect",
+			state:       "http://localhost:3000/safe",
+			expectedLoc: "http://localhost:3000/safe",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state="+tt.state, nil)
+			resp, _ := app.Test(req)
+
+			if resp.StatusCode != http.StatusFound {
+				t.Errorf("Expected status 302, got %d", resp.StatusCode)
+			}
+			loc := resp.Header.Get("Location")
+			if loc != tt.expectedLoc {
+				t.Errorf("Expected Location %s, got %s", tt.expectedLoc, loc)
+			}
+		})
+	}
+}

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -342,6 +342,35 @@ func (h *handler) oauthAuthorizeHandler() http.Handler {
 		redirectURI := r.URL.Query().Get("redirect_uri")
 		state := r.URL.Query().Get("state")
 
+		// Validate redirectURI to prevent open redirect
+		if redirectURI != "" {
+			if strings.HasPrefix(redirectURI, "/") && !strings.HasPrefix(redirectURI, "//") && !strings.HasPrefix(redirectURI, "/\\") {
+				// OK: local path
+			} else {
+				// Parse absolute URL and validate against baseURL
+				pRedirect, err := url.Parse(redirectURI)
+				if err != nil {
+					http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
+					return
+				}
+				if pRedirect.IsAbs() {
+					pBase, err := url.Parse(h.baseURL)
+					if err != nil {
+						http.Error(w, "internal server error", http.StatusInternalServerError)
+						return
+					}
+					if pRedirect.Host != pBase.Host || pRedirect.Scheme != pBase.Scheme {
+						http.Error(w, "invalid redirect_uri: host/scheme mismatch", http.StatusBadRequest)
+						return
+					}
+				} else {
+					// It's not absolute and doesn't start with /
+					http.Error(w, "invalid redirect_uri: relative path must start with /", http.StatusBadRequest)
+					return
+				}
+			}
+		}
+
 		if userID == "" {
 			// Not authenticated, redirect to main login with 'redirect_url'
 			// To return back, building the current full URL:

--- a/backend/internal/handler/mcp/mcp_test.go
+++ b/backend/internal/handler/mcp/mcp_test.go
@@ -96,7 +96,7 @@ func TestOAuthMetadataHandler(t *testing.T) {
 func TestOAuthAuthorizeHandler_Unauthenticated(t *testing.T) {
 	mux, _ := setupTestRouter()
 
-	req := httptest.NewRequest("GET", "/mcp/12345/oauth2/authorize?client_id=test&redirect_uri=http://localhost/callback&state=somestate", nil)
+	req := httptest.NewRequest("GET", "/mcp/12345/oauth2/authorize?client_id=test&redirect_uri=https://agentrq.com/callback&state=somestate", nil)
 	req.SetPathValue("workspaceID", "12345")
 	req.Host = "12345.mcp.agentrq.com"
 	
@@ -119,7 +119,7 @@ func TestOAuthAuthorizeHandler_Unauthenticated(t *testing.T) {
 func TestOAuthAuthorizeHandler_Authenticated(t *testing.T) {
 	mux, _ := setupTestRouter()
 
-	req := httptest.NewRequest("GET", "/mcp/12345/oauth2/authorize?client_id=test&redirect_uri=http://localhost/callback&state=somestate", nil)
+	req := httptest.NewRequest("GET", "/mcp/12345/oauth2/authorize?client_id=test&redirect_uri=https://agentrq.com/callback&state=somestate", nil)
 	req.SetPathValue("workspaceID", "12345")
 	req.Host = "12345.mcp.agentrq.com"
 	req.AddCookie(&http.Cookie{Name: "at", Value: "valid-auth-cookie"})
@@ -132,7 +132,7 @@ func TestOAuthAuthorizeHandler_Authenticated(t *testing.T) {
 	}
 
 	loc := w.Header().Get("Location")
-	if !strings.HasPrefix(loc, "http://localhost/callback") {
+	if !strings.HasPrefix(loc, "https://agentrq.com/callback") {
 		t.Errorf("Expected redirect to client redirect_uri, got %s", loc)
 	}
 	
@@ -142,6 +142,63 @@ func TestOAuthAuthorizeHandler_Authenticated(t *testing.T) {
 	}
 	if u.Query().Get("state") != "somestate" {
 		t.Errorf("Expected state=somestate, got %s", u.Query().Get("state"))
+	}
+}
+
+func TestOAuthAuthorizeHandler_OpenRedirect(t *testing.T) {
+	mux, _ := setupTestRouter()
+
+	tests := []struct {
+		name        string
+		redirectURI string
+		expectedCode int
+	}{
+		{
+			name:         "Safe relative redirect",
+			redirectURI:  "/callback",
+			expectedCode: http.StatusFound,
+		},
+		{
+			name:         "Safe absolute redirect",
+			redirectURI:  "https://agentrq.com/callback",
+			expectedCode: http.StatusFound,
+		},
+		{
+			name:         "Malicious absolute redirect",
+			redirectURI:  "https://evil.com/callback",
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "Malicious relative redirect //",
+			redirectURI:  "//evil.com",
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "Malicious relative redirect /\\",
+			redirectURI:  "/\\evil.com",
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "Host mismatch in absolute redirect",
+			redirectURI:  "https://agentrq.com.evil.com/callback",
+			expectedCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/mcp/12345/oauth2/authorize?client_id=test&redirect_uri="+url.QueryEscape(tt.redirectURI), nil)
+			req.SetPathValue("workspaceID", "12345")
+			req.Host = "12345.mcp.agentrq.com"
+			req.AddCookie(&http.Cookie{Name: "at", Value: "valid-auth-cookie"})
+
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+
+			if w.Code != tt.expectedCode {
+				t.Errorf("Expected status %d, got %d", tt.expectedCode, w.Code)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Open Redirect vulnerabilities

🚨 Severity: HIGH
💡 Vulnerability: Open Redirect in Google OAuth callback and MCP OAuth authorize handler.
🎯 Impact: Attackers could redirect users to malicious domains after authentication, potentially stealing sensitive information or performing phishing attacks. In the MCP flow, this could lead to authorization code interception.
🔧 Fix: Implemented robust redirect URL validation using `url.Parse`. Absolute URLs are now strictly checked against the configured `baseURL` (host and scheme must match), and relative paths are checked for safety (blocking browser-level bypasses like `//` or `/\`).
✅ Verification: Added new security-focused unit tests in `backend/internal/handler/api/api_test.go` and `backend/internal/handler/mcp/mcp_test.go` covering various malicious payloads. Existing tests were also updated to use safe redirect URIs. All tests passed.

---
*PR created automatically by Jules for task [15117531864977433567](https://jules.google.com/task/15117531864977433567) started by @mustafaturan*