### PR TITLE
🛡️ Sentinel: [HIGH] Harden Slack OAuth flow against CSRF

### DIFF
--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -369,12 +369,15 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 	installed := err == nil && link.AccessToken != ""
 
 	workspaceID62 := monoflake.ID(workspaceID).String()
+	signature := security.Sign(workspaceID62, c.tokenKey)
+	state := fmt.Sprintf("%s.%s", workspaceID62, signature)
+
 	redirectURI := fmt.Sprintf("%s/slack/oauth/callback", c.baseURL)
 	authURL := fmt.Sprintf(
 		"https://slack.com/oauth/v2/authorize?client_id=%s&scope=groups:write,groups:read,chat:write,app_mentions:read,commands&redirect_uri=%s&state=%s",
 		c.slack.ClientID(),
 		url.QueryEscape(redirectURI),
-		workspaceID62,
+		url.QueryEscape(state),
 	)
 
 	cfg := &entity.SlackConfig{
@@ -395,7 +398,17 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 // HandleOAuthCallback handles the dynamic Slack OAuth v2 redirect code exchange.
 // It exchanges the temporary code, encrypts the access token, auto-provisions a private channel,
 // and saves the credentials into GORM.
-func (c *controller) HandleOAuthCallback(ctx context.Context, workspaceID62 string, code string, redirectURI string) error {
+func (c *controller) HandleOAuthCallback(ctx context.Context, state string, code string, redirectURI string) error {
+	// Verify state signature to prevent CSRF
+	parts := strings.SplitN(state, ".", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("slack: invalid state format")
+	}
+	workspaceID62, signature := parts[0], parts[1]
+	if !security.Verify(workspaceID62, signature, c.tokenKey) {
+		return fmt.Errorf("slack: invalid state signature (CSRF?)")
+	}
+
 	workspaceID := monoflake.IDFromBase62(workspaceID62).Int64()
 	if workspaceID == 0 {
 		return fmt.Errorf("slack: invalid workspace ID state: %s", workspaceID62)

--- a/backend/internal/controller/slack/slack_test.go
+++ b/backend/internal/controller/slack/slack_test.go
@@ -794,3 +794,63 @@ func TestOnMessageUpdated_SkippedIfDecidedInSlack(t *testing.T) {
 	}
 }
 
+func TestHandleOAuthCallback_CSRF(t *testing.T) {
+	gomockCtrl := gomock.NewController(t)
+	defer gomockCtrl.Finish()
+
+	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
+	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
+	crud := &mockCRUD{}
+	mcp := &mockMCP{}
+
+	tokenKey := "0123456789abcdef0123456789abcdef"
+	c := New(Params{
+		Repository: mockRepo,
+		Crud:       crud,
+		MCPManager: mcp,
+		PubSub:     mockPubSub,
+		TokenKey:   tokenKey,
+	})
+
+	workspaceID62 := "0000000001c"
+	validSig := security.Sign(workspaceID62, tokenKey)
+	validState := workspaceID62 + "." + validSig
+
+	t.Run("ValidSignature", func(t *testing.T) {
+		mockRepo.EXPECT().
+			SystemGetWorkspace(gomock.Any(), int64(100)).
+			Return(model.Workspace{ID: 100}, nil)
+
+		mockRepo.EXPECT().
+			GetSlackWorkspaceLink(gomock.Any(), int64(100)).
+			Return(model.SlackWorkspaceLink{}, nil)
+
+		mockRepo.EXPECT().
+			UpsertSlackWorkspaceLink(gomock.Any(), gomock.Any()).
+			Return(nil)
+
+		// Create a stub slack service that returns an error on ExchangeCode to prevent nil panic
+		stubSlack := &stubSlackService{}
+		c.(*controller).slack = stubSlack
+
+		err := c.HandleOAuthCallback(context.Background(), validState, "code", "http://redirect")
+		if err != nil && strings.Contains(err.Error(), "invalid state signature") {
+			t.Errorf("unexpected signature error: %v", err)
+		}
+	})
+
+	t.Run("InvalidSignature", func(t *testing.T) {
+		invalidState := workspaceID62 + ".invalid-sig"
+		err := c.HandleOAuthCallback(context.Background(), invalidState, "code", "http://redirect")
+		if err == nil || !strings.Contains(err.Error(), "invalid state signature") {
+			t.Errorf("expected CSRF signature error, got: %v", err)
+		}
+	})
+
+	t.Run("MissingSignature", func(t *testing.T) {
+		err := c.HandleOAuthCallback(context.Background(), workspaceID62, "code", "http://redirect")
+		if err == nil || !strings.Contains(err.Error(), "invalid state format") {
+			t.Errorf("expected invalid format error, got: %v", err)
+		}
+	})
+}

--- a/backend/internal/service/security/security.go
+++ b/backend/internal/service/security/security.go
@@ -3,7 +3,9 @@ package security
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
@@ -91,4 +93,25 @@ func GenerateSecret(n int) (string, error) {
 // It wraps crypto/subtle.ConstantTimeCompare to mitigate timing attacks.
 func SecureCompare(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+// Sign generates an HMAC-SHA256 signature for the given message using the provided key.
+// It returns the hex-encoded signature.
+func Sign(message, key string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(message))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// Verify validates an HMAC-SHA256 signature for the given message using the provided key.
+// The signature must be hex-encoded.
+func Verify(message, signatureHex, key string) bool {
+	sig, err := hex.DecodeString(signatureHex)
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(message))
+	expectedSig := mac.Sum(nil)
+	return hmac.Equal(sig, expectedSig)
 }

--- a/backend/internal/service/security/security_test.go
+++ b/backend/internal/service/security/security_test.go
@@ -89,4 +89,30 @@ func TestSecurity(t *testing.T) {
 			t.Error("expected true for empty strings")
 		}
 	})
+
+	t.Run("SignVerify", func(t *testing.T) {
+		msg := "message to sign"
+		key := "secret-key"
+		sig := Sign(msg, key)
+
+		if sig == "" {
+			t.Fatal("empty signature")
+		}
+
+		if !Verify(msg, sig, key) {
+			t.Error("failed to verify valid signature")
+		}
+
+		if Verify(msg, sig, "wrong-key") {
+			t.Error("verified signature with wrong key")
+		}
+
+		if Verify("wrong-message", sig, key) {
+			t.Error("verified signature for wrong message")
+		}
+
+		if Verify(msg, "invalid-hex", key) {
+			t.Error("verified invalid hex signature")
+		}
+	})
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Predictable OAuth 'state' parameter in Slack flow.
🎯 Impact: An attacker could trick a workspace admin into linking an attacker-controlled Slack bot to their AgentRQ workspace, potentially leading to data leakage.
🔧 Fix: Implemented HMAC-SHA256 signing for the 'state' parameter (workspaceID.signature) and mandatory verification upon callback.
✅ Verification: New unit tests in `security_test.go` and regression tests in `slack_test.go` verify that only correctly signed states are accepted.

---
*PR created automatically by Jules for task [6371678771148476004](https://jules.google.com/task/6371678771148476004) started by @mustafaturan*