### PR TITLE
fix(slack): sync permission verdict buttons and real-time updates

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -408,7 +408,20 @@ func New(cfg Config) (*App, error) {
 				return msgID, nil
 			},
 			func(ctx context.Context, taskID int64, messageID int64, metadata any) error {
-				b, _ := json.Marshal(metadata)
+				existingMetadata := make(map[string]any)
+				if m, err := repo.SystemGetMessage(ctx, messageID); err == nil && len(m.Metadata) > 0 {
+					_ = json.Unmarshal(m.Metadata, &existingMetadata)
+				}
+
+				newMetaBytes, _ := json.Marshal(metadata)
+				newMetaMap := make(map[string]any)
+				_ = json.Unmarshal(newMetaBytes, &newMetaMap)
+
+				for k, v := range newMetaMap {
+					existingMetadata[k] = v
+				}
+
+				b, _ := json.Marshal(existingMetadata)
 				err := repo.UpdateMessageMetadata(ctx, taskID, messageID, b)
 				if err == nil {
 					uid := monoflake.IDFromBase62(workspaceOwner).Int64()
@@ -416,6 +429,20 @@ func New(cfg Config) (*App, error) {
 					bus.Publish(workspaceID, workspaceOwner, eventbus.Event{
 						Type:    "task.updated",
 						Payload: mapper.FromModelTaskToView(latest),
+					})
+
+					// Publish ActionMessageUpdate event to pubsub so Slack and telemetry pick it up
+					pubsubSvc.Publish(context.Background(), pubsub.PublishRequest{
+						PubSubID: entity.PubSubTopicCRUD,
+						Event: entity.CRUDEvent{
+							Action:       entity.ActionMessageUpdate,
+							WorkspaceID:  workspaceID,
+							UserID:       uid,
+							ResourceType: entity.ResourceMessage,
+							ResourceID:   messageID,
+							Actor:        entity.ActorHuman,
+							Origin:       entity.OriginAPI,
+						},
 					})
 				}
 				return err

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -56,6 +56,7 @@ type Controller interface {
 	OnWorkspaceCreated(ctx context.Context, workspace entity.Workspace) error
 	OnTaskCreated(ctx context.Context, task entity.Task) error
 	OnMessageCreated(ctx context.Context, msg entity.Message, task entity.Task) error
+	OnMessageUpdated(ctx context.Context, msg entity.Message, task entity.Task) error
 
 	// Channel assignment (called from API handler)
 	SetWorkspaceChannel(ctx context.Context, req entity.SetWorkspaceSlackChannelRequest) error
@@ -234,13 +235,88 @@ func (c *controller) OnMessageCreated(ctx context.Context, msg entity.Message, t
 			workspaceID62 := monoflake.ID(task.WorkspaceID).String()
 			taskID62 := monoflake.ID(task.ID).String()
 			permBlocks := slacksvc.BuildPermissionRequestBlocks(workspaceID62, taskID62, requestID, toolDesc)
-			if _, err := c.slack.PostThreadReply(ctx, decryptedToken, thread.SlackChannelID, thread.ThreadTS, permBlocks); err != nil {
+			ts, err := c.slack.PostThreadReply(ctx, decryptedToken, thread.SlackChannelID, thread.ThreadTS, permBlocks)
+			if err != nil {
 				zlog.Warn().Err(err).Msg("[slack] failed to post permission request buttons")
 				c.handleSlackError(ctx, task.WorkspaceID, err)
+			} else if ts != "" {
+				// Save the channel ID and message timestamp of the permission request block back to metadata in GORM
+				metaMap, _ := msg.Metadata.(map[string]any)
+				if metaMap == nil {
+					metaMap = make(map[string]any)
+				}
+				metaMap["slack_channel_id"] = thread.SlackChannelID
+				metaMap["slack_message_ts"] = ts
+				msg.Metadata = metaMap
+				b, marshalErr := json.Marshal(metaMap)
+				if marshalErr == nil {
+					if updateErr := c.repo.UpdateMessageMetadata(ctx, task.ID, msg.ID, b); updateErr != nil {
+						zlog.Error().Err(updateErr).Int64("messageID", msg.ID).Msg("[slack] failed to update message metadata with slack details")
+					}
+				}
 			}
 		}
 	}
 	return nil
+}
+
+// OnMessageUpdated processes updates to permission request messages (verdicts) and replaces Slack buttons with static text.
+func (c *controller) OnMessageUpdated(ctx context.Context, msg entity.Message, task entity.Task) error {
+	if !c.slack.IsEnabled() {
+		return nil
+	}
+
+	if msg.Metadata == nil {
+		return nil
+	}
+
+	metaMap, _ := msg.Metadata.(map[string]any)
+	if metaMap == nil {
+		return nil
+	}
+
+	mType, _ := metaMap["type"].(string)
+	status, _ := metaMap["status"].(string)
+	if mType != "permission_request" || (status != "allow" && status != "allow_always" && status != "deny") {
+		return nil
+	}
+
+	// Skip if the decision was already executed/marked in Slack
+	if decidedInSlack, _ := metaMap["decided_in_slack"].(bool); decidedInSlack {
+		return nil
+	}
+
+	slackChannelID, _ := metaMap["slack_channel_id"].(string)
+	slackMessageTS, _ := metaMap["slack_message_ts"].(string)
+	if slackChannelID == "" || slackMessageTS == "" {
+		zlog.Debug().Int64("messageID", msg.ID).Msg("[slack] skipping message update because slack coordinates are missing")
+		return nil
+	}
+
+	link, err := c.repo.GetSlackWorkspaceLink(ctx, task.WorkspaceID)
+	if err != nil || link.AccessToken == "" {
+		return nil
+	}
+
+	decryptedToken, err := security.Decrypt(link.AccessToken, c.tokenKey, link.TokenNonce)
+	if err != nil {
+		zlog.Error().Err(err).Int64("workspaceID", task.WorkspaceID).Msg("[slack] failed to decrypt workspace bot token in OnMessageUpdated")
+		return err
+	}
+
+	label := map[string]string{
+		"allow":        "✅ Allowed by operator (via Web UI)",
+		"allow_always": "✅ Allowed by operator (via Web UI)",
+		"deny":         "❌ Denied by operator (via Web UI)",
+	}[status]
+	if label == "" {
+		label = "Done"
+	}
+
+	updateErr := c.slack.UpdateMessage(ctx, decryptedToken, slackChannelID, slackMessageTS,
+		slacksvc.BuildResultBlocks(label))
+	c.handleSlackError(ctx, task.WorkspaceID, updateErr)
+	return updateErr
 }
 
 // ─── Channel assignment ────────────────────────────────────────────────────────
@@ -627,6 +703,35 @@ func (c *controller) HandleMCPPermission(ctx context.Context, action SlackBlockA
 	if c.mcp == nil {
 		return fmt.Errorf("slack: MCP manager not available")
 	}
+
+	// Try to find the permission request message and save the slack decision flag in its metadata first,
+	// so that OnMessageUpdated can skip overwriting the slack-initiated UI update.
+	messages, listErr := c.repo.ListMessages(ctx, taskID)
+	if listErr == nil {
+		for _, m := range messages {
+			var metadata map[string]any
+			if len(m.Metadata) > 0 {
+				_ = json.Unmarshal(m.Metadata, &metadata)
+			}
+			if metadata != nil && metadata["type"] == "permission_request" {
+				reqID, _ := metadata["request_id"].(string)
+				if reqID == "" {
+					reqID, _ = metadata["requestId"].(string)
+				}
+				if reqID == requestID {
+					metadata["decided_in_slack"] = true
+					metadata["slack_user_id"] = action.UserID
+					metadata["slack_user_name"] = action.UserName
+					b, marshalErr := json.Marshal(metadata)
+					if marshalErr == nil {
+						_ = c.repo.UpdateMessageMetadata(ctx, taskID, m.ID, b)
+					}
+					break
+				}
+			}
+		}
+	}
+
 	if err := c.mcp.SendPermissionVerdict(ctx, workspaceID, ownerID, requestID, behavior); err != nil {
 		errMsg := err.Error()
 		var updateErr error
@@ -717,18 +822,33 @@ func extractPermissionRequestFields(msg entity.Message) (requestID, toolDesc str
 		return "", ""
 	}
 	var m struct {
-		RequestID string `json:"requestId"`
-		Tool      string `json:"tool"`
-		Args      string `json:"args"`
+		RequestID  string `json:"requestId"`
+		RequestID2 string `json:"request_id"`
+		Tool       string `json:"tool"`
+		ToolName   string `json:"tool_name"`
+		Args       string `json:"args"`
+		Desc       string `json:"description"`
 	}
 	if err := json.Unmarshal(b, &m); err != nil {
 		return "", ""
 	}
-	desc := m.Tool
-	if m.Args != "" {
-		desc += " " + m.Args
+	reqID := m.RequestID
+	if reqID == "" {
+		reqID = m.RequestID2
 	}
-	return m.RequestID, desc
+	tool := m.Tool
+	if tool == "" {
+		tool = m.ToolName
+	}
+	args := m.Args
+	if args == "" {
+		args = m.Desc
+	}
+	desc := tool
+	if args != "" {
+		desc += " " + args
+	}
+	return reqID, desc
 }
 
 func (c *controller) Start(ctx context.Context) error {
@@ -800,6 +920,16 @@ func (c *controller) processEvent(ctx context.Context, event entity.CRUDEvent) {
 					go c.OnMessageCreated(ctx, message, task)
 				}
 			}
+		} else if event.Action == entity.ActionMessageUpdate {
+			m, err := c.repo.SystemGetMessage(ctx, event.ResourceID)
+			if err == nil {
+				t, err := c.repo.SystemGetTask(ctx, m.TaskID)
+				if err == nil {
+					message := c.fromModelMessageToEntity(m)
+					task := c.fromModelTaskToEntity(t)
+					go c.OnMessageUpdated(ctx, message, task)
+				}
+			}
 		}
 	}
 }
@@ -844,10 +974,15 @@ func (c *controller) fromModelMessageToEntity(m model.Message) entity.Message {
 		UserID:    m.UserID,
 		Sender:    m.Sender,
 		Text:      m.Text,
-		Metadata:  make(map[string]any),
 	}
 	if len(m.Metadata) > 0 {
-		_ = json.Unmarshal(m.Metadata, &res.Metadata)
+		var meta map[string]any
+		if err := json.Unmarshal(m.Metadata, &meta); err == nil {
+			res.Metadata = meta
+		}
+	}
+	if res.Metadata == nil {
+		res.Metadata = make(map[string]any)
 	}
 	return res
 }

--- a/backend/internal/controller/slack/slack_test.go
+++ b/backend/internal/controller/slack/slack_test.go
@@ -643,3 +643,136 @@ func TestOnMessageCreated_HumanUserName(t *testing.T) {
 	}
 }
 
+type stubSlackServiceWithUpdateTracking struct {
+	stubSlackService
+	updateMessageCalled bool
+	capturedChannelID   string
+	capturedTS          string
+}
+
+func (s *stubSlackServiceWithUpdateTracking) UpdateMessage(ctx context.Context, token, channelID, ts string, blocks []slackapi.Block) error {
+	s.updateMessageCalled = true
+	s.capturedChannelID = channelID
+	s.capturedTS = ts
+	return nil
+}
+
+func TestOnMessageUpdated_Success(t *testing.T) {
+	gomockCtrl := gomock.NewController(t)
+	defer gomockCtrl.Finish()
+
+	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
+	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
+	crud := &mockCRUD{}
+	mcp := &mockMCP{}
+
+	stubSlack := &stubSlackServiceWithUpdateTracking{}
+
+	c := New(Params{
+		Repository: mockRepo,
+		SlackSvc:   stubSlack,
+		Crud:       crud,
+		MCPManager: mcp,
+		PubSub:     mockPubSub,
+		TokenKey:   "0123456789abcdef0123456789abcdef", // 32-byte key
+		BaseURL:    "https://app.agentrq.com",
+	})
+
+	decToken := "xoxb-test-token"
+	encToken, nonceStr, err := security.Encrypt(decToken, "0123456789abcdef0123456789abcdef")
+	if err != nil {
+		t.Fatalf("failed to encrypt token: %v", err)
+	}
+
+	msg := entity.Message{
+		ID:     1,
+		TaskID: 99,
+		Sender: "agent",
+		Metadata: map[string]any{
+			"type":             "permission_request",
+			"status":           "allow",
+			"slack_channel_id": "C_TEST",
+			"slack_message_ts": "12345678.90",
+		},
+	}
+
+	task := entity.Task{
+		ID:          99,
+		WorkspaceID: 42,
+	}
+
+	// Expect SlackWorkspaceLink lookup
+	mockRepo.EXPECT().
+		GetSlackWorkspaceLink(gomock.Any(), int64(42)).
+		Return(model.SlackWorkspaceLink{
+			WorkspaceID:    42,
+			AccessToken:    encToken,
+			TokenNonce:     nonceStr,
+			SlackChannelID: "C123",
+		}, nil)
+
+	err = c.OnMessageUpdated(context.Background(), msg, task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !stubSlack.updateMessageCalled {
+		t.Fatal("expected UpdateMessage to be called")
+	}
+	if stubSlack.capturedChannelID != "C_TEST" {
+		t.Errorf("expected channel ID 'C_TEST', got %q", stubSlack.capturedChannelID)
+	}
+	if stubSlack.capturedTS != "12345678.90" {
+		t.Errorf("expected message ts '12345678.90', got %q", stubSlack.capturedTS)
+	}
+}
+
+func TestOnMessageUpdated_SkippedIfDecidedInSlack(t *testing.T) {
+	gomockCtrl := gomock.NewController(t)
+	defer gomockCtrl.Finish()
+
+	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
+	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
+	crud := &mockCRUD{}
+	mcp := &mockMCP{}
+
+	stubSlack := &stubSlackServiceWithUpdateTracking{}
+
+	c := New(Params{
+		Repository: mockRepo,
+		SlackSvc:   stubSlack,
+		Crud:       crud,
+		MCPManager: mcp,
+		PubSub:     mockPubSub,
+		TokenKey:   "0123456789abcdef0123456789abcdef", // 32-byte key
+		BaseURL:    "https://app.agentrq.com",
+	})
+
+	msg := entity.Message{
+		ID:     1,
+		TaskID: 99,
+		Sender: "agent",
+		Metadata: map[string]any{
+			"type":             "permission_request",
+			"status":           "allow",
+			"decided_in_slack": true,
+			"slack_channel_id": "C_TEST",
+			"slack_message_ts": "12345678.90",
+		},
+	}
+
+	task := entity.Task{
+		ID:          99,
+		WorkspaceID: 42,
+	}
+
+	err := c.OnMessageUpdated(context.Background(), msg, task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if stubSlack.updateMessageCalled {
+		t.Fatal("expected UpdateMessage to be skipped because decided_in_slack is true")
+	}
+}
+


### PR DESCRIPTION
Two bugs fixed:

1. Slack permission buttons not appearing in thread
   - extractPermissionRequestFields was looking for camelCase keys (requestId, tool, args) but MCP server stores snake_case (request_id, tool_name, description).
   - Updated to support both naming conventions.

2. Verdict from Web UI not updating Slack buttons in-place
   - OnMessageCreated now captures and persists the Slack ts/channelID of the posted buttons block into message metadata (GORM merge-safe).
   - Implemented OnMessageUpdated lifecycle hook that listens for ActionMessageUpdate pubsub events and calls slack.UpdateMessage to replace the interactive buttons with the final status text.
   - HandleMCPPermission marks decided_in_slack=true in GORM so that Slack-originated decisions are not overwritten.
   - app.go updateMessageMetadata callback now merges new metadata into existing rather than overwriting it.

Tests: TestOnMessageUpdated_Success, TestOnMessageUpdated_SkippedIfDecidedInSlack