### PR TITLE
🛡️ Sentinel: Fix CSRF in Google OAuth flow

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** The `ResizeBase64` service returned the original input string if the `data:image/` prefix was missing. The CRUD controller then stored this unsanitized string in the database. Since the frontend rendered some icons using `v-html`, this allowed for Stored XSS (e.g., using `javascript:` or malicious SVG).
 **Learning:** Fallback mechanisms that return unvalidated user input when processing fails are dangerous. If a service is designed to process/sanitize input, it must fail explicitly if the input doesn't meet the expected format.
 **Prevention:** Enforce strict input validation (e.g., prefix checks) and remove "fallback to original" logic in data processing services. Ensure that only successfully processed and sanitized data reaches the persistence layer.
+
+## 2025-05-23 - CSRF in Google OAuth Flow
+**Vulnerability:** The Google OAuth flow used a simple `state` parameter containing only the redirect URL without any cryptographic signature or session-bound nonce, making it vulnerable to CSRF attacks where an attacker could force a victim to log into the attacker's account.
+**Learning:** For OAuth flows, the `state` parameter must be used to provide CSRF protection by including a session-bound nonce. To prevent tampering and open redirects, the entire state data (redirect URL + nonce) should be cryptographically signed.
+**Prevention:** Always use a signed `state` parameter in OAuth flows. Include a random nonce that is also stored in a secure, HTTP-only, session-bound cookie. Verify the signature and the nonce on the callback before proceeding with the token exchange.

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -294,13 +294,80 @@ func (h *handler) rootLogin() fiber.Handler {
 
 func (h *handler) googleLogin() fiber.Handler {
 	return func(c *fiber.Ctx) error {
-		state := c.Query("redirect_url", "state")
+		redirectURL := c.Query("redirect_url", "/")
+		nonce, err := security.GenerateSecret(16)
+		if err != nil {
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to generate nonce"})
+		}
+
+		cookie := &fiber.Cookie{
+			Name:     "oauth_state",
+			Value:    nonce,
+			Expires:  time.Now().Add(15 * time.Minute),
+			HTTPOnly: true,
+			Secure:   h.sslEnabled,
+			SameSite: "Lax",
+			Path:     "/",
+		}
+		if h.domain != "" && !strings.HasPrefix(h.domain, "localhost") {
+			cookie.Domain = "." + h.domain
+		}
+		c.Cookie(cookie)
+
+		stateData := fmt.Sprintf("%s:%s", redirectURL, nonce)
+		signature := security.Sign(stateData, h.tokenKey)
+		state := fmt.Sprintf("%s.%s", stateData, signature)
+
 		return c.Redirect(h.auth.GetAuthURL(state))
 	}
 }
 
 func (h *handler) googleCallback() fiber.Handler {
 	return func(c *fiber.Ctx) error {
+		state := c.Query("state")
+		if state == "" {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "missing state"})
+		}
+
+		// Verify state signature and CSRF nonce
+		dotIdx := strings.LastIndex(state, ".")
+		if dotIdx == -1 {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid state format"})
+		}
+		stateData := state[:dotIdx]
+		signature := state[dotIdx+1:]
+
+		if !security.Verify(stateData, signature, h.tokenKey) {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid state signature"})
+		}
+
+		colonIdx := strings.LastIndex(stateData, ":")
+		if colonIdx == -1 {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid state data"})
+		}
+		redirectURLFromState := stateData[:colonIdx]
+		nonceFromState := stateData[colonIdx+1:]
+
+		cookieNonce := c.Cookies("oauth_state")
+		// Clear oauth_state cookie
+		clearCookie := &fiber.Cookie{
+			Name:     "oauth_state",
+			Value:    "",
+			Expires:  time.Now().Add(-1 * time.Hour),
+			HTTPOnly: true,
+			Secure:   h.sslEnabled,
+			SameSite: "Lax",
+			Path:     "/",
+		}
+		if h.domain != "" && !strings.HasPrefix(h.domain, "localhost") {
+			clearCookie.Domain = "." + h.domain
+		}
+		c.Cookie(clearCookie)
+
+		if cookieNonce == "" || !security.SecureCompare(cookieNonce, nonceFromState) {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid oauth state"})
+		}
+
 		code := c.Query("code")
 		ctx, cancel := newContext(c)
 		defer cancel()
@@ -362,18 +429,17 @@ func (h *handler) googleCallback() fiber.Handler {
 		}
 		c.Cookie(cookie)
 
-		state := c.Query("state")
 		redirectURL := "/"
 		// Situational security: validate redirect URL to prevent open redirect
-		if state != "" && state != "state" {
-			if strings.HasPrefix(state, "/") && !strings.HasPrefix(state, "//") && !strings.HasPrefix(state, "/\\") {
-				redirectURL = state
+		if redirectURLFromState != "" && redirectURLFromState != "/" {
+			if strings.HasPrefix(redirectURLFromState, "/") && !strings.HasPrefix(redirectURLFromState, "//") && !strings.HasPrefix(redirectURLFromState, "/\\") {
+				redirectURL = redirectURLFromState
 			} else {
 				// Parse absolute URL and validate against baseURL
-				if pRedirect, err := url.Parse(state); err == nil && pRedirect.IsAbs() {
+				if pRedirect, err := url.Parse(redirectURLFromState); err == nil && pRedirect.IsAbs() {
 					if pBase, err := url.Parse(h.baseURL); err == nil {
 						if pRedirect.Host == pBase.Host && pRedirect.Scheme == pBase.Scheme {
-							redirectURL = state
+							redirectURL = redirectURLFromState
 						}
 					}
 				}

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -3,11 +3,13 @@ package api
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/agentrq/agentrq/backend/internal/controller/crud"
+	"github.com/agentrq/agentrq/backend/internal/service/security"
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	"github.com/agentrq/agentrq/backend/internal/repository/base"
 	"github.com/agentrq/agentrq/backend/internal/service/auth"
@@ -56,12 +58,14 @@ func TestGoogleCallback_OpenRedirectPrevention(t *testing.T) {
 	authSvc := &mockAuthService{}
 	tokenSvc := &mockTokenSvc{}
 	crudCtrl := &mockCrudController{}
+	tokenKey := "12345678901234567890123456789012"
 
 	h := &handler{
 		auth:     authSvc,
 		tokenSvc: tokenSvc,
 		crud:     crudCtrl,
 		baseURL:  "http://localhost:3000",
+		tokenKey: tokenKey,
 	}
 
 	app.Get("/google/callback", h.googleCallback())
@@ -80,39 +84,50 @@ func TestGoogleCallback_OpenRedirectPrevention(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		state       string
+		redirectURL string
+		nonce       string
 		expectedLoc string
 	}{
 		{
 			name:        "Safe local redirect",
-			state:       "/workspaces",
+			redirectURL: "/workspaces",
+			nonce:       "nonce1",
 			expectedLoc: "/workspaces",
 		},
 		{
 			name:        "Malicious absolute redirect",
-			state:       "http://localhost:3000.evil.com",
+			redirectURL: "http://localhost:3000.evil.com",
+			nonce:       "nonce2",
 			expectedLoc: "/",
 		},
 		{
 			name:        "Malicious relative redirect //",
-			state:       "//evil.com",
+			redirectURL: "//evil.com",
+			nonce:       "nonce3",
 			expectedLoc: "/",
 		},
 		{
 			name:        "Malicious relative redirect /\\",
-			state:       "/\\evil.com",
+			redirectURL: "/\\evil.com",
+			nonce:       "nonce4",
 			expectedLoc: "/",
 		},
 		{
 			name:        "Safe absolute redirect",
-			state:       "http://localhost:3000/safe",
+			redirectURL: "http://localhost:3000/safe",
+			nonce:       "nonce5",
 			expectedLoc: "http://localhost:3000/safe",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state="+tt.state, nil)
+			stateData := fmt.Sprintf("%s:%s", tt.redirectURL, tt.nonce)
+			signature := security.Sign(stateData, tokenKey)
+			state := fmt.Sprintf("%s.%s", stateData, signature)
+
+			req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state="+state, nil)
+			req.Header.Set("Cookie", "oauth_state="+tt.nonce)
 			resp, _ := app.Test(req)
 
 			if resp.StatusCode != http.StatusFound {

--- a/backend/internal/service/security/security.go
+++ b/backend/internal/service/security/security.go
@@ -3,7 +3,9 @@ package security
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
@@ -91,4 +93,18 @@ func GenerateSecret(n int) (string, error) {
 // It wraps crypto/subtle.ConstantTimeCompare to mitigate timing attacks.
 func SecureCompare(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+// Sign generates an HMAC-SHA256 signature for the given data using the provided key.
+// It returns the hex-encoded signature.
+func Sign(data, key string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(data))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// Verify checks if the provided HMAC-SHA256 signature is valid for the given data and key.
+func Verify(data, signature, key string) bool {
+	expectedSignature := Sign(data, key)
+	return SecureCompare(signature, expectedSignature)
 }

--- a/backend/internal/service/security/security_test.go
+++ b/backend/internal/service/security/security_test.go
@@ -89,4 +89,30 @@ func TestSecurity(t *testing.T) {
 			t.Error("expected true for empty strings")
 		}
 	})
+
+	t.Run("SignVerify", func(t *testing.T) {
+		data := "sensitive info"
+		signKey := "secret"
+		sig := Sign(data, signKey)
+
+		if sig == "" {
+			t.Fatal("empty signature")
+		}
+
+		if !Verify(data, sig, signKey) {
+			t.Error("failed to verify valid signature")
+		}
+
+		if Verify(data, "invalid signature", signKey) {
+			t.Error("expected failure for invalid signature")
+		}
+
+		if Verify("tampered data", sig, signKey) {
+			t.Error("expected failure for tampered data")
+		}
+
+		if Verify(data, sig, "wrong key") {
+			t.Error("expected failure for wrong key")
+		}
+	})
 }


### PR DESCRIPTION
Identified a lack of CSRF protection in the Google OAuth login flow.

Changes:
1.  **Security Service**: Added `Sign` and `Verify` helpers using HMAC-SHA256 in `backend/internal/service/security/security.go`.
2.  **API Handler**:
    *   `googleLogin`: Generates a 16-character random nonce, stores it in an `oauth_state` cookie (HTTP-only, Secure, SameSite=Lax), and includes it in a signed `state` parameter (format: `redirectURL:nonce.signature`).
    *   `googleCallback`: Validates the `state` parameter's cryptographic signature, extracts the nonce, and verifies it against the `oauth_state` cookie.
    *   Ensures the cookie is cleared after use.
    *   Maintains and integrates with existing open-redirect protection logic.
3.  **Testing**:
    *   Added unit tests for `Sign` and `Verify` in `security_test.go`.
    *   Updated `api_test.go` to simulate the new signed state and cookie-based CSRF validation in the callback tests.

Verified that all backend tests pass after generating necessary mocks.

---
*PR created automatically by Jules for task [1080582480694485900](https://jules.google.com/task/1080582480694485900) started by @mustafaturan*