### PR TITLE
Harden Google OAuth flow with CSRF protection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -13,6 +13,11 @@
 **Learning:** Endpoints that operate on specific resources must always verify that the authenticated user has the necessary permissions/ownership for that resource ID, even if they are already authenticated.
 **Prevention:** Always include a user-specific identifier (e.g., `userID`) in repository/controller queries for resource-specific operations to ensure implicit authorization.
 
+## 2026-06-17 - OAuth CSRF Vulnerability
+**Vulnerability:** The Google OAuth flow lacked CSRF protection as it did not use or verify a state-nonce parameter. An attacker could potentially trick a user into performing an OAuth login that links the victim's session to the attacker's account or vice versa.
+**Learning:** Redirect parameters in OAuth are not inherently secure. A cryptographic "state" parameter linked to a session cookie (nonce) is essential to ensure the callback originates from the same session that initiated the login.
+**Prevention:** Always implement the State-Nonce pattern for OAuth flows. Use HMAC to sign the state parameter and verify it against a session-bound `HTTPOnly` cookie.
+
 ## 2024-05-21 - IDOR in Workspace Stats Endpoint
 **Vulnerability:** The `GetDetailedWorkspaceStats` controller method retrieved statistics for any workspace ID provided in the request without verifying if the authenticated user owned or had access to that workspace.
 **Learning:** Even when handlers correctly extract and pass the `userID`, the business logic layer must explicitly use it to authorize access to the requested resource. Simply passing it to a downstream service that ignores it leaves the application vulnerable to IDOR.

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -294,7 +294,31 @@ func (h *handler) rootLogin() fiber.Handler {
 
 func (h *handler) googleLogin() fiber.Handler {
 	return func(c *fiber.Ctx) error {
-		state := c.Query("redirect_url", "state")
+		redirectURL := c.Query("redirect_url", "/")
+		nonce, err := security.GenerateSecret(16)
+		if err != nil {
+			zlog.Error().Err(err).Msg("Failed to generate oauth nonce")
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		}
+
+		cookie := &fiber.Cookie{
+			Name:     "oauth_state",
+			Value:    nonce,
+			Expires:  time.Now().Add(15 * time.Minute),
+			HTTPOnly: true,
+			Secure:   h.sslEnabled,
+			SameSite: "Lax",
+			Path:     "/",
+		}
+		if h.domain != "" && !strings.HasPrefix(h.domain, "localhost") {
+			cookie.Domain = "." + h.domain
+		}
+		c.Cookie(cookie)
+
+		stateData := fmt.Sprintf("%s:%s", redirectURL, nonce)
+		signature := security.Sign(stateData, h.tokenKey)
+		state := fmt.Sprintf("%s.%s", stateData, signature)
+
 		return c.Redirect(h.auth.GetAuthURL(state))
 	}
 }
@@ -302,6 +326,48 @@ func (h *handler) googleLogin() fiber.Handler {
 func (h *handler) googleCallback() fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		code := c.Query("code")
+		state := c.Query("state")
+
+		// 1. Verify CSRF state
+		lastDot := strings.LastIndex(state, ".")
+		if lastDot == -1 {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid state"})
+		}
+		stateData := state[:lastDot]
+		signature := state[lastDot+1:]
+
+		if !security.Verify(stateData, signature, h.tokenKey) {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid state signature"})
+		}
+
+		lastColon := strings.LastIndex(stateData, ":")
+		if lastColon == -1 {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid state data"})
+		}
+		redirectURLFromState := stateData[:lastColon]
+		nonceFromState := stateData[lastColon+1:]
+
+		nonceFromCookie := c.Cookies("oauth_state")
+
+		// Clear oauth_state cookie
+		clearCookie := &fiber.Cookie{
+			Name:     "oauth_state",
+			Value:    "",
+			Expires:  time.Now().Add(-1 * time.Hour),
+			HTTPOnly: true,
+			Secure:   h.sslEnabled,
+			SameSite: "Lax",
+			Path:     "/",
+		}
+		if h.domain != "" && !strings.HasPrefix(h.domain, "localhost") {
+			clearCookie.Domain = "." + h.domain
+		}
+		c.Cookie(clearCookie)
+
+		if nonceFromCookie == "" || !security.SecureCompare(nonceFromState, nonceFromCookie) {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "CSRF detected: invalid or missing state nonce"})
+		}
+
 		ctx, cancel := newContext(c)
 		defer cancel()
 
@@ -362,18 +428,17 @@ func (h *handler) googleCallback() fiber.Handler {
 		}
 		c.Cookie(cookie)
 
-		state := c.Query("state")
 		redirectURL := "/"
 		// Situational security: validate redirect URL to prevent open redirect
-		if state != "" && state != "state" {
-			if strings.HasPrefix(state, "/") && !strings.HasPrefix(state, "//") && !strings.HasPrefix(state, "/\\") {
-				redirectURL = state
+		if redirectURLFromState != "" {
+			if strings.HasPrefix(redirectURLFromState, "/") && !strings.HasPrefix(redirectURLFromState, "//") && !strings.HasPrefix(redirectURLFromState, "/\\") {
+				redirectURL = redirectURLFromState
 			} else {
 				// Parse absolute URL and validate against baseURL
-				if pRedirect, err := url.Parse(state); err == nil && pRedirect.IsAbs() {
+				if pRedirect, err := url.Parse(redirectURLFromState); err == nil && pRedirect.IsAbs() {
 					if pBase, err := url.Parse(h.baseURL); err == nil {
 						if pRedirect.Host == pBase.Host && pRedirect.Scheme == pBase.Scheme {
-							redirectURL = state
+							redirectURL = redirectURLFromState
 						}
 					}
 				}

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -3,11 +3,13 @@ package api
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/agentrq/agentrq/backend/internal/controller/crud"
+	"github.com/agentrq/agentrq/backend/internal/service/security"
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	"github.com/agentrq/agentrq/backend/internal/repository/base"
 	"github.com/agentrq/agentrq/backend/internal/service/auth"
@@ -110,9 +112,17 @@ func TestGoogleCallback_OpenRedirectPrevention(t *testing.T) {
 		},
 	}
 
+	tokenKey := "test-token-key-32-bytes-long-123"
+	h.tokenKey = tokenKey
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state="+tt.state, nil)
+			stateData := fmt.Sprintf("%s:nonce123", tt.state)
+			sig := security.Sign(stateData, tokenKey)
+			state := fmt.Sprintf("%s.%s", stateData, sig)
+
+			req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state="+state, nil)
+			req.Header.Set("Cookie", "oauth_state=nonce123")
 			resp, _ := app.Test(req)
 
 			if resp.StatusCode != http.StatusFound {

--- a/backend/internal/handler/api/csrf_test.go
+++ b/backend/internal/handler/api/csrf_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/agentrq/agentrq/backend/internal/service/security"
+	"github.com/gofiber/fiber/v2"
+)
+
+func TestGoogleOAuth_CSRF(t *testing.T) {
+	app := fiber.New()
+	tokenKey := "test-token-key-32-bytes-long-123"
+	h := &handler{
+		tokenKey:   tokenKey,
+		sslEnabled: false,
+		baseURL:    "http://localhost:3000",
+		auth:       &mockAuthService{},
+	}
+
+	app.Get("/google/login", h.googleLogin())
+	app.Get("/google/callback", h.googleCallback())
+
+	t.Run("Login sets cookie and signed state", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/google/login?redirect_url=/dashboard", nil)
+		resp, _ := app.Test(req)
+
+		if resp.StatusCode != http.StatusFound {
+			t.Errorf("Expected status 302, got %d", resp.StatusCode)
+		}
+
+		// Check cookie
+		cookieHeader := resp.Header.Get("Set-Cookie")
+		if !strings.Contains(cookieHeader, "oauth_state=") {
+			t.Errorf("Expected oauth_state cookie, got %s", cookieHeader)
+		}
+
+		// Check redirect URL for state
+		loc := resp.Header.Get("Location")
+		if !strings.Contains(loc, "state=") {
+			t.Errorf("Expected state parameter in redirect, got %s", loc)
+		}
+	})
+
+	t.Run("Callback rejects invalid signature", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/google/callback?code=123&state=bad.sig", nil)
+		resp, _ := app.Test(req)
+
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("Expected status 400, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("Callback rejects missing nonce cookie", func(t *testing.T) {
+		stateData := "/dashboard:nonce123"
+		sig := security.Sign(stateData, tokenKey)
+		state := fmt.Sprintf("%s.%s", stateData, sig)
+
+		req := httptest.NewRequest("GET", "/google/callback?code=123&state="+state, nil)
+		resp, _ := app.Test(req)
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("Expected status 403, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("Callback rejects nonce mismatch", func(t *testing.T) {
+		stateData := "/dashboard:nonce123"
+		sig := security.Sign(stateData, tokenKey)
+		state := fmt.Sprintf("%s.%s", stateData, sig)
+
+		req := httptest.NewRequest("GET", "/google/callback?code=123&state="+state, nil)
+		req.Header.Set("Cookie", "oauth_state=different-nonce")
+		resp, _ := app.Test(req)
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("Expected status 403, got %d", resp.StatusCode)
+		}
+	})
+}

--- a/backend/internal/service/security/security.go
+++ b/backend/internal/service/security/security.go
@@ -3,7 +3,9 @@ package security
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
@@ -91,4 +93,23 @@ func GenerateSecret(n int) (string, error) {
 // It wraps crypto/subtle.ConstantTimeCompare to mitigate timing attacks.
 func SecureCompare(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+// Sign generates a hex-encoded HMAC-SHA256 signature for the given data using the provided key.
+func Sign(data, key string) string {
+	h := hmac.New(sha256.New, []byte(key))
+	h.Write([]byte(data))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// Verify checks if the provided hex-encoded signature is valid for the given data and key.
+func Verify(data, signature, key string) bool {
+	sigBytes, err := hex.DecodeString(signature)
+	if err != nil {
+		return false
+	}
+	h := hmac.New(sha256.New, []byte(key))
+	h.Write([]byte(data))
+	expectedSig := h.Sum(nil)
+	return hmac.Equal(sigBytes, expectedSig)
 }

--- a/backend/internal/service/security/security_test.go
+++ b/backend/internal/service/security/security_test.go
@@ -89,4 +89,26 @@ func TestSecurity(t *testing.T) {
 			t.Error("expected true for empty strings")
 		}
 	})
+
+	t.Run("SignVerify", func(t *testing.T) {
+		data := "sensitive-oauth-state-data"
+		key := "signing-key"
+		sig := Sign(data, key)
+
+		if !Verify(data, sig, key) {
+			t.Error("verification failed for valid signature")
+		}
+
+		if Verify(data, "invalid-sig", key) {
+			t.Error("verification succeeded for invalid signature")
+		}
+
+		if Verify("different-data", sig, key) {
+			t.Error("verification succeeded for different data")
+		}
+
+		if Verify(data, sig, "different-key") {
+			t.Error("verification succeeded for different key")
+		}
+	})
 }


### PR DESCRIPTION
Harden Google OAuth flow with session-bound CSRF protection. Added HMAC-SHA256 signing to the security service and implemented a state-nonce verification pattern in the API handlers. Verified with new and updated unit tests.

---
*PR created automatically by Jules for task [1381887925627464527](https://jules.google.com/task/1381887925627464527) started by @mustafaturan*