### PR TITLE
🛡️ Sentinel: Fix CSRF vulnerability in Slack OAuth flow

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** The `ResizeBase64` service returned the original input string if the `data:image/` prefix was missing. The CRUD controller then stored this unsanitized string in the database. Since the frontend rendered some icons using `v-html`, this allowed for Stored XSS (e.g., using `javascript:` or malicious SVG).
 **Learning:** Fallback mechanisms that return unvalidated user input when processing fails are dangerous. If a service is designed to process/sanitize input, it must fail explicitly if the input doesn't meet the expected format.
 **Prevention:** Enforce strict input validation (e.g., prefix checks) and remove "fallback to original" logic in data processing services. Ensure that only successfully processed and sanitized data reaches the persistence layer.
+
+## 2024-05-23 - CSRF in Slack OAuth Flow
+**Vulnerability:** The Slack OAuth flow used a predictable `state` parameter (the plain workspace ID), allowing an attacker to initiate the flow and potentially link their own Slack workspace to a user's AgentRQ workspace.
+**Learning:** OAuth `state` parameters must be cryptographically bound to the session or signed to prevent CSRF. In a stateless environment, signing the state with a server-side secret is an effective mitigation.
+**Prevention:** Always sign the `state` parameter in OAuth flows. Use HMAC-SHA256 and verify the signature upon callback before exchanging the authorization code.

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -65,7 +65,7 @@ type Controller interface {
 	GetWorkspaceSlackConfig(ctx context.Context, workspaceID int64) (*entity.SlackConfig, error)
 
 	// OAuth callback
-	HandleOAuthCallback(ctx context.Context, workspaceID62 string, code string, redirectURI string) error
+	HandleOAuthCallback(ctx context.Context, state string, code string, redirectURI string) (string, error)
 
 	// Inbound Slack events
 	HandleSlackEvent(ctx context.Context, payload SlackEventPayload) error
@@ -369,12 +369,16 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 	installed := err == nil && link.AccessToken != ""
 
 	workspaceID62 := monoflake.ID(workspaceID).String()
+	// CSRF Protection: Sign the workspaceID62 to use as OAuth state
+	signature := security.Sign(workspaceID62, c.tokenKey)
+	state := fmt.Sprintf("%s.%s", workspaceID62, signature)
+
 	redirectURI := fmt.Sprintf("%s/slack/oauth/callback", c.baseURL)
 	authURL := fmt.Sprintf(
 		"https://slack.com/oauth/v2/authorize?client_id=%s&scope=groups:write,groups:read,chat:write,app_mentions:read,commands&redirect_uri=%s&state=%s",
 		c.slack.ClientID(),
 		url.QueryEscape(redirectURI),
-		workspaceID62,
+		state,
 	)
 
 	cfg := &entity.SlackConfig{
@@ -395,25 +399,36 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 // HandleOAuthCallback handles the dynamic Slack OAuth v2 redirect code exchange.
 // It exchanges the temporary code, encrypts the access token, auto-provisions a private channel,
 // and saves the credentials into GORM.
-func (c *controller) HandleOAuthCallback(ctx context.Context, workspaceID62 string, code string, redirectURI string) error {
+func (c *controller) HandleOAuthCallback(ctx context.Context, state string, code string, redirectURI string) (string, error) {
+	parts := strings.Split(state, ".")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("slack: invalid oauth state format")
+	}
+	workspaceID62, signature := parts[0], parts[1]
+
+	// CSRF Protection: Verify state signature
+	if !security.Verify(workspaceID62, signature, c.tokenKey) {
+		return "", fmt.Errorf("slack: invalid oauth state signature (CSRF detected)")
+	}
+
 	workspaceID := monoflake.IDFromBase62(workspaceID62).Int64()
 	if workspaceID == 0 {
-		return fmt.Errorf("slack: invalid workspace ID state: %s", workspaceID62)
+		return "", fmt.Errorf("slack: invalid workspace ID state: %s", workspaceID62)
 	}
 
 	ws, err := c.repo.SystemGetWorkspace(ctx, workspaceID)
 	if err != nil {
-		return fmt.Errorf("slack: workspace not found: %w", err)
+		return "", fmt.Errorf("slack: workspace not found: %w", err)
 	}
 
 	token, teamID, botUserID, authedUserID, err := c.slack.ExchangeCode(ctx, code, redirectURI)
 	if err != nil {
-		return fmt.Errorf("slack: oauth exchange failed: %w", err)
+		return "", fmt.Errorf("slack: oauth exchange failed: %w", err)
 	}
 
 	encToken, nonce, err := security.Encrypt(token, c.tokenKey)
 	if err != nil {
-		return fmt.Errorf("slack: failed to encrypt token: %w", err)
+		return "", fmt.Errorf("slack: failed to encrypt token: %w", err)
 	}
 
 	// Resolve existing link to preserve manual channel configurations if any
@@ -432,7 +447,7 @@ func (c *controller) HandleOAuthCallback(ctx context.Context, workspaceID62 stri
 		channelName := slacksvc.BuildChannelNameFromWorkspace(ws.Name, workspaceID)
 		channelID, err := c.slack.CreatePrivateChannel(ctx, token, channelName)
 		if err != nil {
-			return fmt.Errorf("slack: failed to auto-provision channel: %w", err)
+			return "", fmt.Errorf("slack: failed to auto-provision channel: %w", err)
 		}
 		link.SlackChannelID = channelID
 		link.SlackChannelName = channelName
@@ -447,11 +462,11 @@ func (c *controller) HandleOAuthCallback(ctx context.Context, workspaceID62 stri
 	}
 
 	if err := c.repo.UpsertSlackWorkspaceLink(ctx, link); err != nil {
-		return fmt.Errorf("slack: failed to save workspace link: %w", err)
+		return "", fmt.Errorf("slack: failed to save workspace link: %w", err)
 	}
 
 	zlog.Info().Int64("workspaceID", workspaceID).Str("channel", link.SlackChannelName).Msg("[slack] successfully completed dynamic multi-tenant installation")
-	return nil
+	return workspaceID62, nil
 }
 
 // ─── Inbound Slack events ──────────────────────────────────────────────────────

--- a/backend/internal/handler/slack/slack.go
+++ b/backend/internal/handler/slack/slack.go
@@ -191,17 +191,21 @@ func oauthCallbackHandler(svc slacksvc.Service, ctrl slackctrl.Controller, baseU
 		}
 
 		redirectURI := fmt.Sprintf("%s/slack/oauth/callback", baseURL)
-		err := ctrl.HandleOAuthCallback(r.Context(), state, code, redirectURI)
+		verifiedWorkspaceID62, err := ctrl.HandleOAuthCallback(r.Context(), state, code, redirectURI)
 		if err != nil {
 			zlog.Error().Err(err).Msg("[slack/oauth] HandleOAuthCallback error")
+
+			// Fallback: extract workspaceID from state prefix for redirect, even if signature fails
+			workspaceID62 := strings.Split(state, ".")[0]
+
 			// Redirect back with a generic error query param to prevent information leakage
 			errorMsg := url.QueryEscape("failed to complete slack authorization")
-			http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack&slack_error=%s", baseURL, state, errorMsg), http.StatusTemporaryRedirect)
+			http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack&slack_error=%s", baseURL, workspaceID62, errorMsg), http.StatusTemporaryRedirect)
 			return
 		}
 
 		// Redirect back to settings page on success
-		http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack", baseURL, state), http.StatusTemporaryRedirect)
+		http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack", baseURL, verifiedWorkspaceID62), http.StatusTemporaryRedirect)
 	})
 }
 

--- a/backend/internal/service/security/security.go
+++ b/backend/internal/service/security/security.go
@@ -3,7 +3,9 @@ package security
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
@@ -91,4 +93,18 @@ func GenerateSecret(n int) (string, error) {
 // It wraps crypto/subtle.ConstantTimeCompare to mitigate timing attacks.
 func SecureCompare(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+// Sign generates an HMAC-SHA256 signature for a message using the provided key.
+// It returns the hex-encoded signature.
+func Sign(message, key string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(message))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// Verify validates an HMAC-SHA256 signature for a message using the provided key.
+func Verify(message, signature, key string) bool {
+	expected := Sign(message, key)
+	return SecureCompare(signature, expected)
 }

--- a/backend/internal/service/security/security_test.go
+++ b/backend/internal/service/security/security_test.go
@@ -89,4 +89,29 @@ func TestSecurity(t *testing.T) {
 			t.Error("expected true for empty strings")
 		}
 	})
+
+	t.Run("SignVerify", func(t *testing.T) {
+		message := "test message"
+		key := "test key"
+		sig := Sign(message, key)
+		if sig == "" {
+			t.Fatal("empty signature")
+		}
+
+		if !Verify(message, sig, key) {
+			t.Error("expected signature to be valid")
+		}
+
+		if Verify(message+" modified", sig, key) {
+			t.Error("expected signature to be invalid for modified message")
+		}
+
+		if Verify(message, sig, key+" modified") {
+			t.Error("expected signature to be invalid for different key")
+		}
+
+		if Verify(message, "invalid signature", key) {
+			t.Error("expected signature to be invalid for random signature string")
+		}
+	})
 }


### PR DESCRIPTION
### 🛡️ Sentinel: Fix CSRF vulnerability in Slack OAuth flow

🚨 **Severity:** HIGH

💡 **Vulnerability:**
The Slack OAuth2 flow lacked CSRF protection for the `state` parameter. The application used the plain base62 `workspaceID` as the state. An attacker could initiate an OAuth flow with their own Slack account and a victim's `workspaceID`, and if the victim clicked the link, they could inadvertently authorize the attacker's Slack workspace to their AgentRQ workspace.

🎯 **Impact:**
An attacker could gain access to a user's AgentRQ workspace tasks and messages via their own Slack workspace, or vice-versa, potentially leading to data exfiltration or unauthorized task execution.

🔧 **Fix:**
Implemented a signed `state` parameter using HMAC-SHA256.
1.  The `workspaceID` is now signed with the server's `tokenKey`.
2.  The `state` is sent as `workspaceID.signature`.
3.  Upon callback, the signature is verified using constant-time comparison.
4.  The authorization code exchange only proceeds if the signature is valid.

✅ **Verification:**
- Added unit tests for `Sign` and `Verify` in `security_test.go`.
- Verified that all Slack controller tests pass.
- Manually verified the fix with a temporary test case that confirmed rejection of invalid signatures and malformed state strings.
- Updated `.jules/sentinel.md` with the new learning.

---
*PR created automatically by Jules for task [13608545762696691286](https://jules.google.com/task/13608545762696691286) started by @mustafaturan*