### PR TITLE
🛡️ Sentinel: Harden OAuth flows against CSRF using signed state

### DIFF
--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -369,12 +369,15 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 	installed := err == nil && link.AccessToken != ""
 
 	workspaceID62 := monoflake.ID(workspaceID).String()
+	// Harden state with signature to prevent CSRF
+	signedState := workspaceID62 + "." + security.Sign(workspaceID62, c.tokenKey)
+
 	redirectURI := fmt.Sprintf("%s/slack/oauth/callback", c.baseURL)
 	authURL := fmt.Sprintf(
 		"https://slack.com/oauth/v2/authorize?client_id=%s&scope=groups:write,groups:read,chat:write,app_mentions:read,commands&redirect_uri=%s&state=%s",
 		c.slack.ClientID(),
 		url.QueryEscape(redirectURI),
-		workspaceID62,
+		signedState,
 	)
 
 	cfg := &entity.SlackConfig{
@@ -395,7 +398,18 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 // HandleOAuthCallback handles the dynamic Slack OAuth v2 redirect code exchange.
 // It exchanges the temporary code, encrypts the access token, auto-provisions a private channel,
 // and saves the credentials into GORM.
-func (c *controller) HandleOAuthCallback(ctx context.Context, workspaceID62 string, code string, redirectURI string) error {
+func (c *controller) HandleOAuthCallback(ctx context.Context, state string, code string, redirectURI string) error {
+	// Verify signed state
+	lastDot := strings.LastIndex(state, ".")
+	if lastDot == -1 {
+		return fmt.Errorf("slack: invalid state format")
+	}
+	workspaceID62 := state[:lastDot]
+	signature := state[lastDot+1:]
+	if !security.Verify(workspaceID62, signature, c.tokenKey) {
+		return fmt.Errorf("slack: invalid state signature")
+	}
+
 	workspaceID := monoflake.IDFromBase62(workspaceID62).Int64()
 	if workspaceID == 0 {
 		return fmt.Errorf("slack: invalid workspace ID state: %s", workspaceID62)

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -294,7 +294,20 @@ func (h *handler) rootLogin() fiber.Handler {
 
 func (h *handler) googleLogin() fiber.Handler {
 	return func(c *fiber.Ctx) error {
-		state := c.Query("redirect_url", "state")
+		redirectURL := c.Query("redirect_url", "/")
+		nonce, _ := security.GenerateSecret(16)
+		c.Cookie(&fiber.Cookie{
+			Name:     "oauth_state",
+			Value:    nonce,
+			Expires:  time.Now().Add(15 * time.Minute),
+			HTTPOnly: true,
+			Secure:   h.sslEnabled,
+			SameSite: "Lax",
+			Path:     "/",
+		})
+		// Harden state with nonce and signature to prevent CSRF
+		stateData := redirectURL + ":" + nonce
+		state := stateData + "." + security.Sign(stateData, h.tokenKey)
 		return c.Redirect(h.auth.GetAuthURL(state))
 	}
 }
@@ -302,6 +315,43 @@ func (h *handler) googleLogin() fiber.Handler {
 func (h *handler) googleCallback() fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		code := c.Query("code")
+		state := c.Query("state")
+
+		// Verify signed state
+		lastDot := strings.LastIndex(state, ".")
+		if lastDot == -1 {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "invalid state"})
+		}
+		stateData := state[:lastDot]
+		signature := state[lastDot+1:]
+		if !security.Verify(stateData, signature, h.tokenKey) {
+			zlog.Warn().Str("state", state).Msg("CSRF attempt: invalid state signature in google callback")
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "invalid state signature"})
+		}
+
+		lastColon := strings.LastIndex(stateData, ":")
+		if lastColon == -1 {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "invalid state format"})
+		}
+		originalRedirectURL := stateData[:lastColon]
+		nonce := stateData[lastColon+1:]
+
+		cookieNonce := c.Cookies("oauth_state")
+		if cookieNonce == "" || !security.SecureCompare(nonce, cookieNonce) {
+			zlog.Warn().Msg("CSRF attempt: state nonce mismatch in google callback")
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "invalid state nonce"})
+		}
+		// Clear state cookie
+		c.Cookie(&fiber.Cookie{
+			Name:     "oauth_state",
+			Value:    "",
+			Expires:  time.Now().Add(-1 * time.Hour),
+			HTTPOnly: true,
+			Secure:   h.sslEnabled,
+			SameSite: "Lax",
+			Path:     "/",
+		})
+
 		ctx, cancel := newContext(c)
 		defer cancel()
 
@@ -362,18 +412,17 @@ func (h *handler) googleCallback() fiber.Handler {
 		}
 		c.Cookie(cookie)
 
-		state := c.Query("state")
 		redirectURL := "/"
 		// Situational security: validate redirect URL to prevent open redirect
-		if state != "" && state != "state" {
-			if strings.HasPrefix(state, "/") && !strings.HasPrefix(state, "//") && !strings.HasPrefix(state, "/\\") {
-				redirectURL = state
+		if originalRedirectURL != "" {
+			if strings.HasPrefix(originalRedirectURL, "/") && !strings.HasPrefix(originalRedirectURL, "//") && !strings.HasPrefix(originalRedirectURL, "/\\") {
+				redirectURL = originalRedirectURL
 			} else {
 				// Parse absolute URL and validate against baseURL
-				if pRedirect, err := url.Parse(state); err == nil && pRedirect.IsAbs() {
+				if pRedirect, err := url.Parse(originalRedirectURL); err == nil && pRedirect.IsAbs() {
 					if pBase, err := url.Parse(h.baseURL); err == nil {
 						if pRedirect.Host == pBase.Host && pRedirect.Scheme == pBase.Scheme {
-							redirectURL = state
+							redirectURL = originalRedirectURL
 						}
 					}
 				}

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -5,12 +5,14 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/agentrq/agentrq/backend/internal/controller/crud"
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	"github.com/agentrq/agentrq/backend/internal/repository/base"
 	"github.com/agentrq/agentrq/backend/internal/service/auth"
+	"github.com/agentrq/agentrq/backend/internal/service/security"
 	"github.com/gofiber/fiber/v2"
 	"github.com/mustafaturan/monoflake"
 )
@@ -62,6 +64,7 @@ func TestGoogleCallback_OpenRedirectPrevention(t *testing.T) {
 		tokenSvc: tokenSvc,
 		crud:     crudCtrl,
 		baseURL:  "http://localhost:3000",
+		tokenKey: "12345678901234567890123456789012",
 	}
 
 	app.Get("/google/callback", h.googleCallback())
@@ -112,7 +115,22 @@ func TestGoogleCallback_OpenRedirectPrevention(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state="+tt.state, nil)
+			// Test with valid signed state and matching nonce cookie
+			nonce := "test-nonce"
+			stateData := tt.state + ":" + nonce
+			signedState := stateData + "." + security.Sign(stateData, h.tokenKey)
+
+			if tt.state == "http://localhost:3000.evil.com" || tt.state == "http://localhost:3000/safe" {
+				// Re-sign without the colon logic if I'm testing something else?
+				// No, the handler expects a colon.
+			}
+
+			query := url.Values{}
+			query.Set("code", "valid-code")
+			query.Set("state", signedState)
+
+			req := httptest.NewRequest("GET", "/google/callback?"+query.Encode(), nil)
+			req.AddCookie(&http.Cookie{Name: "oauth_state", Value: nonce})
 			resp, _ := app.Test(req)
 
 			if resp.StatusCode != http.StatusFound {
@@ -124,6 +142,26 @@ func TestGoogleCallback_OpenRedirectPrevention(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("Invalid signature", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/google/callback?code=code&state=bad.sig", nil)
+		resp, _ := app.Test(req)
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("Expected status 401, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("Nonce mismatch", func(t *testing.T) {
+		nonce := "valid-nonce"
+		stateData := "/:" + nonce
+		signedState := stateData + "." + security.Sign(stateData, h.tokenKey)
+		req := httptest.NewRequest("GET", "/google/callback?code=code&state="+signedState, nil)
+		req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "wrong-nonce"})
+		resp, _ := app.Test(req)
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("Expected status 401, got %d", resp.StatusCode)
+		}
+	})
 }
 
 type mockCrudGetWorkspace struct {

--- a/backend/internal/handler/slack/slack.go
+++ b/backend/internal/handler/slack/slack.go
@@ -192,16 +192,21 @@ func oauthCallbackHandler(svc slacksvc.Service, ctrl slackctrl.Controller, baseU
 
 		redirectURI := fmt.Sprintf("%s/slack/oauth/callback", baseURL)
 		err := ctrl.HandleOAuthCallback(r.Context(), state, code, redirectURI)
+		workspaceID62 := state
+		if lastDot := strings.LastIndex(state, "."); lastDot != -1 {
+			workspaceID62 = state[:lastDot]
+		}
+
 		if err != nil {
 			zlog.Error().Err(err).Msg("[slack/oauth] HandleOAuthCallback error")
 			// Redirect back with a generic error query param to prevent information leakage
 			errorMsg := url.QueryEscape("failed to complete slack authorization")
-			http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack&slack_error=%s", baseURL, state, errorMsg), http.StatusTemporaryRedirect)
+			http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack&slack_error=%s", baseURL, workspaceID62, errorMsg), http.StatusTemporaryRedirect)
 			return
 		}
 
 		// Redirect back to settings page on success
-		http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack", baseURL, state), http.StatusTemporaryRedirect)
+		http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack", baseURL, workspaceID62), http.StatusTemporaryRedirect)
 	})
 }
 

--- a/backend/internal/service/security/security.go
+++ b/backend/internal/service/security/security.go
@@ -3,7 +3,9 @@ package security
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
@@ -91,4 +93,18 @@ func GenerateSecret(n int) (string, error) {
 // It wraps crypto/subtle.ConstantTimeCompare to mitigate timing attacks.
 func SecureCompare(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+// Sign generates an HMAC-SHA256 signature for the given data using the provided key.
+func Sign(data, key string) string {
+	h := hmac.New(sha256.New, []byte(key))
+	h.Write([]byte(data))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// Verify checks if the provided signature is a valid HMAC-SHA256 signature for the data.
+// It uses constant-time comparison to mitigate timing attacks.
+func Verify(data, signature, key string) bool {
+	expected := Sign(data, key)
+	return SecureCompare(signature, expected)
 }

--- a/backend/internal/service/security/security_test.go
+++ b/backend/internal/service/security/security_test.go
@@ -89,4 +89,28 @@ func TestSecurity(t *testing.T) {
 			t.Error("expected true for empty strings")
 		}
 	})
+
+	t.Run("SignVerify", func(t *testing.T) {
+		data := "some-data-to-sign"
+		sig := Sign(data, key)
+		if sig == "" {
+			t.Fatal("empty signature")
+		}
+
+		if !Verify(data, sig, key) {
+			t.Error("failed to verify valid signature")
+		}
+
+		if Verify(data, "invalid signature", key) {
+			t.Error("verified invalid signature")
+		}
+
+		if Verify("different data", sig, key) {
+			t.Error("verified signature for different data")
+		}
+
+		if Verify(data, sig, "different key 123456789012345678") {
+			t.Error("verified signature with different key")
+		}
+	})
 }


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] Harden OAuth flows against CSRF

🚨 **Severity:** HIGH
💡 **Vulnerability:** The Google and Slack OAuth flows used the `state` parameter to carry data but lacked cryptographic signing and verification, making them vulnerable to OAuth CSRF attacks.
🎯 **Impact:** An attacker could potentially trick a user into completing an OAuth flow initiated by the attacker, leading to account linking or other session-related security issues.
🔧 **Fix:** 
- Implemented `Sign` and `Verify` helpers using HMAC-SHA256 in the security service.
- Hardened the Google OAuth flow by signing the `state` parameter containing the redirect URL and a session-bound nonce (stored in a secure cookie).
- Hardened the Slack OAuth flow by signing the workspace ID in the `state` parameter.
- Updated handlers and controllers to verify these signatures during the OAuth callback.
✅ **Verification:** 
- Added unit tests for `Sign` and `Verify` in `security_test.go`.
- Updated `api_test.go` to verify signature and nonce validation in the Google callback.
- Verified Slack changes with a temporary integration test and standard suite.
- Ran all backend tests (`go test ./internal/...`) to ensure no regressions.

---
*PR created automatically by Jules for task [199377399664060525](https://jules.google.com/task/199377399664060525) started by @mustafaturan*