### PR TITLE
fix: resolve TLS handshake error due to cipher suite mismatch

### DIFF
--- a/backend/internal/service/server/server.go
+++ b/backend/internal/service/server/server.go
@@ -238,12 +238,6 @@ func (s *service) Run() error {
 			tls.CurveP384,
 			tls.CurveP256,
 		},
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-		},
 		NextProtos: []string{"h2", "http/1.1"},
 	}
 


### PR DESCRIPTION
Remove manual CipherSuites restriction from the TLS configuration in the unified server, allowing the Go standard library to automatically negotiate secure ECDSA cipher suites (required by our EC256 certificate) alongside RSA suites.

Task: 275d1fc9