### PR TITLE
fix: increment task creation telemetry for scheduled tasks

### DIFF
--- a/backend/internal/controller/pub/stats.go
+++ b/backend/internal/controller/pub/stats.go
@@ -224,7 +224,9 @@ func (c *statsController) handleCRUD(event entity.CRUDEvent) {
 	case entity.ActionTaskApproveManual:
 		action = model.ActionIDTaskApproveManual
 	case entity.ActionTaskFromScheduled:
-		action = model.ActionIDTaskFromScheduled
+		c.recordAction(model.ActionIDTaskFromScheduled)
+		c.recordAction(model.ActionIDTaskCreate)
+		return
 	case entity.ActionTaskRejectManual:
 		action = model.ActionIDTaskRejectManual
 	case entity.ActionUserCreate:

--- a/backend/internal/controller/telemetry/telemetry.go
+++ b/backend/internal/controller/telemetry/telemetry.go
@@ -135,7 +135,21 @@ func (c *controller) recordCRUD(event entity.CRUDEvent) {
 	case entity.ActionTaskApproveManual:
 		action = model.ActionIDTaskApproveManual
 	case entity.ActionTaskFromScheduled:
-		action = model.ActionIDTaskFromScheduled
+		c.queue <- model.Telemetry{
+			UserID:      event.UserID,
+			WorkspaceID: event.WorkspaceID,
+			OccurredAt:  time.Now().Unix(),
+			Action:      model.ActionIDTaskFromScheduled,
+			Actor:       uint8(event.Actor),
+		}
+		c.queue <- model.Telemetry{
+			UserID:      event.UserID,
+			WorkspaceID: event.WorkspaceID,
+			OccurredAt:  time.Now().Unix(),
+			Action:      model.ActionIDTaskCreate,
+			Actor:       uint8(event.Actor),
+		}
+		return
 	case entity.ActionTaskRejectManual:
 		action = model.ActionIDTaskRejectManual
 	case entity.ActionUserCreate:


### PR DESCRIPTION
Task creation was not incremented when the task created via scheduled tasks. 

For those who want to backfill in PSQL:
```
INSERT INTO telemetries (user_id, workspace_id, occurred_at, action, actor)
SELECT t.user_id, t.workspace_id, t.occurred_at, 4, t.actor
FROM telemetries t
WHERE t.action = 17
  AND NOT EXISTS (
    SELECT 1 FROM telemetries t2 
    WHERE t2.action = 4 
      AND t2.workspace_id = t.workspace_id 
      AND t2.user_id = t.user_id
      AND t2.occurred_at BETWEEN t.occurred_at - 1 AND t.occurred_at + 1
  );
```