### PR TITLE
fix: ensure scheduled task header and empty state are visible when empty

### DIFF
--- a/frontend/src/components/TaskFeed.vue
+++ b/frontend/src/components/TaskFeed.vue
@@ -187,7 +187,7 @@ const displayGroups = computed(() => {
 
   if (f === 'scheduled') {
     const cronTasks = localTasks.value.filter(t => t.status === 'cron').sort((a,b) => getTaskOrder(a) - getTaskOrder(b));
-    if (cronTasks.length === 0) return [];
+    if (cronTasks.length === 0) return [{ title: 'Scheduled', tasks: [] }];
     
     const categories = [
       { label: 'Every 15 mins', values: ['*/15 * * * *'] },


### PR DESCRIPTION
- Updated TaskFeed to return a default 'Scheduled' group when no cron tasks exist.
- Provides visual consistency with other task filters like 'Not Started'.