### PR TITLE
fix: always generate server-controlled monoflake ID in saveAttachments

### DIFF
--- a/backend/internal/controller/crud/task.go
+++ b/backend/internal/controller/crud/task.go
@@ -674,10 +674,10 @@ func (c *controller) GetAttachment(ctx context.Context, req entity.GetAttachment
 
 func (c *controller) saveAttachments(atts []entity.Attachment) {
 	for i := range atts {
-		if atts[i].ID == "" {
-			atts[i].ID = monoflake.ID(c.idgen.NextID()).String()
-		}
 		if atts[i].Data != "" {
+			// Always generate a server-controlled ID; never trust caller-provided IDs.
+			// This prevents slug-keyed files that break the download path.
+			atts[i].ID = monoflake.ID(c.idgen.NextID()).String()
 			_ = c.storage.Save(atts[i].ID, atts[i].Data)
 			atts[i].Data = "" // clear from metadata
 		}

--- a/backend/internal/controller/crud/task_test.go
+++ b/backend/internal/controller/crud/task_test.go
@@ -318,11 +318,12 @@ func TestRespondToTask_Allow(t *testing.T) {
 	e.repo.EXPECT().GetWorkspace(gomock.Any(), int64(1), testUserID).Return(activeWorkspace(), nil)
 	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(10), testUserID).Return(task, nil)
 	e.repo.EXPECT().ListTasks(gomock.Any(), gomock.Any(), testUserID).Return([]model.Task{task}, nil)
-	e.idgen.EXPECT().NextID().Return(int64(100))
+	e.idgen.EXPECT().NextID().Return(int64(100)) // attachment ID (always server-generated)
+	e.idgen.EXPECT().NextID().Return(int64(101)) // message ID
+	e.storage.EXPECT().Save(gomock.Any(), "data1").Return(nil)
 	e.repo.EXPECT().CreateMessage(gomock.Any(), gomock.Any()).Return(nil)
 	e.repo.EXPECT().UpdateTask(gomock.Any(), gomock.Any()).Return(updated, nil)
 	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(10), testUserID).Return(updated, nil)
-	e.storage.EXPECT().Save("att1", "data1").Return(nil)
 
 	resp, err := e.controller.RespondToTask(context.Background(), entity.RespondToTaskRequest{
 		WorkspaceID: 1, TaskID: 10, Action: "allow", UserID: testUserIDStr,


### PR DESCRIPTION
Previously, saveAttachments only generated a new ID when atts[i].ID was empty. If a caller (e.g. an agent via the MCP reply tool) provided a slug like "architecture-md", that slug was kept as the storage key. This caused downloadAttachment to fail because the UI and download path expect a proper monoflake ID.

Fix: when an attachment has data to save, always generate a fresh server-controlled monoflake ID, ignoring whatever the caller provided. Attachments with no data (existing DB references) are left unchanged.

Updated TestRespondToTask_Allow to expect two NextID calls (one for the attachment, one for the message) and Save with any ID.

Task: 0dtmz0u8xAf