### PR TITLE
🛡️ Sentinel: Harden Slack OAuth flow against CSRF

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** The `ResizeBase64` service returned the original input string if the `data:image/` prefix was missing. The CRUD controller then stored this unsanitized string in the database. Since the frontend rendered some icons using `v-html`, this allowed for Stored XSS (e.g., using `javascript:` or malicious SVG).
 **Learning:** Fallback mechanisms that return unvalidated user input when processing fails are dangerous. If a service is designed to process/sanitize input, it must fail explicitly if the input doesn't meet the expected format.
 **Prevention:** Enforce strict input validation (e.g., prefix checks) and remove "fallback to original" logic in data processing services. Ensure that only successfully processed and sanitized data reaches the persistence layer.
+
+## 2024-05-23 - CSRF in Slack OAuth Flow
+**Vulnerability:** The Slack OAuth flow used a predictable `state` parameter (just the workspace ID), making it vulnerable to Cross-Site Request Forgery (CSRF) attacks. An attacker could potentially trick a user into linking their Slack workspace to an attacker-controlled workspace in the application.
+**Learning:** OAuth `state` parameters must be unguessable and cryptographically bound to the user's session or a server-side secret to prevent CSRF.
+**Prevention:** Always use cryptographically signed or random `state` parameters in OAuth flows. Verify the signature or token upon callback before proceeding with the authorization code exchange.

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -65,7 +65,7 @@ type Controller interface {
 	GetWorkspaceSlackConfig(ctx context.Context, workspaceID int64) (*entity.SlackConfig, error)
 
 	// OAuth callback
-	HandleOAuthCallback(ctx context.Context, workspaceID62 string, code string, redirectURI string) error
+	HandleOAuthCallback(ctx context.Context, state string, code string, redirectURI string) error
 
 	// Inbound Slack events
 	HandleSlackEvent(ctx context.Context, payload SlackEventPayload) error
@@ -369,12 +369,17 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 	installed := err == nil && link.AccessToken != ""
 
 	workspaceID62 := monoflake.ID(workspaceID).String()
+
+	// CSRF Hardening: Sign the state parameter
+	signature := security.Sign(workspaceID62, c.tokenKey)
+	state := fmt.Sprintf("%s.%s", workspaceID62, signature)
+
 	redirectURI := fmt.Sprintf("%s/slack/oauth/callback", c.baseURL)
 	authURL := fmt.Sprintf(
 		"https://slack.com/oauth/v2/authorize?client_id=%s&scope=groups:write,groups:read,chat:write,app_mentions:read,commands&redirect_uri=%s&state=%s",
 		c.slack.ClientID(),
 		url.QueryEscape(redirectURI),
-		workspaceID62,
+		state,
 	)
 
 	cfg := &entity.SlackConfig{
@@ -395,10 +400,20 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 // HandleOAuthCallback handles the dynamic Slack OAuth v2 redirect code exchange.
 // It exchanges the temporary code, encrypts the access token, auto-provisions a private channel,
 // and saves the credentials into GORM.
-func (c *controller) HandleOAuthCallback(ctx context.Context, workspaceID62 string, code string, redirectURI string) error {
+func (c *controller) HandleOAuthCallback(ctx context.Context, state string, code string, redirectURI string) error {
+	// CSRF Hardening: Verify the signed state parameter
+	parts := strings.SplitN(state, ".", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("slack: invalid state parameter format")
+	}
+	workspaceID62, signature := parts[0], parts[1]
+	if !security.Verify(workspaceID62, signature, c.tokenKey) {
+		return fmt.Errorf("slack: state verification failed (CSRF protection)")
+	}
+
 	workspaceID := monoflake.IDFromBase62(workspaceID62).Int64()
 	if workspaceID == 0 {
-		return fmt.Errorf("slack: invalid workspace ID state: %s", workspaceID62)
+		return fmt.Errorf("slack: invalid workspace ID in state: %s", workspaceID62)
 	}
 
 	ws, err := c.repo.SystemGetWorkspace(ctx, workspaceID)
@@ -1055,4 +1070,3 @@ func formatSlackAttachments(atts []entity.Attachment) string {
 	}
 	return "Attachments:\n" + strings.Join(parts, "\n")
 }
-

--- a/backend/internal/controller/slack/slack_test.go
+++ b/backend/internal/controller/slack/slack_test.go
@@ -39,7 +39,7 @@ func (s *stubSlackService) UpdateMessage(ctx context.Context, token, channelID, 
 	return nil
 }
 func (s *stubSlackService) ExchangeCode(ctx context.Context, code, redirectURI string) (string, string, string, string, error) {
-	return "", "", "", "", nil
+	return "xoxb-token", "T123", "U_BOT", "U_USER", nil
 }
 func (s *stubSlackService) VerifyRequest(r *http.Request, body []byte) error {
 	return nil
@@ -794,3 +794,65 @@ func TestOnMessageUpdated_SkippedIfDecidedInSlack(t *testing.T) {
 	}
 }
 
+func TestHandleOAuthCallback_CSRF(t *testing.T) {
+	gomockCtrl := gomock.NewController(t)
+	defer gomockCtrl.Finish()
+
+	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
+	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
+	crud := &mockCRUD{}
+	mcp := &mockMCP{}
+	stubSlack := &stubSlackService{}
+
+	tokenKey := "0123456789abcdef0123456789abcdef"
+	c := New(Params{
+		Repository: mockRepo,
+		SlackSvc:   stubSlack,
+		Crud:       crud,
+		MCPManager: mcp,
+		PubSub:     mockPubSub,
+		TokenKey:   tokenKey,
+		BaseURL:    "https://app.agentrq.com",
+	})
+
+	workspaceID62 := "0000000000g" // monoflake ID 42
+	sig := security.Sign(workspaceID62, tokenKey)
+	validState := fmt.Sprintf("%s.%s", workspaceID62, sig)
+	invalidState := workspaceID62 + ".invalid-sig"
+
+	t.Run("ValidSignature", func(t *testing.T) {
+		mockRepo.EXPECT().
+			SystemGetWorkspace(gomock.Any(), int64(42)).
+			Return(model.Workspace{ID: 42, Name: "Test WS"}, nil)
+
+		mockRepo.EXPECT().
+			GetSlackWorkspaceLink(gomock.Any(), int64(42)).
+			Return(model.SlackWorkspaceLink{}, nil)
+
+		mockRepo.EXPECT().
+			UpsertSlackWorkspaceLink(gomock.Any(), gomock.Any()).
+			Return(nil)
+
+		err := c.HandleOAuthCallback(context.Background(), validState, "code123", "https://redirect")
+		if err != nil {
+			t.Errorf("unexpected error for valid signature: %v", err)
+		}
+	})
+
+	t.Run("InvalidSignature", func(t *testing.T) {
+		err := c.HandleOAuthCallback(context.Background(), invalidState, "code123", "https://redirect")
+		if err == nil {
+			t.Error("expected error for invalid signature")
+		}
+		if !strings.Contains(err.Error(), "verification failed") {
+			t.Errorf("expected CSRF error, got %v", err)
+		}
+	})
+
+	t.Run("MalformedState", func(t *testing.T) {
+		err := c.HandleOAuthCallback(context.Background(), workspaceID62, "code123", "https://redirect")
+		if err == nil {
+			t.Error("expected error for malformed state")
+		}
+	})
+}

--- a/backend/internal/service/security/security.go
+++ b/backend/internal/service/security/security.go
@@ -3,7 +3,9 @@ package security
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
@@ -91,4 +93,17 @@ func GenerateSecret(n int) (string, error) {
 // It wraps crypto/subtle.ConstantTimeCompare to mitigate timing attacks.
 func SecureCompare(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+// Sign generates an HMAC-SHA256 signature for the given data using the provided key.
+func Sign(data, key string) string {
+	h := hmac.New(sha256.New, []byte(key))
+	h.Write([]byte(data))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// Verify validates an HMAC-SHA256 signature for the given data using the provided key.
+func Verify(data, signature, key string) bool {
+	expected := Sign(data, key)
+	return SecureCompare(signature, expected)
 }

--- a/backend/internal/service/security/security_test.go
+++ b/backend/internal/service/security/security_test.go
@@ -89,4 +89,28 @@ func TestSecurity(t *testing.T) {
 			t.Error("expected true for empty strings")
 		}
 	})
+
+	t.Run("SignVerify", func(t *testing.T) {
+		data := "some data to sign"
+		sig := Sign(data, key)
+		if sig == "" {
+			t.Fatal("empty signature")
+		}
+
+		if !Verify(data, sig, key) {
+			t.Error("verification failed for valid signature")
+		}
+
+		if Verify(data, "invalid sig", key) {
+			t.Error("verification succeeded for invalid signature")
+		}
+
+		if Verify("different data", sig, key) {
+			t.Error("verification succeeded for different data")
+		}
+
+		if Verify(data, sig, "different key") {
+			t.Error("verification succeeded for different key")
+		}
+	})
 }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Harden Slack OAuth flow against CSRF

This change implements CSRF protection for the Slack OAuth v2 flow by cryptographically signing the 'state' parameter.

Vulnerability:
The Slack OAuth flow previously used a predictable 'state' parameter (the workspace ID), which allowed for CSRF attacks. An attacker could potentially force a user to authorize a Slack workspace for a different AgentRQ workspace.

Fix:
- Added `Sign` and `Verify` helpers to the security service using HMAC-SHA256.
- Updated `GetWorkspaceSlackConfig` to generate a signed state: `workspaceID.signature`.
- Updated `HandleOAuthCallback` to verify the signature before exchanging the code.
- Added comprehensive unit tests for the new security functions and CSRF protection in the Slack controller.

Verification:
- Added `TestHandleOAuthCallback_CSRF` in `slack_test.go`.
- Added `SignVerify` tests in `security_test.go`.
- Ran all backend tests (`go test ./...`) and they passed.

---
*PR created automatically by Jules for task [18101080904931490110](https://jules.google.com/task/18101080904931490110) started by @mustafaturan*