### PR TITLE
fix: share cron granularity validation

### DIFF
--- a/backend/internal/controller/crud/task.go
+++ b/backend/internal/controller/crud/task.go
@@ -9,8 +9,8 @@ import (
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	"github.com/agentrq/agentrq/backend/internal/data/model"
 	"github.com/agentrq/agentrq/backend/internal/repository/base"
+	"github.com/agentrq/agentrq/backend/internal/service/schedule"
 	"github.com/mustafaturan/monoflake"
-	"github.com/robfig/cron/v3"
 	"gorm.io/datatypes"
 )
 
@@ -51,12 +51,10 @@ func (c *controller) CreateTask(ctx context.Context, req entity.CreateTaskReques
 
 	if status == "cron" {
 		if req.Task.CronSchedule == "" {
-			return nil, fmt.Errorf("cron_schedule is required for chronic tasks")
+			return nil, fmt.Errorf("cron schedule is required for scheduled tasks")
 		}
-		// Validate Cron Schedule
-		parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
-		if _, err := parser.Parse(req.Task.CronSchedule); err != nil {
-			return nil, fmt.Errorf("invalid cron schedule: %w", err)
+		if err := schedule.ValidateCronGranularity(req.Task.CronSchedule); err != nil {
+			return nil, err
 		}
 	}
 
@@ -274,7 +272,7 @@ func (c *controller) UpdateTaskStatus(ctx context.Context, req entity.UpdateTask
 		return nil, err
 	}
 	if m.Status == "cron" {
-		return nil, fmt.Errorf("cannot update status of a chronic task template; it must remain in 'cron' state")
+		return nil, fmt.Errorf("cannot update status of a scheduled task template; it must remain in 'cron' state")
 	}
 
 	if !isValidTaskStatus(req.Status) {
@@ -712,17 +710,15 @@ func (c *controller) UpdateScheduledTask(ctx context.Context, req entity.UpdateS
 		return nil, err
 	}
 	if m.Status != "cron" {
-		return nil, fmt.Errorf("only chronic tasks can be edited this way")
+		return nil, fmt.Errorf("only scheduled tasks can be edited this way")
 	}
 
 	if req.CronSchedule == "" {
 		m.Status = "notstarted"
 		m.CronSchedule = ""
 	} else {
-		// Validate Cron Schedule
-		parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
-		if _, err := parser.Parse(req.CronSchedule); err != nil {
-			return nil, fmt.Errorf("invalid cron schedule: %w", err)
+		if err := schedule.ValidateCronGranularity(req.CronSchedule); err != nil {
+			return nil, err
 		}
 		m.CronSchedule = req.CronSchedule
 	}

--- a/backend/internal/controller/crud/task_test.go
+++ b/backend/internal/controller/crud/task_test.go
@@ -183,6 +183,38 @@ func TestCreateTask_InvalidCronSchedule(t *testing.T) {
 	}
 }
 
+func TestCreateTask_RejectsSubHourlyCronSchedule(t *testing.T) {
+	cases := []struct {
+		name     string
+		schedule string
+		errFrag  string
+	}{
+		{"every minute wildcard", "* * * * *", "granularity too fine"},
+		{"every five minutes", "*/5 * * * *", "granularity too fine"},
+		{"every fifteen minutes", "*/15 * * * *", "granularity too fine"},
+		{"twice hourly list", "0,30 * * * *", "granularity too fine"},
+		{"minute range", "0-30 * * * *", "granularity too fine"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newTestController(t)
+			e.repo.EXPECT().GetWorkspace(gomock.Any(), int64(1), testUserID).Return(activeWorkspace(), nil)
+
+			_, err := e.controller.CreateTask(context.Background(), entity.CreateTaskRequest{
+				UserID: testUserIDStr,
+				Task:   entity.Task{WorkspaceID: 1, Title: "t", Status: "cron", CronSchedule: tc.schedule},
+			})
+			if err == nil {
+				t.Fatalf("expected error for cron schedule %q", tc.schedule)
+			}
+			if !strings.Contains(err.Error(), tc.errFrag) {
+				t.Fatalf("expected error containing %q, got %v", tc.errFrag, err)
+			}
+		})
+	}
+}
+
 func TestCreateTask_ValidCronSchedule(t *testing.T) {
 	e := newTestController(t)
 
@@ -612,6 +644,24 @@ func TestUpdateScheduledTask_InvalidCron(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for invalid cron schedule")
+	}
+}
+
+func TestUpdateScheduledTask_RejectsSubHourlyCronSchedule(t *testing.T) {
+	e := newTestController(t)
+
+	task := model.Task{ID: 10, WorkspaceID: 1, Status: "cron"}
+	e.repo.EXPECT().GetWorkspace(gomock.Any(), int64(1), testUserID).Return(activeWorkspace(), nil)
+	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(10), testUserID).Return(task, nil)
+
+	_, err := e.controller.UpdateScheduledTask(context.Background(), entity.UpdateScheduledTaskRequest{
+		WorkspaceID: 1, TaskID: 10, CronSchedule: "*/15 * * * *", UserID: testUserIDStr,
+	})
+	if err == nil {
+		t.Fatal("expected error for sub-hourly cron schedule")
+	}
+	if !strings.Contains(err.Error(), "granularity too fine") {
+		t.Fatalf("expected granularity error, got %v", err)
 	}
 }
 

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -8,14 +8,12 @@ import (
 	"net/http"
 	"reflect"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
 
-	"github.com/robfig/cron/v3"
 	zlog "github.com/rs/zerolog/log"
 
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
@@ -26,6 +24,7 @@ import (
 	"github.com/agentrq/agentrq/backend/internal/service/eventbus"
 	"github.com/agentrq/agentrq/backend/internal/service/idgen"
 	"github.com/agentrq/agentrq/backend/internal/service/pubsub"
+	"github.com/agentrq/agentrq/backend/internal/service/schedule"
 	"github.com/agentrq/agentrq/backend/internal/service/storage"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/mustafaturan/monoflake"
@@ -536,7 +535,7 @@ func (ps *WorkspaceServer) handleCreateTask(ctx context.Context, req *mcp.CallTo
 	}
 
 	if params.CronSchedule != "" {
-		if err := validateCronGranularity(params.CronSchedule); err != nil {
+		if err := schedule.ValidateCronGranularity(params.CronSchedule); err != nil {
 			return &mcp.CallToolResult{
 				IsError: true,
 				Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}},
@@ -1396,40 +1395,4 @@ func formatModelAttachments(raw []byte) string {
 		return ""
 	}
 	return "Attachments:\n" + strings.Join(parts, "\n")
-}
-
-// validateCronGranularity validates that the cron schedule is syntactically valid.
-// For RECURRING schedules (dom or month field is "*"), the minimum granularity is
-// hourly: the minute field must be a single fixed integer 0-59 (no wildcards, steps,
-// ranges, or comma-lists), because sub-hourly recurring tasks are not supported.
-// For ONE-TIME schedules (both dom and month are fixed integers, e.g. "30 14 25 4 *"),
-// any fixed minute value 0-59 is accepted — enabling minute-level precision.
-func validateCronGranularity(schedule string) error {
-	fields := strings.Fields(schedule)
-	if len(fields) != 5 {
-		return fmt.Errorf("cron schedule must have exactly 5 fields (minute hour dom month dow)")
-	}
-
-	minuteField := fields[0]
-
-	// Reject wildcards, steps (*/n), ranges (a-b), and comma-lists in the minute field.
-	if minuteField == "*" ||
-		strings.Contains(minuteField, "/") ||
-		strings.Contains(minuteField, "-") ||
-		strings.Contains(minuteField, ",") {
-		return fmt.Errorf("cron schedule granularity too fine: minute field must be a single fixed value (0-59), not %q — only hourly or coarser schedules are allowed", minuteField)
-	}
-
-	minute, err := strconv.Atoi(minuteField)
-	if err != nil || minute < 0 || minute > 59 {
-		return fmt.Errorf("cron schedule minute field must be a valid integer between 0 and 59, got %q", minuteField)
-	}
-
-	// Validate overall syntax using the standard 5-field parser.
-	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
-	if _, err := parser.Parse(schedule); err != nil {
-		return fmt.Errorf("invalid cron schedule: %w", err)
-	}
-
-	return nil
 }

--- a/backend/internal/controller/mcp/server_test.go
+++ b/backend/internal/controller/mcp/server_test.go
@@ -15,6 +15,7 @@ import (
 	mock_pubsub "github.com/agentrq/agentrq/backend/internal/service/mocks/pubsub"
 	mock_storage "github.com/agentrq/agentrq/backend/internal/service/mocks/storage"
 	"github.com/agentrq/agentrq/backend/internal/service/pubsub"
+	"github.com/agentrq/agentrq/backend/internal/service/schedule"
 	"github.com/golang/mock/gomock"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/mustafaturan/monoflake"
@@ -584,7 +585,7 @@ func TestWorkspaceServer_HandleCreateTask_InvalidCron(t *testing.T) {
 	}
 }
 
-func TestValidateCronGranularity(t *testing.T) {
+func TestWorkspaceServer_UsesSharedCronGranularityValidation(t *testing.T) {
 	validCases := []string{
 		"0 * * * *",    // every hour at :00
 		"30 * * * *",   // every hour at :30
@@ -602,7 +603,7 @@ func TestValidateCronGranularity(t *testing.T) {
 	}
 
 	for _, s := range validCases {
-		if err := validateCronGranularity(s); err != nil {
+		if err := schedule.ValidateCronGranularity(s); err != nil {
 			t.Errorf("expected valid for %q, got error: %v", s, err)
 		}
 	}
@@ -623,7 +624,7 @@ func TestValidateCronGranularity(t *testing.T) {
 	}
 
 	for _, tc := range invalidCases {
-		if err := validateCronGranularity(tc.schedule); err == nil {
+		if err := schedule.ValidateCronGranularity(tc.schedule); err == nil {
 			t.Errorf("expected error for %q, got nil", tc.schedule)
 		} else if !contains(err.Error(), tc.errFrag) {
 			t.Errorf("expected error containing %q for %q, got: %v", tc.errFrag, tc.schedule, err)

--- a/backend/internal/service/schedule/cron.go
+++ b/backend/internal/service/schedule/cron.go
@@ -1,0 +1,39 @@
+package schedule
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/robfig/cron/v3"
+)
+
+// ValidateCronGranularity validates that the cron schedule is syntactically valid.
+// Recurring schedules have hourly-minimum granularity: the minute field must be a
+// single fixed integer 0-59, not a wildcard, step, range, or comma-list.
+func ValidateCronGranularity(schedule string) error {
+	fields := strings.Fields(schedule)
+	if len(fields) != 5 {
+		return fmt.Errorf("cron schedule must have exactly 5 fields (minute hour dom month dow)")
+	}
+
+	minuteField := fields[0]
+	if minuteField == "*" ||
+		strings.Contains(minuteField, "/") ||
+		strings.Contains(minuteField, "-") ||
+		strings.Contains(minuteField, ",") {
+		return fmt.Errorf("cron schedule granularity too fine: minute field must be a single fixed value (0-59), not %q - only hourly or coarser schedules are allowed", minuteField)
+	}
+
+	minute, err := strconv.Atoi(minuteField)
+	if err != nil || minute < 0 || minute > 59 {
+		return fmt.Errorf("cron schedule minute field must be a valid integer between 0 and 59, got %q", minuteField)
+	}
+
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	if _, err := parser.Parse(schedule); err != nil {
+		return fmt.Errorf("invalid cron schedule: %w", err)
+	}
+
+	return nil
+}

--- a/backend/internal/service/schedule/cron_test.go
+++ b/backend/internal/service/schedule/cron_test.go
@@ -1,0 +1,49 @@
+package schedule
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateCronGranularity(t *testing.T) {
+	validCases := []string{
+		"0 * * * *",
+		"30 * * * *",
+		"0 9 * * *",
+		"0 9 * * 1",
+		"0 9 1 * *",
+		"59 23 * * *",
+		"0 */2 * * *",
+		"30 9 * * 1-5",
+		"30 14 25 4 *",
+		"5 9 1 1 *",
+	}
+
+	for _, s := range validCases {
+		if err := ValidateCronGranularity(s); err != nil {
+			t.Errorf("expected valid for %q, got error: %v", s, err)
+		}
+	}
+
+	invalidCases := []struct {
+		schedule string
+		errFrag  string
+	}{
+		{"* * * * *", "granularity too fine"},
+		{"*/5 * * * *", "granularity too fine"},
+		{"*/15 * * * *", "granularity too fine"},
+		{"0,30 * * * *", "granularity too fine"},
+		{"0-5 * * * *", "granularity too fine"},
+		{"60 * * * *", "must be a valid integer"},
+		{"abc * * * *", "must be a valid integer"},
+		{"not-a-cron", "must have exactly 5 fields"},
+	}
+
+	for _, tc := range invalidCases {
+		if err := ValidateCronGranularity(tc.schedule); err == nil {
+			t.Errorf("expected error for %q, got nil", tc.schedule)
+		} else if !strings.Contains(err.Error(), tc.errFrag) {
+			t.Errorf("expected error containing %q for %q, got: %v", tc.errFrag, tc.schedule, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Move hourly-minimum cron validation into a shared `internal/service/schedule` helper
- Use the shared helper from both CRUD/REST scheduled task paths and MCP createTask
- Add CRUD tests for sub-hourly cron rejection
- Keep MCP validation tests pointed at the shared helper
- Clean up “chronic task” wording to “scheduled task”

Closes #179

## Testing

- `git diff --check`

Unable to run Go tests locally because `go`/`gofmt` are not available in PATH.