### PR TITLE
fix(mcp): relax redirect_uri validation and allow http for localhost

### DIFF
--- a/backend/internal/handler/coremcp/coremcp.go
+++ b/backend/internal/handler/coremcp/coremcp.go
@@ -263,6 +263,34 @@ func (h *handler) oauthAuthorizeHandler() http.Handler {
 		redirectURI := r.URL.Query().Get("redirect_uri")
 		state := r.URL.Query().Get("state")
 
+		// Validate redirectURI to prevent open redirect
+		if redirectURI != "" {
+			if strings.HasPrefix(redirectURI, "/") && !strings.HasPrefix(redirectURI, "//") && !strings.HasPrefix(redirectURI, "/\\") {
+				// OK: local path
+			} else {
+				// Parse absolute URL
+				pRedirect, err := url.Parse(redirectURI)
+				if err != nil {
+					http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
+					return
+				}
+				if pRedirect.IsAbs() {
+					// Require https for absolute URLs unless it's localhost
+					isLocal := pRedirect.Host == "localhost" || strings.HasPrefix(pRedirect.Host, "localhost:") ||
+						pRedirect.Host == "127.0.0.1" || strings.HasPrefix(pRedirect.Host, "127.0.0.1:")
+					if pRedirect.Scheme != "https" && !isLocal {
+						http.Error(w, "invalid redirect_uri: https required for non-localhost", http.StatusBadRequest)
+						return
+					}
+					// For CoreMCP we allow external redirects to support various clients
+				} else {
+					// It's not absolute and doesn't start with /
+					http.Error(w, "invalid redirect_uri: relative path must start with /", http.StatusBadRequest)
+					return
+				}
+			}
+		}
+
 		if userID == "" {
 			proto := "https://"
 			if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" && !strings.Contains(r.Host, "mcp.") {

--- a/backend/internal/handler/coremcp/coremcp.go
+++ b/backend/internal/handler/coremcp/coremcp.go
@@ -75,7 +75,9 @@ func New(p Params) (Handler, error) {
 	}
 
 	// Localhost distinct paths
+	p.Mux.Handle("/.well-known/oauth-authorization-server", corsWrapper(h.oauthMetadataHandler()))
 	p.Mux.Handle("/mcp/.well-known/oauth-authorization-server", corsWrapper(h.oauthMetadataHandler()))
+	p.Mux.Handle("/.well-known/oauth-protected-resource", corsWrapper(h.oauthProtectedResourceHandler()))
 	p.Mux.Handle("/.well-known/oauth-protected-resource/mcp", corsWrapper(h.oauthProtectedResourceHandler()))
 	p.Mux.Handle("/mcp/oauth2/authorize", h.oauthAuthorizeHandler())
 	p.Mux.Handle("/mcp/oauth2/token", corsWrapper(h.oauthTokenHandler()))
@@ -209,6 +211,9 @@ func (h *handler) oauthMetadataHandler() http.Handler {
 		pathPrefix := ""
 		if !strings.Contains(r.Host, "mcp.") {
 			pathPrefix = "/mcp"
+		} else if strings.Contains(r.Host, ".mcp.") {
+			// If it's a workspace subdomain, endpoints are at the root
+			pathPrefix = ""
 		}
 
 		authEndpoint := baseURL + pathPrefix + "/oauth2/authorize"
@@ -241,6 +246,11 @@ func (h *handler) oauthProtectedResourceHandler() http.Handler {
 		baseURL := proto + r.Host
 
 		resource := baseURL + "/mcp"
+		if strings.Contains(r.Host, ".mcp.") {
+			// If it's a workspace subdomain, the resource is the root
+			resource = baseURL
+		}
+
 		authServer := baseURL + "/.well-known/oauth-authorization-server"
 
 		json.NewEncoder(w).Encode(map[string]interface{}{

--- a/backend/internal/handler/coremcp/coremcp.go
+++ b/backend/internal/handler/coremcp/coremcp.go
@@ -75,9 +75,7 @@ func New(p Params) (Handler, error) {
 	}
 
 	// Localhost distinct paths
-	p.Mux.Handle("/.well-known/oauth-authorization-server", corsWrapper(h.oauthMetadataHandler()))
 	p.Mux.Handle("/mcp/.well-known/oauth-authorization-server", corsWrapper(h.oauthMetadataHandler()))
-	p.Mux.Handle("/.well-known/oauth-protected-resource", corsWrapper(h.oauthProtectedResourceHandler()))
 	p.Mux.Handle("/.well-known/oauth-protected-resource/mcp", corsWrapper(h.oauthProtectedResourceHandler()))
 	p.Mux.Handle("/mcp/oauth2/authorize", h.oauthAuthorizeHandler())
 	p.Mux.Handle("/mcp/oauth2/token", corsWrapper(h.oauthTokenHandler()))

--- a/backend/internal/handler/coremcp/coremcp.go
+++ b/backend/internal/handler/coremcp/coremcp.go
@@ -75,7 +75,9 @@ func New(p Params) (Handler, error) {
 	}
 
 	// Localhost distinct paths
+	p.Mux.Handle("/.well-known/oauth-authorization-server", corsWrapper(h.oauthMetadataHandler()))
 	p.Mux.Handle("/mcp/.well-known/oauth-authorization-server", corsWrapper(h.oauthMetadataHandler()))
+	p.Mux.Handle("/.well-known/oauth-protected-resource", corsWrapper(h.oauthProtectedResourceHandler()))
 	p.Mux.Handle("/.well-known/oauth-protected-resource/mcp", corsWrapper(h.oauthProtectedResourceHandler()))
 	p.Mux.Handle("/mcp/oauth2/authorize", h.oauthAuthorizeHandler())
 	p.Mux.Handle("/mcp/oauth2/token", corsWrapper(h.oauthTokenHandler()))

--- a/backend/internal/handler/coremcp/coremcp.go
+++ b/backend/internal/handler/coremcp/coremcp.go
@@ -87,6 +87,7 @@ func New(p Params) (Handler, error) {
 	if hostPattern != "" {
 		p.Mux.Handle(hostPattern+"/.well-known/oauth-authorization-server", corsWrapper(h.oauthMetadataHandler()))
 		p.Mux.Handle(hostPattern+"/.well-known/oauth-protected-resource", corsWrapper(h.oauthProtectedResourceHandler()))
+		p.Mux.Handle(hostPattern+"/.well-known/oauth-protected-resource/mcp", corsWrapper(h.oauthProtectedResourceHandler()))
 		p.Mux.Handle(hostPattern+"/oauth2/authorize", h.oauthAuthorizeHandler())
 		p.Mux.Handle(hostPattern+"/oauth2/token", corsWrapper(h.oauthTokenHandler()))
 		p.Mux.Handle(hostPattern+"/oauth2/register", corsWrapper(h.oauthRegisterHandler()))

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -72,12 +72,19 @@ func New(p Params) (Handler, error) {
 	// We handle both exact and trailing slash versions to be robust.
 	p.Mux.Handle("/mcp/{workspaceID}", corsWrapper(h.streamableHandler()))
 
-	// OAuth2 and discovery endpoints
+	// discovery endpoints (both path-based and root-level for subdomains)
 	p.Mux.Handle("/mcp/{workspaceID}/.well-known/oauth-authorization-server", corsWrapper(h.oauthMetadataHandler()))
+	p.Mux.Handle("/.well-known/oauth-authorization-server", corsWrapper(h.oauthMetadataHandler()))
 	p.Mux.Handle("/.well-known/oauth-protected-resource/mcp/{workspaceID}", corsWrapper(h.oauthProtectedResourceHandler()))
+	p.Mux.Handle("/.well-known/oauth-protected-resource", corsWrapper(h.oauthProtectedResourceHandler()))
+
+	// OAuth2 endpoints (both path-based and root-level for subdomains)
 	p.Mux.Handle("/mcp/{workspaceID}/oauth2/authorize", h.oauthAuthorizeHandler())
+	p.Mux.Handle("/oauth2/authorize", h.oauthAuthorizeHandler())
 	p.Mux.Handle("/mcp/{workspaceID}/oauth2/token", corsWrapper(h.oauthTokenHandler()))
+	p.Mux.Handle("/oauth2/token", corsWrapper(h.oauthTokenHandler()))
 	p.Mux.Handle("/mcp/{workspaceID}/oauth2/register", corsWrapper(h.oauthRegisterHandler()))
+	p.Mux.Handle("/oauth2/register", corsWrapper(h.oauthRegisterHandler()))
 
 	return h, nil
 }
@@ -332,6 +339,12 @@ func (h *handler) oauthProtectedResourceHandler() http.Handler {
 func (h *handler) oauthMetadataHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		workspaceID := workspaceIDFromParam(r)
+		if workspaceID == 0 {
+			http.Error(w, "workspace not found", http.StatusNotFound)
+			return
+		}
+
 		proto := "https://"
 		if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" && !strings.Contains(r.Host, "mcp.") {
 			proto = "http://"
@@ -345,13 +358,10 @@ func (h *handler) oauthMetadataHandler() http.Handler {
 
 		// If accessed without a subdomain (e.g. localhost or a custom domain root), append the workspace route
 		if !strings.Contains(r.Host, ".mcp.") {
-			workspaceID := workspaceIDFromParam(r)
-			if workspaceID != 0 {
-				workspaceIDBase62 := monoflake.ID(workspaceID).String()
-				authEndpoint = baseURL + "/mcp/" + workspaceIDBase62 + "/oauth2/authorize"
-				tokenEndpoint = baseURL + "/mcp/" + workspaceIDBase62 + "/oauth2/token"
-				regEndpoint = baseURL + "/mcp/" + workspaceIDBase62 + "/oauth2/register"
-			}
+			workspaceIDBase62 := monoflake.ID(workspaceID).String()
+			authEndpoint = baseURL + "/mcp/" + workspaceIDBase62 + "/oauth2/authorize"
+			tokenEndpoint = baseURL + "/mcp/" + workspaceIDBase62 + "/oauth2/token"
+			regEndpoint = baseURL + "/mcp/" + workspaceIDBase62 + "/oauth2/register"
 		}
 
 		metadata := map[string]interface{}{

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -354,15 +354,16 @@ func (h *handler) oauthAuthorizeHandler() http.Handler {
 					return
 				}
 				if pRedirect.IsAbs() {
-					pBase, err := url.Parse(h.baseURL)
-					if err != nil {
-						http.Error(w, "internal server error", http.StatusInternalServerError)
+					// Require https for absolute URLs unless it's localhost
+					isLocal := pRedirect.Host == "localhost" || strings.HasPrefix(pRedirect.Host, "localhost:") ||
+						pRedirect.Host == "127.0.0.1" || strings.HasPrefix(pRedirect.Host, "127.0.0.1:")
+					if pRedirect.Scheme != "https" && !isLocal {
+						http.Error(w, "invalid redirect_uri: https required for non-localhost", http.StatusBadRequest)
 						return
 					}
-					if pRedirect.Host != pBase.Host || pRedirect.Scheme != pBase.Scheme {
-						http.Error(w, "invalid redirect_uri: host/scheme mismatch", http.StatusBadRequest)
-						return
-					}
+
+					// For MCP we allow external redirects to support various clients (Claude, etc.)
+					// In the future, we might want to validate against a list of allowed domains or registered redirect URIs.
 				} else {
 					// It's not absolute and doesn't start with /
 					http.Error(w, "invalid redirect_uri: relative path must start with /", http.StatusBadRequest)

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -71,9 +71,9 @@ func New(p Params) (Handler, error) {
 	// We handle both exact and trailing slash versions to be robust.
 	p.Mux.Handle("/mcp/{workspaceID}", corsWrapper(h.streamableHandler()))
 
-	// OAuth2 and CIMD endpoints
+	// OAuth2 and discovery endpoints
 	p.Mux.Handle("/mcp/{workspaceID}/.well-known/oauth-authorization-server", corsWrapper(h.oauthMetadataHandler()))
-	p.Mux.Handle("/.well-known/oauth-protected-resource/mcp/{workspaceID}", corsWrapper(h.oauthMetadataHandler()))
+	p.Mux.Handle("/.well-known/oauth-protected-resource/mcp/{workspaceID}", corsWrapper(h.oauthProtectedResourceHandler()))
 	p.Mux.Handle("/mcp/{workspaceID}/oauth2/authorize", h.oauthAuthorizeHandler())
 	p.Mux.Handle("/mcp/{workspaceID}/oauth2/token", corsWrapper(h.oauthTokenHandler()))
 	p.Mux.Handle("/mcp/{workspaceID}/oauth2/register", corsWrapper(h.oauthRegisterHandler()))
@@ -81,9 +81,17 @@ func New(p Params) (Handler, error) {
 	return h, nil
 }
 
-// workspaceIDFromParam parses the base62 workspace ID from the route.
+// workspaceIDFromParam parses the base62 workspace ID from the route or host.
 func workspaceIDFromParam(r *http.Request) int64 {
-	return monoflake.IDFromBase62(r.PathValue("workspaceID")).Int64()
+	idStr := r.PathValue("workspaceID")
+	if idStr == "" {
+		// Try extracting from subdomain: {workspaceID}.mcp.{domain}
+		parts := strings.Split(r.Host, ".")
+		if len(parts) >= 3 && parts[1] == "mcp" {
+			idStr = parts[0]
+		}
+	}
+	return monoflake.IDFromBase62(idStr).Int64()
 }
 
 func getTokenVal(r *http.Request) string {
@@ -277,6 +285,41 @@ func (h *handler) identifyUser(ctx context.Context, workspaceID int64, tokenStr 
 	}
 
 	return ""
+}
+
+func (h *handler) oauthProtectedResourceHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		workspaceID := workspaceIDFromParam(r)
+		if workspaceID == 0 {
+			http.Error(w, "workspace not found", http.StatusNotFound)
+			return
+		}
+
+		workspaceIDBase62 := monoflake.ID(workspaceID).String()
+
+		proto := "https://"
+		if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" && !strings.Contains(r.Host, "mcp.") {
+			proto = "http://"
+		}
+
+		baseURL := proto + r.Host
+
+		resource := baseURL + "/mcp/" + workspaceIDBase62
+		if strings.Contains(r.Host, ".mcp.") {
+			resource = baseURL
+		}
+
+		authServer := baseURL + "/.well-known/oauth-authorization-server"
+		if !strings.Contains(r.Host, ".mcp.") {
+			authServer = baseURL + "/mcp/" + workspaceIDBase62 + "/.well-known/oauth-authorization-server"
+		}
+
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"resource":             resource,
+			"authorization_server": authServer,
+		})
+	})
 }
 
 func (h *handler) oauthMetadataHandler() http.Handler {

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -74,6 +74,7 @@ func New(p Params) (Handler, error) {
 
 	// discovery endpoints (path-based)
 	p.Mux.Handle("/mcp/{workspaceID}/.well-known/oauth-authorization-server", corsWrapper(h.oauthMetadataHandler()))
+	p.Mux.Handle("/mcp/{workspaceID}/.well-known/oauth-protected-resource", corsWrapper(h.oauthProtectedResourceHandler()))
 	p.Mux.Handle("/.well-known/oauth-protected-resource/mcp/{workspaceID}", corsWrapper(h.oauthProtectedResourceHandler()))
 
 	// OAuth2 endpoints (path-based)

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -72,15 +72,20 @@ func New(p Params) (Handler, error) {
 	// We handle both exact and trailing slash versions to be robust.
 	p.Mux.Handle("/mcp/{workspaceID}", corsWrapper(h.streamableHandler()))
 
-	// discovery endpoints (path-based)
+	// discovery endpoints (both path-based and root-level for subdomains)
 	p.Mux.Handle("/mcp/{workspaceID}/.well-known/oauth-authorization-server", corsWrapper(h.oauthMetadataHandler()))
+	p.Mux.Handle("/.well-known/oauth-authorization-server", corsWrapper(h.oauthMetadataHandler()))
 	p.Mux.Handle("/mcp/{workspaceID}/.well-known/oauth-protected-resource", corsWrapper(h.oauthProtectedResourceHandler()))
+	p.Mux.Handle("/.well-known/oauth-protected-resource", corsWrapper(h.oauthProtectedResourceHandler()))
 	p.Mux.Handle("/.well-known/oauth-protected-resource/mcp/{workspaceID}", corsWrapper(h.oauthProtectedResourceHandler()))
 
-	// OAuth2 endpoints (path-based)
+	// OAuth2 endpoints (both path-based and root-level for subdomains)
 	p.Mux.Handle("/mcp/{workspaceID}/oauth2/authorize", h.oauthAuthorizeHandler())
+	p.Mux.Handle("/oauth2/authorize", h.oauthAuthorizeHandler())
 	p.Mux.Handle("/mcp/{workspaceID}/oauth2/token", corsWrapper(h.oauthTokenHandler()))
+	p.Mux.Handle("/oauth2/token", corsWrapper(h.oauthTokenHandler()))
 	p.Mux.Handle("/mcp/{workspaceID}/oauth2/register", corsWrapper(h.oauthRegisterHandler()))
+	p.Mux.Handle("/oauth2/register", corsWrapper(h.oauthRegisterHandler()))
 
 	return h, nil
 }

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -72,19 +72,14 @@ func New(p Params) (Handler, error) {
 	// We handle both exact and trailing slash versions to be robust.
 	p.Mux.Handle("/mcp/{workspaceID}", corsWrapper(h.streamableHandler()))
 
-	// discovery endpoints (both path-based and root-level for subdomains)
+	// discovery endpoints (path-based)
 	p.Mux.Handle("/mcp/{workspaceID}/.well-known/oauth-authorization-server", corsWrapper(h.oauthMetadataHandler()))
-	p.Mux.Handle("/.well-known/oauth-authorization-server", corsWrapper(h.oauthMetadataHandler()))
 	p.Mux.Handle("/.well-known/oauth-protected-resource/mcp/{workspaceID}", corsWrapper(h.oauthProtectedResourceHandler()))
-	p.Mux.Handle("/.well-known/oauth-protected-resource", corsWrapper(h.oauthProtectedResourceHandler()))
 
-	// OAuth2 endpoints (both path-based and root-level for subdomains)
+	// OAuth2 endpoints (path-based)
 	p.Mux.Handle("/mcp/{workspaceID}/oauth2/authorize", h.oauthAuthorizeHandler())
-	p.Mux.Handle("/oauth2/authorize", h.oauthAuthorizeHandler())
 	p.Mux.Handle("/mcp/{workspaceID}/oauth2/token", corsWrapper(h.oauthTokenHandler()))
-	p.Mux.Handle("/oauth2/token", corsWrapper(h.oauthTokenHandler()))
 	p.Mux.Handle("/mcp/{workspaceID}/oauth2/register", corsWrapper(h.oauthRegisterHandler()))
-	p.Mux.Handle("/oauth2/register", corsWrapper(h.oauthRegisterHandler()))
 
 	return h, nil
 }

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -81,17 +82,23 @@ func New(p Params) (Handler, error) {
 	return h, nil
 }
 
-// workspaceIDFromParam parses the base62 workspace ID from the route or host.
+// workspaceIDFromParam parses the base62 workspace ID from the route or base36 from host.
 func workspaceIDFromParam(r *http.Request) int64 {
 	idStr := r.PathValue("workspaceID")
-	if idStr == "" {
-		// Try extracting from subdomain: {workspaceID}.mcp.{domain}
-		parts := strings.Split(r.Host, ".")
-		if len(parts) >= 3 && parts[1] == "mcp" {
-			idStr = parts[0]
+	if idStr != "" {
+		return monoflake.IDFromBase62(idStr).Int64()
+	}
+
+	// Try extracting from subdomain: {workspaceID}.mcp.{domain}
+	parts := strings.Split(r.Host, ".")
+	if len(parts) >= 3 && parts[1] == "mcp" {
+		// Subdomain is in base36 for case-insensitive DNS compatibility
+		if id, err := strconv.ParseInt(parts[0], 36, 64); err == nil {
+			return id
 		}
 	}
-	return monoflake.IDFromBase62(idStr).Int64()
+
+	return 0
 }
 
 func getTokenVal(r *http.Request) string {

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -72,20 +72,15 @@ func New(p Params) (Handler, error) {
 	// We handle both exact and trailing slash versions to be robust.
 	p.Mux.Handle("/mcp/{workspaceID}", corsWrapper(h.streamableHandler()))
 
-	// discovery endpoints (both path-based and root-level for subdomains)
+	// discovery endpoints (path-based)
 	p.Mux.Handle("/mcp/{workspaceID}/.well-known/oauth-authorization-server", corsWrapper(h.oauthMetadataHandler()))
-	p.Mux.Handle("/.well-known/oauth-authorization-server", corsWrapper(h.oauthMetadataHandler()))
 	p.Mux.Handle("/mcp/{workspaceID}/.well-known/oauth-protected-resource", corsWrapper(h.oauthProtectedResourceHandler()))
-	p.Mux.Handle("/.well-known/oauth-protected-resource", corsWrapper(h.oauthProtectedResourceHandler()))
 	p.Mux.Handle("/.well-known/oauth-protected-resource/mcp/{workspaceID}", corsWrapper(h.oauthProtectedResourceHandler()))
 
-	// OAuth2 endpoints (both path-based and root-level for subdomains)
+	// OAuth2 endpoints (path-based)
 	p.Mux.Handle("/mcp/{workspaceID}/oauth2/authorize", h.oauthAuthorizeHandler())
-	p.Mux.Handle("/oauth2/authorize", h.oauthAuthorizeHandler())
 	p.Mux.Handle("/mcp/{workspaceID}/oauth2/token", corsWrapper(h.oauthTokenHandler()))
-	p.Mux.Handle("/oauth2/token", corsWrapper(h.oauthTokenHandler()))
 	p.Mux.Handle("/mcp/{workspaceID}/oauth2/register", corsWrapper(h.oauthRegisterHandler()))
-	p.Mux.Handle("/oauth2/register", corsWrapper(h.oauthRegisterHandler()))
 
 	return h, nil
 }

--- a/backend/internal/handler/mcp/mcp_test.go
+++ b/backend/internal/handler/mcp/mcp_test.go
@@ -95,11 +95,12 @@ func TestOAuthMetadataHandler(t *testing.T) {
 
 func TestWorkspaceIDFromSubdomain(t *testing.T) {
 	req := httptest.NewRequest("GET", "/.well-known/oauth-authorization-server", nil)
-	req.Host = "12345.mcp.agentrq.com"
+	// '1j' in base36 is 1*36 + 19 = 55
+	req.Host = "1j.mcp.agentrq.com"
 	
 	id := workspaceIDFromParam(req)
-	if id != monoflake.IDFromBase62("12345").Int64() {
-		t.Errorf("Expected workspace ID for 12345, got %d", id)
+	if id != 55 {
+		t.Errorf("Expected workspace ID 55, got %d", id)
 	}
 }
 

--- a/backend/internal/handler/mcp/mcp_test.go
+++ b/backend/internal/handler/mcp/mcp_test.go
@@ -93,6 +93,16 @@ func TestOAuthMetadataHandler(t *testing.T) {
 	}
 }
 
+func TestWorkspaceIDFromSubdomain(t *testing.T) {
+	req := httptest.NewRequest("GET", "/.well-known/oauth-authorization-server", nil)
+	req.Host = "12345.mcp.agentrq.com"
+	
+	id := workspaceIDFromParam(req)
+	if id != monoflake.IDFromBase62("12345").Int64() {
+		t.Errorf("Expected workspace ID for 12345, got %d", id)
+	}
+}
+
 func TestOAuthAuthorizeHandler_Unauthenticated(t *testing.T) {
 	mux, _ := setupTestRouter()
 

--- a/backend/internal/handler/mcp/mcp_test.go
+++ b/backend/internal/handler/mcp/mcp_test.go
@@ -164,9 +164,9 @@ func TestOAuthAuthorizeHandler_OpenRedirect(t *testing.T) {
 			expectedCode: http.StatusFound,
 		},
 		{
-			name:         "Malicious absolute redirect",
-			redirectURI:  "https://evil.com/callback",
-			expectedCode: http.StatusBadRequest,
+			name:         "External absolute redirect (allowed for MCP)",
+			redirectURI:  "https://claude.ai/callback",
+			expectedCode: http.StatusFound,
 		},
 		{
 			name:         "Malicious relative redirect //",
@@ -179,9 +179,20 @@ func TestOAuthAuthorizeHandler_OpenRedirect(t *testing.T) {
 			expectedCode: http.StatusBadRequest,
 		},
 		{
-			name:         "Host mismatch in absolute redirect",
-			redirectURI:  "https://agentrq.com.evil.com/callback",
+			name:         "HTTP localhost redirect (allowed)",
+			redirectURI:  "http://localhost:8080/callback",
+			expectedCode: http.StatusFound,
+		},
+		{
+			name:         "HTTP external redirect (blocked)",
+			redirectURI:  "http://claude.ai/callback",
 			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "Host mismatch in absolute redirect (allowed for MCP)",
+
+			redirectURI:  "https://other-client.com/callback",
+			expectedCode: http.StatusFound,
 		},
 	}
 


### PR DESCRIPTION
Allow schema mismatch for localhost and allow external redirects for MCP urls