### PR TITLE
🛡️ Sentinel: [HIGH] Harden Google OAuth flow against CSRF

### DIFF
--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -294,7 +294,35 @@ func (h *handler) rootLogin() fiber.Handler {
 
 func (h *handler) googleLogin() fiber.Handler {
 	return func(c *fiber.Ctx) error {
-		state := c.Query("redirect_url", "state")
+		redirectURL := c.Query("redirect_url", "state")
+
+		// CSRF Protection: Generate a random nonce
+		nonce, err := security.GenerateSecret(16)
+		if err != nil {
+			zlog.Error().Err(err).Msg("Failed to generate OAuth state nonce")
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		}
+
+		// Store nonce in a secure cookie
+		cookie := &fiber.Cookie{
+			Name:     "oauth_state",
+			Value:    nonce,
+			Expires:  time.Now().Add(15 * time.Minute),
+			HTTPOnly: true,
+			Secure:   h.sslEnabled,
+			SameSite: "Lax",
+			Path:     "/",
+		}
+		if h.domain != "" && !strings.HasPrefix(h.domain, "localhost") {
+			cookie.Domain = "." + h.domain
+		}
+		c.Cookie(cookie)
+
+		// Signed state: redirectURL:nonce.signature
+		data := fmt.Sprintf("%s:%s", redirectURL, nonce)
+		signature := security.Sign(data, h.tokenKey)
+		state := fmt.Sprintf("%s.%s", data, signature)
+
 		return c.Redirect(h.auth.GetAuthURL(state))
 	}
 }
@@ -302,6 +330,56 @@ func (h *handler) googleLogin() fiber.Handler {
 func (h *handler) googleCallback() fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		code := c.Query("code")
+		state := c.Query("state")
+
+		// 1. Verify CSRF state
+		if state == "" {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "missing state parameter"})
+		}
+
+		// Parse state: data.signature
+		dotIdx := strings.LastIndex(state, ".")
+		if dotIdx == -1 {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid state format"})
+		}
+		stateData := state[:dotIdx]
+		signature := state[dotIdx+1:]
+
+		if !security.Verify(stateData, signature, h.tokenKey) {
+			zlog.Warn().Msg("OAuth state signature verification failed")
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "invalid state signature"})
+		}
+
+		// Parse data: redirectURL:nonce
+		colonIdx := strings.LastIndex(stateData, ":")
+		if colonIdx == -1 {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid state data format"})
+		}
+		redirectURLParam := stateData[:colonIdx]
+		sessionNonce := stateData[colonIdx+1:]
+
+		// Compare with cookie nonce
+		cookieNonce := c.Cookies("oauth_state")
+		// Clear cookie immediately
+		clearCookie := &fiber.Cookie{
+			Name:     "oauth_state",
+			Value:    "",
+			Expires:  time.Now().Add(-1 * time.Hour),
+			HTTPOnly: true,
+			Secure:   h.sslEnabled,
+			SameSite: "Lax",
+			Path:     "/",
+		}
+		if h.domain != "" && !strings.HasPrefix(h.domain, "localhost") {
+			clearCookie.Domain = "." + h.domain
+		}
+		c.Cookie(clearCookie)
+
+		if sessionNonce == "" || !security.SecureCompare(sessionNonce, cookieNonce) {
+			zlog.Warn().Msg("OAuth CSRF nonce mismatch")
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "CSRF verification failed"})
+		}
+
 		ctx, cancel := newContext(c)
 		defer cancel()
 
@@ -362,18 +440,17 @@ func (h *handler) googleCallback() fiber.Handler {
 		}
 		c.Cookie(cookie)
 
-		state := c.Query("state")
 		redirectURL := "/"
 		// Situational security: validate redirect URL to prevent open redirect
-		if state != "" && state != "state" {
-			if strings.HasPrefix(state, "/") && !strings.HasPrefix(state, "//") && !strings.HasPrefix(state, "/\\") {
-				redirectURL = state
+		if redirectURLParam != "" && redirectURLParam != "state" {
+			if strings.HasPrefix(redirectURLParam, "/") && !strings.HasPrefix(redirectURLParam, "//") && !strings.HasPrefix(redirectURLParam, "/\\") {
+				redirectURL = redirectURLParam
 			} else {
 				// Parse absolute URL and validate against baseURL
-				if pRedirect, err := url.Parse(state); err == nil && pRedirect.IsAbs() {
+				if pRedirect, err := url.Parse(redirectURLParam); err == nil && pRedirect.IsAbs() {
 					if pBase, err := url.Parse(h.baseURL); err == nil {
 						if pRedirect.Host == pBase.Host && pRedirect.Scheme == pBase.Scheme {
-							redirectURL = state
+							redirectURL = redirectURLParam
 						}
 					}
 				}

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -11,6 +11,7 @@ import (
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	"github.com/agentrq/agentrq/backend/internal/repository/base"
 	"github.com/agentrq/agentrq/backend/internal/service/auth"
+	"github.com/agentrq/agentrq/backend/internal/service/security"
 	"github.com/gofiber/fiber/v2"
 	"github.com/mustafaturan/monoflake"
 )
@@ -112,7 +113,13 @@ func TestGoogleCallback_OpenRedirectPrevention(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state="+tt.state, nil)
+			nonce := "nonce12345678901"
+			data := tt.state + ":" + nonce
+			signature := security.Sign(data, h.tokenKey)
+			state := data + "." + signature
+
+			req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state="+state, nil)
+			req.AddCookie(&http.Cookie{Name: "oauth_state", Value: nonce})
 			resp, _ := app.Test(req)
 
 			if resp.StatusCode != http.StatusFound {
@@ -124,6 +131,28 @@ func TestGoogleCallback_OpenRedirectPrevention(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("Invalid signature", func(t *testing.T) {
+		state := "/workspaces:nonce.invalidsig"
+		req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state="+state, nil)
+		resp, _ := app.Test(req)
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("Expected status 403, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("Nonce mismatch", func(t *testing.T) {
+		data := "/workspaces:nonce1"
+		sig := security.Sign(data, h.tokenKey)
+		state := data + "." + sig
+
+		req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state="+state, nil)
+		req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "nonce2"})
+		resp, _ := app.Test(req)
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("Expected status 403, got %d", resp.StatusCode)
+		}
+	})
 }
 
 type mockCrudGetWorkspace struct {

--- a/backend/internal/service/security/security.go
+++ b/backend/internal/service/security/security.go
@@ -3,7 +3,9 @@ package security
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
@@ -91,4 +93,17 @@ func GenerateSecret(n int) (string, error) {
 // It wraps crypto/subtle.ConstantTimeCompare to mitigate timing attacks.
 func SecureCompare(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+// Sign signs data with a key using HMAC-SHA256 and returns a hex-encoded signature.
+func Sign(data, key string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(data))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// Verify verifies a hex-encoded HMAC-SHA256 signature for data with a key.
+func Verify(data, signature, key string) bool {
+	expected := Sign(data, key)
+	return subtle.ConstantTimeCompare([]byte(expected), []byte(signature)) == 1
 }

--- a/backend/internal/service/security/security_test.go
+++ b/backend/internal/service/security/security_test.go
@@ -89,4 +89,22 @@ func TestSecurity(t *testing.T) {
 			t.Error("expected true for empty strings")
 		}
 	})
+
+	t.Run("SignVerify", func(t *testing.T) {
+		data := "some data to sign"
+		secret := "my-secret-key"
+		sig := Sign(data, secret)
+		if sig == "" {
+			t.Fatal("expected non-empty signature")
+		}
+		if !Verify(data, sig, secret) {
+			t.Error("expected signature to be valid")
+		}
+		if Verify(data, sig, "wrong-secret") {
+			t.Error("expected signature to be invalid with wrong secret")
+		}
+		if Verify("wrong data", sig, secret) {
+			t.Error("expected signature to be invalid for different data")
+		}
+	})
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing CSRF protection in Google OAuth flow.
🎯 Impact: An attacker could potentially trick a user into completing an OAuth flow initiated by the attacker, leading to account linking or session fixation issues.
🔧 Fix: Implemented cryptographically signed `state` parameters containing a session-bound nonce. The nonce is stored in a secure `oauth_state` cookie and verified during the callback.
✅ Verification: Added unit tests in `backend/internal/handler/api/api_test.go` and `backend/internal/service/security/security_test.go` covering signature verification, nonce matching, and error handling. Verified that the full backend test suite passes.

---
*PR created automatically by Jules for task [9675210463760596503](https://jules.google.com/task/9675210463760596503) started by @mustafaturan*