### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF in Slack OAuth flow

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** The `ResizeBase64` service returned the original input string if the `data:image/` prefix was missing. The CRUD controller then stored this unsanitized string in the database. Since the frontend rendered some icons using `v-html`, this allowed for Stored XSS (e.g., using `javascript:` or malicious SVG).
 **Learning:** Fallback mechanisms that return unvalidated user input when processing fails are dangerous. If a service is designed to process/sanitize input, it must fail explicitly if the input doesn't meet the expected format.
 **Prevention:** Enforce strict input validation (e.g., prefix checks) and remove "fallback to original" logic in data processing services. Ensure that only successfully processed and sanitized data reaches the persistence layer.
+
+## 2024-05-23 - CSRF in Slack OAuth Flow
+**Vulnerability:** The Slack OAuth flow used a predictable `workspaceID` as the `state` parameter without any cryptographic binding. This allowed an attacker to potentially trick a user into linking their Slack workspace to an attacker-controlled AgentRQ workspace.
+**Learning:** Using a simple ID as the OAuth `state` is insufficient for CSRF protection. The `state` must be either a random nonce or a signed value that proves it originated from the server and is tied to the current session or context.
+**Prevention:** Implement a signed `state` parameter (e.g., `payload.signature`) using HMAC-SHA256 with a server-side secret. Verify the signature upon callback before proceeding with the token exchange.

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -369,12 +369,16 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 	installed := err == nil && link.AccessToken != ""
 
 	workspaceID62 := monoflake.ID(workspaceID).String()
+	// Situational security: sign the state parameter to prevent CSRF
+	signature := security.Sign(workspaceID62, c.tokenKey)
+	state := fmt.Sprintf("%s.%s", workspaceID62, signature)
+
 	redirectURI := fmt.Sprintf("%s/slack/oauth/callback", c.baseURL)
 	authURL := fmt.Sprintf(
 		"https://slack.com/oauth/v2/authorize?client_id=%s&scope=groups:write,groups:read,chat:write,app_mentions:read,commands&redirect_uri=%s&state=%s",
 		c.slack.ClientID(),
 		url.QueryEscape(redirectURI),
-		workspaceID62,
+		url.QueryEscape(state),
 	)
 
 	cfg := &entity.SlackConfig{
@@ -395,7 +399,17 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 // HandleOAuthCallback handles the dynamic Slack OAuth v2 redirect code exchange.
 // It exchanges the temporary code, encrypts the access token, auto-provisions a private channel,
 // and saves the credentials into GORM.
-func (c *controller) HandleOAuthCallback(ctx context.Context, workspaceID62 string, code string, redirectURI string) error {
+func (c *controller) HandleOAuthCallback(ctx context.Context, state string, code string, redirectURI string) error {
+	// Situational security: verify signed state to prevent CSRF
+	parts := strings.Split(state, ".")
+	if len(parts) != 2 {
+		return fmt.Errorf("slack: invalid oauth state format")
+	}
+	workspaceID62, signature := parts[0], parts[1]
+	if !security.Verify(workspaceID62, signature, c.tokenKey) {
+		return fmt.Errorf("slack: oauth state signature mismatch (CSRF attempt?)")
+	}
+
 	workspaceID := monoflake.IDFromBase62(workspaceID62).Int64()
 	if workspaceID == 0 {
 		return fmt.Errorf("slack: invalid workspace ID state: %s", workspaceID62)

--- a/backend/internal/controller/slack/slack_test.go
+++ b/backend/internal/controller/slack/slack_test.go
@@ -794,3 +794,58 @@ func TestOnMessageUpdated_SkippedIfDecidedInSlack(t *testing.T) {
 	}
 }
 
+func TestHandleOAuthCallback_CSRF(t *testing.T) {
+	gomockCtrl := gomock.NewController(t)
+	defer gomockCtrl.Finish()
+
+	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
+	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
+	crud := &mockCRUD{}
+	mcp := &mockMCP{}
+
+	tokenKey := "0123456789abcdef0123456789abcdef"
+	c := New(Params{
+		Repository: mockRepo,
+		SlackSvc:   nil,
+		Crud:       crud,
+		MCPManager: mcp,
+		PubSub:     mockPubSub,
+		TokenKey:   tokenKey,
+		BaseURL:    "https://app.agentrq.com",
+	})
+
+	ctx := context.Background()
+	workspaceID62 := "test-ws"
+
+	t.Run("ValidSignature", func(t *testing.T) {
+		sig := security.Sign(workspaceID62, tokenKey)
+		state := fmt.Sprintf("%s.%s", workspaceID62, sig)
+
+		// We just want to check if it passes the CSRF check, not the whole flow
+		// So we expect a call to SystemGetWorkspace and then we can return an error from it
+		mockRepo.EXPECT().
+			SystemGetWorkspace(gomock.Any(), gomock.Any()).
+			Return(model.Workspace{}, fmt.Errorf("stop flow here"))
+
+		err := c.HandleOAuthCallback(ctx, state, "code", "redir")
+		if err == nil || !strings.Contains(err.Error(), "stop flow here") {
+			t.Errorf("expected flow to proceed to workspace lookup, got error: %v", err)
+		}
+	})
+
+	t.Run("InvalidSignature", func(t *testing.T) {
+		state := workspaceID62 + ".invalid-sig"
+		err := c.HandleOAuthCallback(ctx, state, "code", "redir")
+		if err == nil || !strings.Contains(err.Error(), "signature mismatch") {
+			t.Errorf("expected CSRF error, got: %v", err)
+		}
+	})
+
+	t.Run("MalformedState", func(t *testing.T) {
+		state := "just-workspace-id-without-sig"
+		err := c.HandleOAuthCallback(ctx, state, "code", "redir")
+		if err == nil || !strings.Contains(err.Error(), "invalid oauth state format") {
+			t.Errorf("expected format error, got: %v", err)
+		}
+	})
+}

--- a/backend/internal/service/security/security.go
+++ b/backend/internal/service/security/security.go
@@ -3,7 +3,9 @@ package security
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
@@ -91,4 +93,17 @@ func GenerateSecret(n int) (string, error) {
 // It wraps crypto/subtle.ConstantTimeCompare to mitigate timing attacks.
 func SecureCompare(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+// Sign creates a signature for the given message using HMAC-SHA256 and the provided key.
+func Sign(message, key string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(message))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// Verify checks if the provided signature is valid for the given message and key.
+func Verify(message, signature, key string) bool {
+	expectedSignature := Sign(message, key)
+	return SecureCompare(signature, expectedSignature)
 }

--- a/backend/internal/service/security/security_test.go
+++ b/backend/internal/service/security/security_test.go
@@ -89,4 +89,30 @@ func TestSecurity(t *testing.T) {
 			t.Error("expected true for empty strings")
 		}
 	})
+
+	t.Run("SignVerify", func(t *testing.T) {
+		key := "signing-key"
+		msg := "message to sign"
+
+		sig := Sign(msg, key)
+		if sig == "" {
+			t.Fatal("empty signature")
+		}
+
+		if !Verify(msg, sig, key) {
+			t.Error("verification failed for valid signature")
+		}
+
+		if Verify(msg, "invalid-sig", key) {
+			t.Error("verification succeeded for invalid signature")
+		}
+
+		if Verify("different message", sig, key) {
+			t.Error("verification succeeded for different message")
+		}
+
+		if Verify(msg, sig, "different-key") {
+			t.Error("verification succeeded for different key")
+		}
+	})
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The Slack OAuth flow used a predictable `workspaceID` as the `state` parameter without any cryptographic binding.
🎯 Impact: An attacker could potentially trick a user into linking their Slack workspace to an attacker-controlled AgentRQ workspace.
🔧 Fix: Implemented a signed `state` parameter using HMAC-SHA256. The `state` now follows the format `workspaceID.signature`. The signature is verified upon callback.
✅ Verification: Added unit tests in `security_test.go` for the signing primitives and `slack_test.go` to verify CSRF protection in the OAuth callback handler. All tests passed.

---
*PR created automatically by Jules for task [17470437077592996993](https://jules.google.com/task/17470437077592996993) started by @mustafaturan*