### PR TITLE
🛡️ Sentinel: [HIGH] Harden OAuth flows against CSRF

### DIFF
--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -65,7 +65,7 @@ type Controller interface {
 	GetWorkspaceSlackConfig(ctx context.Context, workspaceID int64) (*entity.SlackConfig, error)
 
 	// OAuth callback
-	HandleOAuthCallback(ctx context.Context, workspaceID62 string, code string, redirectURI string) error
+	HandleOAuthCallback(ctx context.Context, state string, code string, redirectURI string) (string, error)
 
 	// Inbound Slack events
 	HandleSlackEvent(ctx context.Context, payload SlackEventPayload) error
@@ -369,12 +369,14 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 	installed := err == nil && link.AccessToken != ""
 
 	workspaceID62 := monoflake.ID(workspaceID).String()
+	// Situational security: sign the state to prevent CSRF during OAuth flow
+	state := workspaceID62 + "." + security.Sign(workspaceID62, c.tokenKey)
 	redirectURI := fmt.Sprintf("%s/slack/oauth/callback", c.baseURL)
 	authURL := fmt.Sprintf(
 		"https://slack.com/oauth/v2/authorize?client_id=%s&scope=groups:write,groups:read,chat:write,app_mentions:read,commands&redirect_uri=%s&state=%s",
 		c.slack.ClientID(),
 		url.QueryEscape(redirectURI),
-		workspaceID62,
+		state,
 	)
 
 	cfg := &entity.SlackConfig{
@@ -395,25 +397,32 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 // HandleOAuthCallback handles the dynamic Slack OAuth v2 redirect code exchange.
 // It exchanges the temporary code, encrypts the access token, auto-provisions a private channel,
 // and saves the credentials into GORM.
-func (c *controller) HandleOAuthCallback(ctx context.Context, workspaceID62 string, code string, redirectURI string) error {
+func (c *controller) HandleOAuthCallback(ctx context.Context, state string, code string, redirectURI string) (string, error) {
+	// Situational security: verify the signed state to prevent CSRF
+	lastDot := strings.LastIndex(state, ".")
+	if lastDot == -1 || !security.Verify(state[:lastDot], state[lastDot+1:], c.tokenKey) {
+		return "", fmt.Errorf("slack: invalid oauth state signature")
+	}
+	workspaceID62 := state[:lastDot]
+
 	workspaceID := monoflake.IDFromBase62(workspaceID62).Int64()
 	if workspaceID == 0 {
-		return fmt.Errorf("slack: invalid workspace ID state: %s", workspaceID62)
+		return "", fmt.Errorf("slack: invalid workspace ID state: %s", workspaceID62)
 	}
 
 	ws, err := c.repo.SystemGetWorkspace(ctx, workspaceID)
 	if err != nil {
-		return fmt.Errorf("slack: workspace not found: %w", err)
+		return "", fmt.Errorf("slack: workspace not found: %w", err)
 	}
 
 	token, teamID, botUserID, authedUserID, err := c.slack.ExchangeCode(ctx, code, redirectURI)
 	if err != nil {
-		return fmt.Errorf("slack: oauth exchange failed: %w", err)
+		return "", fmt.Errorf("slack: oauth exchange failed: %w", err)
 	}
 
 	encToken, nonce, err := security.Encrypt(token, c.tokenKey)
 	if err != nil {
-		return fmt.Errorf("slack: failed to encrypt token: %w", err)
+		return "", fmt.Errorf("slack: failed to encrypt token: %w", err)
 	}
 
 	// Resolve existing link to preserve manual channel configurations if any
@@ -432,7 +441,7 @@ func (c *controller) HandleOAuthCallback(ctx context.Context, workspaceID62 stri
 		channelName := slacksvc.BuildChannelNameFromWorkspace(ws.Name, workspaceID)
 		channelID, err := c.slack.CreatePrivateChannel(ctx, token, channelName)
 		if err != nil {
-			return fmt.Errorf("slack: failed to auto-provision channel: %w", err)
+			return "", fmt.Errorf("slack: failed to auto-provision channel: %w", err)
 		}
 		link.SlackChannelID = channelID
 		link.SlackChannelName = channelName
@@ -447,11 +456,11 @@ func (c *controller) HandleOAuthCallback(ctx context.Context, workspaceID62 stri
 	}
 
 	if err := c.repo.UpsertSlackWorkspaceLink(ctx, link); err != nil {
-		return fmt.Errorf("slack: failed to save workspace link: %w", err)
+		return "", fmt.Errorf("slack: failed to save workspace link: %w", err)
 	}
 
 	zlog.Info().Int64("workspaceID", workspaceID).Str("channel", link.SlackChannelName).Msg("[slack] successfully completed dynamic multi-tenant installation")
-	return nil
+	return workspaceID62, nil
 }
 
 // ─── Inbound Slack events ──────────────────────────────────────────────────────

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -294,7 +294,9 @@ func (h *handler) rootLogin() fiber.Handler {
 
 func (h *handler) googleLogin() fiber.Handler {
 	return func(c *fiber.Ctx) error {
-		state := c.Query("redirect_url", "state")
+		redirectURL := c.Query("redirect_url", "state")
+		// Situational security: sign the state to prevent CSRF during Google OAuth flow
+		state := redirectURL + "." + security.Sign(redirectURL, h.tokenKey)
 		return c.Redirect(h.auth.GetAuthURL(state))
 	}
 }
@@ -302,6 +304,15 @@ func (h *handler) googleLogin() fiber.Handler {
 func (h *handler) googleCallback() fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		code := c.Query("code")
+		state := c.Query("state")
+
+		// Situational security: verify the signed state to prevent CSRF
+		lastDot := strings.LastIndex(state, ".")
+		if lastDot == -1 || !security.Verify(state[:lastDot], state[lastDot+1:], h.tokenKey) {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "invalid oauth state signature"})
+		}
+		redirectURLParam := state[:lastDot]
+
 		ctx, cancel := newContext(c)
 		defer cancel()
 
@@ -362,18 +373,17 @@ func (h *handler) googleCallback() fiber.Handler {
 		}
 		c.Cookie(cookie)
 
-		state := c.Query("state")
 		redirectURL := "/"
 		// Situational security: validate redirect URL to prevent open redirect
-		if state != "" && state != "state" {
-			if strings.HasPrefix(state, "/") && !strings.HasPrefix(state, "//") && !strings.HasPrefix(state, "/\\") {
-				redirectURL = state
+		if redirectURLParam != "" && redirectURLParam != "state" {
+			if strings.HasPrefix(redirectURLParam, "/") && !strings.HasPrefix(redirectURLParam, "//") && !strings.HasPrefix(redirectURLParam, "/\\") {
+				redirectURL = redirectURLParam
 			} else {
 				// Parse absolute URL and validate against baseURL
-				if pRedirect, err := url.Parse(state); err == nil && pRedirect.IsAbs() {
+				if pRedirect, err := url.Parse(redirectURLParam); err == nil && pRedirect.IsAbs() {
 					if pBase, err := url.Parse(h.baseURL); err == nil {
 						if pRedirect.Host == pBase.Host && pRedirect.Scheme == pBase.Scheme {
-							redirectURL = state
+							redirectURL = redirectURLParam
 						}
 					}
 				}

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -11,6 +11,7 @@ import (
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	"github.com/agentrq/agentrq/backend/internal/repository/base"
 	"github.com/agentrq/agentrq/backend/internal/service/auth"
+	"github.com/agentrq/agentrq/backend/internal/service/security"
 	"github.com/gofiber/fiber/v2"
 	"github.com/mustafaturan/monoflake"
 )
@@ -62,6 +63,7 @@ func TestGoogleCallback_OpenRedirectPrevention(t *testing.T) {
 		tokenSvc: tokenSvc,
 		crud:     crudCtrl,
 		baseURL:  "http://localhost:3000",
+		tokenKey: "test-token-key-32-chars-long-!!!",
 	}
 
 	app.Get("/google/callback", h.googleCallback())
@@ -112,7 +114,8 @@ func TestGoogleCallback_OpenRedirectPrevention(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state="+tt.state, nil)
+			state := tt.state + "." + security.Sign(tt.state, h.tokenKey)
+			req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state="+state, nil)
 			resp, _ := app.Test(req)
 
 			if resp.StatusCode != http.StatusFound {
@@ -124,6 +127,14 @@ func TestGoogleCallback_OpenRedirectPrevention(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("Invalid state signature", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state=invalid.sig", nil)
+		resp, _ := app.Test(req)
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("Expected status 401, got %d", resp.StatusCode)
+		}
+	})
 }
 
 type mockCrudGetWorkspace struct {

--- a/backend/internal/handler/slack/slack.go
+++ b/backend/internal/handler/slack/slack.go
@@ -191,17 +191,22 @@ func oauthCallbackHandler(svc slacksvc.Service, ctrl slackctrl.Controller, baseU
 		}
 
 		redirectURI := fmt.Sprintf("%s/slack/oauth/callback", baseURL)
-		err := ctrl.HandleOAuthCallback(r.Context(), state, code, redirectURI)
+		workspaceID62, err := ctrl.HandleOAuthCallback(r.Context(), state, code, redirectURI)
 		if err != nil {
 			zlog.Error().Err(err).Msg("[slack/oauth] HandleOAuthCallback error")
+			// Try to extract workspaceID from state for better redirect even on error
+			wsID := state
+			if lastDot := strings.LastIndex(state, "."); lastDot != -1 {
+				wsID = state[:lastDot]
+			}
 			// Redirect back with a generic error query param to prevent information leakage
 			errorMsg := url.QueryEscape("failed to complete slack authorization")
-			http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack&slack_error=%s", baseURL, state, errorMsg), http.StatusTemporaryRedirect)
+			http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack&slack_error=%s", baseURL, wsID, errorMsg), http.StatusTemporaryRedirect)
 			return
 		}
 
 		// Redirect back to settings page on success
-		http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack", baseURL, state), http.StatusTemporaryRedirect)
+		http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack", baseURL, workspaceID62), http.StatusTemporaryRedirect)
 	})
 }
 

--- a/backend/internal/service/security/security.go
+++ b/backend/internal/service/security/security.go
@@ -3,7 +3,9 @@ package security
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
@@ -91,4 +93,19 @@ func GenerateSecret(n int) (string, error) {
 // It wraps crypto/subtle.ConstantTimeCompare to mitigate timing attacks.
 func SecureCompare(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+// Sign generates a cryptographic signature for the given data using HMAC-SHA256 with the provided key.
+// The signature is returned as a hex-encoded string.
+func Sign(data, key string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(data))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// Verify validates a hex-encoded signature for the given data using HMAC-SHA256 with the provided key.
+// It returns true if the signature is valid, false otherwise.
+func Verify(data, signature, key string) bool {
+	expected := Sign(data, key)
+	return SecureCompare(signature, expected)
 }

--- a/backend/internal/service/security/security_test.go
+++ b/backend/internal/service/security/security_test.go
@@ -89,4 +89,29 @@ func TestSecurity(t *testing.T) {
 			t.Error("expected true for empty strings")
 		}
 	})
+
+	t.Run("SignVerify", func(t *testing.T) {
+		key := "signing-key"
+		data := "situational-data"
+		sig := Sign(data, key)
+		if sig == "" {
+			t.Fatal("empty signature")
+		}
+
+		if !Verify(data, sig, key) {
+			t.Error("verification failed for valid signature")
+		}
+
+		if Verify(data, "invalid-sig", key) {
+			t.Error("verification succeeded for invalid signature")
+		}
+
+		if Verify("different-data", sig, key) {
+			t.Error("verification succeeded for different data")
+		}
+
+		if Verify(data, sig, "different-key") {
+			t.Error("verification succeeded for different key")
+		}
+	})
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The application was missing CSRF protection in its OAuth flows (Google and Slack). The `state` parameter was being used only for functional purposes (workspace identification or redirection) without any cryptographic validation.
🎯 Impact: This could allow an attacker to perform Cross-Site Request Forgery (CSRF) attacks during the authentication process, potentially leading to account or workspace hijacking.
🔧 Fix: Implemented HMAC-SHA256 signing for all OAuth `state` parameters. The signature is appended to the payload (e.g., `payload.signature`). Upon callback, the signature is verified before processing the payload.
✅ Verification: 
- New unit tests in `security_test.go` verify the core cryptographic functions.
- Updated `api_test.go` confirms that the Google OAuth flow now rejects invalid state signatures while maintaining protection against open redirects.
- Manual verification of robust parsing logic to ensure URLs with dots are handled correctly.

---
*PR created automatically by Jules for task [11680660683025344381](https://jules.google.com/task/11680660683025344381) started by @mustafaturan*