### PR TITLE
feat(ui): refine sidebar design and enforce kebab-case workspace naming

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -62,12 +62,12 @@
           </div>
           <router-link to="/"
               @mouseenter="showTooltip($event, 'Overview')" @mouseleave="hideTooltip"
-              class="flex items-center gap-2.5 px-2 py-1.5 text-sm transition-all duration-150 rounded-md"
+              class="flex items-center gap-2.5 px-2 py-1.5 text-xs transition-all duration-150 rounded-md"
               :class="[
                 (isCollapsed && !isMobileMenuOpen) ? 'justify-center' : '',
-                $route.path === '/' ? 'bg-gray-200 dark:bg-zinc-800 text-black dark:text-white' : 'text-gray-600 dark:text-zinc-300 hover:bg-gray-200 dark:hover:bg-zinc-700 hover:text-gray-900 dark:hover:text-zinc-50'
+                $route.path === '/' ? 'bg-gray-200 dark:bg-zinc-800 text-black dark:text-white' : 'text-gray-500 dark:text-zinc-400 hover:bg-gray-200 dark:hover:bg-zinc-700 hover:text-gray-900 dark:hover:text-zinc-50'
               ]">
-            <svg class="w-4.5 h-4.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
             </svg>
             <span v-if="!isCollapsed || isMobileMenuOpen">Overview</span>
@@ -87,7 +87,7 @@
               <div class="w-1.5 h-1.5 rounded-full shrink-0"
                    :class="ws.agentConnected ? 'bg-green-500 dark:bg-green-400 shadow-[0_0_6px_rgba(34,197,94,0.4)]' : 'bg-gray-300 dark:bg-zinc-600'"
                    :title="ws.agentConnected ? 'Agent Online' : 'Agent Offline'"></div>
-              <span class="truncate flex-1">{{ ws.name }}</span>
+              <span class="truncate flex-1">{{ toKebabCase(ws.name) }}</span>
             </router-link>
           </template>
 
@@ -97,12 +97,12 @@
 
           <router-link to="/tasks/scheduled"
               @mouseenter="showTooltip($event, 'Scheduled')" @mouseleave="hideTooltip"
-              class="flex items-center gap-2.5 px-2 py-1.5 text-sm transition-all duration-150 rounded-md"
+              class="flex items-center gap-2.5 px-2 py-1.5 text-xs transition-all duration-150 rounded-md"
               :class="[
                 (isCollapsed && !isMobileMenuOpen) ? 'justify-center' : '',
-                $route.path === '/tasks/scheduled' ? 'bg-gray-200 dark:bg-zinc-800 text-black dark:text-white' : 'text-gray-600 dark:text-zinc-300 hover:bg-gray-200 dark:hover:bg-zinc-700 hover:text-gray-900 dark:hover:text-zinc-50'
+                $route.path === '/tasks/scheduled' ? 'bg-gray-200 dark:bg-zinc-800 text-black dark:text-white' : 'text-gray-500 dark:text-zinc-400 hover:bg-gray-200 dark:hover:bg-zinc-700 hover:text-gray-900 dark:hover:text-zinc-50'
               ]">
-            <svg class="w-4.5 h-4.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                <path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
             <span v-if="!isCollapsed || isMobileMenuOpen">Scheduled</span>
@@ -110,12 +110,12 @@
 
           <router-link to="/tasks/pending"
               @mouseenter="showTooltip($event, 'Pending on Me')" @mouseleave="hideTooltip"
-              class="flex items-center gap-2.5 px-2 py-1.5 text-sm transition-all duration-150 rounded-md"
+              class="flex items-center gap-2.5 px-2 py-1.5 text-xs transition-all duration-150 rounded-md"
               :class="[
                 (isCollapsed && !isMobileMenuOpen) ? 'justify-center' : '',
-                $route.path === '/tasks/pending' ? 'bg-gray-200 dark:bg-zinc-800 text-black dark:text-white' : 'text-gray-600 dark:text-zinc-300 hover:bg-gray-200 dark:hover:bg-zinc-700 hover:text-gray-900 dark:hover:text-zinc-50'
+                $route.path === '/tasks/pending' ? 'bg-gray-200 dark:bg-zinc-800 text-black dark:text-white' : 'text-gray-500 dark:text-zinc-400 hover:bg-gray-200 dark:hover:bg-zinc-700 hover:text-gray-900 dark:hover:text-zinc-50'
               ]">
-            <svg class="w-4.5 h-4.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                <path stroke-linecap="round" stroke-linejoin="round" d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
             <span v-if="!isCollapsed || isMobileMenuOpen">Pending on Me</span>
@@ -123,12 +123,12 @@
 
           <router-link to="/tasks/notstarted"
               @mouseenter="showTooltip($event, 'Not Started')" @mouseleave="hideTooltip"
-              class="flex items-center gap-2.5 px-2 py-1.5 text-sm transition-all duration-150 rounded-md"
+              class="flex items-center gap-2.5 px-2 py-1.5 text-xs transition-all duration-150 rounded-md"
               :class="[
                 (isCollapsed && !isMobileMenuOpen) ? 'justify-center' : '',
-                $route.path === '/tasks/notstarted' ? 'bg-gray-200 dark:bg-zinc-800 text-black dark:text-white' : 'text-gray-600 dark:text-zinc-300 hover:bg-gray-200 dark:hover:bg-zinc-700 hover:text-gray-900 dark:hover:text-zinc-50'
+                $route.path === '/tasks/notstarted' ? 'bg-gray-200 dark:bg-zinc-800 text-black dark:text-white' : 'text-gray-500 dark:text-zinc-400 hover:bg-gray-200 dark:hover:bg-zinc-700 hover:text-gray-900 dark:hover:text-zinc-50'
               ]">
-            <svg class="w-4.5 h-4.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                <path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
             </svg>
             <span v-if="!isCollapsed || isMobileMenuOpen">Not Started</span>
@@ -136,12 +136,12 @@
 
           <router-link to="/tasks/ongoing"
               @mouseenter="showTooltip($event, 'Ongoing')" @mouseleave="hideTooltip"
-              class="flex items-center gap-2.5 px-2 py-1.5 text-sm transition-all duration-150 rounded-md"
+              class="flex items-center gap-2.5 px-2 py-1.5 text-xs transition-all duration-150 rounded-md"
               :class="[
                 (isCollapsed && !isMobileMenuOpen) ? 'justify-center' : '',
-                $route.path === '/tasks/ongoing' ? 'bg-gray-200 dark:bg-zinc-800 text-black dark:text-white' : 'text-gray-600 dark:text-zinc-300 hover:bg-gray-200 dark:hover:bg-zinc-700 hover:text-gray-900 dark:hover:text-zinc-50'
+                $route.path === '/tasks/ongoing' ? 'bg-gray-200 dark:bg-zinc-800 text-black dark:text-white' : 'text-gray-500 dark:text-zinc-400 hover:bg-gray-200 dark:hover:bg-zinc-700 hover:text-gray-900 dark:hover:text-zinc-50'
               ]">
-            <svg class="w-4.5 h-4.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
             </svg>
             <span v-if="!isCollapsed || isMobileMenuOpen">Ongoing</span>
@@ -149,12 +149,12 @@
 
           <router-link to="/tasks/completed"
               @mouseenter="showTooltip($event, 'Completed')" @mouseleave="hideTooltip"
-              class="flex items-center gap-2.5 px-2 py-1.5 text-sm transition-all duration-150 rounded-md"
+              class="flex items-center gap-2.5 px-2 py-1.5 text-xs transition-all duration-150 rounded-md"
               :class="[
                 (isCollapsed && !isMobileMenuOpen) ? 'justify-center' : '',
-                $route.path === '/tasks/completed' ? 'bg-gray-200 dark:bg-zinc-800 text-black dark:text-white' : 'text-gray-600 dark:text-zinc-300 hover:bg-gray-200 dark:hover:bg-zinc-700 hover:text-gray-900 dark:hover:text-zinc-50'
+                $route.path === '/tasks/completed' ? 'bg-gray-200 dark:bg-zinc-800 text-black dark:text-white' : 'text-gray-500 dark:text-zinc-400 hover:bg-gray-200 dark:hover:bg-zinc-700 hover:text-gray-900 dark:hover:text-zinc-50'
               ]">
-            <svg class="w-4.5 h-4.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
             <span v-if="!isCollapsed || isMobileMenuOpen">Completed</span>
@@ -263,7 +263,10 @@ import { useEventBus } from './useEventBus'
 import { useThemeStore } from './stores/themeStore'
 import { useTooltipStore } from './stores/tooltipStore'
 import { useWorkspaceStore } from './stores/workspaceStore'
+import { useFormat } from './composables/useFormat'
 import Toast from './components/Toast.vue'
+
+const { toKebabCase } = useFormat()
 
 const route = useRoute()
 const { notifySuccess, notifyInfo, notifyError } = useToasts()

--- a/frontend/src/components/ArchiveModal.vue
+++ b/frontend/src/components/ArchiveModal.vue
@@ -7,6 +7,10 @@ defineProps({
   }
 })
 
+import { useFormat } from '../composables/useFormat';
+
+const { toKebabCase } = useFormat();
+
 const emit = defineEmits(['close', 'confirm'])
 
 const closeModal = () => {
@@ -44,7 +48,7 @@ const confirmArchive = () => {
                   </h3>
                   <div class="mt-2 text-sm">
                     <p class="text-[14px] leading-relaxed text-gray-500 dark:text-zinc-400 font-medium">
-                      Are you sure you want to archive <span class="text-black dark:text-white font-semibold">{{ workspaceName }}</span>?
+                      Are you sure you want to archive <span class="text-black dark:text-white font-semibold">{{ toKebabCase(workspaceName) }}</span>?
                       It will be hidden from the active workspaces list, but you can still access it via direct link.
                     </p>
                   </div>

--- a/frontend/src/components/DeleteModal.vue
+++ b/frontend/src/components/DeleteModal.vue
@@ -8,8 +8,15 @@ defineProps({
   taskTitle: {
     type: String,
     default: ''
+  },
+  message: {
+    type: String,
+    default: ''
   }
 })
+
+import { useFormat } from '../composables/useFormat';
+const { toKebabCase } = useFormat();
 
 const emit = defineEmits(['close', 'confirm'])
 
@@ -33,36 +40,39 @@ const confirmDelete = () => {
 
         <!-- Modal Content -->
         <Transition name="modal">
-          <div v-if="show" class="inline-block relative z-[110] align-bottom bg-white rounded-3xl text-left overflow-hidden shadow-2xl transform transition-all sm:my-8 sm:align-middle sm:max-w-md sm:w-full border border-gray-100">
-            <div class="bg-white px-6 pt-7 pb-6 sm:p-8 sm:pb-7">
+          <div v-if="show" class="inline-block relative z-[110] align-bottom bg-white dark:bg-zinc-900 rounded-sm text-left overflow-hidden shadow-2xl transform transition-all sm:my-8 sm:align-middle sm:max-w-md sm:w-full border border-gray-100 dark:border-zinc-800">
+            <div class="bg-white dark:bg-zinc-900 px-6 pt-7 pb-6 sm:p-8 sm:pb-7">
               <div class="sm:flex sm:items-start">
-                <div class="mx-auto shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-50 sm:mx-0 sm:h-10 sm:w-10 border border-red-100 mb-4 sm:mb-0">
-                  <svg class="h-5 w-5 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <div class="mx-auto shrink-0 flex items-center justify-center h-12 w-12 rounded-sm bg-red-50 dark:bg-red-500/10 sm:mx-0 sm:h-10 sm:w-10 border border-red-100 dark:border-red-500/20 mb-4 sm:mb-0">
+                  <svg class="h-5 w-5 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                   </svg>
                 </div>
 
                 <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
-                  <h3 class="text-xl leading-8 font-bold text-gray-900 tracking-tight" id="modal-title">
+                  <h3 class="text-xl leading-8 font-bold text-gray-900 dark:text-zinc-50 tracking-tight" id="modal-title">
                     {{ title }}
                   </h3>
                   <div class="mt-2">
-                    <p class="text-[14px] leading-relaxed text-gray-500 font-medium">
-                      Are you sure you want to delete <span class="text-black font-semibold">{{ taskTitle }}</span>? This action cannot be undone.
+                    <p v-if="message" class="text-[14px] leading-relaxed text-gray-500 dark:text-zinc-400 font-medium">
+                      {{ message }}
+                    </p>
+                    <p v-else class="text-[14px] leading-relaxed text-gray-500 dark:text-zinc-400 font-medium">
+                      Are you sure you want to delete <span class="text-black dark:text-white font-semibold">{{ toKebabCase(taskTitle) }}</span>? This action cannot be undone.
                     </p>
                   </div>
                 </div>
               </div>
             </div>
 
-            <div class="bg-gray-50/50 px-6 py-5 sm:px-8 sm:flex sm:flex-row-reverse gap-3">
+            <div class="bg-gray-50/50 dark:bg-zinc-800/50 px-6 py-5 sm:px-8 sm:flex sm:flex-row-reverse gap-3 border-t border-gray-100 dark:border-zinc-800">
               <button type="button" @click="confirmDelete"
-                class="w-full inline-flex justify-center rounded-2xl shadow-lg shadow-red-200/50 px-6 py-2.5 bg-red-600 text-sm font-bold text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-all duration-200 sm:w-auto">
+                class="w-full inline-flex justify-center rounded-sm px-6 py-2.5 bg-red-600 text-[10px] font-semibold text-white hover:bg-red-700 transition-all duration-200 sm:w-auto">
                 Delete
               </button>
 
               <button type="button" @click="closeModal"
-                class="mt-3 w-full inline-flex justify-center rounded-2xl border border-gray-200 shadow-sm px-6 py-2.5 bg-white text-sm font-bold text-gray-700 hover:bg-gray-50 hover:border-gray-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black sm:mt-0 transition-all duration-200 sm:w-auto">
+                class="mt-3 w-full inline-flex justify-center rounded-sm border border-gray-200 dark:border-zinc-700 px-6 py-2.5 bg-white dark:bg-zinc-900 text-[10px] font-semibold text-gray-700 dark:text-zinc-300 hover:bg-gray-50 dark:hover:bg-zinc-800 sm:mt-0 transition-all duration-200 sm:w-auto">
                 Cancel
               </button>
             </div>

--- a/frontend/src/composables/useFormat.js
+++ b/frontend/src/composables/useFormat.js
@@ -1,0 +1,23 @@
+export function useFormat() {
+  const toKebabCase = (str) => {
+    if (!str) return '';
+    return str
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  };
+
+  const liveKebabCase = (str) => {
+    if (!str) return '';
+    return str
+      .toLowerCase()
+      .replace(/[\s_]+/g, '-')
+      .replace(/[^a-z0-9-]/g, '');
+  };
+
+  return {
+    toKebabCase,
+    liveKebabCase
+  };
+}

--- a/frontend/src/views/WorkspaceDetailView.vue
+++ b/frontend/src/views/WorkspaceDetailView.vue
@@ -29,8 +29,8 @@
 
           <div class="flex flex-col min-w-0 flex-1">
             <h1 class="text-lg md:text-2xl font-black text-gray-800 dark:text-zinc-200 tracking-tight leading-tight truncate">
-              <span v-if="$route.path.includes('/settings') || $route.path.includes('/analytics')" class="opacity-50 cursor-pointer hover:opacity-100" @click="router.push(`/workspaces/${workspaceId}`)">{{ workspace?.name }}</span>
-              <span v-else>{{ workspace?.name || 'Workspace' }}</span>
+              <span v-if="$route.path.includes('/settings') || $route.path.includes('/analytics')" class="opacity-50 cursor-pointer hover:opacity-100" @click="router.push(`/workspaces/${workspaceId}`)">{{ toKebabCase(workspace?.name) }}</span>
+              <span v-else>{{ toKebabCase(workspace?.name) || 'Workspace' }}</span>
               <template v-if="$route.path.includes('/settings') || $route.path.includes('/analytics')">
                 <span class="mx-1.5 text-gray-300 dark:text-zinc-700 font-medium">/</span>
                 <span class="text-gray-400 dark:text-zinc-500">{{ $route.path.includes('/settings') ? 'Settings' : 'Analytics' }}</span>
@@ -168,7 +168,10 @@ import { useToasts } from '../composables/useToasts';
 import { useTooltipStore } from '../stores/tooltipStore';
 import { useViewport } from '../composables/useViewport';
 import { useWorkspaceStore } from '../stores/workspaceStore';
+import { useFormat } from '../composables/useFormat';
 import TaskFeed from '../components/TaskFeed.vue';
+
+const { toKebabCase } = useFormat();
 
 const route = useRoute();
 const router = useRouter();

--- a/frontend/src/views/WorkspaceSettingsView.vue
+++ b/frontend/src/views/WorkspaceSettingsView.vue
@@ -42,7 +42,7 @@
                   <div class="space-y-6">
                     <div class="space-y-2">
                       <label class="block text-[10px] font-bold text-gray-400 dark:text-zinc-500 uppercase tracking-widest ml-1">Workspace Name</label>
-                      <input v-model="form.name" type="text" required class="w-full bg-gray-50 dark:bg-zinc-800/50 border border-gray-200 dark:border-zinc-800 rounded-sm px-4 py-3 text-sm focus:border-gray-900 dark:focus:border-white focus:ring-0 outline-none font-bold text-gray-900 dark:text-zinc-100 transition-all shadow-sm" placeholder="e.g. Project Redstone" />
+                      <input v-model="form.name" @blur="form.name = toKebabCase(form.name)" type="text" required class="w-full bg-gray-50 dark:bg-zinc-800/50 border border-gray-200 dark:border-zinc-800 rounded-sm px-4 py-3 text-sm focus:border-gray-900 dark:focus:border-white focus:ring-0 outline-none font-bold text-gray-900 dark:text-zinc-100 transition-all shadow-sm" placeholder="e.g. project-redstone" />
                     </div>
                     <div class="space-y-2">
                       <label class="block text-[10px] font-bold text-gray-400 dark:text-zinc-500 uppercase tracking-widest ml-1">Mission Description</label>
@@ -294,6 +294,9 @@ import { useToasts } from '../composables/useToasts';
 import ArchiveModal from '../components/ArchiveModal.vue';
 import DeleteModal from '../components/DeleteModal.vue';
 import { useWorkspaceStore } from '../stores/workspaceStore';
+import { useFormat } from '../composables/useFormat';
+
+const { toKebabCase, liveKebabCase } = useFormat();
 
 const route = useRoute();
 const router = useRouter();
@@ -390,6 +393,15 @@ const form = ref({
   autoAllowedTools: [],
   allowAllCommands: false,
   selfLearningLoopNote: ''
+});
+
+watch(() => form.value.name, (newVal) => {
+  if (newVal) {
+    const formatted = liveKebabCase(newVal);
+    if (formatted !== newVal) {
+      form.value.name = formatted;
+    }
+  }
 });
 
 async function load() {

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -31,7 +31,7 @@
             <form @submit.prevent="submit" class="grid grid-cols-1 gap-6">
               <div class="space-y-2">
                 <label class="block text-[10px] font-black text-gray-500 dark:text-zinc-400">Workspace Name</label>
-                <input v-model="form.name" type="text" required class="w-full bg-white dark:bg-zinc-950 border border-gray-200 dark:border-zinc-700 rounded-sm px-4 py-3 text-sm outline-none font-black text-gray-800 dark:text-zinc-200 focus:border-gray-900 dark:focus:border-white focus:ring-0 transition-all shadow-sm" placeholder="e.g. my-saas-backend" />
+                <input v-model="form.name" @blur="form.name = toKebabCase(form.name)" type="text" required class="w-full bg-white dark:bg-zinc-950 border border-gray-200 dark:border-zinc-700 rounded-sm px-4 py-3 text-sm outline-none font-black text-gray-800 dark:text-zinc-200 focus:border-gray-900 dark:focus:border-white focus:ring-0 transition-all shadow-sm" placeholder="e.g. my-saas-backend" />
               </div>
               <div class="space-y-2">
                 <label class="block text-[10px] font-black text-gray-500 dark:text-zinc-400">Mission / Description</label>
@@ -79,6 +79,11 @@
         <span class="text-[9px] font-black text-gray-500 dark:text-zinc-500 uppercase tracking-widest">Scheduled Tasks</span>
         <span class="text-xl font-black text-gray-900 dark:text-zinc-50">{{ globalStats.scheduledTasks }}</span>
       </div>
+    </div>
+ 
+    <!-- Separator -->
+    <div v-if="!loadingWorkspaces && workspaces.length > 0" class="flex justify-center py-2">
+      <div class="h-px w-64 bg-gray-200 dark:bg-zinc-800/60"></div>
     </div>
 
     <!-- Workspace list -->
@@ -138,7 +143,7 @@
                      </div>
                      
                      <div class="min-w-0">
-                       <h3 class="font-black text-sm text-gray-800 dark:text-zinc-200 truncate group-hover:text-black dark:group-hover:text-white transition-colors leading-none">{{ p.name }}</h3>
+                       <h3 class="font-black text-sm text-gray-800 dark:text-zinc-200 truncate group-hover:text-black dark:group-hover:text-white transition-colors leading-none">{{ toKebabCase(p.name) }}</h3>
                        <div class="flex items-center gap-1.5 mt-1">
                          <span class="text-[8px] font-black uppercase tracking-widest transition-colors"
                                :class="p.agentConnected ? 'text-green-600 dark:text-green-500' : 'text-gray-400 dark:text-zinc-500'">
@@ -193,7 +198,7 @@
                 <div class="flex items-center gap-3 min-w-0">
                   <div class="w-1.5 h-1.5 rounded-full bg-gray-300 dark:bg-zinc-600 shrink-0"></div>
                   <div class="min-w-0">
-                    <div class="font-black text-sm text-gray-500 dark:text-zinc-400 group-hover:text-gray-900 dark:group-hover:text-zinc-100 transition-colors truncate leading-none">{{ p.name }}</div>
+                    <div class="font-black text-sm text-gray-500 dark:text-zinc-400 group-hover:text-gray-900 dark:group-hover:text-zinc-100 transition-colors truncate leading-none">{{ toKebabCase(p.name) }}</div>
                     <div class="text-[8px] font-black text-amber-600/70 truncate mt-1 uppercase tracking-widest">Archived {{ new Date(p.archivedAt).toLocaleDateString() }}</div>
                   </div>
                 </div>
@@ -222,6 +227,9 @@ import { fetchWorkspaces, createWorkspace, unarchiveWorkspace, fetchGlobalTasks 
 import { useToasts } from '../composables/useToasts';
 import { useEventBus } from '../useEventBus';
 import { useWorkspaceStore } from '../stores/workspaceStore';
+import { useFormat } from '../composables/useFormat';
+
+const { toKebabCase, liveKebabCase } = useFormat();
 
 const router = useRouter();
 const { notifySuccess, notifyError } = useToasts();
@@ -295,6 +303,15 @@ async function loadWorkspaces() {
     loadingWorkspaces.value = false;
   }
 }
+
+watch(() => form.value.name, (newVal) => {
+  if (newVal) {
+    const formatted = liveKebabCase(newVal);
+    if (formatted !== newVal) {
+      form.value.name = formatted;
+    }
+  }
+});
 
 watch(showCreate, (val) => {
   if (!val) {


### PR DESCRIPTION
- Decreased font size and softened colors for sidebar navigation items.
- Removed bold styling from active navigation states for a cleaner look.
- Created useFormat composable with liveKebabCase utility.
- Enforced kebab-case formatting for workspace names in all UI displays and forms.
- Added live conversion of workspace names as the user types.
- Unified modal designs (Delete/Archive) with dark mode and brand-consistent styling.
- Added a centered horizontal separator between analytics and workspace list.