### PR TITLE
🛡️ Sentinel: [HIGH] Fix Slack OAuth CSRF

### DIFF
--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -369,12 +369,16 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 	installed := err == nil && link.AccessToken != ""
 
 	workspaceID62 := monoflake.ID(workspaceID).String()
+	// Sign the state to prevent CSRF
+	signature := security.Sign(workspaceID62, c.tokenKey)
+	state := fmt.Sprintf("%s.%s", workspaceID62, signature)
+
 	redirectURI := fmt.Sprintf("%s/slack/oauth/callback", c.baseURL)
 	authURL := fmt.Sprintf(
 		"https://slack.com/oauth/v2/authorize?client_id=%s&scope=groups:write,groups:read,chat:write,app_mentions:read,commands&redirect_uri=%s&state=%s",
 		c.slack.ClientID(),
 		url.QueryEscape(redirectURI),
-		workspaceID62,
+		url.QueryEscape(state),
 	)
 
 	cfg := &entity.SlackConfig{
@@ -395,7 +399,20 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 // HandleOAuthCallback handles the dynamic Slack OAuth v2 redirect code exchange.
 // It exchanges the temporary code, encrypts the access token, auto-provisions a private channel,
 // and saves the credentials into GORM.
-func (c *controller) HandleOAuthCallback(ctx context.Context, workspaceID62 string, code string, redirectURI string) error {
+func (c *controller) HandleOAuthCallback(ctx context.Context, state string, code string, redirectURI string) error {
+	// State should be workspaceID62.signature
+	parts := strings.Split(state, ".")
+	if len(parts) != 2 {
+		return fmt.Errorf("slack: invalid state format")
+	}
+	workspaceID62, signature := parts[0], parts[1]
+
+	// Verify the signature
+	if !security.Verify(workspaceID62, signature, c.tokenKey) {
+		zlog.Warn().Str("state", state).Msg("[slack] OAuth callback state signature verification failed")
+		return fmt.Errorf("slack: state verification failed")
+	}
+
 	workspaceID := monoflake.IDFromBase62(workspaceID62).Int64()
 	if workspaceID == 0 {
 		return fmt.Errorf("slack: invalid workspace ID state: %s", workspaceID62)

--- a/backend/internal/controller/slack/slack_test.go
+++ b/backend/internal/controller/slack/slack_test.go
@@ -794,3 +794,76 @@ func TestOnMessageUpdated_SkippedIfDecidedInSlack(t *testing.T) {
 	}
 }
 
+func TestHandleOAuthCallback_CSRF(t *testing.T) {
+	gomockCtrl := gomock.NewController(t)
+	defer gomockCtrl.Finish()
+
+	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
+	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
+	crud := &mockCRUD{}
+	mcp := &mockMCP{}
+
+	tokenKey := "12345678901234567890123456789012"
+	c := New(Params{
+		Repository: mockRepo,
+		SlackSvc:   nil,
+		Crud:       crud,
+		MCPManager: mcp,
+		PubSub:     mockPubSub,
+		TokenKey:   tokenKey,
+		BaseURL:    "https://app.agentrq.com",
+	})
+
+	workspaceID62 := "1c" // 100 in base62
+
+	t.Run("ValidSignature", func(t *testing.T) {
+		sig := security.Sign(workspaceID62, tokenKey)
+		state := fmt.Sprintf("%s.%s", workspaceID62, sig)
+
+		mockRepo.EXPECT().
+			SystemGetWorkspace(gomock.Any(), int64(100)).
+			Return(model.Workspace{ID: 100}, nil)
+
+		// Mock exchange and other logic if needed, but we care about state verification here
+		stubSlack := &stubSlackService{}
+		c.(*controller).slack = stubSlack // Temporarily inject stub
+
+		mockRepo.EXPECT().
+			GetSlackWorkspaceLink(gomock.Any(), int64(100)).
+			Return(model.SlackWorkspaceLink{WorkspaceID: 100}, nil)
+
+		mockRepo.EXPECT().
+			UpsertSlackWorkspaceLink(gomock.Any(), gomock.Any()).
+			Return(nil).AnyTimes()
+
+		err := c.HandleOAuthCallback(context.Background(), state, "code", "redirect")
+		if err != nil && !strings.Contains(err.Error(), "oauth exchange failed") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("InvalidSignature", func(t *testing.T) {
+		state := workspaceID62 + ".invalid-sig"
+		err := c.HandleOAuthCallback(context.Background(), state, "code", "redirect")
+		if err == nil || !strings.Contains(err.Error(), "state verification failed") {
+			t.Fatalf("expected state verification failure, got %v", err)
+		}
+	})
+
+	t.Run("MissingSignature", func(t *testing.T) {
+		state := workspaceID62
+		err := c.HandleOAuthCallback(context.Background(), state, "code", "redirect")
+		if err == nil || !strings.Contains(err.Error(), "invalid state format") {
+			t.Fatalf("expected invalid state format, got %v", err)
+		}
+	})
+
+	t.Run("TamperedWorkspaceID", func(t *testing.T) {
+		sig := security.Sign(workspaceID62, tokenKey)
+		state := "other-ws." + sig
+		err := c.HandleOAuthCallback(context.Background(), state, "code", "redirect")
+		if err == nil || !strings.Contains(err.Error(), "state verification failed") {
+			t.Fatalf("expected state verification failure for tampered ID, got %v", err)
+		}
+	})
+}

--- a/backend/internal/service/security/security.go
+++ b/backend/internal/service/security/security.go
@@ -3,7 +3,9 @@ package security
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
@@ -91,4 +93,17 @@ func GenerateSecret(n int) (string, error) {
 // It wraps crypto/subtle.ConstantTimeCompare to mitigate timing attacks.
 func SecureCompare(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+// Sign generates an HMAC-SHA256 signature for a message using the provided key.
+func Sign(message, key string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(message))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// Verify checks if the provided signature is a valid HMAC-SHA256 signature for the message.
+func Verify(message, signature, key string) bool {
+	expected := Sign(message, key)
+	return SecureCompare(signature, expected)
 }

--- a/backend/internal/service/security/security_test.go
+++ b/backend/internal/service/security/security_test.go
@@ -89,4 +89,29 @@ func TestSecurity(t *testing.T) {
 			t.Error("expected true for empty strings")
 		}
 	})
+
+	t.Run("SignVerify", func(t *testing.T) {
+		message := "hello world"
+		key := "secret-key"
+		sig := Sign(message, key)
+		if sig == "" {
+			t.Fatal("expected non-empty signature")
+		}
+
+		if !Verify(message, sig, key) {
+			t.Error("expected signature to be verified")
+		}
+
+		if Verify(message, "invalid signature", key) {
+			t.Error("expected verification to fail for invalid signature")
+		}
+
+		if Verify("different message", sig, key) {
+			t.Error("expected verification to fail for different message")
+		}
+
+		if Verify(message, sig, "different key") {
+			t.Error("expected verification to fail for different key")
+		}
+	})
 }


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] Fix Slack OAuth CSRF

🚨 **Severity:** HIGH

💡 **Vulnerability:** The Slack OAuth flow lacked protection for the `state` parameter. Previously, it only contained the `workspaceID` without any cryptographic integrity check or origin validation.

🎯 **Impact:** An attacker could potentially perform an OAuth CSRF attack, leading to linking their own Slack workspace to a victim's AgentRQ account or vice versa, which could result in unauthorized data access or manipulation.

🔧 **Fix:** Hardened the Slack OAuth flow by signing the `workspaceID` in the `state` parameter using HMAC-SHA256 and verifying the signature upon callback. Added `Sign` and `Verify` helpers to the security service to support this.

✅ **Verification:**
- Added unit tests for the new `Sign` and `Verify` functions in `backend/internal/service/security/security_test.go`.
- Added regression tests in `backend/internal/controller/slack/slack_test.go` to verify that `HandleOAuthCallback` correctly rejects invalid, missing, or tampered `state` parameters.
- Ran all backend tests using `go test ./...` to ensure no regressions.

---
*PR created automatically by Jules for task [14348743895910408393](https://jules.google.com/task/14348743895910408393) started by @mustafaturan*