### PR TITLE
🛡️ Sentinel: Fix timing attacks on sensitive tokens

### DIFF
--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -235,7 +235,7 @@ func (h *handler) rootLogin() fiber.Handler {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid payload"})
 		}
 
-		if h.rootToken == "" || req.RootToken != h.rootToken {
+		if h.rootToken == "" || !security.SecureCompare(req.RootToken, h.rootToken) {
 			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "invalid root token"})
 		}
 

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -193,7 +193,7 @@ func (h *handler) streamableHandler() http.Handler {
 		// If it's a 16-character mission token, decrypt and check
 		if len(queryToken) == 16 {
 			dec, decErr := security.Decrypt(workspace.TokenEncrypted, h.tokenKey, workspace.TokenNonce)
-			if decErr != nil || dec != queryToken {
+			if decErr != nil || !security.SecureCompare(dec, queryToken) {
 				sendJSONRPCError(w, "situational security: invalid mission token", jsonrpc.CodeInvalidRequest, http.StatusUnauthorized)
 				return
 			}
@@ -265,7 +265,7 @@ func (h *handler) identifyUser(ctx context.Context, workspaceID int64, tokenStr 
 		workspace, err := h.crud.SystemGetWorkspace(ctx, workspaceID)
 		if err == nil && workspace.TokenEncrypted != "" {
 			dec, decErr := security.Decrypt(workspace.TokenEncrypted, h.tokenKey, workspace.TokenNonce)
-			if decErr == nil && dec == tokenStr {
+			if decErr == nil && security.SecureCompare(dec, tokenStr) {
 				return monoflake.ID(workspace.UserID).String()
 			}
 		}

--- a/backend/internal/service/security/security.go
+++ b/backend/internal/service/security/security.go
@@ -4,6 +4,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -84,4 +85,10 @@ func GenerateSecret(n int) (string, error) {
 		b[i] = charset[num.Int64()]
 	}
 	return string(b), nil
+}
+
+// SecureCompare performs a constant-time comparison of two strings.
+// It wraps crypto/subtle.ConstantTimeCompare to mitigate timing attacks.
+func SecureCompare(a, b string) bool {
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }

--- a/backend/internal/service/security/security_test.go
+++ b/backend/internal/service/security/security_test.go
@@ -74,4 +74,19 @@ func TestSecurity(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("SecureCompare", func(t *testing.T) {
+		if !SecureCompare("hello", "hello") {
+			t.Error("expected true for equal strings")
+		}
+		if SecureCompare("hello", "world") {
+			t.Error("expected false for different strings")
+		}
+		if SecureCompare("hello", "hell") {
+			t.Error("expected false for different length strings")
+		}
+		if !SecureCompare("", "") {
+			t.Error("expected true for empty strings")
+		}
+	})
 }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix timing attacks on sensitive tokens

🚨 Severity: HIGH
💡 Vulnerability: Sensitive tokens (root access token and workspace mission tokens) were being compared using standard string equality, which is susceptible to timing attacks.
🎯 Impact: An attacker could potentially brute-force these tokens character by character by observing subtle differences in response times, leading to unauthorized access.
🔧 Fix: Implemented `security.SecureCompare` using `crypto/subtle.ConstantTimeCompare` and applied it to all critical token comparison points.
✅ Verification: Added unit tests for `SecureCompare` in `security_test.go` and verified that all backend tests pass.

---
*PR created automatically by Jules for task [17952391581022942648](https://jules.google.com/task/17952391581022942648) started by @mustafaturan*