### PR TITLE
perf: optimize database queries for tasks, messages, and attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ acp-gateway/coverage
 acp-gateway/dist
 gemini-extension/
 claude-extension/
+.antigravitycli/

--- a/backend/internal/controller/crud/task.go
+++ b/backend/internal/controller/crud/task.go
@@ -617,42 +617,31 @@ func (c *controller) fromModelTaskToEntity(m model.Task) entity.Task {
 }
 
 func (c *controller) GetAttachment(ctx context.Context, req entity.GetAttachmentRequest) (*entity.GetAttachmentResponse, error) {
-	// Need to check if user has access to the workspace
-	// we just list all tasks for user and workspace and search attachmentid inside them
 	uid := monoflake.IDFromBase62(req.UserID).Int64()
-	tasks, err := c.repository.ListTasks(ctx, entity.ListTasksRequest{WorkspaceID: req.WorkspaceID}, uid)
+
+	// 1. Verify workspace access
+	ok, err := c.repository.CheckWorkspaceAccess(ctx, req.WorkspaceID, uid)
+	if err != nil || !ok {
+		return nil, fmt.Errorf("attachment not found or access denied")
+	}
+
+	// 2. Load attachment file data from disk
+	data, err := c.storage.LoadRaw(req.AttachmentID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch tasks for attachment verification: %w", err)
+		return nil, fmt.Errorf("attachment not found or access denied")
 	}
 
-	for _, t := range tasks {
-		if len(t.Attachments) > 0 {
-			var atts []entity.Attachment
-			if err := json.Unmarshal(t.Attachments, &atts); err == nil {
-				for _, a := range atts {
-					if a.ID == req.AttachmentID {
-						data, _ := c.storage.LoadRaw(a.ID)
-						return &entity.GetAttachmentResponse{Data: data, Filename: a.Filename, MimeType: a.MimeType}, nil
-					}
-				}
-			}
-		}
-		for _, m := range t.Messages {
-			if len(m.Attachments) > 0 {
-				var atts []entity.Attachment
-				if err := json.Unmarshal(m.Attachments, &atts); err == nil {
-					for _, a := range atts {
-						if a.ID == req.AttachmentID {
-							data, _ := c.storage.LoadRaw(a.ID)
-							return &entity.GetAttachmentResponse{Data: data, Filename: a.Filename, MimeType: a.MimeType}, nil
-						}
-					}
-				}
-			}
-		}
+	// 3. Query attachment metadata directly from DB
+	filename, mimeType, err := c.repository.FindAttachmentMetadata(ctx, req.WorkspaceID, req.AttachmentID)
+	if err != nil {
+		return nil, fmt.Errorf("attachment not found or access denied")
 	}
 
-	return nil, fmt.Errorf("attachment not found or access denied")
+	return &entity.GetAttachmentResponse{
+		Data:     data,
+		Filename: filename,
+		MimeType: mimeType,
+	}, nil
 }
 
 func (c *controller) saveAttachments(atts []entity.Attachment) {

--- a/backend/internal/controller/crud/task_test.go
+++ b/backend/internal/controller/crud/task_test.go
@@ -655,11 +655,9 @@ func TestDeleteTask_Success(t *testing.T) {
 func TestGetAttachment_Success(t *testing.T) {
 	e := newTestController(t)
 
-	attsJSON := `[{"id":"att-1","filename":"f.txt"}]`
-	e.repo.EXPECT().ListTasks(gomock.Any(), gomock.Any(), testUserID).Return([]model.Task{
-		{ID: 1, Attachments: []byte(attsJSON)},
-	}, nil)
+	e.repo.EXPECT().CheckWorkspaceAccess(gomock.Any(), int64(1), testUserID).Return(true, nil)
 	e.storage.EXPECT().LoadRaw("att-1").Return([]byte("content"), nil)
+	e.repo.EXPECT().FindAttachmentMetadata(gomock.Any(), int64(1), "att-1").Return("f.txt", "text/plain", nil)
 
 	resp, err := e.controller.GetAttachment(context.Background(), entity.GetAttachmentRequest{
 		WorkspaceID:  1,

--- a/backend/internal/controller/crud/workspace.go
+++ b/backend/internal/controller/crud/workspace.go
@@ -94,38 +94,9 @@ func (c *controller) ListWorkspaces(ctx context.Context, req entity.ListWorkspac
 }
 
 func (c *controller) DeleteWorkspace(ctx context.Context, req entity.DeleteWorkspaceRequest) error {
-	// 1. Get all tasks for this workspace to collect attachment IDs
+	// 1. Get all task and message attachment IDs directly from DB
 	uid := monoflake.IDFromBase62(req.UserID).Int64()
-	tasks, err := c.repository.ListTasks(ctx, entity.ListTasksRequest{WorkspaceID: req.ID}, uid)
-	if err != nil {
-		// If workspace doesn't exist etc, repository delete will handle it below
-	}
-
-	var attachmentIDs []string
-	for _, t := range tasks {
-		var atts []entity.Attachment
-		if len(t.Attachments) > 0 {
-			if err := json.Unmarshal(t.Attachments, &atts); err == nil {
-				for _, a := range atts {
-					if a.ID != "" {
-						attachmentIDs = append(attachmentIDs, a.ID)
-					}
-				}
-			}
-		}
-		for _, m := range t.Messages {
-			var mAtts []entity.Attachment
-			if len(m.Attachments) > 0 {
-				if err := json.Unmarshal(m.Attachments, &mAtts); err == nil {
-					for _, a := range mAtts {
-						if a.ID != "" {
-							attachmentIDs = append(attachmentIDs, a.ID)
-						}
-					}
-				}
-			}
-		}
-	}
+	attachmentIDs, _ := c.repository.GetWorkspaceAttachmentIDs(ctx, req.ID)
 
 	// 2. Delete from DB (repository handles cascaded DB delete)
 	if err := c.repository.DeleteWorkspace(ctx, req.ID, uid); err != nil {

--- a/backend/internal/controller/crud/workspace_test.go
+++ b/backend/internal/controller/crud/workspace_test.go
@@ -38,15 +38,7 @@ func TestCreateWorkspace_WithOptions(t *testing.T) {
 func TestDeleteWorkspace_Complex(t *testing.T) {
 	e := newTestController(t)
 
-	// Mocking tasks with attachments
-	task := model.Task{
-		ID:          10,
-		Attachments: []byte(`[{"id":"att-1"}]`),
-		Messages: []model.Message{
-			{ID: 101, Attachments: []byte(`[{"id":"att-2"}]`)},
-		},
-	}
-	e.repo.EXPECT().ListTasks(gomock.Any(), gomock.Any(), testUserID).Return([]model.Task{task}, nil)
+	e.repo.EXPECT().GetWorkspaceAttachmentIDs(gomock.Any(), int64(1)).Return([]string{"att-1", "att-2"}, nil)
 	e.repo.EXPECT().DeleteWorkspace(gomock.Any(), int64(1), testUserID).Return(nil)
 	e.storage.EXPECT().Delete("att-1").Return(nil)
 	e.storage.EXPECT().Delete("att-2").Return(nil)

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -159,13 +159,14 @@ type (
 	}
 
 	ListTasksRequest struct {
-		WorkspaceID int64
-		CreatedBy   string   // optional filter
-		Status      []string // optional filter
-		Filter      string   // e.g. "pending_approval"
-		Limit       int
-		Offset      int
-		UserID      string
+		WorkspaceID     int64
+		CreatedBy       string   // optional filter
+		Status          []string // optional filter
+		Filter          string   // e.g. "pending_approval"
+		Limit           int
+		Offset          int
+		UserID          string
+		PreloadMessages bool
 	}
 
 	ListTasksResponse struct {

--- a/backend/internal/mapper/api/task.go
+++ b/backend/internal/mapper/api/task.go
@@ -81,12 +81,13 @@ func FromHTTPRequestToListTasksRequestEntity(c *fiber.Ctx) *entity.ListTasksRequ
 	offset, _ := strconv.Atoi(c.Query("offset"))
 
 	return &entity.ListTasksRequest{
-		WorkspaceID: workspaceID,
-		CreatedBy:   c.Query("created_by"),
-		Status:      status,
-		Filter:      c.Query("filter"),
-		Limit:       limit,
-		Offset:      offset,
+		WorkspaceID:     workspaceID,
+		CreatedBy:       c.Query("created_by"),
+		Status:          status,
+		Filter:          c.Query("filter"),
+		Limit:           limit,
+		Offset:          offset,
+		PreloadMessages: true,
 	}
 }
 

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -33,6 +34,8 @@ type Repository interface {
 	CreateMessage(ctx context.Context, m model.Message) error
 	ListMessages(ctx context.Context, taskID int64) ([]model.Message, error)
 	UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte) error
+	FindAttachmentMetadata(ctx context.Context, workspaceID int64, attachmentID string) (filename string, mimeType string, err error)
+	GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64) ([]string, error)
 
 	SystemGetWorkspace(ctx context.Context, id int64) (model.Workspace, error)
 	SystemGetTask(ctx context.Context, id int64) (model.Task, error)
@@ -149,7 +152,19 @@ func (r *repository) GetTask(ctx context.Context, workspaceID, taskID int64, use
 
 func (r *repository) ListTasks(ctx context.Context, req entity.ListTasksRequest, userID int64) ([]model.Task, error) {
 	var tasks []model.Task
-	q := r.conn(ctx).Preload("Messages").Where("user_id = ?", userID)
+	q := r.conn(ctx).Where("user_id = ?", userID)
+
+	if req.PreloadMessages {
+		var metadataExpr string
+		if r.conn(ctx).Dialector.Name() == "postgres" {
+			metadataExpr = "metadata @> '{\"type\":\"permission_request\",\"status\":\"pending\"}'::jsonb"
+		} else {
+			metadataExpr = "metadata LIKE '%\"type\":\"permission_request\"%' AND metadata LIKE '%\"status\":\"pending\"%'"
+		}
+		q = q.Preload("Messages", func(db *gorm.DB) *gorm.DB {
+			return db.Where("id = (SELECT MAX(id) FROM messages m2 WHERE m2.task_id = messages.task_id) OR (" + metadataExpr + ")").Order("created_at asc")
+		})
+	}
 
 	if req.WorkspaceID != 0 {
 		q = q.Where("workspace_id = ?", req.WorkspaceID)
@@ -262,6 +277,93 @@ func (r *repository) ListMessages(ctx context.Context, taskID int64) ([]model.Me
 
 func (r *repository) UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte) error {
 	return r.conn(ctx).Model(&model.Message{}).Where("id = ? AND task_id = ?", messageID, taskID).Update("metadata", metadata).Error
+}
+
+func (r *repository) FindAttachmentMetadata(ctx context.Context, workspaceID int64, attachmentID string) (string, string, error) {
+	// Search in tasks of this workspace
+	var tasks []model.Task
+	likeExpr := "%" + attachmentID + "%"
+	err := r.conn(ctx).Where("workspace_id = ? AND attachments LIKE ?", workspaceID, likeExpr).Find(&tasks).Error
+	if err == nil && len(tasks) > 0 {
+		for _, t := range tasks {
+			var atts []entity.Attachment
+			if len(t.Attachments) > 0 {
+				if err := json.Unmarshal(t.Attachments, &atts); err == nil {
+					for _, a := range atts {
+						if a.ID == attachmentID {
+							return a.Filename, a.MimeType, nil
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Search in messages of tasks in this workspace
+	var msgs []model.Message
+	err = r.conn(ctx).Joins("JOIN tasks ON tasks.id = messages.task_id").
+		Where("tasks.workspace_id = ? AND messages.attachments LIKE ?", workspaceID, likeExpr).Find(&msgs).Error
+	if err == nil && len(msgs) > 0 {
+		for _, m := range msgs {
+			var atts []entity.Attachment
+			if len(m.Attachments) > 0 {
+				if err := json.Unmarshal(m.Attachments, &atts); err == nil {
+					for _, a := range atts {
+						if a.ID == attachmentID {
+							return a.Filename, a.MimeType, nil
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return "", "", fmt.Errorf("attachment metadata not found")
+}
+
+func (r *repository) GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64) ([]string, error) {
+	var attachmentIDs []string
+
+	// 1. Get attachments from tasks
+	var taskAttachments []string
+	err := r.conn(ctx).Model(&model.Task{}).Where("workspace_id = ?", workspaceID).Pluck("attachments", &taskAttachments).Error
+	if err == nil {
+		for _, ta := range taskAttachments {
+			if len(ta) > 0 {
+				var atts []entity.Attachment
+				if err := json.Unmarshal([]byte(ta), &atts); err == nil {
+					for _, a := range atts {
+						if a.ID != "" {
+							attachmentIDs = append(attachmentIDs, a.ID)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// 2. Get attachments from messages
+	var msgAttachments []string
+	err = r.conn(ctx).Model(&model.Message{}).
+		Joins("JOIN tasks ON tasks.id = messages.task_id").
+		Where("tasks.workspace_id = ?", workspaceID).
+		Pluck("messages.attachments", &msgAttachments).Error
+	if err == nil {
+		for _, ma := range msgAttachments {
+			if len(ma) > 0 {
+				var atts []entity.Attachment
+				if err := json.Unmarshal([]byte(ma), &atts); err == nil {
+					for _, a := range atts {
+						if a.ID != "" {
+							attachmentIDs = append(attachmentIDs, a.ID)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return attachmentIDs, nil
 }
 
 func (r *repository) SystemGetWorkspace(ctx context.Context, id int64) (model.Workspace, error) {


### PR DESCRIPTION
- Query attachment metadata directly from the database in GetAttachment instead of preloading all tasks and messages.
- Fetch workspace attachment IDs directly in SQL when deleting a workspace.
- Implement conditional/optimized message preloading in ListTasks (only preload the last message or pending permission requests) to reduce DB load.
- Add .antigravitycli/ to .gitignore.

Task: efficient-sql