### PR TITLE
fix: correct JSON body key in login request

### DIFF
--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -105,7 +105,7 @@ const submitRootLogin = async () => {
     const res = await fetch('/api/v1/auth/root/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ root_token: rootToken.value })
+      body: JSON.stringify({ rootToken: rootToken.value })
     })
     
     if (res.ok) {


### PR DESCRIPTION
Fix the login issue caused by inconsistent field names in the request parameters between the frontend and backend, which prevents using ⁠`AGENTRQ_AUTH_ROOT_ACCESS_TOKEN` to log in.