### PR TITLE
🛡️ Sentinel: Fix information leakage in error responses

### DIFF
--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -721,7 +721,10 @@ func (h *handler) setWorkspaceSlackChannel() fiber.Handler {
 			AutoCreated: false,
 		})
 		if err != nil {
-			return c.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+			zlog.Error().Err(err).Int64("workspace_id", workspaceID).Msg("Failed to set workspace Slack channel")
+			c.Set(_headerContentType, _mimeJSON)
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			return c.Status(status).Send(e)
 		}
 
 		return c.Status(http.StatusOK).JSON(fiber.Map{"status": "success"})
@@ -749,7 +752,10 @@ func (h *handler) removeWorkspaceSlackChannel() fiber.Handler {
 			UserID:      userID,
 		})
 		if err != nil {
-			return c.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+			zlog.Error().Err(err).Int64("workspace_id", workspaceID).Msg("Failed to remove workspace Slack channel")
+			c.Set(_headerContentType, _mimeJSON)
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			return c.Status(status).Send(e)
 		}
 
 		return c.Status(http.StatusNoContent).Send([]byte(""))

--- a/backend/internal/handler/slack/slack.go
+++ b/backend/internal/handler/slack/slack.go
@@ -194,8 +194,8 @@ func oauthCallbackHandler(svc slacksvc.Service, ctrl slackctrl.Controller, baseU
 		err := ctrl.HandleOAuthCallback(r.Context(), state, code, redirectURI)
 		if err != nil {
 			zlog.Error().Err(err).Msg("[slack/oauth] HandleOAuthCallback error")
-			// Redirect back with an error query param
-			errorMsg := url.QueryEscape(err.Error())
+			// Redirect back with a generic error query param to prevent information leakage
+			errorMsg := url.QueryEscape("failed to complete slack authorization")
 			http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack&slack_error=%s", baseURL, state, errorMsg), http.StatusTemporaryRedirect)
 			return
 		}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Information Leakage via Error Messages
🎯 Impact: Internal implementation details (e.g., database structure, library errors) could be exposed to potentially malicious users, aiding in further exploitation.
🔧 Fix: Replaced `err.Error()` with generic error responses using `mapper.FromErrorToHTTPResponse(err)` in API handlers and used a generic error string in OAuth callback redirect URLs. Added internal logging via `zlog` to maintain debuggability.
✅ Verification: Ran backend test suite (`go test ./...`) in `backend/` directory; all tests passed. Verified changes by reading the modified files.

---
*PR created automatically by Jules for task [2896893259080566135](https://jules.google.com/task/2896893259080566135) started by @mustafaturan*