### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF in Slack OAuth flow

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** The `ResizeBase64` service returned the original input string if the `data:image/` prefix was missing. The CRUD controller then stored this unsanitized string in the database. Since the frontend rendered some icons using `v-html`, this allowed for Stored XSS (e.g., using `javascript:` or malicious SVG).
 **Learning:** Fallback mechanisms that return unvalidated user input when processing fails are dangerous. If a service is designed to process/sanitize input, it must fail explicitly if the input doesn't meet the expected format.
 **Prevention:** Enforce strict input validation (e.g., prefix checks) and remove "fallback to original" logic in data processing services. Ensure that only successfully processed and sanitized data reaches the persistence layer.
+
+## 2024-05-23 - CSRF in Slack OAuth Flow
+**Vulnerability:** The Slack OAuth flow used a predictable `workspaceID` as the `state` parameter, allowing an attacker to potentially perform a CSRF attack to link their Slack workspace to a victim's AgentRQ workspace.
+**Learning:** OAuth `state` parameters must be cryptographically protected (signed or nonced) to ensure they cannot be forged or reused by an attacker.
+**Prevention:** Always sign the `state` parameter with a server-side secret (e.g., using HMAC-SHA256) and verify it in the callback handler.

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -369,12 +369,15 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 	installed := err == nil && link.AccessToken != ""
 
 	workspaceID62 := monoflake.ID(workspaceID).String()
+	signature := security.Sign(workspaceID62, c.tokenKey)
+	state := fmt.Sprintf("%s.%s", workspaceID62, signature)
+
 	redirectURI := fmt.Sprintf("%s/slack/oauth/callback", c.baseURL)
 	authURL := fmt.Sprintf(
 		"https://slack.com/oauth/v2/authorize?client_id=%s&scope=groups:write,groups:read,chat:write,app_mentions:read,commands&redirect_uri=%s&state=%s",
 		c.slack.ClientID(),
 		url.QueryEscape(redirectURI),
-		workspaceID62,
+		state,
 	)
 
 	cfg := &entity.SlackConfig{
@@ -395,7 +398,17 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 // HandleOAuthCallback handles the dynamic Slack OAuth v2 redirect code exchange.
 // It exchanges the temporary code, encrypts the access token, auto-provisions a private channel,
 // and saves the credentials into GORM.
-func (c *controller) HandleOAuthCallback(ctx context.Context, workspaceID62 string, code string, redirectURI string) error {
+func (c *controller) HandleOAuthCallback(ctx context.Context, state string, code string, redirectURI string) error {
+	// CSRF Protection: verify the signed state parameter
+	parts := strings.SplitN(state, ".", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("slack: invalid oauth state format")
+	}
+	workspaceID62, signature := parts[0], parts[1]
+	if !security.Verify(workspaceID62, signature, c.tokenKey) {
+		return fmt.Errorf("slack: oauth state signature verification failed (CSRF)")
+	}
+
 	workspaceID := monoflake.IDFromBase62(workspaceID62).Int64()
 	if workspaceID == 0 {
 		return fmt.Errorf("slack: invalid workspace ID state: %s", workspaceID62)

--- a/backend/internal/controller/slack/slack_test.go
+++ b/backend/internal/controller/slack/slack_test.go
@@ -794,3 +794,61 @@ func TestOnMessageUpdated_SkippedIfDecidedInSlack(t *testing.T) {
 	}
 }
 
+func TestHandleOAuthCallback_CSRF(t *testing.T) {
+	gomockCtrl := gomock.NewController(t)
+	defer gomockCtrl.Finish()
+
+	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
+	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
+	crud := &mockCRUD{}
+	mcp := &mockMCP{}
+
+	tokenKey := "12345678901234567890123456789012"
+	c := New(Params{
+		Repository: mockRepo,
+		SlackSvc:   &stubSlackService{},
+		Crud:       crud,
+		MCPManager: mcp,
+		PubSub:     mockPubSub,
+		TokenKey:   tokenKey,
+		BaseURL:    "https://app.agentrq.com",
+	})
+
+	workspaceID62 := "00000000001"
+	validSignature := security.Sign(workspaceID62, tokenKey)
+	validState := fmt.Sprintf("%s.%s", workspaceID62, validSignature)
+
+	t.Run("ValidSignature", func(t *testing.T) {
+		// Mock expectations for success path
+		mockRepo.EXPECT().
+			SystemGetWorkspace(gomock.Any(), gomock.Any()).
+			Return(model.Workspace{ID: 1, Name: "Test"}, nil)
+		mockRepo.EXPECT().
+			GetSlackWorkspaceLink(gomock.Any(), gomock.Any()).
+			Return(model.SlackWorkspaceLink{}, nil)
+		mockRepo.EXPECT().
+			UpsertSlackWorkspaceLink(gomock.Any(), gomock.Any()).
+			Return(nil)
+
+		err := c.HandleOAuthCallback(context.Background(), validState, "code123", "https://app.agentrq.com/slack/callback")
+		if err != nil {
+			t.Errorf("expected no error for valid signature, got %v", err)
+		}
+	})
+
+	t.Run("InvalidSignature", func(t *testing.T) {
+		invalidState := workspaceID62 + ".invalid-signature"
+		err := c.HandleOAuthCallback(context.Background(), invalidState, "code123", "https://app.agentrq.com/slack/callback")
+		if err == nil || !strings.Contains(err.Error(), "signature verification failed") {
+			t.Errorf("expected signature verification error, got %v", err)
+		}
+	})
+
+	t.Run("InvalidFormat", func(t *testing.T) {
+		invalidState := "no-dot-format"
+		err := c.HandleOAuthCallback(context.Background(), invalidState, "code123", "https://app.agentrq.com/slack/callback")
+		if err == nil || !strings.Contains(err.Error(), "invalid oauth state format") {
+			t.Errorf("expected format error, got %v", err)
+		}
+	})
+}

--- a/backend/internal/service/security/security.go
+++ b/backend/internal/service/security/security.go
@@ -3,7 +3,9 @@ package security
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
@@ -91,4 +93,19 @@ func GenerateSecret(n int) (string, error) {
 // It wraps crypto/subtle.ConstantTimeCompare to mitigate timing attacks.
 func SecureCompare(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+// Sign generates an HMAC-SHA256 signature for the given data using the provided key.
+// It returns the hex-encoded signature.
+func Sign(data, key string) string {
+	h := hmac.New(sha256.New, []byte(key))
+	h.Write([]byte(data))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// Verify checks if the provided signature is a valid HMAC-SHA256 signature for the given data and key.
+// It uses SecureCompare to prevent timing attacks.
+func Verify(data, signature, key string) bool {
+	expectedSignature := Sign(data, key)
+	return SecureCompare(signature, expectedSignature)
 }

--- a/backend/internal/service/security/security_test.go
+++ b/backend/internal/service/security/security_test.go
@@ -89,4 +89,29 @@ func TestSecurity(t *testing.T) {
 			t.Error("expected true for empty strings")
 		}
 	})
+
+	t.Run("SignVerify", func(t *testing.T) {
+		data := "workspace_123"
+		tokenKey := "super-secret-token-key"
+		signature := Sign(data, tokenKey)
+		if signature == "" {
+			t.Fatal("expected non-empty signature")
+		}
+
+		if !Verify(data, signature, tokenKey) {
+			t.Error("expected signature to be valid")
+		}
+
+		if Verify(data, "invalid-signature", tokenKey) {
+			t.Error("expected invalid signature to fail")
+		}
+
+		if Verify("different-data", signature, tokenKey) {
+			t.Error("expected signature to fail for different data")
+		}
+
+		if Verify(data, signature, "different-key") {
+			t.Error("expected signature to fail for different key")
+		}
+	})
 }


### PR DESCRIPTION
I have hardened the Slack OAuth flow against CSRF vulnerabilities by implementing a signed `state` parameter.

Previously, the application used a predictable `workspaceID` as the `state` parameter, which could allow an attacker to link their own Slack workspace to a victim's AgentRQ workspace.

I have:
1.  Implemented `Sign` and `Verify` functions in the `security` service using HMAC-SHA256.
2.  Updated the Slack controller to sign the `workspaceID` before sending it as the `state` parameter to Slack.
3.  Updated the Slack OAuth callback handler to verify the signature of the `state` parameter.
4.  Added comprehensive unit tests and regression tests to ensure the fix is effective and doesn't break existing functionality.
5.  Updated the Sentinel journal with the findings and prevention strategies.

---
*PR created automatically by Jules for task [6077041571412072665](https://jules.google.com/task/6077041571412072665) started by @mustafaturan*