### PR TITLE
🛡️ Sentinel: Fix Stored XSS in workspace icon

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** The `GetDetailedWorkspaceStats` controller method retrieved statistics for any workspace ID provided in the request without verifying if the authenticated user owned or had access to that workspace.
 **Learning:** Even when handlers correctly extract and pass the `userID`, the business logic layer must explicitly use it to authorize access to the requested resource. Simply passing it to a downstream service that ignores it leaves the application vulnerable to IDOR.
 **Prevention:** Always perform an ownership check (e.g., fetching the resource with both `resourceID` and `userID`) before executing any operations on specific resources, including read-only operations like fetching statistics.
+
+## 2025-05-22 - Stored XSS via Workspace Icon
+**Vulnerability:** The `ResizeBase64` service returned the original input string if the `data:image/` prefix was missing. The CRUD controller then stored this unsanitized string in the database. Since the frontend rendered some icons using `v-html`, this allowed for Stored XSS (e.g., using `javascript:` or malicious SVG).
+**Learning:** Fallback mechanisms that return unvalidated user input when processing fails are dangerous. If a service is designed to process/sanitize input, it must fail explicitly if the input doesn't meet the expected format.
+**Prevention:** Enforce strict input validation (e.g., prefix checks) and remove "fallback to original" logic in data processing services. Ensure that only successfully processed and sanitized data reaches the persistence layer.

--- a/backend/internal/controller/crud/workspace.go
+++ b/backend/internal/controller/crud/workspace.go
@@ -44,10 +44,8 @@ func (c *controller) CreateWorkspace(ctx context.Context, req entity.CreateWorks
 		icon, err := c.image.ResizeBase64(req.Workspace.Icon, 32, 32)
 		if err == nil {
 			m.Icon = icon
-		} else {
-			// Fallback to original if resize fails (maybe not base64)
-			m.Icon = req.Workspace.Icon
 		}
+		// If resize fails (invalid format or malicious string), we don't store it.
 	}
 	created, err := c.repository.CreateWorkspace(ctx, m)
 	if err != nil {
@@ -188,9 +186,8 @@ func (c *controller) UpdateWorkspace(ctx context.Context, req entity.UpdateWorks
 		icon, err := c.image.ResizeBase64(req.Workspace.Icon, 32, 32)
 		if err == nil {
 			m.Icon = icon
-		} else {
-			m.Icon = req.Workspace.Icon
 		}
+		// If resize fails, we don't update/store the icon.
 	}
 	m.UpdatedAt = time.Now()
 

--- a/backend/internal/service/image/image.go
+++ b/backend/internal/service/image/image.go
@@ -25,7 +25,7 @@ func New() Service {
 
 func (s *service) ResizeBase64(dataBase64 string, width, height int) (string, error) {
 	if !strings.HasPrefix(dataBase64, "data:image/") {
-		return dataBase64, nil // Not a base64 image or already resized
+		return "", fmt.Errorf("invalid image format: missing data:image/ prefix")
 	}
 
 	parts := strings.SplitN(dataBase64, ",", 2)

--- a/backend/internal/service/image/image_test.go
+++ b/backend/internal/service/image/image_test.go
@@ -37,12 +37,9 @@ func TestImageService(t *testing.T) {
 
 	t.Run("NotABase64Image", func(t *testing.T) {
 		input := "not a base64 image"
-		output, err := s.ResizeBase64(input, 50, 50)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if output != input {
-			t.Errorf("expected original input, got %s", output)
+		_, err := s.ResizeBase64(input, 50, 50)
+		if err == nil {
+			t.Error("expected error for non-base64 image, got nil")
 		}
 	})
 


### PR DESCRIPTION
I identified a Stored XSS vulnerability in how workspace icons were handled. The application used to fallback to storing the original input string if image resizing failed or if the input lacked a `data:image/` prefix. Since some parts of the frontend (like navigation items) render icons using `v-html`, this allowed an attacker to store a malicious payload (e.g., `javascript:alert(1)`) which would be executed when rendered.

I fixed this by:
1. Enforcing the `data:image/` prefix in the `ResizeBase64` service.
2. Removing the "fallback to original" logic in the workspace CRUD controller, ensuring only successfully processed and sanitized images reach the database.
3. Updating the test suite to reflect these security improvements.

---
*PR created automatically by Jules for task [16345901790882845073](https://jules.google.com/task/16345901790882845073) started by @mustafaturan*