### PR TITLE
🛡️ Sentinel: [HIGH] Harden Slack OAuth against CSRF

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** The `ResizeBase64` service returned the original input string if the `data:image/` prefix was missing. The CRUD controller then stored this unsanitized string in the database. Since the frontend rendered some icons using `v-html`, this allowed for Stored XSS (e.g., using `javascript:` or malicious SVG).
 **Learning:** Fallback mechanisms that return unvalidated user input when processing fails are dangerous. If a service is designed to process/sanitize input, it must fail explicitly if the input doesn't meet the expected format.
 **Prevention:** Enforce strict input validation (e.g., prefix checks) and remove "fallback to original" logic in data processing services. Ensure that only successfully processed and sanitized data reaches the persistence layer.
+
+## 2024-05-23 - CSRF in Slack OAuth Flow
+**Vulnerability:** The Slack OAuth flow used a predictable `state` parameter consisting only of the workspace ID. This lacked CSRF protection, allowing an attacker to potentially forge an OAuth callback.
+**Learning:** OAuth `state` parameters must be non-predictable or signed to prevent CSRF. Even if they contain an identifier like a workspace ID, they must be cryptographically bound to the user's session or signed by the server to ensure they were originated by the application.
+**Prevention:** Use signed tokens or non-predictable random values for all OAuth `state` parameters. When using identifiers in `state`, always append a signature (e.g., HMAC) and verify it before processing the callback.

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -369,12 +369,15 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 	installed := err == nil && link.AccessToken != ""
 
 	workspaceID62 := monoflake.ID(workspaceID).String()
+	// Add signature to state for CSRF protection
+	state := workspaceID62 + "." + security.Sign(workspaceID62, c.tokenKey)
+
 	redirectURI := fmt.Sprintf("%s/slack/oauth/callback", c.baseURL)
 	authURL := fmt.Sprintf(
 		"https://slack.com/oauth/v2/authorize?client_id=%s&scope=groups:write,groups:read,chat:write,app_mentions:read,commands&redirect_uri=%s&state=%s",
 		c.slack.ClientID(),
 		url.QueryEscape(redirectURI),
-		workspaceID62,
+		state,
 	)
 
 	cfg := &entity.SlackConfig{
@@ -395,7 +398,17 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 // HandleOAuthCallback handles the dynamic Slack OAuth v2 redirect code exchange.
 // It exchanges the temporary code, encrypts the access token, auto-provisions a private channel,
 // and saves the credentials into GORM.
-func (c *controller) HandleOAuthCallback(ctx context.Context, workspaceID62 string, code string, redirectURI string) error {
+func (c *controller) HandleOAuthCallback(ctx context.Context, state string, code string, redirectURI string) error {
+	// CSRF validation: verify state signature
+	parts := strings.Split(state, ".")
+	if len(parts) != 2 {
+		return fmt.Errorf("slack: invalid oauth state format")
+	}
+	workspaceID62, signature := parts[0], parts[1]
+	if !security.Verify(workspaceID62, signature, c.tokenKey) {
+		return fmt.Errorf("slack: oauth state signature verification failed (CSRF)")
+	}
+
 	workspaceID := monoflake.IDFromBase62(workspaceID62).Int64()
 	if workspaceID == 0 {
 		return fmt.Errorf("slack: invalid workspace ID state: %s", workspaceID62)

--- a/backend/internal/controller/slack/slack_test.go
+++ b/backend/internal/controller/slack/slack_test.go
@@ -745,6 +745,63 @@ func TestOnMessageUpdated_Success(t *testing.T) {
 	}
 }
 
+func TestHandleOAuthCallback_CSRF(t *testing.T) {
+	gomockCtrl := gomock.NewController(t)
+	defer gomockCtrl.Finish()
+
+	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
+	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
+	crud := &mockCRUD{}
+	mcp := &mockMCP{}
+
+	tokenKey := "0123456789abcdef0123456789abcdef"
+	c := New(Params{
+		Repository: mockRepo,
+		SlackSvc:   &stubSlackService{},
+		Crud:       crud,
+		MCPManager: mcp,
+		PubSub:     mockPubSub,
+		TokenKey:   tokenKey,
+		BaseURL:    "https://app.agentrq.com",
+	})
+
+	workspaceID62 := "test-workspace"
+	validState := workspaceID62 + "." + security.Sign(workspaceID62, tokenKey)
+	invalidState := workspaceID62 + ".invalid-sig"
+	malformedState := "no-dot"
+
+	t.Run("ValidState", func(t *testing.T) {
+		mockRepo.EXPECT().
+			SystemGetWorkspace(gomock.Any(), gomock.Any()).
+			Return(model.Workspace{Name: "test"}, nil)
+		mockRepo.EXPECT().
+			GetSlackWorkspaceLink(gomock.Any(), gomock.Any()).
+			Return(model.SlackWorkspaceLink{}, nil)
+		mockRepo.EXPECT().
+			UpsertSlackWorkspaceLink(gomock.Any(), gomock.Any()).
+			Return(nil)
+
+		err := c.HandleOAuthCallback(context.Background(), validState, "code", "https://app.agentrq.com/slack/oauth/callback")
+		if err != nil {
+			t.Errorf("expected no error for valid state, got %v", err)
+		}
+	})
+
+	t.Run("InvalidSignature", func(t *testing.T) {
+		err := c.HandleOAuthCallback(context.Background(), invalidState, "code", "https://app.agentrq.com/slack/oauth/callback")
+		if err == nil || !strings.Contains(err.Error(), "signature verification failed") {
+			t.Errorf("expected signature verification error, got %v", err)
+		}
+	})
+
+	t.Run("MalformedState", func(t *testing.T) {
+		err := c.HandleOAuthCallback(context.Background(), malformedState, "code", "https://app.agentrq.com/slack/oauth/callback")
+		if err == nil || !strings.Contains(err.Error(), "invalid oauth state format") {
+			t.Errorf("expected malformed state error, got %v", err)
+		}
+	})
+}
+
 func TestOnMessageUpdated_SkippedIfDecidedInSlack(t *testing.T) {
 	gomockCtrl := gomock.NewController(t)
 	defer gomockCtrl.Finish()

--- a/backend/internal/service/security/security.go
+++ b/backend/internal/service/security/security.go
@@ -3,7 +3,9 @@ package security
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
@@ -91,4 +93,17 @@ func GenerateSecret(n int) (string, error) {
 // It wraps crypto/subtle.ConstantTimeCompare to mitigate timing attacks.
 func SecureCompare(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+// Sign generates a HMAC-SHA256 signature for the given data using the provided key.
+func Sign(data, key string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(data))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// Verify validates the HMAC-SHA256 signature for the given data using the provided key.
+func Verify(data, signature, key string) bool {
+	expectedSignature := Sign(data, key)
+	return SecureCompare(signature, expectedSignature)
 }

--- a/backend/internal/service/security/security_test.go
+++ b/backend/internal/service/security/security_test.go
@@ -89,4 +89,29 @@ func TestSecurity(t *testing.T) {
 			t.Error("expected true for empty strings")
 		}
 	})
+
+	t.Run("SignVerify", func(t *testing.T) {
+		data := "my-data"
+		key := "my-secret-key"
+		sig := Sign(data, key)
+		if sig == "" {
+			t.Fatal("empty signature")
+		}
+
+		if !Verify(data, sig, key) {
+			t.Error("expected signature to be valid")
+		}
+
+		if Verify("other-data", sig, key) {
+			t.Error("expected signature to be invalid for different data")
+		}
+
+		if Verify(data, sig, "different-key") {
+			t.Error("expected signature to be invalid for different key")
+		}
+
+		if Verify(data, "invalid-sig", key) {
+			t.Error("expected signature to be invalid for malformed signature")
+		}
+	})
 }


### PR DESCRIPTION
This PR hardens the Slack integration by addressing a CSRF vulnerability in the OAuth2 flow. Previously, the 'state' parameter used a predictable workspace ID, which could allow an attacker to forge or intercept OAuth callbacks.

The fix introduces a signed state parameter (workspaceID.signature) using HMAC-SHA256. This ensures that the callback can only be processed if it was initiated by the same application with the correct security key.

Verified with new unit tests for both the cryptographic helpers and the Slack controller flow.

---
*PR created automatically by Jules for task [13841518366353123515](https://jules.google.com/task/13841518366353123515) started by @mustafaturan*