### PR TITLE
🛡️ Sentinel: Harden Slack OAuth CSRF protection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** The `ResizeBase64` service returned the original input string if the `data:image/` prefix was missing. The CRUD controller then stored this unsanitized string in the database. Since the frontend rendered some icons using `v-html`, this allowed for Stored XSS (e.g., using `javascript:` or malicious SVG).
 **Learning:** Fallback mechanisms that return unvalidated user input when processing fails are dangerous. If a service is designed to process/sanitize input, it must fail explicitly if the input doesn't meet the expected format.
 **Prevention:** Enforce strict input validation (e.g., prefix checks) and remove "fallback to original" logic in data processing services. Ensure that only successfully processed and sanitized data reaches the persistence layer.
+
+## 2026-06-08 - Slack OAuth CSRF via Unsigned State
+**Vulnerability:** The Slack OAuth flow used a plain base62 workspace ID as the `state` parameter. This allowed an attacker to initiate an OAuth flow and swap the `state` to link their authorization to a victim's workspace (CSRF).
+**Learning:** OAuth `state` parameters must be cryptographically bound to the session or signed by the server to prevent cross-site request forgery. Even if the parameter contains a resource ID, it is not inherently secure without a signature or nonce.
+**Prevention:** Always sign the `state` parameter using a server-side secret (e.g., HMAC-SHA256) or use a per-session random nonce stored in a secure cookie to verify the authenticity of the OAuth callback.

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -65,7 +65,7 @@ type Controller interface {
 	GetWorkspaceSlackConfig(ctx context.Context, workspaceID int64) (*entity.SlackConfig, error)
 
 	// OAuth callback
-	HandleOAuthCallback(ctx context.Context, workspaceID62 string, code string, redirectURI string) error
+	HandleOAuthCallback(ctx context.Context, state string, code string, redirectURI string) (string, error)
 
 	// Inbound Slack events
 	HandleSlackEvent(ctx context.Context, payload SlackEventPayload) error
@@ -369,12 +369,15 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 	installed := err == nil && link.AccessToken != ""
 
 	workspaceID62 := monoflake.ID(workspaceID).String()
+	// Situational security: sign the state parameter to prevent CSRF
+	signedState := security.Sign(workspaceID62, c.tokenKey)
+
 	redirectURI := fmt.Sprintf("%s/slack/oauth/callback", c.baseURL)
 	authURL := fmt.Sprintf(
 		"https://slack.com/oauth/v2/authorize?client_id=%s&scope=groups:write,groups:read,chat:write,app_mentions:read,commands&redirect_uri=%s&state=%s",
 		c.slack.ClientID(),
 		url.QueryEscape(redirectURI),
-		workspaceID62,
+		url.QueryEscape(signedState),
 	)
 
 	cfg := &entity.SlackConfig{
@@ -395,25 +398,31 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 // HandleOAuthCallback handles the dynamic Slack OAuth v2 redirect code exchange.
 // It exchanges the temporary code, encrypts the access token, auto-provisions a private channel,
 // and saves the credentials into GORM.
-func (c *controller) HandleOAuthCallback(ctx context.Context, workspaceID62 string, code string, redirectURI string) error {
+func (c *controller) HandleOAuthCallback(ctx context.Context, state string, code string, redirectURI string) (string, error) {
+	// Situational security: verify the state parameter to prevent CSRF
+	workspaceID62, ok := security.Verify(state, c.tokenKey)
+	if !ok {
+		return "", fmt.Errorf("slack: invalid or tampered state parameter (CSRF detected)")
+	}
+
 	workspaceID := monoflake.IDFromBase62(workspaceID62).Int64()
 	if workspaceID == 0 {
-		return fmt.Errorf("slack: invalid workspace ID state: %s", workspaceID62)
+		return "", fmt.Errorf("slack: invalid workspace ID in state: %s", workspaceID62)
 	}
 
 	ws, err := c.repo.SystemGetWorkspace(ctx, workspaceID)
 	if err != nil {
-		return fmt.Errorf("slack: workspace not found: %w", err)
+		return "", fmt.Errorf("slack: workspace not found: %w", err)
 	}
 
 	token, teamID, botUserID, authedUserID, err := c.slack.ExchangeCode(ctx, code, redirectURI)
 	if err != nil {
-		return fmt.Errorf("slack: oauth exchange failed: %w", err)
+		return "", fmt.Errorf("slack: oauth exchange failed: %w", err)
 	}
 
 	encToken, nonce, err := security.Encrypt(token, c.tokenKey)
 	if err != nil {
-		return fmt.Errorf("slack: failed to encrypt token: %w", err)
+		return "", fmt.Errorf("slack: failed to encrypt token: %w", err)
 	}
 
 	// Resolve existing link to preserve manual channel configurations if any
@@ -432,7 +441,7 @@ func (c *controller) HandleOAuthCallback(ctx context.Context, workspaceID62 stri
 		channelName := slacksvc.BuildChannelNameFromWorkspace(ws.Name, workspaceID)
 		channelID, err := c.slack.CreatePrivateChannel(ctx, token, channelName)
 		if err != nil {
-			return fmt.Errorf("slack: failed to auto-provision channel: %w", err)
+			return "", fmt.Errorf("slack: failed to auto-provision channel: %w", err)
 		}
 		link.SlackChannelID = channelID
 		link.SlackChannelName = channelName
@@ -447,11 +456,11 @@ func (c *controller) HandleOAuthCallback(ctx context.Context, workspaceID62 stri
 	}
 
 	if err := c.repo.UpsertSlackWorkspaceLink(ctx, link); err != nil {
-		return fmt.Errorf("slack: failed to save workspace link: %w", err)
+		return "", fmt.Errorf("slack: failed to save workspace link: %w", err)
 	}
 
 	zlog.Info().Int64("workspaceID", workspaceID).Str("channel", link.SlackChannelName).Msg("[slack] successfully completed dynamic multi-tenant installation")
-	return nil
+	return workspaceID62, nil
 }
 
 // ─── Inbound Slack events ──────────────────────────────────────────────────────

--- a/backend/internal/controller/slack/slack_test.go
+++ b/backend/internal/controller/slack/slack_test.go
@@ -15,6 +15,7 @@ import (
 	mock_repo "github.com/agentrq/agentrq/backend/internal/service/mocks/repository"
 	"github.com/agentrq/agentrq/backend/internal/service/security"
 	"github.com/golang/mock/gomock"
+	"github.com/mustafaturan/monoflake"
 	slackapi "github.com/slack-go/slack"
 )
 
@@ -39,7 +40,7 @@ func (s *stubSlackService) UpdateMessage(ctx context.Context, token, channelID, 
 	return nil
 }
 func (s *stubSlackService) ExchangeCode(ctx context.Context, code, redirectURI string) (string, string, string, string, error) {
-	return "", "", "", "", nil
+	return "xoxb-test-token", "T123", "U_BOT", "U_INSTALLER", nil
 }
 func (s *stubSlackService) VerifyRequest(r *http.Request, body []byte) error {
 	return nil
@@ -742,6 +743,83 @@ func TestOnMessageUpdated_Success(t *testing.T) {
 	}
 	if stubSlack.capturedTS != "12345678.90" {
 		t.Errorf("expected message ts '12345678.90', got %q", stubSlack.capturedTS)
+	}
+}
+
+func TestHandleOAuthCallback_CSRF(t *testing.T) {
+	gomockCtrl := gomock.NewController(t)
+	defer gomockCtrl.Finish()
+
+	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
+	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
+	c := New(Params{
+		Repository: mockRepo,
+		SlackSvc:   &stubSlackService{},
+		Crud:       &mockCRUD{},
+		MCPManager: &mockMCP{},
+		PubSub:     mockPubSub,
+		TokenKey:   "secret-key-1234567890123456789012",
+	})
+
+	// Case 1: No signature
+	_, err := c.HandleOAuthCallback(context.Background(), "workspace123", "code", "uri")
+	if err == nil || !strings.Contains(err.Error(), "CSRF") {
+		t.Errorf("expected CSRF error for unsigned state, got %v", err)
+	}
+
+	// Case 2: Invalid signature
+	_, err = c.HandleOAuthCallback(context.Background(), "workspace123.invalidsig", "code", "uri")
+	if err == nil || !strings.Contains(err.Error(), "CSRF") {
+		t.Errorf("expected CSRF error for invalid signature, got %v", err)
+	}
+}
+
+func TestHandleOAuthCallback_Success(t *testing.T) {
+	gomockCtrl := gomock.NewController(t)
+	defer gomockCtrl.Finish()
+
+	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
+	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
+	tokenKey := "12345678901234567890123456789012"
+	c := New(Params{
+		Repository: mockRepo,
+		SlackSvc:   &stubSlackService{},
+		Crud:       &mockCRUD{},
+		MCPManager: &mockMCP{},
+		PubSub:     mockPubSub,
+		TokenKey:   tokenKey,
+	})
+
+	workspaceID := int64(12345)
+	workspaceID62 := monoflake.ID(workspaceID).String()
+	state := security.Sign(workspaceID62, tokenKey)
+
+	mockRepo.EXPECT().
+		SystemGetWorkspace(gomock.Any(), workspaceID).
+		Return(model.Workspace{ID: workspaceID, Name: "Test Workspace"}, nil)
+
+	mockRepo.EXPECT().
+		GetSlackWorkspaceLink(gomock.Any(), workspaceID).
+		Return(model.SlackWorkspaceLink{}, fmt.Errorf("not found"))
+
+	mockRepo.EXPECT().
+		UpsertSlackWorkspaceLink(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, link model.SlackWorkspaceLink) error {
+			if link.WorkspaceID != workspaceID {
+				t.Errorf("expected workspace ID %d, got %d", workspaceID, link.WorkspaceID)
+			}
+			if link.AccessToken == "" {
+				t.Error("expected encrypted access token")
+			}
+			return nil
+		})
+
+	verifiedID, err := c.HandleOAuthCallback(context.Background(), state, "code", "uri")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if verifiedID != workspaceID62 {
+		t.Errorf("expected verified ID %s, got %s", workspaceID62, verifiedID)
 	}
 }
 

--- a/backend/internal/handler/slack/slack.go
+++ b/backend/internal/handler/slack/slack.go
@@ -191,17 +191,24 @@ func oauthCallbackHandler(svc slacksvc.Service, ctrl slackctrl.Controller, baseU
 		}
 
 		redirectURI := fmt.Sprintf("%s/slack/oauth/callback", baseURL)
-		err := ctrl.HandleOAuthCallback(r.Context(), state, code, redirectURI)
+		workspaceID62, err := ctrl.HandleOAuthCallback(r.Context(), state, code, redirectURI)
 		if err != nil {
 			zlog.Error().Err(err).Msg("[slack/oauth] HandleOAuthCallback error")
 			// Redirect back with a generic error query param to prevent information leakage
 			errorMsg := url.QueryEscape("failed to complete slack authorization")
-			http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack&slack_error=%s", baseURL, state, errorMsg), http.StatusTemporaryRedirect)
+
+			// Try to use the state if it looks like a workspace ID for the redirect, otherwise use a safe fallback
+			redirectWorkspaceID := state
+			if parts := strings.Split(state, "."); len(parts) > 0 {
+				redirectWorkspaceID = parts[0]
+			}
+
+			http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack&slack_error=%s", baseURL, redirectWorkspaceID, errorMsg), http.StatusTemporaryRedirect)
 			return
 		}
 
 		// Redirect back to settings page on success
-		http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack", baseURL, state), http.StatusTemporaryRedirect)
+		http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack", baseURL, workspaceID62), http.StatusTemporaryRedirect)
 	})
 }
 

--- a/backend/internal/service/security/security.go
+++ b/backend/internal/service/security/security.go
@@ -3,12 +3,15 @@ package security
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
 	"io"
 	"math/big"
+	"strings"
 )
 
 // Encrypt encrypts a plain text string using AES-256 GCM with the provided key.
@@ -91,4 +94,34 @@ func GenerateSecret(n int) (string, error) {
 // It wraps crypto/subtle.ConstantTimeCompare to mitigate timing attacks.
 func SecureCompare(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+// Sign signs the data with the provided key using HMAC-SHA256 and returns a "data.signature" string.
+func Sign(data, key string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(data))
+	signature := hex.EncodeToString(mac.Sum(nil))
+	return fmt.Sprintf("%s.%s", data, signature)
+}
+
+// Verify verifies the signature of a "data.signature" string and returns the original data if valid.
+func Verify(signedData, key string) (string, bool) {
+	parts := strings.Split(signedData, ".")
+	if len(parts) != 2 {
+		return "", false
+	}
+	data, signatureHex := parts[0], parts[1]
+	signature, err := hex.DecodeString(signatureHex)
+	if err != nil {
+		return "", false
+	}
+
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(data))
+	expectedMAC := mac.Sum(nil)
+
+	if !hmac.Equal(signature, expectedMAC) {
+		return "", false
+	}
+	return data, true
 }

--- a/backend/internal/service/security/security_test.go
+++ b/backend/internal/service/security/security_test.go
@@ -89,4 +89,42 @@ func TestSecurity(t *testing.T) {
 			t.Error("expected true for empty strings")
 		}
 	})
+
+	t.Run("SignVerify", func(t *testing.T) {
+		data := "workspace123"
+		key := "secret-key"
+		signed := Sign(data, key)
+
+		if !strings.HasPrefix(signed, data+".") {
+			t.Errorf("expected signed string to start with data, got %s", signed)
+		}
+
+		verified, ok := Verify(signed, key)
+		if !ok {
+			t.Fatal("expected verification to succeed")
+		}
+		if verified != data {
+			t.Errorf("expected verified data %s, got %s", data, verified)
+		}
+
+		// Tamper data
+		if _, ok := Verify("tampered."+strings.Split(signed, ".")[1], key); ok {
+			t.Error("expected verification to fail for tampered data")
+		}
+
+		// Tamper signature
+		if _, ok := Verify(data+".tampered", key); ok {
+			t.Error("expected verification to fail for tampered signature")
+		}
+
+		// Wrong key
+		if _, ok := Verify(signed, "wrong-key"); ok {
+			t.Error("expected verification to fail for wrong key")
+		}
+
+		// Invalid format
+		if _, ok := Verify("no-dot", key); ok {
+			t.Error("expected verification to fail for invalid format")
+		}
+	})
 }


### PR DESCRIPTION
Hardened the Slack OAuth flow against CSRF vulnerabilities by signing the `state` parameter with HMAC-SHA256 and verifying it upon callback. Added regression tests and utility helpers.

---
*PR created automatically by Jules for task [8069356768445923547](https://jules.google.com/task/8069356768445923547) started by @mustafaturan*