### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attacks in token validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** The `GetDetailedWorkspaceStats` controller method retrieved statistics for any workspace ID provided in the request without verifying if the authenticated user owned or had access to that workspace.
 **Learning:** Even when handlers correctly extract and pass the `userID`, the business logic layer must explicitly use it to authorize access to the requested resource. Simply passing it to a downstream service that ignores it leaves the application vulnerable to IDOR.
 **Prevention:** Always perform an ownership check (e.g., fetching the resource with both `resourceID` and `userID`) before executing any operations on specific resources, including read-only operations like fetching statistics.
+
+## 2025-05-22 - Timing Attacks in Token Validation
+**Vulnerability:** Sensitive tokens (Root Access Token and Workspace Mission Tokens) were validated using standard string comparison operators (`==` and `!=`). This can leak information about the secret via timing differences.
+**Learning:** Standard string comparison in Go (and many other languages) returns as soon as it finds a mismatching character. An attacker can use this to perform a timing attack to guess tokens character by character.
+**Prevention:** Use `crypto/subtle.ConstantTimeCompare` for all sensitive token or secret comparisons to ensure that the time taken to validate is independent of the value of the provided token.

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"crypto/subtle"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -235,7 +236,7 @@ func (h *handler) rootLogin() fiber.Handler {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid payload"})
 		}
 
-		if h.rootToken == "" || req.RootToken != h.rootToken {
+		if h.rootToken == "" || subtle.ConstantTimeCompare([]byte(req.RootToken), []byte(h.rootToken)) != 1 {
 			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "invalid root token"})
 		}
 

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -5,6 +5,7 @@ package mcp
 import (
 	"bytes"
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -193,7 +194,7 @@ func (h *handler) streamableHandler() http.Handler {
 		// If it's a 16-character mission token, decrypt and check
 		if len(queryToken) == 16 {
 			dec, decErr := security.Decrypt(workspace.TokenEncrypted, h.tokenKey, workspace.TokenNonce)
-			if decErr != nil || dec != queryToken {
+			if decErr != nil || subtle.ConstantTimeCompare([]byte(dec), []byte(queryToken)) != 1 {
 				sendJSONRPCError(w, "situational security: invalid mission token", jsonrpc.CodeInvalidRequest, http.StatusUnauthorized)
 				return
 			}
@@ -265,7 +266,7 @@ func (h *handler) identifyUser(ctx context.Context, workspaceID int64, tokenStr 
 		workspace, err := h.crud.SystemGetWorkspace(ctx, workspaceID)
 		if err == nil && workspace.TokenEncrypted != "" {
 			dec, decErr := security.Decrypt(workspace.TokenEncrypted, h.tokenKey, workspace.TokenNonce)
-			if decErr == nil && dec == tokenStr {
+			if decErr == nil && subtle.ConstantTimeCompare([]byte(dec), []byte(tokenStr)) == 1 {
 				return monoflake.ID(workspace.UserID).String()
 			}
 		}


### PR DESCRIPTION
I have implemented constant-time comparisons for sensitive tokens in the application to mitigate potential timing attacks.

### 🛡️ Sentinel: [HIGH] Fix timing attacks in token validation

🚨 **Severity:** HIGH
💡 **Vulnerability:** Sensitive tokens (Root Access Token and Workspace Mission Tokens) were being compared using standard string equality operators (`==` and `!=`).
🎯 **Impact:** An attacker could potentially perform a timing attack to guess these secrets character by character by measuring the response time of the server.
🔧 **Fix:** Replaced standard string comparisons with `crypto/subtle.ConstantTimeCompare` for all sensitive token validations in `backend/internal/handler/api/api.go` and `backend/internal/handler/mcp/mcp.go`.
✅ **Verification:** Verified that all backend tests pass, ensuring that the new validation logic correctly handles both valid and invalid tokens without introducing regressions.

Additionally, I updated the Sentinel journal in `.jules/sentinel.md` to document this vulnerability pattern and its prevention.

---
*PR created automatically by Jules for task [11617301543595334937](https://jules.google.com/task/11617301543595334937) started by @mustafaturan*