### PR TITLE
🛡️ Sentinel: [HIGH] Fix IDOR in UpdateMessageMetadata

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -400,7 +400,7 @@ func New(cfg Config) (*App, error) {
 			},
 			func(ctx context.Context, taskID int64, messageID int64, metadata any) error {
 				b, _ := json.Marshal(metadata)
-				err := repo.UpdateMessageMetadata(ctx, messageID, b)
+				err := repo.UpdateMessageMetadata(ctx, taskID, messageID, b)
 				if err == nil {
 					uid := monoflake.IDFromBase62(workspaceOwner).Int64()
 					latest, _ := repo.GetTask(ctx, workspaceID, taskID, uid)

--- a/backend/internal/controller/crud/task.go
+++ b/backend/internal/controller/crud/task.go
@@ -552,7 +552,7 @@ func (c *controller) UpdateMessageMetadata(ctx context.Context, req entity.Updat
 		return err
 	}
 
-	if err := c.repository.UpdateMessageMetadata(ctx, req.MessageID, b); err != nil {
+	if err := c.repository.UpdateMessageMetadata(ctx, req.TaskID, req.MessageID, b); err != nil {
 		return err
 	}
 	c.emitEvent(ctx, entity.CRUDEvent{

--- a/backend/internal/controller/crud/task_test.go
+++ b/backend/internal/controller/crud/task_test.go
@@ -615,7 +615,7 @@ func TestUpdateMessageMetadata_Success(t *testing.T) {
 	e := newTestController(t)
 
 	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(10), testUserID).Return(model.Task{}, nil)
-	e.repo.EXPECT().UpdateMessageMetadata(gomock.Any(), int64(500), gomock.Any()).Return(nil)
+	e.repo.EXPECT().UpdateMessageMetadata(gomock.Any(), int64(10), int64(500), gomock.Any()).Return(nil)
 
 	err := e.controller.UpdateMessageMetadata(context.Background(), entity.UpdateMessageMetadataRequest{
 		WorkspaceID: 1,

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -31,7 +31,7 @@ type Repository interface {
 	// Message
 	CreateMessage(ctx context.Context, m model.Message) error
 	ListMessages(ctx context.Context, taskID int64) ([]model.Message, error)
-	UpdateMessageMetadata(ctx context.Context, messageID int64, metadata []byte) error
+	UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte) error
 
 	SystemGetWorkspace(ctx context.Context, id int64) (model.Workspace, error)
 	SystemGetTask(ctx context.Context, id int64) (model.Task, error)
@@ -247,8 +247,8 @@ func (r *repository) ListMessages(ctx context.Context, taskID int64) ([]model.Me
 	return msgs, err
 }
 
-func (r *repository) UpdateMessageMetadata(ctx context.Context, messageID int64, metadata []byte) error {
-	return r.conn(ctx).Model(&model.Message{}).Where("id = ?", messageID).Update("metadata", metadata).Error
+func (r *repository) UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte) error {
+	return r.conn(ctx).Model(&model.Message{}).Where("id = ? AND task_id = ?", messageID, taskID).Update("metadata", metadata).Error
 }
 
 func (r *repository) SystemGetWorkspace(ctx context.Context, id int64) (model.Workspace, error) {

--- a/backend/internal/repository/base/repository_test.go
+++ b/backend/internal/repository/base/repository_test.go
@@ -126,3 +126,46 @@ func TestRepository_GetNextTask(t *testing.T) {
 		t.Errorf("expected task 11 (tie-break by ID), got %d", task.ID)
 	}
 }
+
+func TestRepository_UpdateMessageMetadata(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+
+	_ = db.AutoMigrate(&model.Message{})
+	repo := New(&mockDB{db: db})
+
+	ctx := context.Background()
+	taskID := int64(100)
+	messageID := int64(500)
+
+	db.Create(&model.Message{
+		ID:     messageID,
+		TaskID: taskID,
+		Text:   "Initial text",
+	})
+
+	// Case 1: Success update with correct taskID
+	err = repo.UpdateMessageMetadata(ctx, taskID, messageID, []byte(`{"updated":true}`))
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+
+	var m model.Message
+	db.First(&m, messageID)
+	if string(m.Metadata) != `{"updated":true}` {
+		t.Errorf("expected metadata to be updated, got %s", string(m.Metadata))
+	}
+
+	// Case 2: Update with WRONG taskID (IDOR)
+	err = repo.UpdateMessageMetadata(ctx, 999, messageID, []byte(`{"hacked":true}`))
+	if err != nil {
+		t.Errorf("expected nil error (GORM Update doesn't return error on no rows), got %v", err)
+	}
+
+	db.First(&m, messageID)
+	if string(m.Metadata) == `{"hacked":true}` {
+		t.Error("vulnerability detected: metadata was updated with wrong taskID")
+	}
+}


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix IDOR in UpdateMessageMetadata

### 🚨 Severity: HIGH
### 💡 Vulnerability: Insecure Direct Object Reference (IDOR)
### 🎯 Impact: An attacker or a malfunctioning agent could potentially update metadata for messages belonging to tasks they shouldn't have access to, or cross-pollinate metadata between tasks by manipulating message IDs.
### 🔧 Fix: Bound the update operation to both `messageID` and `taskID` at the repository level.
### ✅ Verification: Added a new test case `TestRepository_UpdateMessageMetadata` in `backend/internal/repository/base/repository_test.go` that specifically verifies updates are ignored when a mismatching `taskID` is provided. All backend tests passed.

---
*PR created automatically by Jules for task [7181215254989848021](https://jules.google.com/task/7181215254989848021) started by @mustafaturan*