### PR TITLE
🛡️ Sentinel: Harden repository against BOLA/IDOR vulnerabilities

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -422,9 +422,9 @@ func New(cfg Config) (*App, error) {
 				}
 
 				b, _ := json.Marshal(existingMetadata)
-				err := repo.UpdateMessageMetadata(ctx, taskID, messageID, b)
+				uid := monoflake.IDFromBase62(workspaceOwner).Int64()
+				err := repo.UpdateMessageMetadata(ctx, taskID, messageID, uid, b)
 				if err == nil {
-					uid := monoflake.IDFromBase62(workspaceOwner).Int64()
 					latest, _ := repo.GetTask(ctx, workspaceID, taskID, uid)
 					bus.Publish(workspaceID, workspaceOwner, eventbus.Event{
 						Type:    "task.updated",
@@ -556,7 +556,8 @@ func New(cfg Config) (*App, error) {
 					t, err := repo.SystemGetTask(ctx, taskID)
 					if err == nil {
 						// Preload task messages
-						messages, err := repo.ListMessages(ctx, t.ID)
+						uid := monoflake.IDFromBase62(ownerID).Int64()
+						messages, err := repo.ListMessages(ctx, t.ID, uid)
 						if err == nil {
 							t.Messages = messages
 						}

--- a/backend/internal/controller/crud/task.go
+++ b/backend/internal/controller/crud/task.go
@@ -566,7 +566,7 @@ func (c *controller) UpdateMessageMetadata(ctx context.Context, req entity.Updat
 		return err
 	}
 
-	if err := c.repository.UpdateMessageMetadata(ctx, req.TaskID, req.MessageID, b); err != nil {
+	if err := c.repository.UpdateMessageMetadata(ctx, req.TaskID, req.MessageID, uid, b); err != nil {
 		return err
 	}
 	c.emitEvent(ctx, entity.CRUDEvent{

--- a/backend/internal/controller/crud/task_test.go
+++ b/backend/internal/controller/crud/task_test.go
@@ -615,7 +615,7 @@ func TestUpdateMessageMetadata_Success(t *testing.T) {
 	e := newTestController(t)
 
 	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(10), testUserID).Return(model.Task{}, nil)
-	e.repo.EXPECT().UpdateMessageMetadata(gomock.Any(), int64(10), int64(500), gomock.Any()).Return(nil)
+	e.repo.EXPECT().UpdateMessageMetadata(gomock.Any(), int64(10), int64(500), testUserID, gomock.Any()).Return(nil)
 
 	err := e.controller.UpdateMessageMetadata(context.Background(), entity.UpdateMessageMetadataRequest{
 		WorkspaceID: 1,

--- a/backend/internal/controller/crud/workspace.go
+++ b/backend/internal/controller/crud/workspace.go
@@ -94,7 +94,7 @@ func (c *controller) ListWorkspaces(ctx context.Context, req entity.ListWorkspac
 func (c *controller) DeleteWorkspace(ctx context.Context, req entity.DeleteWorkspaceRequest) error {
 	// 1. Get all task and message attachment IDs directly from DB
 	uid := monoflake.IDFromBase62(req.UserID).Int64()
-	attachmentIDs, _ := c.repository.GetWorkspaceAttachmentIDs(ctx, req.ID)
+	attachmentIDs, _ := c.repository.GetWorkspaceAttachmentIDs(ctx, req.ID, uid)
 
 	// 2. Delete from DB (repository handles cascaded DB delete)
 	if err := c.repository.DeleteWorkspace(ctx, req.ID, uid); err != nil {

--- a/backend/internal/controller/crud/workspace_test.go
+++ b/backend/internal/controller/crud/workspace_test.go
@@ -38,7 +38,7 @@ func TestCreateWorkspace_WithOptions(t *testing.T) {
 func TestDeleteWorkspace_Complex(t *testing.T) {
 	e := newTestController(t)
 
-	e.repo.EXPECT().GetWorkspaceAttachmentIDs(gomock.Any(), int64(1)).Return([]string{"att-1", "att-2"}, nil)
+	e.repo.EXPECT().GetWorkspaceAttachmentIDs(gomock.Any(), int64(1), testUserID).Return([]string{"att-1", "att-2"}, nil)
 	e.repo.EXPECT().DeleteWorkspace(gomock.Any(), int64(1), testUserID).Return(nil)
 	e.storage.EXPECT().Delete("att-1").Return(nil)
 	e.storage.EXPECT().Delete("att-2").Return(nil)

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -251,7 +251,7 @@ func (c *controller) OnMessageCreated(ctx context.Context, msg entity.Message, t
 				msg.Metadata = metaMap
 				b, marshalErr := json.Marshal(metaMap)
 				if marshalErr == nil {
-					if updateErr := c.repo.UpdateMessageMetadata(ctx, task.ID, msg.ID, b); updateErr != nil {
+					if updateErr := c.repo.UpdateMessageMetadata(ctx, task.ID, msg.ID, task.UserID, b); updateErr != nil {
 						zlog.Error().Err(updateErr).Int64("messageID", msg.ID).Msg("[slack] failed to update message metadata with slack details")
 					}
 				}
@@ -724,7 +724,7 @@ func (c *controller) HandleMCPPermission(ctx context.Context, action SlackBlockA
 
 	// Try to find the permission request message and save the slack decision flag in its metadata first,
 	// so that OnMessageUpdated can skip overwriting the slack-initiated UI update.
-	messages, listErr := c.repo.ListMessages(ctx, taskID)
+	messages, listErr := c.repo.ListMessages(ctx, taskID, ws.UserID)
 	if listErr == nil {
 		for _, m := range messages {
 			var metadata map[string]any
@@ -742,7 +742,7 @@ func (c *controller) HandleMCPPermission(ctx context.Context, action SlackBlockA
 					metadata["slack_user_name"] = action.UserName
 					b, marshalErr := json.Marshal(metadata)
 					if marshalErr == nil {
-						_ = c.repo.UpdateMessageMetadata(ctx, taskID, m.ID, b)
+						_ = c.repo.UpdateMessageMetadata(ctx, taskID, m.ID, ws.UserID, b)
 					}
 					break
 				}

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -32,10 +32,10 @@ type Repository interface {
 
 	// Message
 	CreateMessage(ctx context.Context, m model.Message) error
-	ListMessages(ctx context.Context, taskID int64) ([]model.Message, error)
-	UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte) error
+	ListMessages(ctx context.Context, taskID int64, userID int64) ([]model.Message, error)
+	UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, userID int64, metadata []byte) error
 	FindAttachmentMetadata(ctx context.Context, workspaceID int64, attachmentID string) (filename string, mimeType string, err error)
-	GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64) ([]string, error)
+	GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64, userID int64) ([]string, error)
 
 	SystemGetWorkspace(ctx context.Context, id int64) (model.Workspace, error)
 	SystemGetTask(ctx context.Context, id int64) (model.Task, error)
@@ -278,14 +278,21 @@ func (r *repository) CreateMessage(ctx context.Context, m model.Message) error {
 	return r.conn(ctx).Create(&m).Error
 }
 
-func (r *repository) ListMessages(ctx context.Context, taskID int64) ([]model.Message, error) {
+func (r *repository) ListMessages(ctx context.Context, taskID int64, userID int64) ([]model.Message, error) {
 	var msgs []model.Message
-	err := r.conn(ctx).Where("task_id = ?", taskID).Order("created_at asc").Find(&msgs).Error
+	err := r.conn(ctx).
+		Joins("JOIN tasks ON tasks.id = messages.task_id").
+		Where("messages.task_id = ? AND tasks.user_id = ?", taskID, userID).
+		Order("messages.created_at asc").
+		Find(&msgs).Error
 	return msgs, err
 }
 
-func (r *repository) UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte) error {
-	return r.conn(ctx).Model(&model.Message{}).Where("id = ? AND task_id = ?", messageID, taskID).Update("metadata", metadata).Error
+func (r *repository) UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, userID int64, metadata []byte) error {
+	return r.conn(ctx).Exec(
+		"UPDATE messages SET metadata = ? WHERE id = ? AND task_id = ? AND task_id IN (SELECT id FROM tasks WHERE user_id = ?)",
+		metadata, messageID, taskID, userID,
+	).Error
 }
 
 func (r *repository) FindAttachmentMetadata(ctx context.Context, workspaceID int64, attachmentID string) (string, string, error) {
@@ -330,12 +337,12 @@ func (r *repository) FindAttachmentMetadata(ctx context.Context, workspaceID int
 	return "", "", fmt.Errorf("attachment metadata not found")
 }
 
-func (r *repository) GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64) ([]string, error) {
+func (r *repository) GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64, userID int64) ([]string, error) {
 	var attachmentIDs []string
 
 	// 1. Get attachments from tasks
 	var taskAttachments []string
-	err := r.conn(ctx).Model(&model.Task{}).Where("workspace_id = ?", workspaceID).Pluck("attachments", &taskAttachments).Error
+	err := r.conn(ctx).Model(&model.Task{}).Where("workspace_id = ? AND user_id = ?", workspaceID, userID).Pluck("attachments", &taskAttachments).Error
 	if err == nil {
 		for _, ta := range taskAttachments {
 			if len(ta) > 0 {
@@ -355,7 +362,7 @@ func (r *repository) GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID 
 	var msgAttachments []string
 	err = r.conn(ctx).Model(&model.Message{}).
 		Joins("JOIN tasks ON tasks.id = messages.task_id").
-		Where("tasks.workspace_id = ?", workspaceID).
+		Where("tasks.workspace_id = ? AND tasks.user_id = ?", workspaceID, userID).
 		Pluck("messages.attachments", &msgAttachments).Error
 	if err == nil {
 		for _, ma := range msgAttachments {

--- a/backend/internal/repository/base/repository_test.go
+++ b/backend/internal/repository/base/repository_test.go
@@ -133,13 +133,18 @@ func TestRepository_UpdateMessageMetadata(t *testing.T) {
 		t.Fatalf("failed to connect database: %v", err)
 	}
 
-	_ = db.AutoMigrate(&model.Message{})
+	_ = db.AutoMigrate(&model.Task{}, &model.Message{})
 	repo := New(&mockDB{db: db})
 
 	ctx := context.Background()
 	taskID := int64(100)
 	messageID := int64(500)
+	userID := int64(1)
 
+	db.Create(&model.Task{
+		ID:     taskID,
+		UserID: userID,
+	})
 	db.Create(&model.Message{
 		ID:     messageID,
 		TaskID: taskID,
@@ -147,7 +152,7 @@ func TestRepository_UpdateMessageMetadata(t *testing.T) {
 	})
 
 	// Case 1: Success update with correct taskID
-	err = repo.UpdateMessageMetadata(ctx, taskID, messageID, []byte(`{"updated":true}`))
+	err = repo.UpdateMessageMetadata(ctx, taskID, messageID, userID, []byte(`{"updated":true}`))
 	if err != nil {
 		t.Errorf("expected nil error, got %v", err)
 	}
@@ -159,7 +164,7 @@ func TestRepository_UpdateMessageMetadata(t *testing.T) {
 	}
 
 	// Case 2: Update with WRONG taskID (IDOR)
-	err = repo.UpdateMessageMetadata(ctx, 999, messageID, []byte(`{"hacked":true}`))
+	err = repo.UpdateMessageMetadata(ctx, 999, messageID, userID, []byte(`{"hacked":true}`))
 	if err != nil {
 		t.Errorf("expected nil error (GORM Update doesn't return error on no rows), got %v", err)
 	}


### PR DESCRIPTION
Hardened the repository layer to prevent Broken Object Level Authorization (BOLA) / Insecure Direct Object Reference (IDOR) vulnerabilities. Enforced user ownership checks at the database level for message listing, message metadata updates, and workspace attachment retrieval. Updated all call sites in controllers and application background loops, and adjusted unit tests and mocks to maintain compatibility.

---
*PR created automatically by Jules for task [8578209342001385129](https://jules.google.com/task/8578209342001385129) started by @mustafaturan*