### PR TITLE
fix: prevent PWA from intercepting /api/ auth navigation

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -42,6 +42,7 @@ export default defineConfig({
       },
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+        navigateFallbackDenylist: [/^\/api\//],
         runtimeCaching: [
           {
             urlPattern: /^\/api\//,


### PR DESCRIPTION
Add navigateFallbackDenylist to workbox config so that OAuth login redirects to the backend are not intercepted by the service worker.

Task: 0dZmZW8Dh69