### PR TITLE
🛡️ Sentinel: Fix IDOR in Workspace Stats Endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The `getWorkspaceToken` endpoint allowed any authenticated user to generate access tokens for any workspace by providing its ID, lacking an ownership check.
 **Learning:** Endpoints that operate on specific resources must always verify that the authenticated user has the necessary permissions/ownership for that resource ID, even if they are already authenticated.
 **Prevention:** Always include a user-specific identifier (e.g., `userID`) in repository/controller queries for resource-specific operations to ensure implicit authorization.
+
+## 2024-05-21 - IDOR in Workspace Stats Endpoint
+**Vulnerability:** The `GetDetailedWorkspaceStats` controller method retrieved statistics for any workspace ID provided in the request without verifying if the authenticated user owned or had access to that workspace.
+**Learning:** Even when handlers correctly extract and pass the `userID`, the business logic layer must explicitly use it to authorize access to the requested resource. Simply passing it to a downstream service that ignores it leaves the application vulnerable to IDOR.
+**Prevention:** Always perform an ownership check (e.g., fetching the resource with both `resourceID` and `userID`) before executing any operations on specific resources, including read-only operations like fetching statistics.

--- a/backend/internal/controller/crud/workspace.go
+++ b/backend/internal/controller/crud/workspace.go
@@ -292,6 +292,12 @@ func (c *controller) GetDetailedWorkspaceStats(ctx context.Context, req entity.G
 		startTime = now.AddDate(0, 0, -7).Unix()
 	}
 
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	// Verify user ownership to prevent IDOR
+	if _, err := c.repository.GetWorkspace(ctx, req.ID, uid); err != nil {
+		return nil, err
+	}
+
 	res, err := c.repository.GetDetailedWorkspaceStats(ctx, req.ID, startTime, endTime)
 	if err != nil {
 		return nil, err

--- a/backend/internal/controller/crud/workspace_idor_test.go
+++ b/backend/internal/controller/crud/workspace_idor_test.go
@@ -1,0 +1,31 @@
+package crud
+
+import (
+	"context"
+	"testing"
+
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	"github.com/agentrq/agentrq/backend/internal/repository/base"
+	"github.com/golang/mock/gomock"
+)
+
+func TestGetDetailedWorkspaceStats_IDOR(t *testing.T) {
+	e := newTestController(t)
+
+	// Workspace 2 belongs to a different user, so GetWorkspace will return ErrNotFound for current user
+	e.repo.EXPECT().GetWorkspace(gomock.Any(), int64(2), testUserID).Return(model.Workspace{}, base.ErrNotFound)
+
+	resp, err := e.controller.GetDetailedWorkspaceStats(context.Background(), entity.GetWorkspaceStatsRequest{
+		ID:     2,
+		UserID: testUserIDStr,
+		Range:  "7d",
+	})
+
+	if err == nil {
+		t.Errorf("expected error due to IDOR, but got nil")
+	}
+	if resp != nil {
+		t.Errorf("expected nil response, but got %v", resp)
+	}
+}

--- a/backend/internal/controller/crud/workspace_test.go
+++ b/backend/internal/controller/crud/workspace_test.go
@@ -180,6 +180,7 @@ func TestUpdateWorkspaceAutoAllowedTools_Success(t *testing.T) {
 func TestGetDetailedWorkspaceStats_Success(t *testing.T) {
 	e := newTestController(t)
 
+	e.repo.EXPECT().GetWorkspace(gomock.Any(), int64(1), testUserID).Return(model.Workspace{ID: 1, UserID: testUserID}, nil)
 	e.repo.EXPECT().GetDetailedWorkspaceStats(gomock.Any(), int64(1), gomock.Any(), gomock.Any()).Return(entity.GetDetailedWorkspaceStatsResponse{
 		Summary: entity.WorkspaceStatsSummary{TasksCompleted: 10},
 	}, nil)


### PR DESCRIPTION
Identified and fixed a High severity IDOR vulnerability in the `GetDetailedWorkspaceStats` controller.

Previously, the method accepted a workspace ID and fetched statistics directly from the repository without verifying that the requesting user actually owned or had access to that workspace.

Fixed by introducing an explicit ownership check using `c.repository.GetWorkspace(ctx, req.ID, uid)` before proceeding to fetch the statistics.

Added a new reproduction test `TestGetDetailedWorkspaceStats_IDOR` in `backend/internal/controller/crud/workspace_idor_test.go` and updated existing tests to include the new mock expectation.

---
*PR created automatically by Jules for task [5960987764523859358](https://jules.google.com/task/5960987764523859358) started by @mustafaturan*