### PR TITLE
chore: redact command details from backend logs for privacy

### DIFF
--- a/backend/internal/controller/mcp/autoallow.go
+++ b/backend/internal/controller/mcp/autoallow.go
@@ -72,7 +72,6 @@ func (ps *WorkspaceServer) buildAutoAllowRule(toolName string, params *Permissio
 					base := extractBaseCommand(subcommands[0])
 					if base != "" {
 						rule := fmt.Sprintf("%s:%s *", toolName, base)
-						//zlog.Debug().Str("rule", rule).Str("command", cmd).Msg("shell auto-allow rule generated")
 						return rule
 					}
 				}

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -1111,7 +1111,7 @@ func (ps *WorkspaceServer) SendPermissionVerdict(ctx context.Context, requestID 
 				}
 			}
 			ps.autoAllowedToolsMu.Unlock()
-			zlog.Info().Str("rule", rule).Msg("auto-allow rule saved")
+			zlog.Info().Msg("auto-allow rule saved")
 		}
 	}
 

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -219,7 +219,7 @@ func (h *handler) streamableHandler() http.Handler {
 			// Custom handling for notifications/claude/channel/permission_request
 			// because mcp-go (SDK) rejects them as unsupported methods.
 			if strings.Contains(string(body), "notifications/claude/channel/permission_request") {
-				zlog.Debug().Str("session_id", sessionID).Str("body", string(body)).Msg("Handling custom permission notification")
+				zlog.Debug().Str("session_id", sessionID).Msg("Handling custom permission notification")
 				srv.HandleCustomNotification(ctx, sessionID, body)
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Improve privacy on logging by removing the rules allowed directly from logs.