### PR TITLE
chore: bump minor version to v0.2.0

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.1.3"
+	_appVersion   = "v0.2.0"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "cron-parser": "^5.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
Updates version to v0.2.0 in all locations:
- backend/internal/service/config/config.go (_appVersion)
- frontend/package.json
- frontend/package-lock.json

Changes since v0.1.3 (4 PRs):

Features
- Auto-delete attachments from local storage: daily midnight UTC cron removes files in _storage/ older than AGENTRQ_APP_ATTACHMENT_RETENTION (default 7d); *.db files are always preserved (PR #158)

Fixes
- App lifecycle context: background services stop cleanly on server exit (PR #158)
- Attachment security: enforce user workspace ownership as first check (PR #157)
- Attachment query: add workspace scope to prevent cross-workspace access (PR #157)
- Allow attachment-only messages without a text body (PR #157)
- Correct attachment metadata lookup; return 404 for missing files (PR #157)
- Body limit reverted to 4 MB (PR #157)
- Light background for human messages in light mode (PR #156)
- Dismiss update banner immediately on Update Now click (PR #154)

Task: 0dpAItMLevx