### PR TITLE
🛡️ Sentinel: Fix Modulo Bias and Timing Attacks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** The `GetDetailedWorkspaceStats` controller method retrieved statistics for any workspace ID provided in the request without verifying if the authenticated user owned or had access to that workspace.
 **Learning:** Even when handlers correctly extract and pass the `userID`, the business logic layer must explicitly use it to authorize access to the requested resource. Simply passing it to a downstream service that ignores it leaves the application vulnerable to IDOR.
 **Prevention:** Always perform an ownership check (e.g., fetching the resource with both `resourceID` and `userID`) before executing any operations on specific resources, including read-only operations like fetching statistics.
+
+## 2025-05-22 - Modulo Bias and Timing Attacks
+**Vulnerability:** `GenerateSecret` used the modulo operator on random bytes, leading to non-uniform character distribution. Root and mission tokens were compared using standard equality, susceptible to timing attacks.
+**Learning:** Using `crypto/rand` is insufficient if the post-processing (e.g., modulo) introduces bias. Constant-time comparison is critical for any sensitive token validation in authentication handlers.
+**Prevention:** Use rejection sampling for uniform secret generation. Always use `crypto/subtle.ConstantTimeCompare` (or a secure wrapper) for sensitive string comparisons in security-critical paths.

--- a/backend/internal/controller/crud/task.go
+++ b/backend/internal/controller/crud/task.go
@@ -361,8 +361,9 @@ func (c *controller) UpdateTaskAssignee(ctx context.Context, req entity.UpdateTa
 
 	if req.Assignee == "agent" && m.Assignee != "agent" {
 		if w.SelfLearningLoopNote != "" {
+			note := "\n\nSelf Learning Loop Note:\n" + w.SelfLearningLoopNote
 			if m.Body != "" {
-				m.Body += "\n\n" + w.SelfLearningLoopNote
+				m.Body += note
 			} else {
 				m.Body = w.SelfLearningLoopNote
 			}

--- a/backend/internal/controller/crud/task_test.go
+++ b/backend/internal/controller/crud/task_test.go
@@ -107,12 +107,13 @@ func TestCreateTask_AgentAppendLoopNote(t *testing.T) {
 	ws := activeWorkspace()
 	ws.SelfLearningLoopNote = "Be concise."
 
-	created := model.Task{ID: 45, WorkspaceID: 1, Assignee: "agent", Body: "Hello world.\n\nBe concise."}
+	expectedBody := "Hello world.\n\nSelf Learning Loop Note:\nBe concise."
+	created := model.Task{ID: 45, WorkspaceID: 1, Assignee: "agent", Body: expectedBody}
 
 	e.repo.EXPECT().GetWorkspace(gomock.Any(), int64(1), testUserID).Return(ws, nil)
 	e.idgen.EXPECT().NextID().Return(int64(45))
 	e.repo.EXPECT().CreateTask(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, m model.Task) (model.Task, error) {
-		if m.Body != "Hello world.\n\nBe concise." {
+		if m.Body != expectedBody {
 			return model.Task{}, fmt.Errorf("expected Body to have loop note appended, got %q", m.Body)
 		}
 		return created, nil
@@ -126,8 +127,8 @@ func TestCreateTask_AgentAppendLoopNote(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if resp.Task.Body != "Hello world.\n\nBe concise." {
-		t.Errorf("expected task body with note")
+	if resp.Task.Body != expectedBody {
+		t.Errorf("expected task body with note, got %q", resp.Task.Body)
 	}
 }
 
@@ -507,14 +508,15 @@ func TestUpdateTaskAssignee_AgentAppendLoopNote(t *testing.T) {
 	ws := activeWorkspace()
 	ws.SelfLearningLoopNote = "Be concise."
 
+	expectedBody := "Original body.\n\nSelf Learning Loop Note:\nBe concise."
 	task := model.Task{ID: 10, WorkspaceID: 1, Assignee: "human", Body: "Original body."}
-	updated := model.Task{ID: 10, WorkspaceID: 1, Assignee: "agent", Body: "Original body.\n\nBe concise."}
+	updated := model.Task{ID: 10, WorkspaceID: 1, Assignee: "agent", Body: expectedBody}
 
 	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(10), testUserID).Return(task, nil)
 	e.repo.EXPECT().GetWorkspace(gomock.Any(), int64(1), testUserID).Return(ws, nil)
 	
 	e.repo.EXPECT().UpdateTask(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, m model.Task) (model.Task, error) {
-		if m.Body != "Original body.\n\nBe concise." {
+		if m.Body != expectedBody {
 			return model.Task{}, fmt.Errorf("expected Body to have loop note appended, got %q", m.Body)
 		}
 		return updated, nil
@@ -529,8 +531,8 @@ func TestUpdateTaskAssignee_AgentAppendLoopNote(t *testing.T) {
 	if resp.Task.Assignee != "agent" {
 		t.Errorf("expected assignee agent, got %s", resp.Task.Assignee)
 	}
-	if resp.Task.Body != "Original body.\n\nBe concise." {
-		t.Errorf("expected task body to be updated")
+	if resp.Task.Body != expectedBody {
+		t.Errorf("expected task body to be updated, got %q", resp.Task.Body)
 	}
 }
 

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -235,7 +235,7 @@ func (h *handler) rootLogin() fiber.Handler {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid payload"})
 		}
 
-		if h.rootToken == "" || req.RootToken != h.rootToken {
+		if h.rootToken == "" || !security.SecureCompare(req.RootToken, h.rootToken) {
 			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "invalid root token"})
 		}
 

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -193,7 +193,7 @@ func (h *handler) streamableHandler() http.Handler {
 		// If it's a 16-character mission token, decrypt and check
 		if len(queryToken) == 16 {
 			dec, decErr := security.Decrypt(workspace.TokenEncrypted, h.tokenKey, workspace.TokenNonce)
-			if decErr != nil || dec != queryToken {
+			if decErr != nil || !security.SecureCompare(dec, queryToken) {
 				sendJSONRPCError(w, "situational security: invalid mission token", jsonrpc.CodeInvalidRequest, http.StatusUnauthorized)
 				return
 			}
@@ -265,7 +265,7 @@ func (h *handler) identifyUser(ctx context.Context, workspaceID int64, tokenStr 
 		workspace, err := h.crud.SystemGetWorkspace(ctx, workspaceID)
 		if err == nil && workspace.TokenEncrypted != "" {
 			dec, decErr := security.Decrypt(workspace.TokenEncrypted, h.tokenKey, workspace.TokenNonce)
-			if decErr == nil && dec == tokenStr {
+			if decErr == nil && security.SecureCompare(dec, tokenStr) {
 				return monoflake.ID(workspace.UserID).String()
 			}
 		}

--- a/backend/internal/service/security/security.go
+++ b/backend/internal/service/security/security.go
@@ -4,6 +4,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -70,14 +71,31 @@ func Decrypt(ciphertextHex, key, nonceHex string) (string, error) {
 }
 
 // GenerateSecret generates a random base62 string of a certain length.
+// It uses rejection sampling to ensure a uniform distribution and avoid modulo bias.
 func GenerateSecret(n int) (string, error) {
 	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	b := make([]byte, n)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
-	for i := 0; i < n; i++ {
-		b[i] = charset[int(b[i])%len(charset)]
+	maxIdx := 256 - (256 % len(charset))
+	rb := make([]byte, n+(n/4)+5) // Buffer with extra space to minimize rand.Read calls
+	for i := 0; i < n; {
+		if _, err := rand.Read(rb); err != nil {
+			return "", err
+		}
+		for _, v := range rb {
+			if int(v) < maxIdx {
+				b[i] = charset[int(v)%len(charset)]
+				i++
+				if i == n {
+					return string(b), nil
+				}
+			}
+		}
 	}
 	return string(b), nil
+}
+
+// SecureCompare performs a constant-time comparison of two strings.
+// This is used to prevent timing attacks when comparing sensitive tokens.
+func SecureCompare(s1, s2 string) bool {
+	return subtle.ConstantTimeCompare([]byte(s1), []byte(s2)) == 1
 }


### PR DESCRIPTION
🚨 Severity: HIGH/MEDIUM
💡 Vulnerability:
1. Modulo bias in `GenerateSecret` leading to non-uniform secrets.
2. Timing attacks in `rootLogin` and `mcp` mission token validation.
3. Potential context confusion with system-appended loop notes.

🎯 Impact:
1. Slightly weaker secrets.
2. Attackers could potentially guess tokens by measuring response times.
3. Agents or humans might confuse system instructions with user content.

🔧 Fix:
1. Refactored `GenerateSecret` to use rejection sampling with a buffer for efficiency.
2. Introduced `security.SecureCompare` and applied it to authentication paths.
3. Enhanced "Self Learning Loop Note" formatting with a clear header to improve context separation.

✅ Verification:
1. `go test ./internal/service/security/...` passed.
2. `go test ./internal/handler/api/...` and `./internal/handler/mcp/...` passed.
3. `go test ./internal/controller/crud/...` passed after updating expectations.

---
*PR created automatically by Jules for task [7563333466474265970](https://jules.google.com/task/7563333466474265970) started by @mustafaturan*