### PR TITLE
fix: dismiss update banner immediately on Update Now click

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -301,6 +301,7 @@ const appVersion = __APP_VERSION__
 const { needRefresh, updateServiceWorker } = useRegisterSW()
 
 const handleUpdateNow = async () => {
+  needRefresh.value = false
   await updateServiceWorker(false)
   window.location.reload()
 }


### PR DESCRIPTION
The banner stayed visible while updateServiceWorker processed because needRefresh was never set to false in handleUpdateNow. Setting it to false first makes the banner disappear the instant the user clicks.

Task: 0dongFMkqbh