### PR TITLE
🛡️ Sentinel: [HIGH] Fix IDOR in getWorkspaceToken endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The application had a hardcoded default JWT secret ("agentrq-secret-change-me") as a fallback, and the Google OAuth callback allowed redirects to any absolute URL starting with "http".
 **Learning:** Fallback secrets can lead to insecure production deployments if configuration is missed. Weak validation of redirect parameters in OAuth flows is a common entry point for phishing.
 **Prevention:** Remove all hardcoded security defaults; the application should fail to start if critical secrets are missing. Always validate redirect URLs against a whitelist or ensure they are local paths.
+
+## 2024-05-20 - IDOR in Workspace Endpoints
+**Vulnerability:** The `getWorkspaceToken` endpoint allowed any authenticated user to generate access tokens for any workspace by providing its ID, lacking an ownership check.
+**Learning:** Endpoints that operate on specific resources must always verify that the authenticated user has the necessary permissions/ownership for that resource ID, even if they are already authenticated.
+**Prevention:** Always include a user-specific identifier (e.g., `userID`) in repository/controller queries for resource-specific operations to ensure implicit authorization.

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -566,6 +566,26 @@ func (h *handler) getWorkspaceToken() fiber.Handler {
 		workspaceID := c.Params("id")
 		userID := c.Locals("user_id").(string)
 
+		// Authorization: verify that the user has access to this workspace
+		workspace64 := monoflake.IDFromBase62(workspaceID).Int64()
+		if workspace64 == 0 {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+
+		ctx, cancel := newContext(c)
+		defer cancel()
+
+		_, err := h.crud.GetWorkspace(ctx, entity.GetWorkspaceRequest{
+			ID:     workspace64,
+			UserID: userID,
+		})
+		if err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+
 		token, err := h.tokenSvc.CreateMCPToken(userID, workspaceID, "access")
 		if err != nil {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to generate workspace token"})

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/agentrq/agentrq/backend/internal/controller/crud"
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/agentrq/agentrq/backend/internal/repository/base"
 	"github.com/agentrq/agentrq/backend/internal/service/auth"
 	"github.com/gofiber/fiber/v2"
 )
@@ -27,11 +28,16 @@ func (m *mockAuthService) Exchange(ctx context.Context, code string) (*auth.User
 
 type mockTokenSvc struct {
 	auth.TokenService
-	createTokenFunc func(userID, email, name, picture string) (string, error)
+	createTokenFunc    func(userID, email, name, picture string) (string, error)
+	createMCPTokenFunc func(userID, workspaceID, tokenType string) (string, error)
 }
 
 func (m *mockTokenSvc) CreateToken(userID, email, name, picture string) (string, error) {
 	return m.createTokenFunc(userID, email, name, picture)
+}
+
+func (m *mockTokenSvc) CreateMCPToken(userID, workspaceID, tokenType string) (string, error) {
+	return m.createMCPTokenFunc(userID, workspaceID, tokenType)
 }
 
 type mockCrudController struct {
@@ -116,4 +122,61 @@ func TestGoogleCallback_OpenRedirectPrevention(t *testing.T) {
 			}
 		})
 	}
+}
+
+type mockCrudGetWorkspace struct {
+	crud.Controller
+	getWorkspaceFunc func(ctx context.Context, req entity.GetWorkspaceRequest) (*entity.GetWorkspaceResponse, error)
+}
+
+func (m *mockCrudGetWorkspace) GetWorkspace(ctx context.Context, req entity.GetWorkspaceRequest) (*entity.GetWorkspaceResponse, error) {
+	return m.getWorkspaceFunc(ctx, req)
+}
+
+func TestGetWorkspaceToken_Unauthorized(t *testing.T) {
+	app := fiber.New()
+	crudCtrl := &mockCrudGetWorkspace{}
+	tokenSvc := &mockTokenSvc{}
+
+	h := &handler{
+		crud:     crudCtrl,
+		tokenSvc: tokenSvc,
+	}
+
+	app.Get("/api/v1/workspaces/:id/token", func(c *fiber.Ctx) error {
+		c.Locals("user_id", "user1")
+		return h.getWorkspaceToken()(c)
+	})
+
+	t.Run("Unauthorized access to workspace", func(t *testing.T) {
+		workspaceID := "work1"
+		crudCtrl.getWorkspaceFunc = func(ctx context.Context, req entity.GetWorkspaceRequest) (*entity.GetWorkspaceResponse, error) {
+			// Simulate "not found" or "no access" from repository
+			return nil, base.ErrNotFound // Using a known error that maps to 404
+		}
+
+		req := httptest.NewRequest("GET", "/api/v1/workspaces/"+workspaceID+"/token", nil)
+		resp, _ := app.Test(req)
+
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("Expected status 404, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("Authorized access to workspace", func(t *testing.T) {
+		workspaceID := "work1"
+		crudCtrl.getWorkspaceFunc = func(ctx context.Context, req entity.GetWorkspaceRequest) (*entity.GetWorkspaceResponse, error) {
+			return &entity.GetWorkspaceResponse{}, nil
+		}
+		tokenSvc.createMCPTokenFunc = func(userID, workspaceID, tokenType string) (string, error) {
+			return "token123", nil
+		}
+
+		req := httptest.NewRequest("GET", "/api/v1/workspaces/"+workspaceID+"/token", nil)
+		resp, _ := app.Test(req)
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Expected status 200, got %d", resp.StatusCode)
+		}
+	})
 }


### PR DESCRIPTION
Fixed an Insecure Direct Object Reference (IDOR) vulnerability in the `getWorkspaceToken` endpoint. Previously, any authenticated user could generate an access token for any workspace by knowing its ID. The fix adds an explicit authorization check to verify user access to the requested workspace. Added unit tests to cover authorized and unauthorized scenarios.

---
*PR created automatically by Jules for task [11696593869304377156](https://jules.google.com/task/11696593869304377156) started by @mustafaturan*