### PR TITLE
fix: always regenerate attachment ID in MCP reply path

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -378,10 +378,8 @@ func New(cfg Config) (*App, error) {
 				taskID := id.Int64()
 
 				for i := range attachments {
-					if attachments[i].ID == "" {
-						attachments[i].ID = monoflake.ID(ids.NextID()).String()
-					}
 					if attachments[i].Data != "" {
+						attachments[i].ID = monoflake.ID(ids.NextID()).String()
 						_ = storageSvc.Save(attachments[i].ID, attachments[i].Data)
 						attachments[i].Data = ""
 					}


### PR DESCRIPTION
The workspace MCP reply closure in app.go only generated a server-controlled monoflake ID when the caller-provided ID was blank. If an agent supplied any ID (e.g. a slug), that slug was used as the storage key, causing download failures because the download path expects monoflake IDs.

Fix: always regenerate the monoflake ID when attachment data is present, matching the behaviour of saveAttachments in the CRUD controller.

Task: 0dtmz0u8xAf