### PR TITLE
fix: update PWA status bar and theme-color dynamically on dark mode t…

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,7 +10,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="AgentRQ" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#f4f4f5" />
     <meta name="mobile-web-app-capable" content="yes" />
   </head>
   <body class="bg-slate-50 text-slate-900 font-sans antialiased">

--- a/frontend/src/stores/themeStore.js
+++ b/frontend/src/stores/themeStore.js
@@ -12,12 +12,18 @@ export const useThemeStore = defineStore('theme', {
     },
     applyTheme() {
       const isDark = this.theme === 'dark' || (this.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
-      
+
       if (isDark) {
         document.documentElement.classList.add('dark')
       } else {
         document.documentElement.classList.remove('dark')
       }
+
+      const themeColorMeta = document.querySelector('meta[name="theme-color"]')
+      if (themeColorMeta) themeColorMeta.setAttribute('content', isDark ? '#09090b' : '#f4f4f5')
+
+      const statusBarMeta = document.querySelector('meta[name="apple-mobile-web-app-status-bar-style"]')
+      if (statusBarMeta) statusBarMeta.setAttribute('content', isDark ? 'black' : 'default')
     },
     init() {
       this.applyTheme()


### PR DESCRIPTION
…oggle

When switching to dark mode, the iOS PWA status bar remained white because apple-mobile-web-app-status-bar-style was always "default" and theme-color was never updated. applyTheme() now sets both meta tags to their correct dark (#09090b / black) or light (#f4f4f5 / default) values every time the theme changes or system preference changes.

Task: 0doeo7ASbbN