### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF in Slack OAuth flow

### DIFF
--- a/backend/internal/controller/slack/csrf_test.go
+++ b/backend/internal/controller/slack/csrf_test.go
@@ -1,0 +1,61 @@
+package slack
+
+import (
+	"context"
+	"testing"
+	"fmt"
+
+	"github.com/agentrq/agentrq/backend/internal/service/security"
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	mock_repo "github.com/agentrq/agentrq/backend/internal/service/mocks/repository"
+	"github.com/golang/mock/gomock"
+)
+
+func TestHandleOAuthCallback_CSRFProtection(t *testing.T) {
+	gomockCtrl := gomock.NewController(t)
+	defer gomockCtrl.Finish()
+
+	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
+	tokenKey := "0123456789abcdef0123456789abcdef"
+	c := &controller{
+		tokenKey: tokenKey,
+		repo: mockRepo,
+	}
+
+	workspaceID62 := "test-workspace"
+	validSignature := security.Sign(workspaceID62, tokenKey)
+	validState := workspaceID62 + "." + validSignature
+
+	t.Run("ValidSignature", func(t *testing.T) {
+		// Valid signature reaches the repo call
+		mockRepo.EXPECT().SystemGetWorkspace(gomock.Any(), gomock.Any()).Return(model.Workspace{}, fmt.Errorf("next step")).AnyTimes()
+		err := c.HandleOAuthCallback(context.Background(), validState, "code", "redirect")
+		if err != nil && err.Error() == "slack: invalid state signature (CSRF suspected)" {
+			t.Errorf("expected signature to be valid, but got CSRF error")
+		}
+	})
+
+	t.Run("InvalidSignature", func(t *testing.T) {
+		invalidState := workspaceID62 + ".invalid-sig"
+		err := c.HandleOAuthCallback(context.Background(), invalidState, "code", "redirect")
+		if err == nil || err.Error() != "slack: invalid state signature (CSRF suspected)" {
+			t.Errorf("expected CSRF error for invalid signature, got %v", err)
+		}
+	})
+
+	t.Run("MissingSignature", func(t *testing.T) {
+		invalidState := workspaceID62
+		err := c.HandleOAuthCallback(context.Background(), invalidState, "code", "redirect")
+		if err == nil || err.Error() != "slack: invalid state parameter format" {
+			t.Errorf("expected format error for missing signature, got %v", err)
+		}
+	})
+
+	t.Run("TamperedMessage", func(t *testing.T) {
+		tamperedState := "other-workspace." + validSignature
+		err := c.HandleOAuthCallback(context.Background(), tamperedState, "code", "redirect")
+		if err == nil || err.Error() != "slack: invalid state signature (CSRF suspected)" {
+			t.Errorf("expected CSRF error for tampered message, got %v", err)
+		}
+	})
+}

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -65,7 +65,7 @@ type Controller interface {
 	GetWorkspaceSlackConfig(ctx context.Context, workspaceID int64) (*entity.SlackConfig, error)
 
 	// OAuth callback
-	HandleOAuthCallback(ctx context.Context, workspaceID62 string, code string, redirectURI string) error
+	HandleOAuthCallback(ctx context.Context, state string, code string, redirectURI string) error
 
 	// Inbound Slack events
 	HandleSlackEvent(ctx context.Context, payload SlackEventPayload) error
@@ -369,12 +369,16 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 	installed := err == nil && link.AccessToken != ""
 
 	workspaceID62 := monoflake.ID(workspaceID).String()
+	// Situational security: sign the state parameter to prevent CSRF during OAuth callback
+	signature := security.Sign(workspaceID62, c.tokenKey)
+	state := fmt.Sprintf("%s.%s", workspaceID62, signature)
+
 	redirectURI := fmt.Sprintf("%s/slack/oauth/callback", c.baseURL)
 	authURL := fmt.Sprintf(
 		"https://slack.com/oauth/v2/authorize?client_id=%s&scope=groups:write,groups:read,chat:write,app_mentions:read,commands&redirect_uri=%s&state=%s",
 		c.slack.ClientID(),
 		url.QueryEscape(redirectURI),
-		workspaceID62,
+		url.QueryEscape(state),
 	)
 
 	cfg := &entity.SlackConfig{
@@ -395,7 +399,18 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 // HandleOAuthCallback handles the dynamic Slack OAuth v2 redirect code exchange.
 // It exchanges the temporary code, encrypts the access token, auto-provisions a private channel,
 // and saves the credentials into GORM.
-func (c *controller) HandleOAuthCallback(ctx context.Context, workspaceID62 string, code string, redirectURI string) error {
+func (c *controller) HandleOAuthCallback(ctx context.Context, state string, code string, redirectURI string) error {
+	parts := strings.SplitN(state, ".", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("slack: invalid state parameter format")
+	}
+	workspaceID62, signature := parts[0], parts[1]
+
+	// Situational security: verify signature to prevent CSRF
+	if !security.Verify(workspaceID62, signature, c.tokenKey) {
+		return fmt.Errorf("slack: invalid state signature (CSRF suspected)")
+	}
+
 	workspaceID := monoflake.IDFromBase62(workspaceID62).Int64()
 	if workspaceID == 0 {
 		return fmt.Errorf("slack: invalid workspace ID state: %s", workspaceID62)

--- a/backend/internal/handler/slack/slack.go
+++ b/backend/internal/handler/slack/slack.go
@@ -192,16 +192,20 @@ func oauthCallbackHandler(svc slacksvc.Service, ctrl slackctrl.Controller, baseU
 
 		redirectURI := fmt.Sprintf("%s/slack/oauth/callback", baseURL)
 		err := ctrl.HandleOAuthCallback(r.Context(), state, code, redirectURI)
+
+		// Extract workspaceID for redirect (even if state signature fails, we try to get the prefix for UI routing)
+		workspaceID62 := strings.SplitN(state, ".", 2)[0]
+
 		if err != nil {
 			zlog.Error().Err(err).Msg("[slack/oauth] HandleOAuthCallback error")
 			// Redirect back with a generic error query param to prevent information leakage
 			errorMsg := url.QueryEscape("failed to complete slack authorization")
-			http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack&slack_error=%s", baseURL, state, errorMsg), http.StatusTemporaryRedirect)
+			http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack&slack_error=%s", baseURL, workspaceID62, errorMsg), http.StatusTemporaryRedirect)
 			return
 		}
 
 		// Redirect back to settings page on success
-		http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack", baseURL, state), http.StatusTemporaryRedirect)
+		http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack", baseURL, workspaceID62), http.StatusTemporaryRedirect)
 	})
 }
 

--- a/backend/internal/service/security/security.go
+++ b/backend/internal/service/security/security.go
@@ -3,7 +3,9 @@ package security
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
@@ -91,4 +93,18 @@ func GenerateSecret(n int) (string, error) {
 // It wraps crypto/subtle.ConstantTimeCompare to mitigate timing attacks.
 func SecureCompare(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+// Sign generates an HMAC-SHA256 signature for a message using the provided key.
+func Sign(message, key string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(message))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// Verify validates an HMAC-SHA256 signature for a message using the provided key.
+// It uses SecureCompare to prevent timing attacks.
+func Verify(message, signature, key string) bool {
+	expectedSignature := Sign(message, key)
+	return SecureCompare(expectedSignature, signature)
 }

--- a/backend/internal/service/security/security_test.go
+++ b/backend/internal/service/security/security_test.go
@@ -89,4 +89,30 @@ func TestSecurity(t *testing.T) {
 			t.Error("expected true for empty strings")
 		}
 	})
+
+	t.Run("SignVerify", func(t *testing.T) {
+		message := "test-message"
+		key := "secret-key"
+		signature := Sign(message, key)
+
+		if signature == "" {
+			t.Fatal("empty signature")
+		}
+
+		if !Verify(message, signature, key) {
+			t.Error("failed to verify valid signature")
+		}
+
+		if Verify(message, "invalid-signature", key) {
+			t.Error("verified invalid signature")
+		}
+
+		if Verify("different-message", signature, key) {
+			t.Error("verified signature for different message")
+		}
+
+		if Verify(message, signature, "different-key") {
+			t.Error("verified signature with different key")
+		}
+	})
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Potential CSRF in Slack OAuth callback flow. The 'state' parameter was used without cryptographic verification.
🎯 Impact: An attacker could potentially forge OAuth callbacks, leading to unauthorized workspace linking.
🔧 Fix: Added 'Sign' and 'Verify' HMAC-SHA256 helpers. Signed the 'state' parameter as 'workspaceID62.signature' and verified it in the callback handler.
✅ Verification: Added unit tests for security helpers and a new CSRF-specific test for the Slack controller. Verified backend compilation and full test suite passing.

---
*PR created automatically by Jules for task [9394993800419648749](https://jules.google.com/task/9394993800419648749) started by @mustafaturan*