### PR TITLE
chore: bump patch version to v0.2.2

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "cron-parser": "^5.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
  Changes since v0.2.1
  
  - fix: always regenerate attachment ID in MCP reply path (agent-provided IDs no longer used as storage keys)
   - docs: add ARCHITECTURE.md whitepaper