### PR TITLE
feat: Events system — named signals that trigger tasks across workspaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,18 @@ Mock packages are **generated** (gitignored). Run `make mocks` before testing if
 - Cron validation also lives here for the REST API path (same rules).
 - `isValidTaskStatus` — valid statuses: `notstarted`, `ongoing`, `completed`, `rejected`, `cron`, `blocked`.
 
+## Events (experimental)
+
+Named signals that let one workspace trigger tasks in another.
+
+- **DB models**: `events` and `event_triggers` tables (monoflake IDs).
+- **REST API** (all under `/api/v1/events`): CRUD for events + triggers, plus `GET /events/:id/tasks` to list tasks spawned by an event. These routes are handled by Fiber — do NOT add them to the stdlib `mux` in `app.go` (that mux is only for SSE and pub-stats routes).
+- **MCP tool**: `publishEvent` — agents call this to fire an event by name with a payload and optional FAQ.
+- **Task `eventId` field** (base62): set at task creation (REST or MCP) to link a task to an event. When the task reaches `completed` status, the linked event is auto-published via `updateStatusFunc` in `app.go`. The createTask notification sent to the agent via the MCP channel automatically appends `[On completion: call publishEvent("name", "...")]` so the agent knows to publish with a meaningful payload before completing.
+- **Consumer**: `backend/internal/controller/event/` subscribes to `PubSubTopicEvents` (ID 3) and fans out to all `EventTrigger` rows, creating tasks via `renderTemplate` substituting `{{EVENT_PAYLOAD}}` and `{{EVENT_FAQ}}` **in the body only** — the title is always static text.
+- **`EventTrigger.emitEventId`**: optional field that chains events — when the trigger's spawned task completes it publishes this second event. The consumer appends the same `publishEvent` instruction to the task body. Triggered tasks always start as `notstarted` (no cron scheduling).
+- **Frontend**: `/events` list + `/events/:id` detail (triggers CRUD + resulting tasks, 10 shown with load-more). Both the task-creation form and the trigger-creation form have an optional "Emit event on completion" selector.
+
 ## Commit convention
 
 Include `Task: <taskID>` in the commit body for traceability.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,6 +32,8 @@ A task is the atomic unit of work. Key fields:
 | `Title` / `Body` | Task description |
 | `CronSchedule` | 5-field cron string (for scheduled task templates) |
 | `ParentID` | Set when a task is spawned from a cron template |
+| `TriggerID` | ID of the event that caused this task (set by the event consumer) |
+| `EventID` | ID of the event this task should publish on completion |
 | `SortOrder` | Controls queue priority for `getNextTask` |
 | `AllowAllCommands` | Per-task override for permission gating |
 
@@ -95,10 +97,11 @@ Every agent connected to a per-workspace MCP server has access to exactly these 
 | `getWorkspace()` | Returns workspace name, description, and task stats |
 | `getNextTask()` | Dequeues the next `notstarted` agent-assigned task (sorted by `SortOrder`) |
 | `getTaskMessages(taskId, cursor?, limit?)` | Paginated message history for a task |
-| `createTask(title, body, assignee?, attachments?, cronSchedule?)` | Creates a new task (or cron template) in this workspace |
+| `createTask(title, body, assignee?, attachments?, cronSchedule?, eventId?)` | Creates a new task (or cron template) in this workspace; `eventId` links a task to the event it should publish on completion |
 | `updateTaskStatus(taskId, status)` | Transitions task state; auto-appends a status message |
 | `reply(chatId, text, attachments?)` | Sends a message in a task's conversation thread |
 | `downloadAttachment(attachmentId, taskId)` | Retrieves a file attachment as base64 |
+| `publishEvent(name, payload, faq?)` | Fires a named event with a payload and optional FAQ; fans out to all matching `EventTrigger` rows, creating tasks in subscribed workspaces |
 
 All state mutations go through the MCP tool layer — there is no direct database access for agents.
 
@@ -219,8 +222,8 @@ AgentRQ uses two complementary event systems:
 
 ### PubSub (Internal)
 - Separate async bus for system-level concerns
-- Topics: `PubSubTopicCRUD` (entity lifecycle events), `PubSubTopicMCP` (tool call telemetry)
-- Consumed by: Slack controller, notification service, push service, central SSE forwarder, telemetry
+- Topics: `PubSubTopicCRUD` (entity lifecycle events), `PubSubTopicMCP` (tool call telemetry), `PubSubTopicEvents` (named event signals)
+- Consumed by: Slack controller, notification service, push service, central SSE forwarder, telemetry, event consumer
 
 The **Central Forwarder** bridges them: it subscribes to the CRUD PubSub topic and translates entity events into workspace-scoped SSE events on the EventBus.
 
@@ -238,6 +241,132 @@ Tasks with `status = "cron"` are templates managed by the Scheduler service:
 - **Granularity rule**: minute field must be a single integer (0–59); wildcards/ranges/steps are rejected — enforcing a minimum hourly granularity
 
 This allows supervisors to schedule recurring subtask generation without human intervention.
+
+---
+
+## Events (Cross-Workspace Signals)
+
+Events are named signals that let one workspace trigger tasks in other workspaces — enabling decoupled, event-driven multi-agent pipelines without requiring a supervisor agent to coordinate.
+
+### Core Concepts
+
+| Entity | Description |
+|--------|-------------|
+| `Event` | A named signal definition owned by a user. Has a `name` (unique per user, lowercase letters/digits/underscores) and an optional `payloadGuidelines` hint for agents publishing it |
+| `EventTrigger` | A subscription: when a named event fires, create a task in `WorkspaceID` using the stored `Title` and `Body` template. Optional `EmitEventID` chains to a second event on the spawned task's completion |
+| `Task.EventID` | Links a task to the event it should publish when completed. The assigned agent receives an explicit `publishEvent` instruction in its task notification |
+| `Task.TriggerID` | Records which event caused this task (set by the event consumer at creation time) |
+
+### Publishing Flow
+
+```
+Agent calls publishEvent("deploy_done", "v2.3 deployed to prod")
+  → WorkspaceServer.handlePublishEvent
+  → PublishEventFunc (wired in app.go): looks up event by name + userID
+  → pubsubSvc.Publish(PubSubTopicEvents, EventPublishedPayload{...})
+  → Event Consumer (controller/event) receives message
+  → repo.SystemListEventTriggersByEventID(eventID)
+  → For each EventTrigger:
+      body = renderTemplate(trigger.Body, payload, faqText)   ← {{EVENT_PAYLOAD}} / {{EVENT_FAQ}} substituted
+      title = trigger.Title                                   ← always static text, no substitution
+      if trigger.EmitEventID != 0:
+          body += "[On completion: call publishEvent(\"chain_event\", ...)]"
+          task.EventID = trigger.EmitEventID
+      repo.CreateTask(...)
+      pubsubSvc.Publish(PubSubTopicCRUD, ActionTaskCreate)    ← SSE push to human UI
+      bus.Publish(workspaceID, ...)                           ← EventBus SSE for real-time update
+```
+
+### Agent Instruction Injection
+
+When a task is created with an `EventID` (via REST or triggered by an `EventTrigger.EmitEventID`), the MCP channel notification delivered to the agent is augmented:
+
+```
+[Task abc123] Review and summarize the latest deploy
+<task body>
+
+[On completion: call publishEvent("deploy_reviewed", "<your output payload>")]
+Payload guidelines: Summarise key changes, risks, and sign-off status
+```
+
+This ensures the agent knows to publish the event explicitly with a meaningful payload before marking the task completed.
+
+### Event Chaining
+
+`EventTrigger.EmitEventID` enables pipelines: the spawned task inherits an `EventID` pointing to a second event. When the agent completes that task and calls `publishEvent`, the second event fires, triggering its own set of `EventTrigger` rows — and so on.
+
+```
+Event A fires
+  → Trigger T1 creates Task X in Workspace B (EventID = Event B)
+    → Agent completes Task X, calls publishEvent("event_b", payload)
+      → Event B fires
+        → Trigger T2 creates Task Y in Workspace C
+```
+
+### Diagrams
+
+**Single event fan-out:**
+
+```mermaid
+sequenceDiagram
+    participant A as Agent (Workspace A)
+    participant MCP as WorkspaceServer (MCP)
+    participant PS as PubSub<br/>(topic: Events)
+    participant EC as Event Consumer
+    participant DB as Repository
+    participant B as Workspace B
+    participant C as Workspace C
+    participant UI as Human UI (SSE)
+
+    A->>MCP: publishEvent("deploy_done", payload)
+    MCP->>DB: GetEventByName("deploy_done", userID)
+    DB-->>MCP: Event{id, name}
+    MCP->>PS: Publish(EventPublishedPayload)
+
+    PS->>EC: EventPublishedPayload received
+    EC->>DB: SystemListEventTriggersByEventID(eventID)
+    DB-->>EC: [Trigger→WS-B, Trigger→WS-C]
+
+    EC->>DB: CreateTask(WS-B, title, renderTemplate(body, payload))
+    EC->>DB: CreateTask(WS-C, title, renderTemplate(body, payload))
+
+    EC->>PS: Publish(ActionTaskCreate, WS-B)
+    EC->>PS: Publish(ActionTaskCreate, WS-C)
+    PS-->>UI: SSE task.created (WS-B)
+    PS-->>UI: SSE task.created (WS-C)
+
+    B-->>B: Agent picks up task via getNextTask()
+    C-->>C: Agent picks up task via getNextTask()
+```
+
+**Event chaining (EmitEventID):**
+
+```mermaid
+sequenceDiagram
+    participant A as Agent A<br/>(Workspace A)
+    participant EC as Event Consumer
+    participant B as Agent B<br/>(Workspace B)
+    participant C as Agent C<br/>(Workspace C)
+    participant PS as PubSub
+
+    Note over A: Task has EventID = "event_b"
+    A->>PS: publishEvent("event_a", payload_a)
+    PS->>EC: fan-out → create Task in WS-B<br/>(body includes publishEvent("event_b") instruction)<br/>Task.EventID = event_b
+
+    B-->>B: getNextTask() → works on task
+    Note over B: Notification includes:<br/>[On completion: call publishEvent("event_b", ...)]
+    B->>PS: publishEvent("event_b", payload_b)
+
+    PS->>EC: fan-out → create Task in WS-C<br/>(body includes payload_b via {{EVENT_PAYLOAD}})
+    C-->>C: getNextTask() → works on task
+```
+
+### Ownership & Authorization
+
+All event and trigger operations are scoped to the requesting user at the repository layer (`WHERE id = ? AND user_id = ?`). The `CreateEventTrigger` controller additionally validates:
+- The target event belongs to the user (`GetEvent(eventID, uid)`)
+- The target workspace belongs to the user (`CheckWorkspaceAccess(workspaceID, uid)`)
+- The `EmitEventID`, if set, belongs to the user (`GetEvent(emitEventID, uid)`)
 
 ---
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -80,6 +80,30 @@ Views define the external structures, like JSON inputs/outputs.
 - **Payload transformation:** Return raw `[]byte` payloads from `...ToHTTPResponse` mappers using `json.Marshal` internally, preventing the caller (handler) from doing repetitive marshaling.
 - **Formatting:** After your changes use always go format
 
+## 5. Events (experimental)
+
+Event-driven agent-to-agent communication wired through three layers:
+
+- **Models** (`internal/data/model`):
+  - `Event` — name (unique per user), payloadGuidelines, FAQ JSON.
+  - `EventTrigger` — workspaceID, title, body, assignee, allowAllCommands, **emitEventId** (optional: which event the spawned task should publish on completion).
+  - `Task.EventID` — links a task to an event it should publish when completed.
+
+- **PubSub topic**: `PubSubTopicEvents = 3` (see `internal/data/entity/crud/entity.go`). Payload: `EventPublishedPayload{EventID, Name, Payload, FAQ}`.
+
+- **Consumer** (`internal/controller/event/event.go`): subscribes to topic 3, fans out to all matching `EventTrigger` rows via `SystemListEventTriggersByEventID`.
+  - `renderTemplate` substitutes `{{EVENT_PAYLOAD}}` and `{{EVENT_FAQ}}` **in the task body only** — the title uses static text (`strings.TrimSpace`).
+  - If `trigger.EmitEventID != 0`, appends `[On completion: call publishEvent("name", "...")]` to the body and sets `Task.EventID = trigger.EmitEventID` (event chaining).
+  - Triggered tasks always start as `notstarted`; `CronSchedule` on `EventTrigger` is ignored at fire time.
+
+- **MCP tool** `publishEvent`: looks up event by name via `PublishEventFunc` callback (wired in `app.go`), publishes to topic 3 with agent-supplied payload.
+
+- **Task auto-publish** (`updateStatusFunc` in `app.go`): when `status == "completed" && task.EventID != 0`, publishes the linked event automatically as a fallback. The `createTask` handler also injects `[On completion: call publishEvent("name", "...")]` into the MCP channel notification so the agent publishes explicitly with a real payload first.
+
+- **REST routes** (`internal/handler/api/event.go`): events CRUD + `/events/:id/triggers` CRUD + `GET /events/:id/tasks`. **Do not register these in the stdlib `mux`** — only SSE routes (`/api/v1/workspaces/{id}/events`) and pub-stats belong there. All events CRUD is handled by Fiber.
+
+- **Routing pitfall**: the stdlib `mux` in `app.go` takes precedence over Fiber for exact path matches. Adding `mux.Handle("/api/v1/events", ...)` would silently shadow the Fiber CRUD handler and cause all requests to hang (the SSE stream writer never delivers a JSON body).
+
 ## 4. Unit Testing and Mocking
 
 Unit testing is critical for maintaining service reliability.

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -14,6 +14,7 @@ import (
 	"gorm.io/datatypes"
 
 	"github.com/agentrq/agentrq/backend/internal/controller/crud"
+	eventctrl "github.com/agentrq/agentrq/backend/internal/controller/event"
 	"github.com/agentrq/agentrq/backend/internal/controller/mcp"
 	"github.com/agentrq/agentrq/backend/internal/controller/notification"
 	"github.com/agentrq/agentrq/backend/internal/controller/pub"
@@ -153,6 +154,8 @@ func New(cfg Config) (*App, error) {
 		&model.SlackWorkspaceLink{},
 		&model.SlackTaskThread{},
 		&model.PushSubscription{},
+		&model.Event{},
+		&model.EventTrigger{},
 	); err != nil {
 		return nil, fmt.Errorf("migrate db: %w", err)
 	}
@@ -205,6 +208,9 @@ func New(cfg Config) (*App, error) {
 	}
 	if _, err := pubsubSvc.Create(context.Background(), pubsub.CreatePubSubRequest{ID: entity.PubSubTopicMCP}); err != nil {
 		return nil, fmt.Errorf("create global pubsub (id:%d): %w", entity.PubSubTopicMCP, err)
+	}
+	if _, err := pubsubSvc.Create(context.Background(), pubsub.CreatePubSubRequest{ID: entity.PubSubTopicEvents}); err != nil {
+		return nil, fmt.Errorf("create global pubsub (id:%d): %w", entity.PubSubTopicEvents, err)
 	}
 
 	// ── Controllers ────────────────────────────────────────────────────────────
@@ -324,6 +330,7 @@ func New(cfg Config) (*App, error) {
 								Origin:       entity.OriginMCP,
 							},
 						})
+
 					}
 					pubsubSvc.Publish(context.Background(), pubsub.PublishRequest{
 						PubSubID: entity.PubSubTopicCRUD,
@@ -498,6 +505,23 @@ func New(cfg Config) (*App, error) {
 					UserID:      monoflake.ID(workspace.UserID).String(),
 				})
 			},
+			func(ctx context.Context, eventName string, payload string, faq []entity.EventFAQ) error {
+				uid := monoflake.IDFromBase62(workspaceOwner).Int64()
+				ev, err := repo.GetEventByName(ctx, eventName, uid)
+				if err != nil {
+					return fmt.Errorf("event %q not found", eventName)
+				}
+				pubsubSvc.Publish(ctx, pubsub.PublishRequest{
+					PubSubID: entity.PubSubTopicEvents,
+					Event: entity.EventPublishedPayload{
+						EventID: ev.ID,
+						Name:    ev.Name,
+						Payload: payload,
+						FAQ:     faq,
+					},
+				})
+				return nil
+			},
 			bus,
 			ids,
 			storageSvc,
@@ -555,6 +579,16 @@ func New(cfg Config) (*App, error) {
 	})
 	if err := pushCtrl.Start(context.Background()); err != nil {
 		zlog.Error().Err(err).Msg("failed to start push controller")
+	}
+
+	eventConsumer := eventctrl.New(eventctrl.Params{
+		Repository: repo,
+		PubSub:     pubsubSvc,
+		IDGen:      ids,
+		Bus:        bus,
+	})
+	if err := eventConsumer.Start(context.Background()); err != nil {
+		zlog.Error().Err(err).Msg("failed to start event consumer")
 	}
 
 	// Central PubSub to EventBus SSE Forwarder
@@ -727,7 +761,6 @@ func New(cfg Config) (*App, error) {
 	// ── Server Start ─────────────────────────────────────────────────
 	mux.Handle("/pub/stats", pubStatsHandler(pubStatsCtrl))
 	mux.Handle("/api/v1/workspaces/{id}/events", eventsHandler(crudCtrl, bus, tokenSvc))
-	mux.Handle("/api/v1/events", eventsHandler(crudCtrl, bus, tokenSvc))
 	mux.Handle("/", adaptor.FiberApp(fiberApp))
 
 	var finalRouter http.Handler = mux

--- a/backend/internal/controller/crud/crud.go
+++ b/backend/internal/controller/crud/crud.go
@@ -27,6 +27,8 @@ type (
 		WorkspaceController
 		UserController
 		TaskController
+		EventController
+		EventTriggerController
 	}
 
 	controller struct {

--- a/backend/internal/controller/crud/event.go
+++ b/backend/internal/controller/crud/event.go
@@ -1,0 +1,248 @@
+package crud
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	mapper "github.com/agentrq/agentrq/backend/internal/mapper/api"
+	"github.com/mustafaturan/monoflake"
+	"github.com/robfig/cron/v3"
+)
+
+// EventController defines event operations.
+type EventController interface {
+	CreateEvent(ctx context.Context, req entity.CreateEventRequest) (*entity.CreateEventResponse, error)
+	GetEvent(ctx context.Context, req entity.GetEventRequest) (*entity.GetEventResponse, error)
+	ListEvents(ctx context.Context, req entity.ListEventsRequest) (*entity.ListEventsResponse, error)
+	UpdateEvent(ctx context.Context, req entity.UpdateEventRequest) (*entity.UpdateEventResponse, error)
+	DeleteEvent(ctx context.Context, req entity.DeleteEventRequest) error
+}
+
+// EventTriggerController defines event trigger operations.
+type EventTriggerController interface {
+	CreateEventTrigger(ctx context.Context, req entity.CreateEventTriggerRequest) (*entity.CreateEventTriggerResponse, error)
+	GetEventTrigger(ctx context.Context, req entity.GetEventTriggerRequest) (*entity.GetEventTriggerResponse, error)
+	ListEventTriggers(ctx context.Context, req entity.ListEventTriggersRequest) (*entity.ListEventTriggersResponse, error)
+	DeleteEventTrigger(ctx context.Context, req entity.DeleteEventTriggerRequest) error
+	ListTasksFromEvent(ctx context.Context, req entity.ListTasksFromEventRequest) (*entity.ListTasksFromEventResponse, error)
+}
+
+// ── Events ────────────────────────────────────────────────────────────────────
+
+func (c *controller) CreateEvent(ctx context.Context, req entity.CreateEventRequest) (*entity.CreateEventResponse, error) {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	if uid == 0 {
+		return nil, fmt.Errorf("invalid userID")
+	}
+	if !isValidEventName(req.Name) {
+		return nil, fmt.Errorf("invalid event name: must match ^[a-z][a-z0-9_]{0,128}$")
+	}
+
+	now := time.Now()
+	m := model.Event{
+		ID:                c.idgen.NextID(),
+		CreatedAt:         now,
+		UpdatedAt:         now,
+		UserID:            uid,
+		Name:              req.Name,
+		PayloadGuidelines: req.PayloadGuidelines,
+	}
+
+	created, err := c.repository.CreateEvent(ctx, m)
+	if err != nil {
+		return nil, err
+	}
+	return &entity.CreateEventResponse{Event: mapper.FromModelEventToEntity(created)}, nil
+}
+
+func (c *controller) GetEvent(ctx context.Context, req entity.GetEventRequest) (*entity.GetEventResponse, error) {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	e, err := c.repository.GetEvent(ctx, req.ID, uid)
+	if err != nil {
+		return nil, err
+	}
+	return &entity.GetEventResponse{Event: mapper.FromModelEventToEntity(e)}, nil
+}
+
+func (c *controller) ListEvents(ctx context.Context, req entity.ListEventsRequest) (*entity.ListEventsResponse, error) {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	models, err := c.repository.ListEventsByUser(ctx, uid)
+	if err != nil {
+		return nil, err
+	}
+	events := make([]entity.Event, len(models))
+	for i, m := range models {
+		events[i] = mapper.FromModelEventToEntity(m)
+	}
+	return &entity.ListEventsResponse{Events: events}, nil
+}
+
+func (c *controller) UpdateEvent(ctx context.Context, req entity.UpdateEventRequest) (*entity.UpdateEventResponse, error) {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	if uid == 0 {
+		return nil, fmt.Errorf("invalid userID")
+	}
+	updated, err := c.repository.UpdateEvent(ctx, req.ID, uid, req.PayloadGuidelines)
+	if err != nil {
+		return nil, err
+	}
+	return &entity.UpdateEventResponse{Event: mapper.FromModelEventToEntity(updated)}, nil
+}
+
+func (c *controller) DeleteEvent(ctx context.Context, req entity.DeleteEventRequest) error {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	return c.repository.DeleteEvent(ctx, req.ID, uid)
+}
+
+// ── EventTriggers ─────────────────────────────────────────────────────────────
+
+func (c *controller) CreateEventTrigger(ctx context.Context, req entity.CreateEventTriggerRequest) (*entity.CreateEventTriggerResponse, error) {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	if uid == 0 {
+		return nil, fmt.Errorf("invalid userID")
+	}
+
+	// Verify the event exists and belongs to this user.
+	if _, err := c.repository.GetEvent(ctx, req.EventID, uid); err != nil {
+		return nil, fmt.Errorf("event not found")
+	}
+
+	// Verify the target workspace belongs to this user.
+	ok, err := c.repository.CheckWorkspaceAccess(ctx, req.WorkspaceID, uid)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("workspace not found")
+	}
+
+	if req.Title == "" {
+		return nil, fmt.Errorf("title is required")
+	}
+
+	if req.CronSchedule != "" {
+		if err := validateEventTriggerCron(req.CronSchedule); err != nil {
+			return nil, err
+		}
+	}
+
+	if req.EmitEventID != 0 {
+		if _, err := c.repository.GetEvent(ctx, req.EmitEventID, uid); err != nil {
+			return nil, fmt.Errorf("emit event not found")
+		}
+	}
+
+	now := time.Now()
+	m := model.EventTrigger{
+		ID:               c.idgen.NextID(),
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		EventID:          req.EventID,
+		WorkspaceID:      req.WorkspaceID,
+		UserID:           uid,
+		Title:            req.Title,
+		Body:             req.Body,
+		Assignee:         req.Assignee,
+		CronSchedule:     req.CronSchedule,
+		AllowAllCommands: req.AllowAllCommands,
+		EmitEventID:      req.EmitEventID,
+	}
+
+	created, err := c.repository.CreateEventTrigger(ctx, m)
+	if err != nil {
+		return nil, err
+	}
+	return &entity.CreateEventTriggerResponse{EventTrigger: mapper.FromModelEventTriggerToEntity(created)}, nil
+}
+
+func (c *controller) GetEventTrigger(ctx context.Context, req entity.GetEventTriggerRequest) (*entity.GetEventTriggerResponse, error) {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	t, err := c.repository.GetEventTrigger(ctx, req.ID, uid)
+	if err != nil {
+		return nil, err
+	}
+	return &entity.GetEventTriggerResponse{EventTrigger: mapper.FromModelEventTriggerToEntity(t)}, nil
+}
+
+func (c *controller) ListEventTriggers(ctx context.Context, req entity.ListEventTriggersRequest) (*entity.ListEventTriggersResponse, error) {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	models, err := c.repository.ListEventTriggersByEvent(ctx, req.EventID, uid)
+	if err != nil {
+		return nil, err
+	}
+	triggers := make([]entity.EventTrigger, len(models))
+	for i, m := range models {
+		triggers[i] = mapper.FromModelEventTriggerToEntity(m)
+	}
+	return &entity.ListEventTriggersResponse{EventTriggers: triggers}, nil
+}
+
+func (c *controller) DeleteEventTrigger(ctx context.Context, req entity.DeleteEventTriggerRequest) error {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	return c.repository.DeleteEventTrigger(ctx, req.ID, uid)
+}
+
+func (c *controller) ListTasksFromEvent(ctx context.Context, req entity.ListTasksFromEventRequest) (*entity.ListTasksFromEventResponse, error) {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	models, err := c.repository.ListTasksByTriggerID(ctx, req.EventID, uid)
+	if err != nil {
+		return nil, err
+	}
+	tasks := make([]entity.Task, len(models))
+	for i, m := range models {
+		tasks[i] = c.fromModelTaskToEntity(m)
+	}
+	return &entity.ListTasksFromEventResponse{Tasks: tasks}, nil
+}
+
+// ── Validation helpers ────────────────────────────────────────────────────────
+
+// validateEventTriggerCron enforces the same cron rules as the MCP server:
+// - exactly 5 fields
+// - minute field must be a single fixed integer 0-59 (no wildcards, steps, ranges, or comma-lists)
+// - valid cron syntax overall
+func validateEventTriggerCron(schedule string) error {
+	fields := strings.Fields(schedule)
+	if len(fields) != 5 {
+		return fmt.Errorf("cron schedule must have exactly 5 fields (minute hour dom month dow)")
+	}
+	minuteField := fields[0]
+	if minuteField == "*" ||
+		strings.Contains(minuteField, "/") ||
+		strings.Contains(minuteField, "-") ||
+		strings.Contains(minuteField, ",") {
+		return fmt.Errorf("cron schedule granularity too fine: minute field must be a single fixed value (0-59), got %q", minuteField)
+	}
+	minute, err := strconv.Atoi(minuteField)
+	if err != nil || minute < 0 || minute > 59 {
+		return fmt.Errorf("cron schedule minute field must be a valid integer between 0 and 59, got %q", minuteField)
+	}
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	if _, err := parser.Parse(schedule); err != nil {
+		return fmt.Errorf("invalid cron schedule: %w", err)
+	}
+	return nil
+}
+
+func isValidEventName(name string) bool {
+	if len(name) == 0 || len(name) > 129 {
+		return false
+	}
+	for i, ch := range name {
+		if i == 0 {
+			if ch < 'a' || ch > 'z' {
+				return false
+			}
+		} else {
+			if !((ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '_') {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/backend/internal/controller/crud/event_test.go
+++ b/backend/internal/controller/crud/event_test.go
@@ -1,0 +1,440 @@
+package crud
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	"github.com/agentrq/agentrq/backend/internal/repository/base"
+	"github.com/golang/mock/gomock"
+)
+
+// ── isValidEventName ──────────────────────────────────────────────────────────
+
+func TestIsValidEventName(t *testing.T) {
+	valid := []string{"a", "abc", "a1", "a_b", "task_done", "a" + repeat("b", 128)}
+	for _, n := range valid {
+		if !isValidEventName(n) {
+			t.Errorf("expected %q to be valid", n)
+		}
+	}
+	invalid := []string{
+		"", "A", "1abc", "_abc", "abc-def", "abc def",
+		"a" + repeat("b", 129), // 130 chars total — over limit
+	}
+	for _, n := range invalid {
+		if isValidEventName(n) {
+			t.Errorf("expected %q to be invalid", n)
+		}
+	}
+}
+
+func repeat(s string, n int) string {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = s[0]
+	}
+	return string(out)
+}
+
+// ── validateEventTriggerCron ──────────────────────────────────────────────────
+
+func TestValidateEventTriggerCron(t *testing.T) {
+	valid := []string{
+		"0 * * * *",    // every hour at :00
+		"30 * * * *",   // every hour at :30
+		"0 0 * * *",    // every day midnight
+		"30 14 25 4 *", // one-time
+	}
+	for _, s := range valid {
+		if err := validateEventTriggerCron(s); err != nil {
+			t.Errorf("expected %q to be valid, got %v", s, err)
+		}
+	}
+	invalid := []string{
+		"* * * * *",    // wildcard minute
+		"*/5 * * * *",  // step
+		"0-5 * * * *",  // range
+		"0,30 * * * *", // comma list
+		"60 * * * *",   // out of range
+		"abc * * * *",  // non-integer
+		"0 * * *",      // too few fields
+	}
+	for _, s := range invalid {
+		if err := validateEventTriggerCron(s); err == nil {
+			t.Errorf("expected %q to be invalid", s)
+		}
+	}
+}
+
+// ── CreateEvent ───────────────────────────────────────────────────────────────
+
+func TestCreateEvent_Success(t *testing.T) {
+	e := newTestController(t)
+	now := time.Now()
+	created := model.Event{ID: 100, UserID: testUserID, Name: "deploy_done", CreatedAt: now, UpdatedAt: now}
+
+	e.idgen.EXPECT().NextID().Return(int64(100))
+	e.repo.EXPECT().CreateEvent(gomock.Any(), gomock.Any()).Return(created, nil)
+
+	resp, err := e.controller.CreateEvent(context.Background(), entity.CreateEventRequest{
+		UserID: testUserIDStr,
+		Name:   "deploy_done",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Event.ID != 100 {
+		t.Errorf("expected ID 100, got %d", resp.Event.ID)
+	}
+}
+
+func TestCreateEvent_InvalidName(t *testing.T) {
+	e := newTestController(t)
+	_, err := e.controller.CreateEvent(context.Background(), entity.CreateEventRequest{
+		UserID: testUserIDStr,
+		Name:   "InvalidName",
+	})
+	if err == nil {
+		t.Error("expected error for invalid event name")
+	}
+}
+
+func TestCreateEvent_EmptyName(t *testing.T) {
+	e := newTestController(t)
+	_, err := e.controller.CreateEvent(context.Background(), entity.CreateEventRequest{
+		UserID: testUserIDStr,
+		Name:   "",
+	})
+	if err == nil {
+		t.Error("expected error for empty name")
+	}
+}
+
+
+func TestCreateEvent_InvalidUserID(t *testing.T) {
+	e := newTestController(t)
+	_, err := e.controller.CreateEvent(context.Background(), entity.CreateEventRequest{
+		UserID: "",
+		Name:   "valid_name",
+	})
+	if err == nil {
+		t.Error("expected error for invalid userID")
+	}
+}
+
+// ── GetEvent ──────────────────────────────────────────────────────────────────
+
+func TestGetEvent_Success(t *testing.T) {
+	e := newTestController(t)
+	now := time.Now()
+	m := model.Event{ID: 200, UserID: testUserID, Name: "code_done", CreatedAt: now}
+
+	e.repo.EXPECT().GetEvent(gomock.Any(), int64(200), testUserID).Return(m, nil)
+
+	resp, err := e.controller.GetEvent(context.Background(), entity.GetEventRequest{
+		ID:     200,
+		UserID: testUserIDStr,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Event.Name != "code_done" {
+		t.Errorf("expected name code_done, got %s", resp.Event.Name)
+	}
+}
+
+func TestGetEvent_NotFound(t *testing.T) {
+	e := newTestController(t)
+	e.repo.EXPECT().GetEvent(gomock.Any(), int64(999), testUserID).Return(model.Event{}, base.ErrNotFound)
+
+	_, err := e.controller.GetEvent(context.Background(), entity.GetEventRequest{
+		ID:     999,
+		UserID: testUserIDStr,
+	})
+	if err == nil {
+		t.Error("expected error for missing event")
+	}
+}
+
+// ── ListEvents ────────────────────────────────────────────────────────────────
+
+func TestListEvents_Success(t *testing.T) {
+	e := newTestController(t)
+	models := []model.Event{
+		{ID: 1, UserID: testUserID, Name: "event_a"},
+		{ID: 2, UserID: testUserID, Name: "event_b"},
+	}
+	e.repo.EXPECT().ListEventsByUser(gomock.Any(), testUserID).Return(models, nil)
+
+	resp, err := e.controller.ListEvents(context.Background(), entity.ListEventsRequest{UserID: testUserIDStr})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Events) != 2 {
+		t.Errorf("expected 2 events, got %d", len(resp.Events))
+	}
+}
+
+// ── DeleteEvent ───────────────────────────────────────────────────────────────
+
+func TestDeleteEvent_Success(t *testing.T) {
+	e := newTestController(t)
+	e.repo.EXPECT().DeleteEvent(gomock.Any(), int64(100), testUserID).Return(nil)
+
+	err := e.controller.DeleteEvent(context.Background(), entity.DeleteEventRequest{
+		ID:     100,
+		UserID: testUserIDStr,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteEvent_NotFound(t *testing.T) {
+	e := newTestController(t)
+	e.repo.EXPECT().DeleteEvent(gomock.Any(), int64(999), testUserID).Return(base.ErrNotFound)
+
+	err := e.controller.DeleteEvent(context.Background(), entity.DeleteEventRequest{
+		ID:     999,
+		UserID: testUserIDStr,
+	})
+	if err == nil {
+		t.Error("expected error for missing event")
+	}
+}
+
+// ── CreateEventTrigger ────────────────────────────────────────────────────────
+
+func TestCreateEventTrigger_Success(t *testing.T) {
+	e := newTestController(t)
+	now := time.Now()
+	created := model.EventTrigger{
+		ID: 500, EventID: 100, WorkspaceID: 1, UserID: testUserID,
+		Title: "Deploy done: {{EVENT_PAYLOAD}}", Assignee: "agent",
+		CreatedAt: now,
+	}
+
+	e.repo.EXPECT().GetEvent(gomock.Any(), int64(100), testUserID).Return(model.Event{ID: 100}, nil)
+	e.repo.EXPECT().CheckWorkspaceAccess(gomock.Any(), int64(1), testUserID).Return(true, nil)
+	e.idgen.EXPECT().NextID().Return(int64(500))
+	e.repo.EXPECT().CreateEventTrigger(gomock.Any(), gomock.Any()).Return(created, nil)
+
+	resp, err := e.controller.CreateEventTrigger(context.Background(), entity.CreateEventTriggerRequest{
+		EventID:     100,
+		WorkspaceID: 1,
+		Title:       "Deploy done: {{EVENT_PAYLOAD}}",
+		Assignee:    "agent",
+		UserID:      testUserIDStr,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.EventTrigger.ID != 500 {
+		t.Errorf("expected ID 500, got %d", resp.EventTrigger.ID)
+	}
+}
+
+func TestCreateEventTrigger_EventNotFound(t *testing.T) {
+	e := newTestController(t)
+	e.repo.EXPECT().GetEvent(gomock.Any(), int64(999), testUserID).Return(model.Event{}, base.ErrNotFound)
+
+	_, err := e.controller.CreateEventTrigger(context.Background(), entity.CreateEventTriggerRequest{
+		EventID:     999,
+		WorkspaceID: 1,
+		Title:       "My trigger",
+		UserID:      testUserIDStr,
+	})
+	if err == nil {
+		t.Error("expected error when event not found")
+	}
+}
+
+func TestCreateEventTrigger_WorkspaceNotOwned(t *testing.T) {
+	e := newTestController(t)
+	e.repo.EXPECT().GetEvent(gomock.Any(), int64(100), testUserID).Return(model.Event{ID: 100}, nil)
+	e.repo.EXPECT().CheckWorkspaceAccess(gomock.Any(), int64(99), testUserID).Return(false, nil)
+
+	_, err := e.controller.CreateEventTrigger(context.Background(), entity.CreateEventTriggerRequest{
+		EventID:     100,
+		WorkspaceID: 99,
+		Title:       "My trigger",
+		UserID:      testUserIDStr,
+	})
+	if err == nil {
+		t.Error("expected error for unowned workspace")
+	}
+}
+
+func TestCreateEventTrigger_InvalidCron(t *testing.T) {
+	e := newTestController(t)
+	e.repo.EXPECT().GetEvent(gomock.Any(), int64(100), testUserID).Return(model.Event{ID: 100}, nil)
+	e.repo.EXPECT().CheckWorkspaceAccess(gomock.Any(), int64(1), testUserID).Return(true, nil)
+
+	_, err := e.controller.CreateEventTrigger(context.Background(), entity.CreateEventTriggerRequest{
+		EventID:      100,
+		WorkspaceID:  1,
+		Title:        "My trigger",
+		CronSchedule: "*/5 * * * *", // sub-hourly — rejected
+		UserID:       testUserIDStr,
+	})
+	if err == nil {
+		t.Error("expected error for invalid cron schedule")
+	}
+}
+
+func TestCreateEventTrigger_EmptyTitle(t *testing.T) {
+	e := newTestController(t)
+	e.repo.EXPECT().GetEvent(gomock.Any(), int64(100), testUserID).Return(model.Event{ID: 100}, nil)
+	e.repo.EXPECT().CheckWorkspaceAccess(gomock.Any(), int64(1), testUserID).Return(true, nil)
+
+	_, err := e.controller.CreateEventTrigger(context.Background(), entity.CreateEventTriggerRequest{
+		EventID:     100,
+		WorkspaceID: 1,
+		Title:       "",
+		UserID:      testUserIDStr,
+	})
+	if err == nil {
+		t.Error("expected error for empty title")
+	}
+}
+
+func TestCreateEventTrigger_InvalidUserID(t *testing.T) {
+	e := newTestController(t)
+	_, err := e.controller.CreateEventTrigger(context.Background(), entity.CreateEventTriggerRequest{
+		EventID:     100,
+		WorkspaceID: 1,
+		Title:       "My trigger",
+		UserID:      "",
+	})
+	if err == nil {
+		t.Error("expected error for invalid userID")
+	}
+}
+
+func TestCreateEventTrigger_EmitEventNotOwned(t *testing.T) {
+	e := newTestController(t)
+	e.repo.EXPECT().GetEvent(gomock.Any(), int64(100), testUserID).Return(model.Event{ID: 100}, nil)
+	e.repo.EXPECT().CheckWorkspaceAccess(gomock.Any(), int64(1), testUserID).Return(true, nil)
+	e.repo.EXPECT().GetEvent(gomock.Any(), int64(999), testUserID).Return(model.Event{}, base.ErrNotFound)
+
+	_, err := e.controller.CreateEventTrigger(context.Background(), entity.CreateEventTriggerRequest{
+		EventID:     100,
+		WorkspaceID: 1,
+		Title:       "My trigger",
+		EmitEventID: 999,
+		UserID:      testUserIDStr,
+	})
+	if err == nil {
+		t.Error("expected error when emit event not owned by user")
+	}
+}
+
+// ── ListEventTriggers ─────────────────────────────────────────────────────────
+
+func TestListEventTriggers_Success(t *testing.T) {
+	e := newTestController(t)
+	models := []model.EventTrigger{
+		{ID: 1, EventID: 10, UserID: testUserID},
+		{ID: 2, EventID: 10, UserID: testUserID},
+	}
+	e.repo.EXPECT().ListEventTriggersByEvent(gomock.Any(), int64(10), testUserID).Return(models, nil)
+
+	resp, err := e.controller.ListEventTriggers(context.Background(), entity.ListEventTriggersRequest{
+		EventID: 10,
+		UserID:  testUserIDStr,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.EventTriggers) != 2 {
+		t.Errorf("expected 2 triggers, got %d", len(resp.EventTriggers))
+	}
+}
+
+// ── DeleteEventTrigger ────────────────────────────────────────────────────────
+
+func TestDeleteEventTrigger_Success(t *testing.T) {
+	e := newTestController(t)
+	e.repo.EXPECT().DeleteEventTrigger(gomock.Any(), int64(500), testUserID).Return(nil)
+
+	err := e.controller.DeleteEventTrigger(context.Background(), entity.DeleteEventTriggerRequest{
+		ID:     500,
+		UserID: testUserIDStr,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteEventTrigger_NotFound(t *testing.T) {
+	e := newTestController(t)
+	e.repo.EXPECT().DeleteEventTrigger(gomock.Any(), int64(999), testUserID).Return(base.ErrNotFound)
+
+	err := e.controller.DeleteEventTrigger(context.Background(), entity.DeleteEventTriggerRequest{
+		ID:     999,
+		UserID: testUserIDStr,
+	})
+	if err == nil {
+		t.Error("expected error for missing trigger")
+	}
+}
+
+// ── ListTasksFromEvent ────────────────────────────────────────────────────────
+
+func TestListTasksFromEvent_Success(t *testing.T) {
+	e := newTestController(t)
+	models := []model.Task{
+		{ID: 1, TriggerID: 10, UserID: testUserID, Status: "completed"},
+		{ID: 2, TriggerID: 10, UserID: testUserID, Status: "notstarted"},
+	}
+	e.repo.EXPECT().ListTasksByTriggerID(gomock.Any(), int64(10), testUserID).Return(models, nil)
+
+	resp, err := e.controller.ListTasksFromEvent(context.Background(), entity.ListTasksFromEventRequest{
+		EventID: 10,
+		UserID:  testUserIDStr,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Tasks) != 2 {
+		t.Errorf("expected 2 tasks, got %d", len(resp.Tasks))
+	}
+}
+
+func TestListTasksFromEvent_Empty(t *testing.T) {
+	e := newTestController(t)
+	e.repo.EXPECT().ListTasksByTriggerID(gomock.Any(), int64(42), testUserID).Return(nil, nil)
+
+	resp, err := e.controller.ListTasksFromEvent(context.Background(), entity.ListTasksFromEventRequest{
+		EventID: 42,
+		UserID:  testUserIDStr,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Tasks) != 0 {
+		t.Errorf("expected 0 tasks, got %d", len(resp.Tasks))
+	}
+}
+
+// ── GetEventTrigger ───────────────────────────────────────────────────────────
+
+func TestGetEventTrigger_Success(t *testing.T) {
+	e := newTestController(t)
+	m := model.EventTrigger{ID: 500, EventID: 100, UserID: testUserID, Title: "my trigger"}
+	e.repo.EXPECT().GetEventTrigger(gomock.Any(), int64(500), testUserID).Return(m, nil)
+
+	resp, err := e.controller.GetEventTrigger(context.Background(), entity.GetEventTriggerRequest{
+		ID:     500,
+		UserID: testUserIDStr,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.EventTrigger.Title != "my trigger" {
+		t.Errorf("expected title 'my trigger', got %s", resp.EventTrigger.Title)
+	}
+}

--- a/backend/internal/controller/crud/task.go
+++ b/backend/internal/controller/crud/task.go
@@ -91,21 +91,22 @@ func (c *controller) CreateTask(ctx context.Context, req entity.CreateTaskReques
 	}
 
 	m := model.Task{
-		ID:           c.idgen.NextID(),
-		CreatedAt:    now,
-		UpdatedAt:    now,
-		UserID:       userID,
-		WorkspaceID:  req.Task.WorkspaceID,
-		CreatedBy:    req.Task.CreatedBy,
-		Assignee:     req.Task.Assignee,
-		Status:       status,
-		Title:        req.Task.Title,
-		Body:         req.Task.Body,
-		Attachments:  attachJSON,
-		CronSchedule: req.Task.CronSchedule,
-		ParentID:     req.Task.ParentID,
-		SortOrder:    sortOrder,
+		ID:               c.idgen.NextID(),
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		UserID:           userID,
+		WorkspaceID:      req.Task.WorkspaceID,
+		CreatedBy:        req.Task.CreatedBy,
+		Assignee:         req.Task.Assignee,
+		Status:           status,
+		Title:            req.Task.Title,
+		Body:             req.Task.Body,
+		Attachments:      attachJSON,
+		CronSchedule:     req.Task.CronSchedule,
+		ParentID:         req.Task.ParentID,
+		SortOrder:        sortOrder,
 		AllowAllCommands: allowAll,
+		EventID:          req.Task.EventID,
 	}
 	created, err := c.repository.CreateTask(ctx, m)
 	if err != nil {
@@ -637,10 +638,11 @@ func (c *controller) fromModelTaskToEntity(m model.Task) entity.Task {
 		ReplyText:    m.ReplyText,
 		Attachments:  atts,
 		Messages:     msgs,
-		CronSchedule: m.CronSchedule,
-		ParentID:     m.ParentID,
-		SortOrder:    m.SortOrder,
+		CronSchedule:     m.CronSchedule,
+		ParentID:         m.ParentID,
+		SortOrder:        m.SortOrder,
 		AllowAllCommands: m.AllowAllCommands,
+		EventID:          m.EventID,
 	}
 }
 

--- a/backend/internal/controller/event/event.go
+++ b/backend/internal/controller/event/event.go
@@ -1,0 +1,184 @@
+package event
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	mapper "github.com/agentrq/agentrq/backend/internal/mapper/api"
+	"github.com/agentrq/agentrq/backend/internal/repository/base"
+	"github.com/agentrq/agentrq/backend/internal/service/eventbus"
+	"github.com/agentrq/agentrq/backend/internal/service/idgen"
+	"github.com/agentrq/agentrq/backend/internal/service/pubsub"
+	"github.com/mustafaturan/monoflake"
+	zlog "github.com/rs/zerolog/log"
+)
+
+type (
+	Params struct {
+		Repository base.Repository
+		PubSub     pubsub.Service
+		IDGen      idgen.Service
+		Bus        *eventbus.Bus
+	}
+
+	Controller interface {
+		Start(ctx context.Context) error
+	}
+
+	controller struct {
+		repo   base.Repository
+		pubsub pubsub.Service
+		ids    idgen.Service
+		bus    *eventbus.Bus
+	}
+)
+
+func New(p Params) Controller {
+	return &controller{
+		repo:   p.Repository,
+		pubsub: p.PubSub,
+		ids:    p.IDGen,
+		bus:    p.Bus,
+	}
+}
+
+func (c *controller) Start(ctx context.Context) error {
+	res, err := c.pubsub.Subscribe(ctx, pubsub.SubscribeRequest{PubSubID: entity.PubSubTopicEvents})
+	if err != nil {
+		return fmt.Errorf("failed to subscribe to events topic: %w", err)
+	}
+
+	zlog.Info().Msg("[event-consumer] started controller")
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg, ok := <-res.Events:
+				if !ok {
+					zlog.Warn().Msg("[event-consumer] pubsub channel closed")
+					return
+				}
+				ev, ok := msg.(entity.EventPublishedPayload)
+				if !ok {
+					continue
+				}
+				go c.processEvent(context.Background(), ev)
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (c *controller) processEvent(ctx context.Context, ev entity.EventPublishedPayload) {
+	triggers, err := c.repo.SystemListEventTriggersByEventID(ctx, ev.EventID)
+	if err != nil || len(triggers) == 0 {
+		return
+	}
+
+	faqText := renderFAQ(ev.FAQ)
+
+	for _, trigger := range triggers {
+		c.createTriggeredTask(ctx, trigger, ev.Payload, faqText)
+	}
+}
+
+func (c *controller) createTriggeredTask(ctx context.Context, trigger model.EventTrigger, payload string, faqText string) {
+	title := strings.TrimSpace(trigger.Title)
+	if title == "" {
+		zlog.Warn().Int64("triggerID", trigger.ID).Msg("[event-consumer] rendered title is empty, skipping")
+		return
+	}
+	body := renderTemplate(trigger.Body, payload, faqText)
+
+	ws, err := c.repo.SystemGetWorkspace(ctx, trigger.WorkspaceID)
+	if err != nil {
+		zlog.Warn().Err(err).Int64("workspaceID", trigger.WorkspaceID).Msg("[event-consumer] workspace not found")
+		return
+	}
+
+	// If the trigger chains to another event, append publish instruction to the body.
+	if trigger.EmitEventID != 0 {
+		if emitEv, evErr := c.repo.GetEvent(ctx, trigger.EmitEventID, ws.UserID); evErr == nil {
+			instruction := fmt.Sprintf("\n\n[On completion: call publishEvent(\"%s\", \"<your output payload>\")]", emitEv.Name)
+			if emitEv.PayloadGuidelines != "" {
+				instruction += fmt.Sprintf("\nPayload guidelines: %s", emitEv.PayloadGuidelines)
+			}
+			body += instruction
+		}
+	}
+
+	now := time.Now()
+	task := model.Task{
+		ID:               c.ids.NextID(),
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		WorkspaceID:      trigger.WorkspaceID,
+		UserID:           ws.UserID,
+		CreatedBy:        "agent",
+		Assignee:         trigger.Assignee,
+		Status:           "notstarted",
+		Title:            title,
+		Body:             body,
+		AllowAllCommands: trigger.AllowAllCommands,
+		TriggerID:        trigger.EventID,
+		EventID:          trigger.EmitEventID,
+	}
+
+	created, err := c.repo.CreateTask(ctx, task)
+	if err != nil {
+		zlog.Warn().Err(err).Int64("triggerID", trigger.ID).Msg("[event-consumer] failed to create task")
+		return
+	}
+
+	ownerID := monoflake.ID(ws.UserID).String()
+
+	c.pubsub.Publish(ctx, pubsub.PublishRequest{
+		PubSubID: entity.PubSubTopicCRUD,
+		Event: entity.CRUDEvent{
+			Action:       entity.ActionTaskCreate,
+			WorkspaceID:  trigger.WorkspaceID,
+			UserID:       ws.UserID,
+			ResourceType: entity.ResourceTask,
+			ResourceID:   created.ID,
+			Actor:        entity.ActorAgent,
+			Origin:       entity.OriginAPI,
+		},
+	})
+
+	c.bus.Publish(trigger.WorkspaceID, ownerID, eventbus.Event{
+		Type:    "task.created",
+		Payload: mapper.FromModelTaskToView(created),
+	})
+}
+
+// renderTemplate substitutes {{EVENT_PAYLOAD}} and {{EVENT_FAQ}} in s.
+func renderTemplate(s string, payload string, faqText string) string {
+	s = strings.ReplaceAll(s, "{{EVENT_PAYLOAD}}", payload)
+	s = strings.ReplaceAll(s, "{{EVENT_FAQ}}", faqText)
+	return strings.TrimSpace(s)
+}
+
+// renderFAQ formats FAQ items as human-readable Q/A text.
+func renderFAQ(faq []entity.EventFAQ) string {
+	if len(faq) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for i, f := range faq {
+		if i > 0 {
+			sb.WriteString("\n\n")
+		}
+		sb.WriteString("Q: ")
+		sb.WriteString(f.Q)
+		sb.WriteString("\nA: ")
+		sb.WriteString(f.A)
+	}
+	return sb.String()
+}

--- a/backend/internal/controller/event/event_test.go
+++ b/backend/internal/controller/event/event_test.go
@@ -1,0 +1,292 @@
+package event
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	"github.com/agentrq/agentrq/backend/internal/repository/base"
+	"github.com/agentrq/agentrq/backend/internal/service/eventbus"
+	mock_idgen "github.com/agentrq/agentrq/backend/internal/service/mocks/idgen"
+	mock_pubsub "github.com/agentrq/agentrq/backend/internal/service/mocks/pubsub"
+	mock_repo "github.com/agentrq/agentrq/backend/internal/service/mocks/repository"
+	"github.com/agentrq/agentrq/backend/internal/service/pubsub"
+	"github.com/golang/mock/gomock"
+)
+
+func newTestController(t *testing.T) (*controller, *mock_repo.MockRepository, *mock_pubsub.MockService, *mock_idgen.MockService) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	mockRepo := mock_repo.NewMockRepository(ctrl)
+	mockPubSub := mock_pubsub.NewMockService(ctrl)
+	mockIDGen := mock_idgen.NewMockService(ctrl)
+	c := &controller{
+		repo:   mockRepo,
+		pubsub: mockPubSub,
+		ids:    mockIDGen,
+		bus:    eventbus.New(),
+	}
+	return c, mockRepo, mockPubSub, mockIDGen
+}
+
+// ── renderTemplate ────────────────────────────────────────────────────────────
+
+func TestRenderTemplate_PayloadSubstitution(t *testing.T) {
+	result := renderTemplate("Deploy: {{EVENT_PAYLOAD}}", "v1.2.3", "")
+	if result != "Deploy: v1.2.3" {
+		t.Errorf("unexpected result: %q", result)
+	}
+}
+
+func TestRenderTemplate_FAQSubstitution(t *testing.T) {
+	result := renderTemplate("Context:\n{{EVENT_FAQ}}", "", "Q: What?\nA: Nothing.")
+	if result != "Context:\nQ: What?\nA: Nothing." {
+		t.Errorf("unexpected result: %q", result)
+	}
+}
+
+func TestRenderTemplate_BothVars(t *testing.T) {
+	result := renderTemplate("{{EVENT_PAYLOAD}}\n{{EVENT_FAQ}}", "deployed", "Q: Why?\nA: Because.")
+	want := "deployed\nQ: Why?\nA: Because."
+	if result != want {
+		t.Errorf("got %q, want %q", result, want)
+	}
+}
+
+func TestRenderTemplate_NoVars(t *testing.T) {
+	result := renderTemplate("Fixed title", "payload", "faq")
+	if result != "Fixed title" {
+		t.Errorf("unexpected result: %q", result)
+	}
+}
+
+func TestRenderTemplate_EmptyAfterSubstitution(t *testing.T) {
+	result := renderTemplate("  {{EVENT_PAYLOAD}}  ", "", "")
+	if result != "" {
+		t.Errorf("expected empty after trim, got %q", result)
+	}
+}
+
+func TestRenderTemplate_MissingVarSafe(t *testing.T) {
+	// Template with only one var — the other substitution is a no-op
+	result := renderTemplate("Payload: {{EVENT_PAYLOAD}}", "hello", "")
+	if result != "Payload: hello" {
+		t.Errorf("unexpected result: %q", result)
+	}
+}
+
+// ── renderFAQ ─────────────────────────────────────────────────────────────────
+
+func TestRenderFAQ_Empty(t *testing.T) {
+	result := renderFAQ(nil)
+	if result != "" {
+		t.Errorf("expected empty, got %q", result)
+	}
+}
+
+func TestRenderFAQ_SingleItem(t *testing.T) {
+	faq := []entity.EventFAQ{{Q: "What happened?", A: "Deploy succeeded."}}
+	result := renderFAQ(faq)
+	want := "Q: What happened?\nA: Deploy succeeded."
+	if result != want {
+		t.Errorf("got %q, want %q", result, want)
+	}
+}
+
+func TestRenderFAQ_MultipleItems(t *testing.T) {
+	faq := []entity.EventFAQ{
+		{Q: "What?", A: "Deployment."},
+		{Q: "Where?", A: "Production."},
+	}
+	result := renderFAQ(faq)
+	want := "Q: What?\nA: Deployment.\n\nQ: Where?\nA: Production."
+	if result != want {
+		t.Errorf("got %q, want %q", result, want)
+	}
+}
+
+// ── processEvent ──────────────────────────────────────────────────────────────
+
+func TestProcessEvent_NoTriggers(t *testing.T) {
+	c, mockRepo, _, _ := newTestController(t)
+
+	mockRepo.EXPECT().
+		SystemListEventTriggersByEventID(gomock.Any(), int64(42)).
+		Return(nil, nil)
+
+	// No other repo calls expected
+	c.processEvent(context.Background(), entity.EventPublishedPayload{
+		EventID: 42,
+		Name:    "deploy_done",
+		Payload: "v1",
+	})
+}
+
+func TestProcessEvent_SingleTrigger(t *testing.T) {
+	c, mockRepo, mockPubSub, mockIDGen := newTestController(t)
+
+	trigger := model.EventTrigger{
+		ID:          1,
+		EventID:     42,
+		WorkspaceID: 10,
+		Title:       "Deploy: {{EVENT_PAYLOAD}}",
+		Body:        "Details",
+		Assignee:    "agent",
+	}
+
+	mockRepo.EXPECT().
+		SystemListEventTriggersByEventID(gomock.Any(), int64(42)).
+		Return([]model.EventTrigger{trigger}, nil)
+
+	mockRepo.EXPECT().
+		SystemGetWorkspace(gomock.Any(), int64(10)).
+		Return(model.Workspace{ID: 10, UserID: 100}, nil)
+
+	mockIDGen.EXPECT().NextID().Return(int64(999))
+
+	mockRepo.EXPECT().
+		CreateTask(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, t model.Task) (model.Task, error) {
+			if t.Title != "Deploy: v1.2.3" {
+				return model.Task{}, nil
+			}
+			if t.TriggerID != 42 {
+				return model.Task{}, nil
+			}
+			if t.WorkspaceID != 10 {
+				return model.Task{}, nil
+			}
+			t.CreatedAt = time.Now()
+			return t, nil
+		})
+
+	mockPubSub.EXPECT().
+		Publish(gomock.Any(), gomock.Any()).
+		Return(&pubsub.PublishResponse{}, nil)
+
+	c.processEvent(context.Background(), entity.EventPublishedPayload{
+		EventID: 42,
+		Name:    "deploy_done",
+		Payload: "v1.2.3",
+	})
+}
+
+func TestProcessEvent_MultipleWorkspaces(t *testing.T) {
+	c, mockRepo, mockPubSub, mockIDGen := newTestController(t)
+
+	triggers := []model.EventTrigger{
+		{ID: 1, EventID: 42, WorkspaceID: 10, Title: "Task in ws10", Assignee: "agent"},
+		{ID: 2, EventID: 42, WorkspaceID: 20, Title: "Task in ws20", Assignee: "human"},
+	}
+
+	mockRepo.EXPECT().
+		SystemListEventTriggersByEventID(gomock.Any(), int64(42)).
+		Return(triggers, nil)
+
+	mockRepo.EXPECT().
+		SystemGetWorkspace(gomock.Any(), int64(10)).
+		Return(model.Workspace{ID: 10, UserID: 100}, nil)
+	mockRepo.EXPECT().
+		SystemGetWorkspace(gomock.Any(), int64(20)).
+		Return(model.Workspace{ID: 20, UserID: 200}, nil)
+
+	mockIDGen.EXPECT().NextID().Return(int64(111)).Times(1)
+	mockIDGen.EXPECT().NextID().Return(int64(222)).Times(1)
+
+	mockRepo.EXPECT().CreateTask(gomock.Any(), gomock.Any()).Return(model.Task{ID: 111}, nil).Times(1)
+	mockRepo.EXPECT().CreateTask(gomock.Any(), gomock.Any()).Return(model.Task{ID: 222}, nil).Times(1)
+
+	mockPubSub.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(&pubsub.PublishResponse{}, nil).Times(2)
+
+	c.processEvent(context.Background(), entity.EventPublishedPayload{
+		EventID: 42,
+		Name:    "deploy_done",
+		Payload: "v1.2.3",
+	})
+}
+
+func TestProcessEvent_EmptyTitleSkipped(t *testing.T) {
+	c, mockRepo, _, _ := newTestController(t)
+
+	trigger := model.EventTrigger{
+		ID:          1,
+		EventID:     42,
+		WorkspaceID: 10,
+		Title:       "  ", // whitespace-only title is treated as empty
+		Assignee:    "agent",
+	}
+
+	mockRepo.EXPECT().
+		SystemListEventTriggersByEventID(gomock.Any(), int64(42)).
+		Return([]model.EventTrigger{trigger}, nil)
+
+	// SystemGetWorkspace and CreateTask must NOT be called — empty title guard fires first
+	c.processEvent(context.Background(), entity.EventPublishedPayload{
+		EventID: 42,
+		Name:    "deploy_done",
+		Payload: "some payload",
+	})
+}
+
+func TestProcessEvent_WorkspaceNotFound(t *testing.T) {
+	c, mockRepo, _, _ := newTestController(t)
+
+	trigger := model.EventTrigger{
+		ID: 1, EventID: 42, WorkspaceID: 99, Title: "My task", Assignee: "agent",
+	}
+
+	mockRepo.EXPECT().
+		SystemListEventTriggersByEventID(gomock.Any(), int64(42)).
+		Return([]model.EventTrigger{trigger}, nil)
+
+	mockRepo.EXPECT().
+		SystemGetWorkspace(gomock.Any(), int64(99)).
+		Return(model.Workspace{}, base.ErrNotFound)
+
+	// No CreateTask call expected
+	c.processEvent(context.Background(), entity.EventPublishedPayload{
+		EventID: 42,
+		Name:    "deploy_done",
+	})
+}
+
+func TestProcessEvent_WithCronSchedule(t *testing.T) {
+	c, mockRepo, mockPubSub, mockIDGen := newTestController(t)
+
+	trigger := model.EventTrigger{
+		ID:           1,
+		EventID:      42,
+		WorkspaceID:  10,
+		Title:        "Recurring check",
+		Assignee:     "agent",
+		CronSchedule: "0 * * * *",
+	}
+
+	mockRepo.EXPECT().
+		SystemListEventTriggersByEventID(gomock.Any(), int64(42)).
+		Return([]model.EventTrigger{trigger}, nil)
+
+	mockRepo.EXPECT().
+		SystemGetWorkspace(gomock.Any(), int64(10)).
+		Return(model.Workspace{ID: 10, UserID: 100}, nil)
+
+	mockIDGen.EXPECT().NextID().Return(int64(500))
+
+	mockRepo.EXPECT().
+		CreateTask(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, t model.Task) (model.Task, error) {
+			if t.Status != "cron" {
+				return model.Task{}, nil
+			}
+			return t, nil
+		})
+
+	mockPubSub.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(&pubsub.PublishResponse{}, nil)
+
+	c.processEvent(context.Background(), entity.EventPublishedPayload{
+		EventID: 42,
+		Name:    "deploy_done",
+	})
+}

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -37,6 +37,7 @@ import (
 type CreateTaskFunc func(ctx context.Context, task model.Task) (model.Task, error)
 type UpdateTaskStatusFunc func(ctx context.Context, taskID int64, status string) (model.Task, error)
 type GetTaskFunc func(ctx context.Context, taskID int64) (model.Task, error)
+
 // ListTasksFilter specifies optional filters for listing tasks.
 type ListTasksFilter struct {
 	Status []string
@@ -48,6 +49,7 @@ type GetNextTaskFunc func(ctx context.Context) (model.Task, error)
 type ReplyFunc func(ctx context.Context, chatID string, text string, attachments []entity.Attachment, metadata any) (int64, error)
 type UpdateMessageMetadataFunc func(ctx context.Context, taskID int64, messageID int64, metadata any) error
 type UpdateWorkspaceAutoAllowedToolsFunc func(ctx context.Context, tools []string) error
+type PublishEventFunc func(ctx context.Context, eventName string, payload string, faq []entity.EventFAQ) error
 
 type PermissionRequestParams struct {
 	RequestID    string `json:"request_id"`
@@ -71,6 +73,7 @@ type WorkspaceServer struct {
 	reply                 ReplyFunc
 	updateMessageMetadata UpdateMessageMetadataFunc
 	updateAutoAllowed     UpdateWorkspaceAutoAllowedToolsFunc
+	publishEvent          PublishEventFunc
 	bus                   *eventbus.Bus
 	idgen                 idgen.Service
 	storage               storage.Service
@@ -107,6 +110,20 @@ type CreateTaskParams struct {
 	Assignee     string `json:"assignee,omitempty" jsonschema:"Who should complete the task: 'human' or 'agent'. Default is 'agent'."`
 	Attachments  []any  `json:"attachments,omitempty" jsonschema:"Optional attachments"`
 	CronSchedule string `json:"cronSchedule,omitempty" jsonschema:"Optional cron schedule (5-field format: minute hour dom month dow). For RECURRING tasks (dom and month use wildcards) the minimum granularity is hourly — the minute field must be a single integer 0-59, not a wildcard or step (e.g. '30 * * * *'). For ONE-TIME tasks (fixed dom and month, e.g. '30 14 25 4 *') any fixed minute value 0-59 is accepted, enabling minute-level precision."`
+	EventID      string `json:"eventId,omitempty" jsonschema:"Optional event ID (base62) — when this task completes the named event is published automatically."`
+}
+
+// PublishEventParams is the input to the publishEvent tool.
+type PublishEventParams struct {
+	Name    string            `json:"name" jsonschema:"The event name to publish (must match an existing event in this workspace's owner account)"`
+	Payload string            `json:"payload,omitempty" jsonschema:"Unstructured text payload describing what happened"`
+	FAQ     []PublishEventFAQ `json:"faq,omitempty" jsonschema:"Optional question-answer pairs providing additional context"`
+}
+
+// PublishEventFAQ is a single question-answer pair in a publishEvent call.
+type PublishEventFAQ struct {
+	Q string `json:"q"`
+	A string `json:"a"`
 }
 
 // UpdateTaskStatusParams is the input to the update_task_status tool.
@@ -147,6 +164,7 @@ func NewWorkspaceServer(
 	reply ReplyFunc,
 	updateMessageMetadata UpdateMessageMetadataFunc,
 	updateAutoAllowed UpdateWorkspaceAutoAllowedToolsFunc,
+	publishEvent PublishEventFunc,
 	bus *eventbus.Bus,
 	ids idgen.Service,
 	store storage.Service,
@@ -170,6 +188,7 @@ func NewWorkspaceServer(
 		reply:                 reply,
 		updateMessageMetadata: updateMessageMetadata,
 		updateAutoAllowed:     updateAutoAllowed,
+		publishEvent:          publishEvent,
 		bus:                   bus,
 		idgen:                 ids,
 		storage:               store,
@@ -271,6 +290,11 @@ func NewWorkspaceServer(
 		Name:        "getNextTask",
 		Description: "Get the next available \"not started\" task assigned to the agent.",
 	}, ps.handleGetNextTask)
+
+	mcp.AddTool(mcpSrv, &mcp.Tool{
+		Name:        "publishEvent",
+		Description: "Publish a named event so that subscriber workspaces are notified and their trigger tasks are created automatically.",
+	}, ps.handlePublishEvent)
 
 	// Add middleware to handle incoming notifications (like permission_request)
 	mcpSrv.AddReceivingMiddleware(ps.notificationMiddleware)
@@ -562,6 +586,8 @@ func (ps *WorkspaceServer) handleCreateTask(ctx context.Context, req *mcp.CallTo
 		status = "cron"
 	}
 
+	eventID := monoflake.IDFromBase62(params.EventID).Int64()
+
 	t := model.Task{
 		ID:           ps.idgen.NextID(),
 		CreatedAt:    now,
@@ -574,6 +600,7 @@ func (ps *WorkspaceServer) handleCreateTask(ctx context.Context, req *mcp.CallTo
 		Title:        params.Title,
 		Body:         params.Body,
 		CronSchedule: params.CronSchedule,
+		EventID:      eventID,
 	}
 
 	if attachmentsJSON != "" {
@@ -778,6 +805,31 @@ func (ps *WorkspaceServer) handleDownloadAttachment(ctx context.Context, req *mc
 	return &mcp.CallToolResult{
 		IsError: true,
 		Content: []mcp.Content{&mcp.TextContent{Text: "attachment not found in task"}},
+	}, nil, nil
+}
+
+func (ps *WorkspaceServer) handlePublishEvent(ctx context.Context, _ *mcp.CallToolRequest, params PublishEventParams) (*mcp.CallToolResult, any, error) {
+	ps.emitTelemetry(ctx, ActionMCPToolCall, "publishEvent")
+	if params.Name == "" {
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{&mcp.TextContent{Text: "name is required"}},
+		}, nil, nil
+	}
+	faq := make([]entity.EventFAQ, len(params.FAQ))
+	for i, f := range params.FAQ {
+		faq[i] = entity.EventFAQ{Q: f.Q, A: f.A}
+	}
+	if err := ps.publishEvent(ctx, params.Name, params.Payload, faq); err != nil {
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("failed to publish event: %v", err)}},
+		}, nil, nil
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{
+			Text: fmt.Sprintf("event %q published", params.Name),
+		}},
 	}, nil, nil
 }
 

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -170,6 +170,7 @@ type (
 		ParentID         int64
 		SortOrder        float64
 		AllowAllCommands bool
+		EventID          int64
 	}
 
 	CreateTaskRequest struct {
@@ -420,12 +421,144 @@ type (
 		WorkspaceID int64
 		Endpoint    string
 	}
+
+	// Event entities
+
+	EventFAQ struct {
+		Q string
+		A string
+	}
+
+	Event struct {
+		ID                int64
+		CreatedAt         time.Time
+		UpdatedAt         time.Time
+		UserID            int64
+		Name              string
+		PayloadGuidelines string
+	}
+
+	CreateEventRequest struct {
+		Name              string
+		PayloadGuidelines string
+		UserID            string
+	}
+
+	CreateEventResponse struct {
+		Event Event
+	}
+
+	GetEventRequest struct {
+		ID     int64
+		UserID string
+	}
+
+	GetEventResponse struct {
+		Event Event
+	}
+
+	ListEventsRequest struct {
+		UserID string
+	}
+
+	ListEventsResponse struct {
+		Events []Event
+	}
+
+	UpdateEventRequest struct {
+		ID                int64
+		UserID            string
+		PayloadGuidelines string
+	}
+
+	UpdateEventResponse struct {
+		Event Event
+	}
+
+	DeleteEventRequest struct {
+		ID     int64
+		UserID string
+	}
+
+	// EventTrigger entities
+
+	EventTrigger struct {
+		ID               int64
+		CreatedAt        time.Time
+		UpdatedAt        time.Time
+		EventID          int64
+		WorkspaceID      int64
+		UserID           int64
+		Title            string
+		Body             string
+		Assignee         string
+		CronSchedule     string
+		AllowAllCommands bool
+		EmitEventID      int64
+	}
+
+	CreateEventTriggerRequest struct {
+		EventID          int64
+		WorkspaceID      int64
+		Title            string
+		Body             string
+		Assignee         string
+		CronSchedule     string
+		AllowAllCommands bool
+		EmitEventID      int64
+		UserID           string
+	}
+
+	CreateEventTriggerResponse struct {
+		EventTrigger EventTrigger
+	}
+
+	GetEventTriggerRequest struct {
+		ID     int64
+		UserID string
+	}
+
+	GetEventTriggerResponse struct {
+		EventTrigger EventTrigger
+	}
+
+	ListEventTriggersRequest struct {
+		EventID int64
+		UserID  string
+	}
+
+	ListEventTriggersResponse struct {
+		EventTriggers []EventTrigger
+	}
+
+	DeleteEventTriggerRequest struct {
+		ID     int64
+		UserID string
+	}
+
+	ListTasksFromEventRequest struct {
+		EventID int64
+		UserID  string
+	}
+
+	ListTasksFromEventResponse struct {
+		Tasks []Task
+	}
 )
 
 const (
-	PubSubTopicCRUD int64 = 1
-	PubSubTopicMCP  int64 = 2
+	PubSubTopicCRUD   int64 = 1
+	PubSubTopicMCP    int64 = 2
+	PubSubTopicEvents int64 = 3
 )
+
+// EventPublishedPayload is the message sent on PubSubTopicEvents when an event fires.
+type EventPublishedPayload struct {
+	EventID int64
+	Name    string
+	Payload string
+	FAQ     []EventFAQ
+}
 
 const (
 	ActorHuman Actor = 1
@@ -520,6 +653,7 @@ const (
 	ActionMCPPermissionManual        Action = 21
 	ActionMCPPermissionAuto          Action = 22
 	ActionTaskAllowAllCommandsToggle Action = 23
+	ActionEventPublished             Action = 30
 )
 
 func (a Action) String() string {
@@ -562,6 +696,8 @@ func (a Action) String() string {
 		return "mcp_permission_auto"
 	case ActionTaskAllowAllCommandsToggle:
 		return "task_allow_all_commands_toggle"
+	case ActionEventPublished:
+		return "event_published"
 	}
 	return "unknown"
 }

--- a/backend/internal/data/model/model.go
+++ b/backend/internal/data/model/model.go
@@ -47,6 +47,36 @@ type (
 		ParentID         int64   `gorm:"index:idx_tasks_parent_id"`
 		SortOrder        float64 `gorm:"type:real;default:0"`
 		AllowAllCommands bool    `gorm:"default:false"`
+		TriggerID        int64   `gorm:"index:idx_tasks_trigger_id"` // event that caused this task
+		EventID          int64   `gorm:"index:idx_tasks_event_id"`   // event this task emits on completion
+	}
+
+	// Event defines a named event that agents can publish after completing a task.
+	// Other workspaces can subscribe to it via EventTrigger.
+	Event struct {
+		ID                int64 `gorm:"primaryKey;autoIncrement:false"`
+		CreatedAt         time.Time
+		UpdatedAt         time.Time
+		UserID            int64          `gorm:"index:idx_events_user_id"`
+		Name              string `gorm:"type:varchar(140);uniqueIndex:idx_events_name_user_id"`
+		PayloadGuidelines string `gorm:"type:text"`
+	}
+
+	// EventTrigger subscribes a workspace to an Event; when the event fires, a task
+	// is created in the target workspace using the stored template.
+	EventTrigger struct {
+		ID               int64 `gorm:"primaryKey;autoIncrement:false"`
+		CreatedAt        time.Time
+		UpdatedAt        time.Time
+		EventID          int64  `gorm:"index:idx_event_triggers_event_id"`
+		WorkspaceID      int64  `gorm:"index:idx_event_triggers_workspace_id"`
+		UserID           int64  `gorm:"index:idx_event_triggers_user_id"`
+		Title            string `gorm:"type:varchar(255)"`
+		Body             string `gorm:"type:text"`
+		Assignee         string `gorm:"type:varchar(16)"`
+		CronSchedule     string `gorm:"type:varchar(64)"`
+		AllowAllCommands bool   `gorm:"default:false"`
+		EmitEventID      int64  `gorm:"index:idx_event_triggers_emit_event_id"` // event this trigger's task emits on completion
 	}
 
 	// Message is an entry in a task's chat history

--- a/backend/internal/data/view/api/view.go
+++ b/backend/internal/data/view/api/view.go
@@ -104,6 +104,7 @@ type (
 		ParentID         string       `json:"parentId,omitempty"`
 		SortOrder        float64      `json:"sortOrder"`
 		AllowAllCommands bool         `json:"allowAllCommands"`
+		EventID          string       `json:"eventId,omitempty"`
 	}
 
 	CreateTaskRequest struct {
@@ -234,5 +235,73 @@ type (
 
 	PushSubscriptionStatusResponse struct {
 		Subscribed bool `json:"subscribed"`
+	}
+
+	// Event views
+
+	Event struct {
+		ID                string    `json:"id"`
+		CreatedAt         time.Time `json:"createdAt"`
+		UpdatedAt         time.Time `json:"updatedAt"`
+		Name              string    `json:"name"`
+		PayloadGuidelines string    `json:"payloadGuidelines"`
+	}
+
+	CreateEventRequest struct {
+		Name              string `json:"name"`
+		PayloadGuidelines string `json:"payloadGuidelines"`
+	}
+
+	CreateEventResponse struct {
+		Event Event `json:"event"`
+	}
+
+	UpdateEventRequest struct {
+		PayloadGuidelines string `json:"payloadGuidelines"`
+	}
+
+	UpdateEventResponse struct {
+		Event Event `json:"event"`
+	}
+
+	GetEventResponse struct {
+		Event Event `json:"event"`
+	}
+
+	ListEventsResponse struct {
+		Events []Event `json:"events"`
+	}
+
+	// EventTrigger views
+
+	EventTrigger struct {
+		ID               string    `json:"id"`
+		CreatedAt        time.Time `json:"createdAt"`
+		EventID          string    `json:"eventId"`
+		WorkspaceID      string    `json:"workspaceId"`
+		Title            string    `json:"title"`
+		Body             string    `json:"body"`
+		Assignee         string    `json:"assignee"`
+		CronSchedule     string    `json:"cronSchedule,omitempty"`
+		AllowAllCommands bool      `json:"allowAllCommands"`
+		EmitEventID      string    `json:"emitEventId,omitempty"`
+	}
+
+	CreateEventTriggerRequest struct {
+		WorkspaceID      string `json:"workspaceId"`
+		Title            string `json:"title"`
+		Body             string `json:"body"`
+		Assignee         string `json:"assignee"`
+		CronSchedule     string `json:"cronSchedule,omitempty"`
+		AllowAllCommands bool   `json:"allowAllCommands"`
+		EmitEventID      string `json:"emitEventId,omitempty"`
+	}
+
+	CreateEventTriggerResponse struct {
+		EventTrigger EventTrigger `json:"eventTrigger"`
+	}
+
+	ListEventTriggersResponse struct {
+		EventTriggers []EventTrigger `json:"eventTriggers"`
 	}
 )

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -106,6 +106,7 @@ func New(p Params) (Handler, error) {
 	if err := h.registerTaskRoutes(); err != nil {
 		return nil, err
 	}
+	h.registerEventRoutes()
 	if p.PushCtrl != nil {
 		h.registerPushRoutes(p.PushCtrl)
 	}

--- a/backend/internal/handler/api/event.go
+++ b/backend/internal/handler/api/event.go
@@ -1,0 +1,237 @@
+package api
+
+import (
+	"net/http"
+
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	mapper "github.com/agentrq/agentrq/backend/internal/mapper/api"
+	"github.com/agentrq/agentrq/backend/internal/repository/base"
+	"github.com/gofiber/fiber/v2"
+	"github.com/mustafaturan/monoflake"
+)
+
+func (h *handler) registerEventRoutes() {
+	h.router.Post("/events", h.createEvent())
+	h.router.Get("/events", h.listEvents())
+	h.router.Get("/events/:id", h.getEvent())
+	h.router.Patch("/events/:id", h.updateEvent())
+	h.router.Delete("/events/:id", h.deleteEvent())
+	h.router.Post("/events/:id/triggers", h.createEventTrigger())
+	h.router.Get("/events/:id/triggers", h.listEventTriggers())
+	h.router.Delete("/events/:id/triggers/:triggerID", h.deleteEventTrigger())
+	h.router.Get("/events/:id/tasks", h.listTasksFromEvent())
+}
+
+func (h *handler) createEvent() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		rq := mapper.FromHTTPRequestToCreateEventRequestEntity(c)
+		if rq == nil {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		rq.UserID = c.Locals("user_id").(string)
+		ctx, cancel := newContext(c)
+		defer cancel()
+		rs, err := h.crud.CreateEvent(ctx, *rq)
+		if err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		c.Status(http.StatusCreated)
+		return c.Send(mapper.FromCreateEventResponseEntityToHTTPResponse(rs))
+	}
+}
+
+func (h *handler) listEvents() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		ctx, cancel := newContext(c)
+		defer cancel()
+		rs, err := h.crud.ListEvents(ctx, entity.ListEventsRequest{
+			UserID: c.Locals("user_id").(string),
+		})
+		if err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		return c.Send(mapper.FromListEventsResponseEntityToHTTPResponse(rs))
+	}
+}
+
+func (h *handler) getEvent() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		rq := mapper.FromHTTPRequestToGetEventRequestEntity(c)
+		if rq == nil {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		rq.UserID = c.Locals("user_id").(string)
+		ctx, cancel := newContext(c)
+		defer cancel()
+		rs, err := h.crud.GetEvent(ctx, *rq)
+		if err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		return c.Send(mapper.FromGetEventResponseEntityToHTTPResponse(rs))
+	}
+}
+
+func (h *handler) updateEvent() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		rq := mapper.FromHTTPRequestToUpdateEventRequestEntity(c)
+		if rq == nil {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		rq.UserID = c.Locals("user_id").(string)
+		ctx, cancel := newContext(c)
+		defer cancel()
+		rs, err := h.crud.UpdateEvent(ctx, *rq)
+		if err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		return c.Send(mapper.FromUpdateEventResponseEntityToHTTPResponse(rs))
+	}
+}
+
+func (h *handler) deleteEvent() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		rq := mapper.FromHTTPRequestToDeleteEventRequestEntity(c)
+		if rq == nil {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		rq.UserID = c.Locals("user_id").(string)
+		ctx, cancel := newContext(c)
+		defer cancel()
+		if err := h.crud.DeleteEvent(ctx, *rq); err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		c.Status(http.StatusNoContent)
+		return c.Send([]byte(""))
+	}
+}
+
+func (h *handler) createEventTrigger() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		rq := mapper.FromHTTPRequestToCreateEventTriggerRequestEntity(c)
+		if rq == nil {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		rq.UserID = c.Locals("user_id").(string)
+		ctx, cancel := newContext(c)
+		defer cancel()
+		rs, err := h.crud.CreateEventTrigger(ctx, *rq)
+		if err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		c.Status(http.StatusCreated)
+		return c.Send(mapper.FromCreateEventTriggerResponseEntityToHTTPResponse(rs))
+	}
+}
+
+func (h *handler) listEventTriggers() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		eventID := monoflake.IDFromBase62(c.Params("id")).Int64()
+		if eventID == 0 {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		userID := c.Locals("user_id").(string)
+		ctx, cancel := newContext(c)
+		defer cancel()
+
+		// Verify event ownership before listing triggers.
+		if _, err := h.crud.GetEvent(ctx, entity.GetEventRequest{ID: eventID, UserID: userID}); err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+
+		rs, err := h.crud.ListEventTriggers(ctx, entity.ListEventTriggersRequest{
+			EventID: eventID,
+			UserID:  userID,
+		})
+		if err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		return c.Send(mapper.FromListEventTriggersResponseEntityToHTTPResponse(rs))
+	}
+}
+
+func (h *handler) deleteEventTrigger() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		rq := mapper.FromHTTPRequestToDeleteEventTriggerRequestEntity(c)
+		if rq == nil {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		rq.UserID = c.Locals("user_id").(string)
+		ctx, cancel := newContext(c)
+		defer cancel()
+		if err := h.crud.DeleteEventTrigger(ctx, *rq); err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		c.Status(http.StatusNoContent)
+		return c.Send([]byte(""))
+	}
+}
+
+func (h *handler) listTasksFromEvent() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		eventID := monoflake.IDFromBase62(c.Params("id")).Int64()
+		if eventID == 0 {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		userID := c.Locals("user_id").(string)
+		ctx, cancel := newContext(c)
+		defer cancel()
+
+		// Verify event ownership before listing resulting tasks.
+		if _, err := h.crud.GetEvent(ctx, entity.GetEventRequest{ID: eventID, UserID: userID}); err != nil {
+			if err == base.ErrNotFound {
+				c.Status(http.StatusNotFound)
+				e, _ := mapper.FromErrorToHTTPResponse(err)
+				return c.Send(e)
+			}
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+
+		rs, err := h.crud.ListTasksFromEvent(ctx, entity.ListTasksFromEventRequest{
+			EventID: eventID,
+			UserID:  userID,
+		})
+		if err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		return c.Send(mapper.FromListTasksFromEventResponseEntityToHTTPResponse(rs))
+	}
+}

--- a/backend/internal/handler/api/event_test.go
+++ b/backend/internal/handler/api/event_test.go
@@ -1,0 +1,438 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/agentrq/agentrq/backend/internal/controller/crud"
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/agentrq/agentrq/backend/internal/repository/base"
+	"github.com/gofiber/fiber/v2"
+	"github.com/mustafaturan/monoflake"
+)
+
+// ── mock event crud controller ────────────────────────────────────────────────
+
+type mockEventCrud struct {
+	crud.Controller
+	createEventFunc        func(ctx context.Context, req entity.CreateEventRequest) (*entity.CreateEventResponse, error)
+	getEventFunc           func(ctx context.Context, req entity.GetEventRequest) (*entity.GetEventResponse, error)
+	listEventsFunc         func(ctx context.Context, req entity.ListEventsRequest) (*entity.ListEventsResponse, error)
+	deleteEventFunc        func(ctx context.Context, req entity.DeleteEventRequest) error
+	createEventTriggerFunc func(ctx context.Context, req entity.CreateEventTriggerRequest) (*entity.CreateEventTriggerResponse, error)
+	listEventTriggersFunc  func(ctx context.Context, req entity.ListEventTriggersRequest) (*entity.ListEventTriggersResponse, error)
+	deleteEventTriggerFunc func(ctx context.Context, req entity.DeleteEventTriggerRequest) error
+	listTasksFromEventFunc func(ctx context.Context, req entity.ListTasksFromEventRequest) (*entity.ListTasksFromEventResponse, error)
+}
+
+func (m *mockEventCrud) CreateEvent(ctx context.Context, req entity.CreateEventRequest) (*entity.CreateEventResponse, error) {
+	return m.createEventFunc(ctx, req)
+}
+func (m *mockEventCrud) GetEvent(ctx context.Context, req entity.GetEventRequest) (*entity.GetEventResponse, error) {
+	return m.getEventFunc(ctx, req)
+}
+func (m *mockEventCrud) ListEvents(ctx context.Context, req entity.ListEventsRequest) (*entity.ListEventsResponse, error) {
+	return m.listEventsFunc(ctx, req)
+}
+func (m *mockEventCrud) DeleteEvent(ctx context.Context, req entity.DeleteEventRequest) error {
+	return m.deleteEventFunc(ctx, req)
+}
+func (m *mockEventCrud) CreateEventTrigger(ctx context.Context, req entity.CreateEventTriggerRequest) (*entity.CreateEventTriggerResponse, error) {
+	return m.createEventTriggerFunc(ctx, req)
+}
+func (m *mockEventCrud) ListEventTriggers(ctx context.Context, req entity.ListEventTriggersRequest) (*entity.ListEventTriggersResponse, error) {
+	return m.listEventTriggersFunc(ctx, req)
+}
+func (m *mockEventCrud) DeleteEventTrigger(ctx context.Context, req entity.DeleteEventTriggerRequest) error {
+	return m.deleteEventTriggerFunc(ctx, req)
+}
+func (m *mockEventCrud) ListTasksFromEvent(ctx context.Context, req entity.ListTasksFromEventRequest) (*entity.ListTasksFromEventResponse, error) {
+	return m.listTasksFromEventFunc(ctx, req)
+}
+
+func newEventApp(ctrl *mockEventCrud) *fiber.App {
+	app := fiber.New()
+	h := &handler{crud: ctrl}
+	app.Post("/events", func(c *fiber.Ctx) error {
+		c.Locals("user_id", "user1")
+		return h.createEvent()(c)
+	})
+	app.Get("/events", func(c *fiber.Ctx) error {
+		c.Locals("user_id", "user1")
+		return h.listEvents()(c)
+	})
+	app.Get("/events/:id", func(c *fiber.Ctx) error {
+		c.Locals("user_id", "user1")
+		return h.getEvent()(c)
+	})
+	app.Delete("/events/:id", func(c *fiber.Ctx) error {
+		c.Locals("user_id", "user1")
+		return h.deleteEvent()(c)
+	})
+	app.Post("/events/:id/triggers", func(c *fiber.Ctx) error {
+		c.Locals("user_id", "user1")
+		return h.createEventTrigger()(c)
+	})
+	app.Get("/events/:id/triggers", func(c *fiber.Ctx) error {
+		c.Locals("user_id", "user1")
+		return h.listEventTriggers()(c)
+	})
+	app.Delete("/events/:id/triggers/:triggerID", func(c *fiber.Ctx) error {
+		c.Locals("user_id", "user1")
+		return h.deleteEventTrigger()(c)
+	})
+	app.Get("/events/:id/tasks", func(c *fiber.Ctx) error {
+		c.Locals("user_id", "user1")
+		return h.listTasksFromEvent()(c)
+	})
+	return app
+}
+
+var testEventID = monoflake.ID(100).String()
+var testTriggerID = monoflake.ID(200).String()
+
+// ── createEvent ───────────────────────────────────────────────────────────────
+
+func TestCreateEvent_Created(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.createEventFunc = func(_ context.Context, req entity.CreateEventRequest) (*entity.CreateEventResponse, error) {
+		return &entity.CreateEventResponse{Event: entity.Event{ID: 100, Name: req.Name}}, nil
+	}
+	app := newEventApp(ctrl)
+
+	body := []byte(`{"name":"deploy_done","payloadGuidelines":"what was deployed"}`)
+	req := httptest.NewRequest(http.MethodPost, "/events", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("expected 201, got %d", resp.StatusCode)
+	}
+}
+
+func TestCreateEvent_InvalidPayload(t *testing.T) {
+	app := newEventApp(&mockEventCrud{})
+	req := httptest.NewRequest(http.MethodPost, "/events", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d", resp.StatusCode)
+	}
+}
+
+func TestCreateEvent_ControllerError(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.createEventFunc = func(_ context.Context, _ entity.CreateEventRequest) (*entity.CreateEventResponse, error) {
+		return nil, errors.New("invalid event name")
+	}
+	app := newEventApp(ctrl)
+
+	body := []byte(`{"name":"bad name"}`)
+	req := httptest.NewRequest(http.MethodPost, "/events", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", resp.StatusCode)
+	}
+}
+
+// ── listEvents ────────────────────────────────────────────────────────────────
+
+func TestListEvents_OK(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.listEventsFunc = func(_ context.Context, _ entity.ListEventsRequest) (*entity.ListEventsResponse, error) {
+		return &entity.ListEventsResponse{Events: []entity.Event{{ID: 1, Name: "ev"}}}, nil
+	}
+	app := newEventApp(ctrl)
+
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+// ── getEvent ──────────────────────────────────────────────────────────────────
+
+func TestGetEvent_OK(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.getEventFunc = func(_ context.Context, req entity.GetEventRequest) (*entity.GetEventResponse, error) {
+		return &entity.GetEventResponse{Event: entity.Event{ID: req.ID, Name: "ev"}}, nil
+	}
+	app := newEventApp(ctrl)
+
+	req := httptest.NewRequest(http.MethodGet, "/events/"+testEventID, nil)
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestGetEvent_NotFound(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.getEventFunc = func(_ context.Context, _ entity.GetEventRequest) (*entity.GetEventResponse, error) {
+		return nil, base.ErrNotFound
+	}
+	app := newEventApp(ctrl)
+
+	req := httptest.NewRequest(http.MethodGet, "/events/"+testEventID, nil)
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestGetEvent_InvalidID(t *testing.T) {
+	app := newEventApp(&mockEventCrud{})
+	// "0" encodes to monoflake ID 0 which will fail base62 parse
+	req := httptest.NewRequest(http.MethodGet, "/events/!!!", nil)
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d", resp.StatusCode)
+	}
+}
+
+// ── deleteEvent ───────────────────────────────────────────────────────────────
+
+func TestDeleteEvent_NoContent(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.deleteEventFunc = func(_ context.Context, _ entity.DeleteEventRequest) error {
+		return nil
+	}
+	app := newEventApp(ctrl)
+
+	req := httptest.NewRequest(http.MethodDelete, "/events/"+testEventID, nil)
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("expected 204, got %d", resp.StatusCode)
+	}
+}
+
+func TestDeleteEvent_NotFound(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.deleteEventFunc = func(_ context.Context, _ entity.DeleteEventRequest) error {
+		return base.ErrNotFound
+	}
+	app := newEventApp(ctrl)
+
+	req := httptest.NewRequest(http.MethodDelete, "/events/"+testEventID, nil)
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestDeleteEvent_InvalidID(t *testing.T) {
+	app := newEventApp(&mockEventCrud{})
+	req := httptest.NewRequest(http.MethodDelete, "/events/!!!", nil)
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d", resp.StatusCode)
+	}
+}
+
+// ── IDOR: getEvent returns 404 for unowned events ─────────────────────────────
+
+func TestGetEvent_IDOR(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.getEventFunc = func(_ context.Context, req entity.GetEventRequest) (*entity.GetEventResponse, error) {
+		// Simulate: event exists but belongs to a different user
+		return nil, base.ErrNotFound
+	}
+	app := newEventApp(ctrl)
+
+	req := httptest.NewRequest(http.MethodGet, "/events/"+testEventID, nil)
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 for IDOR attempt, got %d", resp.StatusCode)
+	}
+}
+
+// ── createEventTrigger ────────────────────────────────────────────────────────
+
+func TestCreateEventTrigger_Created(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.createEventTriggerFunc = func(_ context.Context, req entity.CreateEventTriggerRequest) (*entity.CreateEventTriggerResponse, error) {
+		return &entity.CreateEventTriggerResponse{
+			EventTrigger: entity.EventTrigger{ID: 200, EventID: req.EventID},
+		}, nil
+	}
+	app := newEventApp(ctrl)
+
+	wsID := monoflake.ID(1).String()
+	body := []byte(`{"workspaceId":"` + wsID + `","title":"Deploy done","assignee":"agent"}`)
+	req := httptest.NewRequest(http.MethodPost, "/events/"+testEventID+"/triggers", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("expected 201, got %d", resp.StatusCode)
+	}
+}
+
+func TestCreateEventTrigger_InvalidPayload(t *testing.T) {
+	app := newEventApp(&mockEventCrud{})
+	// Missing title → mapper returns nil
+	body := []byte(`{"workspaceId":"` + monoflake.ID(1).String() + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/events/"+testEventID+"/triggers", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d", resp.StatusCode)
+	}
+}
+
+func TestCreateEventTrigger_EventNotOwned(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.createEventTriggerFunc = func(_ context.Context, _ entity.CreateEventTriggerRequest) (*entity.CreateEventTriggerResponse, error) {
+		return nil, base.ErrNotFound
+	}
+	app := newEventApp(ctrl)
+
+	wsID := monoflake.ID(1).String()
+	body := []byte(`{"workspaceId":"` + wsID + `","title":"My trigger","assignee":"agent"}`)
+	req := httptest.NewRequest(http.MethodPost, "/events/"+testEventID+"/triggers", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 for unowned event, got %d", resp.StatusCode)
+	}
+}
+
+// ── listEventTriggers ─────────────────────────────────────────────────────────
+
+func TestListEventTriggers_OK(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.getEventFunc = func(_ context.Context, _ entity.GetEventRequest) (*entity.GetEventResponse, error) {
+		return &entity.GetEventResponse{}, nil
+	}
+	ctrl.listEventTriggersFunc = func(_ context.Context, _ entity.ListEventTriggersRequest) (*entity.ListEventTriggersResponse, error) {
+		return &entity.ListEventTriggersResponse{EventTriggers: []entity.EventTrigger{{ID: 200}}}, nil
+	}
+	app := newEventApp(ctrl)
+
+	req := httptest.NewRequest(http.MethodGet, "/events/"+testEventID+"/triggers", nil)
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestListEventTriggers_IDOR(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.getEventFunc = func(_ context.Context, _ entity.GetEventRequest) (*entity.GetEventResponse, error) {
+		return nil, base.ErrNotFound
+	}
+	app := newEventApp(ctrl)
+
+	req := httptest.NewRequest(http.MethodGet, "/events/"+testEventID+"/triggers", nil)
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 for IDOR, got %d", resp.StatusCode)
+	}
+}
+
+// ── deleteEventTrigger ────────────────────────────────────────────────────────
+
+func TestDeleteEventTrigger_NoContent(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.deleteEventTriggerFunc = func(_ context.Context, _ entity.DeleteEventTriggerRequest) error {
+		return nil
+	}
+	app := newEventApp(ctrl)
+
+	req := httptest.NewRequest(http.MethodDelete, "/events/"+testEventID+"/triggers/"+testTriggerID, nil)
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("expected 204, got %d", resp.StatusCode)
+	}
+}
+
+func TestDeleteEventTrigger_NotFound(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.deleteEventTriggerFunc = func(_ context.Context, _ entity.DeleteEventTriggerRequest) error {
+		return base.ErrNotFound
+	}
+	app := newEventApp(ctrl)
+
+	req := httptest.NewRequest(http.MethodDelete, "/events/"+testEventID+"/triggers/"+testTriggerID, nil)
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestDeleteEventTrigger_InvalidID(t *testing.T) {
+	app := newEventApp(&mockEventCrud{})
+	req := httptest.NewRequest(http.MethodDelete, "/events/"+testEventID+"/triggers/!!!", nil)
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d", resp.StatusCode)
+	}
+}
+
+// ── listTasksFromEvent ────────────────────────────────────────────────────────
+
+func TestListTasksFromEvent_OK(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.getEventFunc = func(_ context.Context, _ entity.GetEventRequest) (*entity.GetEventResponse, error) {
+		return &entity.GetEventResponse{}, nil
+	}
+	ctrl.listTasksFromEventFunc = func(_ context.Context, _ entity.ListTasksFromEventRequest) (*entity.ListTasksFromEventResponse, error) {
+		return &entity.ListTasksFromEventResponse{Tasks: []entity.Task{{ID: 99}}}, nil
+	}
+	app := newEventApp(ctrl)
+
+	req := httptest.NewRequest(http.MethodGet, "/events/"+testEventID+"/tasks", nil)
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestListTasksFromEvent_IDOR(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.getEventFunc = func(_ context.Context, _ entity.GetEventRequest) (*entity.GetEventResponse, error) {
+		return nil, base.ErrNotFound
+	}
+	app := newEventApp(ctrl)
+
+	req := httptest.NewRequest(http.MethodGet, "/events/"+testEventID+"/tasks", nil)
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 for IDOR, got %d", resp.StatusCode)
+	}
+}
+
+func TestListTasksFromEvent_InvalidEventID(t *testing.T) {
+	app := newEventApp(&mockEventCrud{})
+	req := httptest.NewRequest(http.MethodGet, "/events/!!!/tasks", nil)
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d", resp.StatusCode)
+	}
+}

--- a/backend/internal/handler/api/task.go
+++ b/backend/internal/handler/api/task.go
@@ -105,6 +105,15 @@ func (h *handler) createTask() fiber.Handler {
 				if atts := formatAttachments(rs.Task.Attachments); atts != "" {
 					content += "\n" + atts
 				}
+				if rs.Task.EventID != 0 {
+					if ev, evErr := h.crud.GetEvent(ctx, entity.GetEventRequest{ID: rs.Task.EventID, UserID: rq.UserID}); evErr == nil {
+						instruction := fmt.Sprintf("\n\n[On completion: call publishEvent(\"%s\", \"<your output payload>\")]", ev.Event.Name)
+						if ev.Event.PayloadGuidelines != "" {
+							instruction += fmt.Sprintf("\nPayload guidelines: %s", ev.Event.PayloadGuidelines)
+						}
+						content += instruction
+					}
+				}
 				srv.SendChannelNotification(ctx, rs.Task.ID, content)
 			}
 		}

--- a/backend/internal/mapper/api/event.go
+++ b/backend/internal/mapper/api/event.go
@@ -1,0 +1,201 @@
+package api
+
+import (
+	"encoding/json"
+
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	view "github.com/agentrq/agentrq/backend/internal/data/view/api"
+	"github.com/gofiber/fiber/v2"
+	"github.com/mustafaturan/monoflake"
+)
+
+// ── Event HTTP mappers ────────────────────────────────────────────────────────
+
+func FromHTTPRequestToCreateEventRequestEntity(c *fiber.Ctx) *entity.CreateEventRequest {
+	var payload view.CreateEventRequest
+	if err := json.Unmarshal(c.BodyRaw(), &payload); err != nil {
+		return nil
+	}
+	if payload.Name == "" {
+		return nil
+	}
+	return &entity.CreateEventRequest{
+		Name:              payload.Name,
+		PayloadGuidelines: payload.PayloadGuidelines,
+	}
+}
+
+func FromCreateEventResponseEntityToHTTPResponse(rs *entity.CreateEventResponse) []byte {
+	payload, _ := json.Marshal(view.CreateEventResponse{Event: fromEntityEventToView(rs.Event)})
+	return payload
+}
+
+func FromHTTPRequestToGetEventRequestEntity(c *fiber.Ctx) *entity.GetEventRequest {
+	id := monoflake.IDFromBase62(c.Params("id")).Int64()
+	if id == 0 {
+		return nil
+	}
+	return &entity.GetEventRequest{ID: id}
+}
+
+func FromGetEventResponseEntityToHTTPResponse(rs *entity.GetEventResponse) []byte {
+	payload, _ := json.Marshal(view.GetEventResponse{Event: fromEntityEventToView(rs.Event)})
+	return payload
+}
+
+func FromListEventsResponseEntityToHTTPResponse(rs *entity.ListEventsResponse) []byte {
+	events := make([]view.Event, len(rs.Events))
+	for i, e := range rs.Events {
+		events[i] = fromEntityEventToView(e)
+	}
+	payload, _ := json.Marshal(view.ListEventsResponse{Events: events})
+	return payload
+}
+
+func FromHTTPRequestToUpdateEventRequestEntity(c *fiber.Ctx) *entity.UpdateEventRequest {
+	id := monoflake.IDFromBase62(c.Params("id")).Int64()
+	if id == 0 {
+		return nil
+	}
+	var payload view.UpdateEventRequest
+	if err := json.Unmarshal(c.BodyRaw(), &payload); err != nil {
+		return nil
+	}
+	return &entity.UpdateEventRequest{ID: id, PayloadGuidelines: payload.PayloadGuidelines}
+}
+
+func FromUpdateEventResponseEntityToHTTPResponse(rs *entity.UpdateEventResponse) []byte {
+	payload, _ := json.Marshal(view.UpdateEventResponse{Event: fromEntityEventToView(rs.Event)})
+	return payload
+}
+
+func FromHTTPRequestToDeleteEventRequestEntity(c *fiber.Ctx) *entity.DeleteEventRequest {
+	id := monoflake.IDFromBase62(c.Params("id")).Int64()
+	if id == 0 {
+		return nil
+	}
+	return &entity.DeleteEventRequest{ID: id}
+}
+
+// ── EventTrigger HTTP mappers ─────────────────────────────────────────────────
+
+func FromHTTPRequestToCreateEventTriggerRequestEntity(c *fiber.Ctx) *entity.CreateEventTriggerRequest {
+	eventID := monoflake.IDFromBase62(c.Params("id")).Int64()
+	if eventID == 0 {
+		return nil
+	}
+	var payload view.CreateEventTriggerRequest
+	if err := json.Unmarshal(c.BodyRaw(), &payload); err != nil {
+		return nil
+	}
+	workspaceID := monoflake.IDFromBase62(payload.WorkspaceID).Int64()
+	if payload.Title == "" || workspaceID == 0 {
+		return nil
+	}
+	assignee := payload.Assignee
+	if assignee == "" {
+		assignee = "agent"
+	}
+	return &entity.CreateEventTriggerRequest{
+		EventID:          eventID,
+		WorkspaceID:      workspaceID,
+		Title:            payload.Title,
+		Body:             payload.Body,
+		Assignee:         assignee,
+		CronSchedule:     payload.CronSchedule,
+		AllowAllCommands: payload.AllowAllCommands,
+		EmitEventID:      monoflake.IDFromBase62(payload.EmitEventID).Int64(),
+	}
+}
+
+func FromCreateEventTriggerResponseEntityToHTTPResponse(rs *entity.CreateEventTriggerResponse) []byte {
+	payload, _ := json.Marshal(view.CreateEventTriggerResponse{EventTrigger: fromEntityEventTriggerToView(rs.EventTrigger)})
+	return payload
+}
+
+func FromListEventTriggersResponseEntityToHTTPResponse(rs *entity.ListEventTriggersResponse) []byte {
+	triggers := make([]view.EventTrigger, len(rs.EventTriggers))
+	for i, t := range rs.EventTriggers {
+		triggers[i] = fromEntityEventTriggerToView(t)
+	}
+	payload, _ := json.Marshal(view.ListEventTriggersResponse{EventTriggers: triggers})
+	return payload
+}
+
+func FromHTTPRequestToDeleteEventTriggerRequestEntity(c *fiber.Ctx) *entity.DeleteEventTriggerRequest {
+	id := monoflake.IDFromBase62(c.Params("triggerID")).Int64()
+	if id == 0 {
+		return nil
+	}
+	return &entity.DeleteEventTriggerRequest{ID: id}
+}
+
+func FromListTasksFromEventResponseEntityToHTTPResponse(rs *entity.ListTasksFromEventResponse) []byte {
+	tasks := make([]view.Task, len(rs.Tasks))
+	for i, t := range rs.Tasks {
+		tasks[i] = FromEntityTaskToView(t)
+	}
+	payload, _ := json.Marshal(view.ListTasksResponse{Tasks: tasks})
+	return payload
+}
+
+// ── Internal model↔entity mappers ─────────────────────────────────────────────
+
+func FromModelEventToEntity(m model.Event) entity.Event {
+	return entity.Event{
+		ID:                m.ID,
+		CreatedAt:         m.CreatedAt,
+		UpdatedAt:         m.UpdatedAt,
+		UserID:            m.UserID,
+		Name:              m.Name,
+		PayloadGuidelines: m.PayloadGuidelines,
+	}
+}
+
+func FromModelEventTriggerToEntity(m model.EventTrigger) entity.EventTrigger {
+	return entity.EventTrigger{
+		ID:               m.ID,
+		CreatedAt:        m.CreatedAt,
+		UpdatedAt:        m.UpdatedAt,
+		EventID:          m.EventID,
+		WorkspaceID:      m.WorkspaceID,
+		UserID:           m.UserID,
+		Title:            m.Title,
+		Body:             m.Body,
+		Assignee:         m.Assignee,
+		CronSchedule:     m.CronSchedule,
+		AllowAllCommands: m.AllowAllCommands,
+		EmitEventID:      m.EmitEventID,
+	}
+}
+
+// ── Internal entity↔view mappers ──────────────────────────────────────────────
+
+func fromEntityEventToView(e entity.Event) view.Event {
+	return view.Event{
+		ID:                monoflake.ID(e.ID).String(),
+		CreatedAt:         e.CreatedAt,
+		UpdatedAt:         e.UpdatedAt,
+		Name:              e.Name,
+		PayloadGuidelines: e.PayloadGuidelines,
+	}
+}
+
+func fromEntityEventTriggerToView(t entity.EventTrigger) view.EventTrigger {
+	v := view.EventTrigger{
+		ID:               monoflake.ID(t.ID).String(),
+		CreatedAt:        t.CreatedAt,
+		EventID:          monoflake.ID(t.EventID).String(),
+		WorkspaceID:      monoflake.ID(t.WorkspaceID).String(),
+		Title:            t.Title,
+		Body:             t.Body,
+		Assignee:         t.Assignee,
+		CronSchedule:     t.CronSchedule,
+		AllowAllCommands: t.AllowAllCommands,
+	}
+	if t.EmitEventID != 0 {
+		v.EmitEventID = monoflake.ID(t.EmitEventID).String()
+	}
+	return v
+}

--- a/backend/internal/mapper/api/task.go
+++ b/backend/internal/mapper/api/task.go
@@ -35,16 +35,17 @@ func FromHTTPRequestToCreateTaskRequestEntity(c *fiber.Ctx) *entity.CreateTaskRe
 
 	return &entity.CreateTaskRequest{
 		Task: entity.Task{
-			WorkspaceID:  workspaceID,
-			CreatedBy:    payload.Task.CreatedBy,
-			Assignee:     payload.Task.Assignee,
-			Title:        payload.Task.Title,
-			Body:         payload.Task.Body,
-			Status:       payload.Task.Status,
-			Attachments:  entityAttachments,
-			CronSchedule: payload.Task.CronSchedule,
-			SortOrder:    payload.Task.SortOrder,
+			WorkspaceID:      workspaceID,
+			CreatedBy:        payload.Task.CreatedBy,
+			Assignee:         payload.Task.Assignee,
+			Title:            payload.Task.Title,
+			Body:             payload.Task.Body,
+			Status:           payload.Task.Status,
+			Attachments:      entityAttachments,
+			CronSchedule:     payload.Task.CronSchedule,
+			SortOrder:        payload.Task.SortOrder,
 			AllowAllCommands: payload.Task.AllowAllCommands,
+			EventID:          monoflake.IDFromBase62(payload.Task.EventID).Int64(),
 		},
 	}
 }
@@ -280,25 +281,28 @@ func FromEntityTaskToView(t entity.Task) view.Task {
 		workspaceID = monoflake.ID(t.WorkspaceID).String()
 	}
 	res := view.Task{
-		ID:           monoflake.ID(t.ID).String(),
-		CreatedAt:    t.CreatedAt,
-		UpdatedAt:    t.UpdatedAt,
-		WorkspaceID:  workspaceID,
-		CreatedBy:    t.CreatedBy,
-		Assignee:     t.Assignee,
-		Status:       t.Status,
-		Title:        t.Title,
-		Body:         t.Body,
-		Response:     t.Response,
-		ReplyText:    t.ReplyText,
-		Attachments:  fromEntityAttachmentsToView(t.Attachments),
-		Messages:     fromEntityMessagesToView(t.Messages),
-		CronSchedule: t.CronSchedule,
-		SortOrder:    t.SortOrder,
+		ID:               monoflake.ID(t.ID).String(),
+		CreatedAt:        t.CreatedAt,
+		UpdatedAt:        t.UpdatedAt,
+		WorkspaceID:      workspaceID,
+		CreatedBy:        t.CreatedBy,
+		Assignee:         t.Assignee,
+		Status:           t.Status,
+		Title:            t.Title,
+		Body:             t.Body,
+		Response:         t.Response,
+		ReplyText:        t.ReplyText,
+		Attachments:      fromEntityAttachmentsToView(t.Attachments),
+		Messages:         fromEntityMessagesToView(t.Messages),
+		CronSchedule:     t.CronSchedule,
+		SortOrder:        t.SortOrder,
 		AllowAllCommands: t.AllowAllCommands,
 	}
 	if t.ParentID != 0 {
 		res.ParentID = monoflake.ID(t.ParentID).String()
+	}
+	if t.EventID != 0 {
+		res.EventID = monoflake.ID(t.EventID).String()
 	}
 	return res
 }
@@ -366,25 +370,28 @@ func FromModelTaskToView(t model.Task) view.Task {
 	}
 
 	res := view.Task{
-		ID:           monoflake.ID(t.ID).String(),
-		CreatedAt:    t.CreatedAt,
-		UpdatedAt:    t.UpdatedAt,
-		WorkspaceID:  workspaceID,
-		CreatedBy:    t.CreatedBy,
-		Assignee:     t.Assignee,
-		Status:       t.Status,
-		Title:        t.Title,
-		Body:         t.Body,
-		Response:     t.Response,
-		ReplyText:    t.ReplyText,
-		Attachments:  atts,
-		Messages:     msgs,
-		CronSchedule: t.CronSchedule,
-		SortOrder:    t.SortOrder,
+		ID:               monoflake.ID(t.ID).String(),
+		CreatedAt:        t.CreatedAt,
+		UpdatedAt:        t.UpdatedAt,
+		WorkspaceID:      workspaceID,
+		CreatedBy:        t.CreatedBy,
+		Assignee:         t.Assignee,
+		Status:           t.Status,
+		Title:            t.Title,
+		Body:             t.Body,
+		Response:         t.Response,
+		ReplyText:        t.ReplyText,
+		Attachments:      atts,
+		Messages:         msgs,
+		CronSchedule:     t.CronSchedule,
+		SortOrder:        t.SortOrder,
 		AllowAllCommands: t.AllowAllCommands,
 	}
 	if t.ParentID != 0 {
 		res.ParentID = monoflake.ID(t.ParentID).String()
+	}
+	if t.EventID != 0 {
+		res.EventID = monoflake.ID(t.EventID).String()
 	}
 	return res
 }

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	"github.com/agentrq/agentrq/backend/internal/data/model"
@@ -67,6 +68,22 @@ type Repository interface {
 	DeletePushSubscriptionByWorkspace(ctx context.Context, userID int64, workspaceID int64, endpoint string) error
 	GetPushSubscriptionForWorkspace(ctx context.Context, userID int64, workspaceID int64, endpoint string) (bool, error)
 	ListPushSubscriptionsByUserAndWorkspace(ctx context.Context, userID int64, workspaceID int64) ([]model.PushSubscription, error)
+
+	// Events
+	CreateEvent(ctx context.Context, e model.Event) (model.Event, error)
+	GetEvent(ctx context.Context, id int64, userID int64) (model.Event, error)
+	GetEventByName(ctx context.Context, name string, userID int64) (model.Event, error)
+	ListEventsByUser(ctx context.Context, userID int64) ([]model.Event, error)
+	UpdateEvent(ctx context.Context, id int64, userID int64, payloadGuidelines string) (model.Event, error)
+	DeleteEvent(ctx context.Context, id int64, userID int64) error
+
+	// EventTriggers
+	CreateEventTrigger(ctx context.Context, t model.EventTrigger) (model.EventTrigger, error)
+	GetEventTrigger(ctx context.Context, id int64, userID int64) (model.EventTrigger, error)
+	ListEventTriggersByEvent(ctx context.Context, eventID int64, userID int64) ([]model.EventTrigger, error)
+	SystemListEventTriggersByEventID(ctx context.Context, eventID int64) ([]model.EventTrigger, error)
+	DeleteEventTrigger(ctx context.Context, id int64, userID int64) error
+	ListTasksByTriggerID(ctx context.Context, triggerID int64, userID int64) ([]model.Task, error)
 }
 
 type repository struct {
@@ -723,4 +740,112 @@ func (r *repository) ListPushSubscriptionsByUserAndWorkspace(ctx context.Context
 	var subs []model.PushSubscription
 	err := r.conn(ctx).Where("user_id = ? AND workspace_id = ?", userID, workspaceID).Find(&subs).Error
 	return subs, err
+}
+
+// ── Events ─────────────────────────────────────────────────────────────────────
+
+func (r *repository) CreateEvent(ctx context.Context, e model.Event) (model.Event, error) {
+	if err := r.conn(ctx).Create(&e).Error; err != nil {
+		return model.Event{}, err
+	}
+	return e, nil
+}
+
+func (r *repository) GetEvent(ctx context.Context, id int64, userID int64) (model.Event, error) {
+	var e model.Event
+	err := r.conn(ctx).Where("id = ? AND user_id = ?", id, userID).First(&e).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return model.Event{}, ErrNotFound
+	}
+	return e, err
+}
+
+func (r *repository) GetEventByName(ctx context.Context, name string, userID int64) (model.Event, error) {
+	var e model.Event
+	err := r.conn(ctx).Where("name = ? AND user_id = ?", name, userID).First(&e).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return model.Event{}, ErrNotFound
+	}
+	return e, err
+}
+
+func (r *repository) ListEventsByUser(ctx context.Context, userID int64) ([]model.Event, error) {
+	var events []model.Event
+	err := r.conn(ctx).Where("user_id = ?", userID).Order("created_at desc").Find(&events).Error
+	return events, err
+}
+
+func (r *repository) UpdateEvent(ctx context.Context, id int64, userID int64, payloadGuidelines string) (model.Event, error) {
+	var e model.Event
+	err := r.conn(ctx).Where("id = ? AND user_id = ?", id, userID).First(&e).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return model.Event{}, ErrNotFound
+	}
+	if err != nil {
+		return model.Event{}, err
+	}
+	e.PayloadGuidelines = payloadGuidelines
+	e.UpdatedAt = time.Now()
+	if err := r.conn(ctx).Save(&e).Error; err != nil {
+		return model.Event{}, err
+	}
+	return e, nil
+}
+
+func (r *repository) DeleteEvent(ctx context.Context, id int64, userID int64) error {
+	res := r.conn(ctx).Where("id = ? AND user_id = ?", id, userID).Delete(&model.Event{})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ── EventTriggers ──────────────────────────────────────────────────────────────
+
+func (r *repository) CreateEventTrigger(ctx context.Context, t model.EventTrigger) (model.EventTrigger, error) {
+	if err := r.conn(ctx).Create(&t).Error; err != nil {
+		return model.EventTrigger{}, err
+	}
+	return t, nil
+}
+
+func (r *repository) GetEventTrigger(ctx context.Context, id int64, userID int64) (model.EventTrigger, error) {
+	var t model.EventTrigger
+	err := r.conn(ctx).Where("id = ? AND user_id = ?", id, userID).First(&t).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return model.EventTrigger{}, ErrNotFound
+	}
+	return t, err
+}
+
+func (r *repository) ListEventTriggersByEvent(ctx context.Context, eventID int64, userID int64) ([]model.EventTrigger, error) {
+	var triggers []model.EventTrigger
+	err := r.conn(ctx).Where("event_id = ? AND user_id = ?", eventID, userID).Order("created_at desc").Find(&triggers).Error
+	return triggers, err
+}
+
+func (r *repository) SystemListEventTriggersByEventID(ctx context.Context, eventID int64) ([]model.EventTrigger, error) {
+	var triggers []model.EventTrigger
+	err := r.conn(ctx).Where("event_id = ?", eventID).Find(&triggers).Error
+	return triggers, err
+}
+
+func (r *repository) DeleteEventTrigger(ctx context.Context, id int64, userID int64) error {
+	res := r.conn(ctx).Where("id = ? AND user_id = ?", id, userID).Delete(&model.EventTrigger{})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *repository) ListTasksByTriggerID(ctx context.Context, triggerID int64, userID int64) ([]model.Task, error) {
+	var tasks []model.Task
+	err := r.conn(ctx).Where("trigger_id = ? AND user_id = ?", triggerID, userID).Order("created_at desc").Find(&tasks).Error
+	return tasks, err
 }

--- a/backend/internal/repository/base/repository_test.go
+++ b/backend/internal/repository/base/repository_test.go
@@ -286,3 +286,207 @@ func TestRepository_GetWorkspaceTaskCountsByCategory(t *testing.T) {
 	}
 }
 
+func TestRepository_Event_CRUD(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+	_ = db.AutoMigrate(&model.Event{})
+	repo := New(&mockDB{db: db})
+
+	ctx := context.Background()
+	userID := int64(1)
+	otherUserID := int64(2)
+
+	// Create
+	e, err := repo.CreateEvent(ctx, model.Event{
+		ID:                100,
+		UserID:            userID,
+		Name:              "code_review_done",
+		PayloadGuidelines: "Describe what was reviewed",
+	})
+	if err != nil {
+		t.Fatalf("CreateEvent: %v", err)
+	}
+	if e.ID != 100 {
+		t.Errorf("expected ID 100, got %d", e.ID)
+	}
+
+	// GetEvent — owner
+	got, err := repo.GetEvent(ctx, 100, userID)
+	if err != nil {
+		t.Fatalf("GetEvent: %v", err)
+	}
+	if got.Name != "code_review_done" {
+		t.Errorf("expected name code_review_done, got %s", got.Name)
+	}
+
+	// GetEvent — wrong user (IDOR guard)
+	_, err = repo.GetEvent(ctx, 100, otherUserID)
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound for wrong user, got %v", err)
+	}
+
+	// GetEventByName
+	got, err = repo.GetEventByName(ctx, "code_review_done", userID)
+	if err != nil {
+		t.Fatalf("GetEventByName: %v", err)
+	}
+	if got.ID != 100 {
+		t.Errorf("expected ID 100, got %d", got.ID)
+	}
+
+	// GetEventByName — wrong user
+	_, err = repo.GetEventByName(ctx, "code_review_done", otherUserID)
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound for wrong user in GetEventByName, got %v", err)
+	}
+
+	// ListEventsByUser
+	_ = db.Create(&model.Event{ID: 101, UserID: userID, Name: "deploy_done"})
+	_ = db.Create(&model.Event{ID: 200, UserID: otherUserID, Name: "other_event"})
+
+	list, err := repo.ListEventsByUser(ctx, userID)
+	if err != nil {
+		t.Fatalf("ListEventsByUser: %v", err)
+	}
+	if len(list) != 2 {
+		t.Errorf("expected 2 events for user 1, got %d", len(list))
+	}
+
+	// DeleteEvent — wrong user (IDOR guard)
+	err = repo.DeleteEvent(ctx, 100, otherUserID)
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound when deleting with wrong user, got %v", err)
+	}
+
+	// DeleteEvent — owner
+	err = repo.DeleteEvent(ctx, 100, userID)
+	if err != nil {
+		t.Fatalf("DeleteEvent: %v", err)
+	}
+	_, err = repo.GetEvent(ctx, 100, userID)
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound after delete, got %v", err)
+	}
+}
+
+func TestRepository_EventTrigger_CRUD(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+	_ = db.AutoMigrate(&model.Event{}, &model.EventTrigger{}, &model.Task{})
+	repo := New(&mockDB{db: db})
+
+	ctx := context.Background()
+	userID := int64(1)
+	otherUserID := int64(2)
+	eventID := int64(500)
+	workspaceID := int64(10)
+
+	// Create trigger
+	tr, err := repo.CreateEventTrigger(ctx, model.EventTrigger{
+		ID:          1000,
+		EventID:     eventID,
+		WorkspaceID: workspaceID,
+		UserID:      userID,
+		Title:       "Review completed: {{EVENT_PAYLOAD}}",
+		Body:        "Details: {{EVENT_FAQ}}",
+		Assignee:    "agent",
+	})
+	if err != nil {
+		t.Fatalf("CreateEventTrigger: %v", err)
+	}
+	if tr.ID != 1000 {
+		t.Errorf("expected ID 1000, got %d", tr.ID)
+	}
+
+	// GetEventTrigger — owner
+	got, err := repo.GetEventTrigger(ctx, 1000, userID)
+	if err != nil {
+		t.Fatalf("GetEventTrigger: %v", err)
+	}
+	if got.EventID != eventID {
+		t.Errorf("expected eventID %d, got %d", eventID, got.EventID)
+	}
+
+	// GetEventTrigger — wrong user (IDOR)
+	_, err = repo.GetEventTrigger(ctx, 1000, otherUserID)
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound for wrong user, got %v", err)
+	}
+
+	// ListEventTriggersByEvent — user-scoped
+	_ = db.Create(&model.EventTrigger{ID: 1001, EventID: eventID, UserID: userID, WorkspaceID: 20})
+	_ = db.Create(&model.EventTrigger{ID: 1002, EventID: eventID, UserID: otherUserID, WorkspaceID: 30})
+
+	list, err := repo.ListEventTriggersByEvent(ctx, eventID, userID)
+	if err != nil {
+		t.Fatalf("ListEventTriggersByEvent: %v", err)
+	}
+	if len(list) != 2 {
+		t.Errorf("expected 2 triggers for user 1 on event, got %d", len(list))
+	}
+
+	// SystemListEventTriggersByEventID — cross-user
+	all, err := repo.SystemListEventTriggersByEventID(ctx, eventID)
+	if err != nil {
+		t.Fatalf("SystemListEventTriggersByEventID: %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("expected 3 triggers system-wide, got %d", len(all))
+	}
+
+	// DeleteEventTrigger — wrong user (IDOR)
+	err = repo.DeleteEventTrigger(ctx, 1000, otherUserID)
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound for wrong user delete, got %v", err)
+	}
+
+	// DeleteEventTrigger — owner
+	err = repo.DeleteEventTrigger(ctx, 1000, userID)
+	if err != nil {
+		t.Fatalf("DeleteEventTrigger: %v", err)
+	}
+	_, err = repo.GetEventTrigger(ctx, 1000, userID)
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound after delete, got %v", err)
+	}
+}
+
+func TestRepository_ListTasksByTriggerID(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+	_ = db.AutoMigrate(&model.Task{})
+	repo := New(&mockDB{db: db})
+
+	ctx := context.Background()
+	userID := int64(1)
+	otherUserID := int64(2)
+	triggerID := int64(500)
+
+	db.Create(&model.Task{ID: 1, UserID: userID, TriggerID: triggerID, WorkspaceID: 10, Status: "completed"})
+	db.Create(&model.Task{ID: 2, UserID: userID, TriggerID: triggerID, WorkspaceID: 10, Status: "notstarted"})
+	db.Create(&model.Task{ID: 3, UserID: otherUserID, TriggerID: triggerID, WorkspaceID: 20, Status: "completed"})
+	db.Create(&model.Task{ID: 4, UserID: userID, TriggerID: 999, WorkspaceID: 10, Status: "completed"})
+
+	tasks, err := repo.ListTasksByTriggerID(ctx, triggerID, userID)
+	if err != nil {
+		t.Fatalf("ListTasksByTriggerID: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Errorf("expected 2 tasks for user 1 with triggerID %d, got %d", triggerID, len(tasks))
+	}
+	for _, task := range tasks {
+		if task.TriggerID != triggerID {
+			t.Errorf("unexpected triggerID %d", task.TriggerID)
+		}
+		if task.UserID != userID {
+			t.Errorf("unexpected userID %d (IDOR leak)", task.UserID)
+		}
+	}
+}
+

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -183,6 +183,24 @@
             </svg>
             <span v-if="!isCollapsed || isMobileMenuOpen">Completed</span>
           </router-link>
+
+          <div v-if="!isCollapsed || isMobileMenuOpen" class="px-2 mt-5 mb-2 pt-4 border-t border-gray-200/50 dark:border-zinc-600/50">
+            <span class="text-[11px] font-medium text-gray-500 dark:text-zinc-400">Experimental</span>
+          </div>
+          <div v-else class="mt-4 pt-4 border-t border-gray-200/50 dark:border-zinc-600/50"></div>
+
+          <router-link to="/events"
+              @mouseenter="showTooltip($event, 'Events')" @mouseleave="hideTooltip"
+              class="flex items-center gap-2.5 px-2 py-1.5 text-xs transition-all duration-150 rounded-md"
+              :class="[
+                (isCollapsed && !isMobileMenuOpen) ? 'justify-center' : '',
+                $route.path.startsWith('/events') ? 'bg-gray-200 dark:bg-zinc-800 text-black dark:text-white' : 'text-gray-500 dark:text-zinc-400 hover:bg-gray-200 dark:hover:bg-zinc-700 hover:text-gray-900 dark:hover:text-zinc-50'
+              ]">
+            <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9.348 14.651a3.75 3.75 0 010-5.303m5.304-.002a3.75 3.75 0 010 5.304m-7.425 2.122a6.75 6.75 0 010-9.546m9.546.001a6.75 6.75 0 010 9.545m-11.667 2.121a9.75 9.75 0 010-13.788m13.788.001a9.75 9.75 0 010 13.787M12 12h.008v.008H12V12z" />
+            </svg>
+            <span v-if="!isCollapsed || isMobileMenuOpen">Events</span>
+          </router-link>
         </div>
 
         <!-- Sidebar Footer -->

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -86,22 +86,13 @@ export async function getTask(workspaceId, taskId) {
   return res.json();
 }
 
-export async function createTask(workspaceId, title, body, assignee = 'agent', attachments = [], status = 'notstarted', cronSchedule = '', allowAllCommands = false) {
+export async function createTask(workspaceId, title, body, assignee = 'agent', attachments = [], status = 'notstarted', cronSchedule = '', allowAllCommands = false, eventId = '') {
+  const task = { title, body, createdBy: 'human', assignee, attachments, status, cronSchedule, allowAllCommands };
+  if (eventId) task.eventId = eventId;
   const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ 
-      task: { 
-        title, 
-        body, 
-        createdBy: 'human', 
-        assignee, 
-        attachments, 
-        status, 
-        cronSchedule,
-        allowAllCommands: allowAllCommands
-      } 
-    })
+    body: JSON.stringify({ task })
   });
   if (!res.ok) throw new Error('Failed to create task');
   return res.json();
@@ -272,5 +263,89 @@ export async function removeWorkspaceSlackChannel(id) {
 export async function fetchGlobalTaskStats() {
   const res = await fetch(`${API_BASE_URL}/tasks/stats`);
   if (!res.ok) throw new Error('Failed to fetch global task stats');
+  return res.json();
+}
+
+export async function fetchEvents() {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10000);
+  try {
+    const res = await fetch(`${API_BASE_URL}/events`, { signal: controller.signal });
+    if (!res.ok) throw new Error('Failed to fetch events');
+    return res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function createEvent(name, payloadGuidelines) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10000);
+  try {
+    const res = await fetch(`${API_BASE_URL}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, payloadGuidelines }),
+      signal: controller.signal
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(body.error?.message || body.error || `Failed to create event (${res.status})`);
+    }
+    return res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function getEvent(id) {
+  const res = await fetch(`${API_BASE_URL}/events/${id}`);
+  if (!res.ok) throw new Error('Failed to fetch event');
+  return res.json();
+}
+
+export async function updateEvent(id, payloadGuidelines) {
+  const res = await fetch(`${API_BASE_URL}/events/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ payloadGuidelines }),
+  });
+  if (!res.ok) throw new Error('Failed to update event');
+  return res.json();
+}
+
+export async function deleteEvent(id) {
+  const res = await fetch(`${API_BASE_URL}/events/${id}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error('Failed to delete event');
+  return true;
+}
+
+export async function fetchEventTriggers(eventId) {
+  const res = await fetch(`${API_BASE_URL}/events/${eventId}/triggers`);
+  if (!res.ok) throw new Error('Failed to fetch event triggers');
+  return res.json();
+}
+
+export async function createEventTrigger(eventId, { workspaceId, title, body, assignee = 'agent', cronSchedule = '', allowAllCommands = false, emitEventId = '' }) {
+  const payload = { workspaceId, title, body, assignee, cronSchedule, allowAllCommands };
+  if (emitEventId) payload.emitEventId = emitEventId;
+  const res = await fetch(`${API_BASE_URL}/events/${eventId}/triggers`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!res.ok) throw new Error('Failed to create event trigger');
+  return res.json();
+}
+
+export async function deleteEventTrigger(eventId, triggerId) {
+  const res = await fetch(`${API_BASE_URL}/events/${eventId}/triggers/${triggerId}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error('Failed to delete event trigger');
+  return true;
+}
+
+export async function fetchEventTasks(eventId) {
+  const res = await fetch(`${API_BASE_URL}/events/${eventId}/tasks`);
+  if (!res.ok) throw new Error('Failed to fetch event tasks');
   return res.json();
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -31,6 +31,9 @@ const routes = [
   { path: '/workspaces/:id/tasks/new', component: () => import('./views/TaskFormView.vue') },
   { path: '/workspaces/:id/tasks/:taskId/edit', component: () => import('./views/TaskFormView.vue') },
 
+  { path: '/events', component: () => import('./views/EventsView.vue') },
+  { path: '/events/:id', component: () => import('./views/EventDetailView.vue') },
+
   { path: '/login', component: () => import('./views/LoginView.vue'), meta: { public: true } }
 ]
 

--- a/frontend/src/views/EventDetailView.vue
+++ b/frontend/src/views/EventDetailView.vue
@@ -1,0 +1,574 @@
+<script setup>
+import { ref, computed, watch, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { getEvent, updateEvent, deleteEvent, fetchEvents, fetchEventTriggers, createEventTrigger, deleteEventTrigger, fetchEventTasks } from '../api'
+import { useToasts } from '../composables/useToasts'
+import { useCron } from '../composables/useCron'
+import { useWorkspaceStore } from '../stores/workspaceStore'
+import DeleteModal from '../components/DeleteModal.vue'
+
+const route = useRoute()
+const router = useRouter()
+const { notifyError, notifySuccess } = useToasts()
+const { getNextRunLabel, daysOptions } = useCron()
+const workspaceStore = useWorkspaceStore()
+
+const eventId = route.params.id
+
+// ── event ──────────────────────────────────────────────────────────────────────
+
+const event = ref(null)
+const loadingEvent = ref(false)
+
+async function loadEvent() {
+  loadingEvent.value = true
+  try {
+    const data = await getEvent(eventId)
+    event.value = data.event
+  } catch (e) {
+    notifyError(e.message)
+  } finally {
+    loadingEvent.value = false
+  }
+}
+
+// edit payload guidelines
+const editingGuidelines = ref(false)
+const guidelinesInput = ref('')
+const savingGuidelines = ref(false)
+
+function startEditGuidelines() {
+  guidelinesInput.value = event.value?.payloadGuidelines ?? ''
+  editingGuidelines.value = true
+}
+
+async function saveGuidelines() {
+  savingGuidelines.value = true
+  try {
+    const data = await updateEvent(eventId, guidelinesInput.value.trim())
+    event.value = data.event
+    editingGuidelines.value = false
+    notifySuccess('Payload guidelines updated')
+  } catch (e) {
+    notifyError(e.message)
+  } finally {
+    savingGuidelines.value = false
+  }
+}
+
+// ── triggers ───────────────────────────────────────────────────────────────────
+
+const triggers = ref([])
+const loadingTriggers = ref(false)
+
+async function loadTriggers() {
+  loadingTriggers.value = true
+  try {
+    const data = await fetchEventTriggers(eventId)
+    triggers.value = data.eventTriggers ?? []
+  } catch (e) {
+    notifyError(e.message)
+  } finally {
+    loadingTriggers.value = false
+  }
+}
+
+// create trigger form
+const showTriggerForm = ref(false)
+const creatingTrigger = ref(false)
+
+const triggerForm = ref({
+  workspaceId: '',
+  title: '',
+  body: '',
+  assignee: 'agent',
+  allowAllCommands: false,
+  cronSchedule: '',
+  emitEventId: '',
+})
+
+// events list for the "emit on completion" selector
+const allEvents = ref([])
+async function loadAllEvents() {
+  try {
+    const data = await fetchEvents()
+    // exclude the current event from the list
+    allEvents.value = (data.events ?? []).filter(e => e.id !== eventId)
+  } catch (_) {}
+}
+
+// trigger cron UI
+const triggerScheduleType = ref('none')
+const triggerOneTimeDate = ref('')
+const triggerRepeatPreset = ref('daily')
+const triggerRepeatTime = ref('09:00')
+const triggerSelectedDays = ref([1, 2, 3, 4, 5])
+
+const triggerNextRunPreview = computed(() => {
+  if (triggerScheduleType.value === 'none' || !triggerForm.value.cronSchedule) return ''
+  return getNextRunLabel(triggerForm.value.cronSchedule)
+})
+
+watch([triggerScheduleType, triggerOneTimeDate, triggerRepeatPreset, triggerRepeatTime, triggerSelectedDays], () => {
+  if (triggerScheduleType.value === 'none') { triggerForm.value.cronSchedule = ''; return }
+  if (triggerScheduleType.value === 'onetime') {
+    if (!triggerOneTimeDate.value) { triggerForm.value.cronSchedule = ''; return }
+    const d = new Date(triggerOneTimeDate.value)
+    triggerForm.value.cronSchedule = `${d.getUTCMinutes()} ${d.getUTCHours()} ${d.getUTCDate()} ${d.getUTCMonth() + 1} *`
+    return
+  }
+  const [lh, lm] = triggerRepeatTime.value.split(':').map(Number)
+  const d = new Date(); d.setHours(lh, lm, 0, 0)
+  const minutes = d.getUTCMinutes()
+  const hours = d.getUTCHours()
+  const p = triggerRepeatPreset.value
+  if (p === '15min') triggerForm.value.cronSchedule = '*/15 * * * *'
+  else if (p === '30min') triggerForm.value.cronSchedule = '*/30 * * * *'
+  else if (p === 'hourly') triggerForm.value.cronSchedule = '0 * * * *'
+  else if (p === '2hour') triggerForm.value.cronSchedule = '0 */2 * * *'
+  else if (p === '12hour') {
+    const h2 = new Date(d); h2.setHours(h2.getHours() + 12)
+    const hrs = [d.getUTCHours(), h2.getUTCHours()].sort((a, b) => a - b).join(',')
+    triggerForm.value.cronSchedule = `${minutes} ${hrs} * * *`
+  } else if (p === 'daily') triggerForm.value.cronSchedule = `${minutes} ${hours} * * *`
+  else if (p === 'weekly') { const utcDay = d.getUTCDay(); triggerForm.value.cronSchedule = `${minutes} ${hours} * * ${utcDay}` }
+  else if (p === 'monthly') { const dd = new Date(); dd.setHours(lh, lm, 0, 0); dd.setDate(1); triggerForm.value.cronSchedule = `${minutes} ${hours} ${dd.getUTCDate()} * *` }
+  else if (p === 'custom') {
+    const utcDays = new Set()
+    triggerSelectedDays.value.forEach(day => {
+      const dd = new Date(); dd.setHours(lh, lm, 0, 0)
+      dd.setDate(dd.getDate() + (day - dd.getDay()))
+      utcDays.add(dd.getUTCDay())
+    })
+    triggerForm.value.cronSchedule = `${minutes} ${hours} * * ${[...utcDays].sort().join(',')}`
+  }
+}, { deep: true })
+
+function toggleTriggerDay(day) {
+  const idx = triggerSelectedDays.value.indexOf(day)
+  if (idx === -1) triggerSelectedDays.value.push(day)
+  else if (triggerSelectedDays.value.length > 1) triggerSelectedDays.value.splice(idx, 1)
+}
+
+function insertTemplate(token) {
+  const body = triggerForm.value.body
+  triggerForm.value.body = body ? body + ' ' + token : token
+}
+
+function resetTriggerForm() {
+  triggerForm.value = { workspaceId: '', title: '', body: '', assignee: 'agent', allowAllCommands: false, cronSchedule: '', emitEventId: '' }
+  triggerScheduleType.value = 'none'
+  triggerOneTimeDate.value = ''
+  triggerRepeatPreset.value = 'daily'
+  triggerRepeatTime.value = '09:00'
+  triggerSelectedDays.value = [1, 2, 3, 4, 5]
+  showTriggerForm.value = false
+}
+
+async function handleCreateTrigger() {
+  if (!triggerForm.value.workspaceId || !triggerForm.value.title) return
+  creatingTrigger.value = true
+  try {
+    const data = await createEventTrigger(eventId, {
+      workspaceId: triggerForm.value.workspaceId,
+      title: triggerForm.value.title,
+      body: triggerForm.value.body,
+      assignee: triggerForm.value.assignee,
+      cronSchedule: triggerForm.value.cronSchedule,
+      allowAllCommands: triggerForm.value.allowAllCommands,
+      emitEventId: triggerForm.value.emitEventId,
+    })
+    triggers.value.unshift(data.eventTrigger)
+    notifySuccess('Trigger created')
+    resetTriggerForm()
+  } catch (e) {
+    notifyError(e.message)
+  } finally {
+    creatingTrigger.value = false
+  }
+}
+
+// delete event
+const showDeleteEventModal = ref(false)
+const deletingEvent = ref(false)
+
+async function handleDeleteEvent() {
+  deletingEvent.value = true
+  try {
+    await deleteEvent(eventId)
+    notifySuccess('Event deleted')
+    router.push('/events')
+  } catch (e) {
+    notifyError(e.message)
+  } finally {
+    deletingEvent.value = false
+    showDeleteEventModal.value = false
+  }
+}
+
+// delete trigger
+const showDeleteTriggerModal = ref(false)
+const deletingTrigger = ref(null)
+const deletingTriggerInProgress = ref(false)
+
+function confirmDeleteTrigger(t) {
+  deletingTrigger.value = t
+  showDeleteTriggerModal.value = true
+}
+
+async function handleDeleteTrigger() {
+  if (!deletingTrigger.value) return
+  deletingTriggerInProgress.value = true
+  try {
+    await deleteEventTrigger(eventId, deletingTrigger.value.id)
+    triggers.value = triggers.value.filter(t => t.id !== deletingTrigger.value.id)
+    notifySuccess('Trigger deleted')
+  } catch (e) {
+    notifyError(e.message)
+  } finally {
+    deletingTriggerInProgress.value = false
+    showDeleteTriggerModal.value = false
+    deletingTrigger.value = null
+  }
+}
+
+function workspaceName(wsId) {
+  return workspaceStore.workspaces.find(w => w.id === wsId)?.name ?? wsId
+}
+
+// ── tasks ─────────────────────────────────────────────────────────────────────
+
+const TASKS_PAGE_SIZE = 10
+const tasks = ref([])
+const loadingTasks = ref(false)
+const visibleTaskCount = ref(TASKS_PAGE_SIZE)
+const visibleTasks = computed(() => tasks.value.slice(0, visibleTaskCount.value))
+const hasMoreTasks = computed(() => visibleTaskCount.value < tasks.value.length)
+
+function loadMoreTasks() {
+  visibleTaskCount.value += TASKS_PAGE_SIZE
+}
+
+async function loadTasks() {
+  loadingTasks.value = true
+  try {
+    const data = await fetchEventTasks(eventId)
+    tasks.value = data.tasks ?? []
+    visibleTaskCount.value = TASKS_PAGE_SIZE
+  } catch (e) {
+    notifyError(e.message)
+  } finally {
+    loadingTasks.value = false
+  }
+}
+
+function formatDate(iso) {
+  if (!iso) return ''
+  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+function statusColor(s) {
+  const map = {
+    notstarted: 'text-gray-400 dark:text-zinc-500',
+    ongoing: 'text-sky-500 dark:text-sky-400',
+    completed: 'text-emerald-500 dark:text-emerald-400',
+    rejected: 'text-red-500 dark:text-red-400',
+    blocked: 'text-amber-500 dark:text-amber-400',
+    cron: 'text-violet-500 dark:text-violet-400',
+  }
+  return map[s] ?? 'text-gray-400'
+}
+
+// ── init ──────────────────────────────────────────────────────────────────────
+
+onMounted(async () => {
+  if (!workspaceStore.workspaces.length) await workspaceStore.fetchWorkspaces()
+  await Promise.all([loadEvent(), loadTriggers(), loadTasks(), loadAllEvents()])
+})
+</script>
+
+<template>
+  <div class="flex flex-col h-full w-full overflow-y-auto custom-scrollbar">
+
+    <!-- Header -->
+    <div class="w-full px-4 py-2 mb-6 shrink-0 flex flex-row items-center justify-between gap-4">
+      <div class="flex flex-col min-w-0 flex-1">
+        <div v-if="loadingEvent" class="h-8 w-64 bg-gray-100 dark:bg-zinc-800 animate-pulse rounded-lg"></div>
+        <template v-else>
+          <h1 class="text-lg md:text-2xl font-black text-gray-800 dark:text-zinc-200 tracking-tight leading-tight truncate">
+            <span class="opacity-50 cursor-pointer hover:opacity-100 transition-opacity" @click="router.push('/events')">Events</span>
+            <span class="mx-1.5 text-gray-300 dark:text-zinc-700 font-medium">/</span>
+            <span class="font-mono">{{ event?.name }}</span>
+          </h1>
+        </template>
+      </div>
+      <div v-if="!loadingEvent && !editingGuidelines" class="flex items-center gap-1 shrink-0">
+        <button @click="startEditGuidelines"
+                class="p-2 text-gray-400 dark:text-zinc-500 hover:text-gray-700 dark:hover:text-zinc-300 hover:bg-gray-100 dark:hover:bg-zinc-800 rounded-lg transition-all active:scale-95">
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+          </svg>
+        </button>
+        <button @click="showDeleteEventModal = true"
+                class="p-2 text-gray-400 dark:text-zinc-500 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 rounded-lg transition-all active:scale-95">
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+          </svg>
+        </button>
+      </div>
+    </div>
+
+    <div class="px-4 space-y-8 pb-10">
+
+      <!-- Payload Guidelines Section -->
+      <Transition name="slide-down">
+        <div v-if="editingGuidelines" class="bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-xl p-5 space-y-4">
+          <textarea
+            v-model="guidelinesInput"
+            rows="3"
+            placeholder="Describe what agents should include in the payload when publishing this event…"
+            class="w-full px-3 py-2 text-sm border border-gray-200 dark:border-zinc-700 rounded-lg bg-white dark:bg-zinc-800 text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-500 resize-none focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white transition-all"
+            @keydown.escape="editingGuidelines = false"
+          ></textarea>
+          <div class="flex items-center gap-2 pt-2 border-t border-gray-100 dark:border-zinc-800">
+            <button @click="saveGuidelines" :disabled="savingGuidelines"
+                    class="px-4 py-2 bg-black dark:bg-white text-white dark:text-black text-[11px] font-black uppercase tracking-widest rounded-lg hover:opacity-80 transition-all active:scale-95 disabled:opacity-50">
+              {{ savingGuidelines ? 'Saving…' : 'Save' }}
+            </button>
+            <button @click="editingGuidelines = false"
+                    class="px-4 py-2 bg-white dark:bg-zinc-800 text-gray-700 dark:text-zinc-300 border border-gray-200 dark:border-zinc-700 text-[11px] font-black uppercase tracking-widest rounded-lg hover:bg-gray-50 dark:hover:bg-zinc-700 transition-all active:scale-95">
+              Cancel
+            </button>
+          </div>
+        </div>
+      </Transition>
+
+      <!-- Triggers Section -->
+      <div>
+        <div class="flex items-center justify-between mb-3">
+          <div>
+            <h2 class="text-sm font-bold text-gray-800 dark:text-zinc-200">Triggers</h2>
+            <p class="text-[11px] text-gray-400 dark:text-zinc-500 mt-0.5">Workspaces that receive a task when this event fires.</p>
+          </div>
+          <button
+            @click="showTriggerForm = !showTriggerForm"
+            class="px-4 py-2 bg-black dark:bg-white text-white dark:text-black text-[11px] font-black uppercase tracking-widest rounded-lg hover:opacity-80 transition-all active:scale-95 shrink-0">
+            + Add Trigger
+          </button>
+        </div>
+
+        <!-- Create Trigger Form -->
+        <Transition name="slide-down">
+          <div v-if="showTriggerForm" class="bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-xl p-5 space-y-4 mb-4">
+            <h3 class="text-xs font-bold text-gray-800 dark:text-zinc-200">New Trigger</h3>
+
+            <!-- Workspace Picker -->
+            <div>
+              <label class="block text-[11px] font-bold text-gray-500 dark:text-zinc-400 uppercase tracking-widest mb-1">
+                Target Workspace <span class="text-red-500">*</span>
+              </label>
+              <select
+                v-model="triggerForm.workspaceId"
+                class="w-full px-3 py-2 text-sm border border-gray-200 dark:border-zinc-700 rounded-lg bg-white dark:bg-zinc-800 text-gray-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white transition-all">
+                <option value="">Select workspace…</option>
+                <option v-for="ws in workspaceStore.workspaces" :key="ws.id" :value="ws.id">{{ ws.name }}</option>
+              </select>
+            </div>
+
+            <!-- Task Title -->
+            <div>
+              <label class="block text-[11px] font-bold text-gray-500 dark:text-zinc-400 uppercase tracking-widest mb-1">
+                Task Title <span class="text-red-500">*</span>
+              </label>
+              <input
+                v-model="triggerForm.title"
+                type="text"
+                placeholder="e.g. Review the latest deploy"
+                class="w-full px-3 py-2 text-sm border border-gray-200 dark:border-zinc-700 rounded-lg bg-white dark:bg-zinc-800 text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white transition-all"
+              />
+            </div>
+
+            <!-- Task Body -->
+            <div>
+              <div class="flex items-center justify-between mb-1">
+                <label class="block text-[11px] font-bold text-gray-500 dark:text-zinc-400 uppercase tracking-widest">Task Instructions</label>
+                <div class="flex items-center gap-1.5">
+                  <span class="text-[10px] text-gray-400 dark:text-zinc-500">Insert:</span>
+                  <button
+                    type="button"
+                    @click="insertTemplate('{{EVENT_PAYLOAD}}')"
+                    class="px-2 py-0.5 text-[10px] font-mono font-bold bg-violet-50 dark:bg-violet-900/20 text-violet-600 dark:text-violet-400 border border-violet-200 dark:border-violet-800 rounded hover:bg-violet-100 dark:hover:bg-violet-900/40 transition-colors">
+                    {{EVENT_PAYLOAD}}
+                  </button>
+                  <button
+                    type="button"
+                    @click="insertTemplate('{{EVENT_FAQ}}')"
+                    class="px-2 py-0.5 text-[10px] font-mono font-bold bg-sky-50 dark:bg-sky-900/20 text-sky-600 dark:text-sky-400 border border-sky-200 dark:border-sky-800 rounded hover:bg-sky-100 dark:hover:bg-sky-900/40 transition-colors">
+                    {{EVENT_FAQ}}
+                  </button>
+                </div>
+              </div>
+              <textarea
+                v-model="triggerForm.body"
+                rows="3"
+                placeholder="Describe what the agent should do. Use {{EVENT_PAYLOAD}} and {{EVENT_FAQ}} as template variables."
+                class="w-full px-3 py-2 text-sm border border-gray-200 dark:border-zinc-700 rounded-lg bg-white dark:bg-zinc-800 text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-500 resize-none focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white transition-all"
+              ></textarea>
+            </div>
+
+            <!-- Assignee + YOLO -->
+            <div class="flex flex-wrap gap-6">
+              <div>
+                <label class="block text-[11px] font-bold text-gray-500 dark:text-zinc-400 uppercase tracking-widest mb-1.5">Responsibility</label>
+                <div class="flex p-1 bg-gray-100 dark:bg-zinc-950 border border-gray-200 dark:border-zinc-800 rounded-lg w-fit">
+                  <button type="button" @click="triggerForm.assignee = 'agent'"
+                    :class="triggerForm.assignee === 'agent' ? 'bg-white dark:bg-zinc-800 text-gray-900 dark:text-white shadow-sm border border-gray-200 dark:border-zinc-700' : 'text-gray-500 dark:text-zinc-500 border border-transparent'"
+                    class="px-5 py-1.5 rounded-md text-[10px] font-semibold transition-all">Agent</button>
+                  <button type="button" @click="triggerForm.assignee = 'human'"
+                    :class="triggerForm.assignee === 'human' ? 'bg-white dark:bg-zinc-800 text-gray-900 dark:text-white shadow-sm border border-gray-200 dark:border-zinc-700' : 'text-gray-500 dark:text-zinc-500 border border-transparent'"
+                    class="px-5 py-1.5 rounded-md text-[10px] font-semibold transition-all">Human</button>
+                </div>
+              </div>
+              <div v-if="triggerForm.assignee === 'agent'">
+                <label class="block text-[11px] font-bold text-gray-500 dark:text-zinc-400 uppercase tracking-widest mb-1.5">YOLO (Auto-Allow)</label>
+                <div class="flex p-1 bg-gray-100 dark:bg-zinc-950 border border-gray-200 dark:border-zinc-800 rounded-lg w-fit">
+                  <button type="button" @click="triggerForm.allowAllCommands = true"
+                    :class="triggerForm.allowAllCommands ? 'bg-white dark:bg-zinc-800 text-gray-900 dark:text-white shadow-sm border border-gray-200 dark:border-zinc-700' : 'text-gray-500 dark:text-zinc-500 border border-transparent'"
+                    class="px-5 py-1.5 rounded-md text-[10px] font-semibold uppercase transition-all">ON</button>
+                  <button type="button" @click="triggerForm.allowAllCommands = false"
+                    :class="!triggerForm.allowAllCommands ? 'bg-white dark:bg-zinc-800 text-gray-900 dark:text-white shadow-sm border border-gray-200 dark:border-zinc-700' : 'text-gray-500 dark:text-zinc-500 border border-transparent'"
+                    class="px-5 py-1.5 rounded-md text-[10px] font-semibold uppercase transition-all">OFF</button>
+                </div>
+              </div>
+            </div>
+
+            <!-- Emit Event on Completion -->
+            <div v-if="allEvents.length > 0" class="pt-2 border-t border-gray-100 dark:border-zinc-800">
+              <label class="block text-[11px] font-bold text-gray-500 dark:text-zinc-400 uppercase tracking-widest mb-1">Emit Event on Completion</label>
+              <select v-model="triggerForm.emitEventId"
+                class="w-full bg-white dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-zinc-50 outline-none focus:border-gray-900 dark:focus:border-white focus:ring-0 transition-all">
+                <option value="">None</option>
+                <option v-for="ev in allEvents" :key="ev.id" :value="ev.id">{{ ev.name }}</option>
+              </select>
+            </div>
+
+            <!-- Form Actions -->
+            <div class="flex items-center gap-2 pt-2 border-t border-gray-100 dark:border-zinc-800">
+              <button
+                @click="handleCreateTrigger"
+                :disabled="creatingTrigger || !triggerForm.workspaceId || !triggerForm.title"
+                class="px-4 py-2 bg-black dark:bg-white text-white dark:text-black text-[11px] font-black uppercase tracking-widest rounded-lg hover:opacity-80 transition-all active:scale-95 disabled:opacity-50">
+                {{ creatingTrigger ? 'Creating…' : 'Create Trigger' }}
+              </button>
+              <button
+                @click="resetTriggerForm"
+                class="px-4 py-2 bg-white dark:bg-zinc-800 text-gray-700 dark:text-zinc-300 border border-gray-200 dark:border-zinc-700 text-[11px] font-black uppercase tracking-widest rounded-lg hover:bg-gray-50 dark:hover:bg-zinc-700 transition-all active:scale-95">
+                Cancel
+              </button>
+            </div>
+          </div>
+        </Transition>
+
+        <!-- Triggers List -->
+        <div v-if="loadingTriggers" class="text-sm text-gray-500 dark:text-zinc-400 py-4 text-center">Loading triggers…</div>
+        <div v-else-if="triggers.length === 0 && !showTriggerForm"
+          class="py-8 px-4 border border-dashed border-gray-200 dark:border-zinc-800 rounded-xl text-center">
+          <p class="text-sm font-semibold text-gray-500 dark:text-zinc-400">No triggers yet</p>
+          <p class="text-xs text-gray-400 dark:text-zinc-500 mt-1">Add a trigger to auto-create tasks in a workspace when this event fires.</p>
+        </div>
+        <div v-else class="space-y-2">
+          <div v-for="t in triggers" :key="t.id"
+            class="group flex items-start gap-3 px-4 py-3 bg-white dark:bg-zinc-900 border border-gray-100 dark:border-zinc-800 rounded-xl hover:border-gray-200 dark:hover:border-zinc-700 transition-all">
+            <div class="shrink-0 w-8 h-8 flex items-center justify-center rounded-lg bg-gray-50 dark:bg-zinc-800 border border-gray-100 dark:border-zinc-700 mt-0.5">
+              <svg class="w-3.5 h-3.5 text-gray-500 dark:text-zinc-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
+              </svg>
+            </div>
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center gap-2 flex-wrap">
+                <span class="text-[10px] font-bold text-gray-400 dark:text-zinc-500 uppercase tracking-wider">{{ workspaceName(t.workspaceId) }}</span>
+                <svg class="w-3 h-3 text-gray-300 dark:text-zinc-600 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+                <span class="text-xs font-bold text-gray-800 dark:text-zinc-200 truncate">{{ t.title }}</span>
+              </div>
+              <p v-if="t.body" class="text-[11px] text-gray-500 dark:text-zinc-400 truncate mt-0.5">{{ t.body }}</p>
+              <div class="flex items-center gap-3 mt-1 flex-wrap">
+                <span class="text-[10px] text-gray-400 dark:text-zinc-500">{{ t.assignee }}</span>
+                <code v-if="t.cronSchedule" class="text-[10px] font-mono text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-900/20 px-1.5 py-0.5 rounded">{{ t.cronSchedule }}</code>
+              </div>
+            </div>
+            <button
+              @click="confirmDeleteTrigger(t)"
+              class="p-1.5 text-gray-300 dark:text-zinc-600 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 rounded transition-all opacity-0 group-hover:opacity-100 shrink-0">
+              <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Tasks From This Event -->
+      <div>
+        <div class="mb-3">
+          <h2 class="text-sm font-bold text-gray-800 dark:text-zinc-200">Tasks created from this event</h2>
+          <p class="text-[11px] text-gray-400 dark:text-zinc-500 mt-0.5">Tasks automatically spawned each time this event fired.</p>
+        </div>
+
+        <div v-if="loadingTasks" class="text-sm text-gray-500 dark:text-zinc-400 py-4 text-center">Loading tasks…</div>
+        <div v-else-if="tasks.length === 0"
+          class="py-8 px-4 border border-dashed border-gray-200 dark:border-zinc-800 rounded-xl text-center">
+          <p class="text-sm font-semibold text-gray-500 dark:text-zinc-400">No tasks yet</p>
+          <p class="text-xs text-gray-400 dark:text-zinc-500 mt-1">Tasks will appear here after the event fires and triggers are executed.</p>
+        </div>
+        <div v-else class="space-y-2">
+          <router-link
+            v-for="t in visibleTasks"
+            :key="t.id"
+            :to="`/workspaces/${t.workspaceId}/tasks/${t.id}`"
+            class="flex items-center gap-3 px-4 py-3 bg-white dark:bg-zinc-900 border border-gray-100 dark:border-zinc-800 rounded-xl hover:border-gray-200 dark:hover:border-zinc-700 transition-all">
+            <div class="flex-1 min-w-0">
+              <p class="text-sm font-semibold text-gray-800 dark:text-zinc-200 truncate">{{ t.title }}</p>
+              <div class="flex items-center gap-3 mt-0.5 flex-wrap">
+                <span :class="['text-[11px] font-semibold', statusColor(t.status)]">{{ t.status }}</span>
+                <span class="text-[11px] text-gray-400 dark:text-zinc-500">{{ t.assignee }}</span>
+                <span class="text-[11px] text-gray-400 dark:text-zinc-500 tabular-nums">{{ formatDate(t.createdAt) }}</span>
+              </div>
+            </div>
+            <svg class="w-4 h-4 text-gray-300 dark:text-zinc-600 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+          </router-link>
+          <button
+            v-if="hasMoreTasks"
+            @click="loadMoreTasks"
+            class="w-full py-2 text-[11px] font-bold uppercase tracking-widest text-gray-500 dark:text-zinc-400 hover:text-gray-800 dark:hover:text-zinc-200 border border-gray-100 dark:border-zinc-800 rounded-xl hover:border-gray-200 dark:hover:border-zinc-700 transition-all">
+            Load more ({{ tasks.length - visibleTaskCount }} remaining)
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Delete Event Modal -->
+    <DeleteModal
+      :show="showDeleteEventModal"
+      title="Delete Event"
+      :taskTitle="event?.name ?? ''"
+      @close="showDeleteEventModal = false"
+      @confirm="handleDeleteEvent"
+    />
+
+    <!-- Delete Trigger Modal -->
+    <DeleteModal
+      :show="showDeleteTriggerModal"
+      title="Delete Trigger"
+      :taskTitle="deletingTrigger?.title ?? ''"
+      @close="showDeleteTriggerModal = false; deletingTrigger = null"
+      @confirm="handleDeleteTrigger"
+    />
+  </div>
+</template>
+
+<style scoped>
+.slide-down-enter-active { transition: all 0.2s ease; }
+.slide-down-leave-active { transition: all 0.15s ease; }
+.slide-down-enter-from { opacity: 0; transform: translateY(-8px); }
+.slide-down-leave-to { opacity: 0; transform: translateY(-4px); }
+</style>

--- a/frontend/src/views/EventsView.vue
+++ b/frontend/src/views/EventsView.vue
@@ -1,0 +1,244 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { fetchEvents, createEvent, deleteEvent } from '../api'
+import { useToasts } from '../composables/useToasts'
+import DeleteModal from '../components/DeleteModal.vue'
+
+const router = useRouter()
+const { notifyError, notifySuccess } = useToasts()
+
+// ── state ─────────────────────────────────────────────────────────────────────
+
+const events = ref([])
+const loading = ref(true)
+
+// create form
+const showCreateForm = ref(false)
+const creating = ref(false)
+const formName = ref('')
+const formNameError = ref('')
+const formGuidelines = ref('')
+
+// delete modal
+const showDeleteModal = ref(false)
+const deletingEvent = ref(null)
+const deleting = ref(false)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+const EVENT_NAME_RE = /^[a-z][a-z0-9_]*$/
+
+function formatDate(iso) {
+  if (!iso) return ''
+  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+function sanitizeName(raw) {
+  return raw
+    .toLowerCase()
+    .replace(/ /g, '_')
+    .replace(/[^a-z0-9_]/g, '')
+}
+
+function validateName(name) {
+  if (!name) return 'Name is required'
+  if (!EVENT_NAME_RE.test(name)) return 'Must start with a-z, then only a-z, 0-9, _'
+  if (name.length > 129) return 'Max 129 characters'
+  return ''
+}
+
+// ── data ops ──────────────────────────────────────────────────────────────────
+
+async function loadEvents() {
+  loading.value = true
+  try {
+    const data = await fetchEvents()
+    events.value = data.events ?? []
+  } catch (e) {
+    notifyError(e.message)
+  } finally {
+    loading.value = false
+  }
+}
+
+function resetForm() {
+  formName.value = ''
+  formNameError.value = ''
+  formGuidelines.value = ''
+  showCreateForm.value = false
+}
+
+async function handleCreate() {
+  formNameError.value = validateName(formName.value)
+  if (formNameError.value) return
+
+  creating.value = true
+  try {
+    await createEvent(formName.value.trim(), formGuidelines.value.trim())
+    notifySuccess('Event created')
+    resetForm()
+    await loadEvents()
+  } catch (e) {
+    notifyError(e.message)
+  } finally {
+    creating.value = false
+  }
+}
+
+function confirmDelete(ev) {
+  deletingEvent.value = ev
+  showDeleteModal.value = true
+}
+
+async function handleDelete() {
+  if (!deletingEvent.value) return
+  deleting.value = true
+  try {
+    await deleteEvent(deletingEvent.value.id)
+    notifySuccess('Event deleted')
+    events.value = events.value.filter(e => e.id !== deletingEvent.value.id)
+  } catch (e) {
+    notifyError(e.message)
+  } finally {
+    deleting.value = false
+    showDeleteModal.value = false
+    deletingEvent.value = null
+  }
+}
+
+onMounted(loadEvents)
+</script>
+
+<template>
+  <div class="flex flex-col h-full w-full overflow-y-auto custom-scrollbar">
+    <!-- Header -->
+    <div class="w-full px-4 py-2 mb-6 shrink-0 flex flex-row items-center justify-between gap-4">
+      <div class="flex flex-col min-w-0 flex-1">
+        <h1 class="text-lg md:text-2xl font-black text-gray-800 dark:text-zinc-200 truncate leading-tight">Events</h1>
+        <p class="text-xs text-gray-500 dark:text-zinc-400 mt-0.5">Named signals that trigger tasks in subscriber workspaces.</p>
+      </div>
+      <button
+        @click="showCreateForm = !showCreateForm"
+        class="px-4 py-2 bg-black dark:bg-white text-white dark:text-black text-[11px] font-black uppercase tracking-widest rounded-lg hover:opacity-80 transition-all active:scale-95 shrink-0">
+        + New Event
+      </button>
+    </div>
+
+    <div class="px-4 space-y-6 pb-10">
+
+      <!-- Create Form -->
+      <Transition name="slide-down">
+        <div v-if="showCreateForm" class="bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-xl p-5 space-y-4">
+          <h2 class="text-sm font-bold text-gray-800 dark:text-zinc-200">New Event</h2>
+
+          <!-- Name -->
+          <div>
+            <label class="block text-[11px] font-bold text-gray-500 dark:text-zinc-400 uppercase tracking-widest mb-1">
+              Event Name <span class="text-red-500">*</span>
+            </label>
+            <input
+              :value="formName"
+              @input="e => { formName = sanitizeName(e.target.value); formNameError = '' }"
+              type="text"
+              placeholder="deploy_done"
+              class="w-full px-3 py-2 text-sm border rounded-lg bg-white dark:bg-zinc-800 text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white transition-all font-mono"
+              :class="formNameError ? 'border-red-400' : 'border-gray-200 dark:border-zinc-700'"
+            />
+            <p v-if="formNameError" class="text-[11px] text-red-500 mt-1">{{ formNameError }}</p>
+            <p v-else class="text-[11px] text-gray-400 dark:text-zinc-500 mt-1">Spaces become <code class="font-mono">_</code> · only lowercase letters, digits, underscores</p>
+          </div>
+
+          <!-- Payload Guidelines -->
+          <div>
+            <label class="block text-[11px] font-bold text-gray-500 dark:text-zinc-400 uppercase tracking-widest mb-1">
+              Payload Guidelines
+            </label>
+            <textarea
+              v-model="formGuidelines"
+              rows="2"
+              placeholder="Describe what the agent should include in the payload when publishing this event…"
+              class="w-full px-3 py-2 text-sm border border-gray-200 dark:border-zinc-700 rounded-lg bg-white dark:bg-zinc-800 text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-500 resize-none focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white transition-all"
+            ></textarea>
+          </div>
+
+          <!-- Actions -->
+          <div class="flex items-center gap-2 pt-2 border-t border-gray-100 dark:border-zinc-800">
+            <button
+              @click="handleCreate"
+              :disabled="creating"
+              class="px-4 py-2 bg-black dark:bg-white text-white dark:text-black text-[11px] font-black uppercase tracking-widest rounded-lg hover:opacity-80 transition-all active:scale-95 disabled:opacity-50">
+              {{ creating ? 'Creating…' : 'Create Event' }}
+            </button>
+            <button
+              @click="resetForm"
+              class="px-4 py-2 bg-white dark:bg-zinc-800 text-gray-700 dark:text-zinc-300 border border-gray-200 dark:border-zinc-700 text-[11px] font-black uppercase tracking-widest rounded-lg hover:bg-gray-50 dark:hover:bg-zinc-700 transition-all active:scale-95">
+              Cancel
+            </button>
+          </div>
+        </div>
+      </Transition>
+
+      <!-- Events List -->
+      <div>
+        <div v-if="loading" class="text-sm text-gray-500 dark:text-zinc-400 py-8 text-center">Loading events…</div>
+
+        <div v-else-if="events.length === 0 && !showCreateForm"
+             class="py-12 px-4 border border-dashed border-gray-200 dark:border-zinc-800 rounded-xl text-center">
+          <p class="text-sm font-semibold text-gray-500 dark:text-zinc-400 mb-1">No events yet</p>
+          <p class="text-xs text-gray-400 dark:text-zinc-500">Create an event to let agents signal other workspaces.</p>
+        </div>
+
+        <div v-else class="space-y-2">
+          <div
+            v-for="ev in events"
+            :key="ev.id"
+            class="group flex items-center gap-4 px-4 py-3 bg-white dark:bg-zinc-900 border border-gray-100 dark:border-zinc-800 rounded-xl hover:border-gray-200 dark:hover:border-zinc-700 transition-all cursor-pointer"
+            @click="router.push(`/events/${ev.id}`)">
+
+            <!-- Icon -->
+            <div class="shrink-0 w-8 h-8 flex items-center justify-center rounded-lg bg-gray-50 dark:bg-zinc-800 border border-gray-100 dark:border-zinc-700">
+              <svg class="w-4 h-4 text-gray-500 dark:text-zinc-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9.348 14.651a3.75 3.75 0 010-5.303m5.304-.002a3.75 3.75 0 010 5.304m-7.425 2.122a6.75 6.75 0 010-9.546m9.546.001a6.75 6.75 0 010 9.545m-11.667 2.121a9.75 9.75 0 010-13.788m13.788.001a9.75 9.75 0 010 13.787M12 12h.008v.008H12V12z" />
+              </svg>
+            </div>
+
+            <!-- Info -->
+            <div class="flex-1 min-w-0">
+              <p class="text-sm font-bold text-gray-800 dark:text-zinc-200 truncate font-mono">{{ ev.name }}</p>
+              <p v-if="ev.payloadGuidelines" class="text-xs text-gray-500 dark:text-zinc-400 truncate mt-0.5">{{ ev.payloadGuidelines }}</p>
+            </div>
+
+            <!-- Date + actions -->
+            <div class="flex items-center gap-3 shrink-0">
+              <span class="text-[11px] text-gray-400 dark:text-zinc-500 tabular-nums">{{ formatDate(ev.createdAt) }}</span>
+              <button
+                @click.stop="confirmDelete(ev)"
+                class="p-1.5 text-gray-300 dark:text-zinc-600 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 rounded transition-all opacity-0 group-hover:opacity-100">
+                <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Delete Modal -->
+    <DeleteModal
+      :show="showDeleteModal"
+      title="Delete Event"
+      :taskTitle="deletingEvent?.name ?? ''"
+      @close="showDeleteModal = false; deletingEvent = null"
+      @confirm="handleDelete"
+    />
+  </div>
+</template>
+
+<style scoped>
+.slide-down-enter-active { transition: all 0.2s ease; }
+.slide-down-leave-active { transition: all 0.15s ease; }
+.slide-down-enter-from { opacity: 0; transform: translateY(-8px); }
+.slide-down-leave-to { opacity: 0; transform: translateY(-4px); }
+</style>

--- a/frontend/src/views/TaskFormView.vue
+++ b/frontend/src/views/TaskFormView.vue
@@ -131,6 +131,17 @@
                     </div>
                   </div>
                 </div>
+                <!-- Emit Event on Completion -->
+                <div v-if="!isEditMode && events.length > 0" class="pt-6 border-t border-gray-100 dark:border-zinc-800/50">
+                  <label class="text-[10px] font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-wider block mb-2">Emit Event on Completion</label>
+                  <select v-model="selectedEventId"
+                          class="bg-white dark:bg-zinc-950 border border-gray-200 dark:border-zinc-700 rounded-sm px-3 py-2 text-[10px] font-semibold text-gray-900 dark:text-zinc-50 outline-none focus:border-gray-900 dark:focus:border-white focus:ring-0 transition-all shadow-sm w-full max-w-xs font-mono">
+                    <option value="">None</option>
+                    <option v-for="ev in events" :key="ev.id" :value="ev.id">{{ ev.name }}</option>
+                  </select>
+                  <p class="text-[10px] text-gray-400 dark:text-zinc-500 mt-1">Agent will be asked to fire the event on task completion</p>
+                </div>
+
                 <!-- Schedule Section -->
                 <div class="flex flex-col gap-6 pt-6 border-t border-gray-100 dark:border-zinc-800/50">
                   <div class="flex flex-col gap-4">
@@ -231,7 +242,7 @@
 import { ref, computed, watch, onMounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import cronParser from 'cron-parser';
-import { getWorkspace, createTask, updateScheduledTask, getTask } from '../api';
+import { getWorkspace, createTask, updateScheduledTask, getTask, fetchEvents } from '../api';
 import { useToasts } from '../composables/useToasts';
 import { useCron } from '../composables/useCron';
 
@@ -252,6 +263,10 @@ const fileInput = ref(null);
 const newTask = ref({ title: '', body: '', assignee: 'agent', cronSchedule: '', allowAllCommands: false });
 const newTaskAttachments = ref([]);
 
+// Event-on-completion
+const events = ref([]);
+const selectedEventId = ref('');
+
 // Scheduling state
 const scheduleType = ref('none');
 const oneTimeDate = ref('');
@@ -270,26 +285,30 @@ function handleDrop(e) {
 
 onMounted(async () => {
   try {
-    const res = await getWorkspace(workspaceId);
-    workspace.value = res.workspace;
+    const [wsRes, eventsRes] = await Promise.all([
+      getWorkspace(workspaceId),
+      fetchEvents().catch(() => ({ events: [] })),
+    ]);
+    workspace.value = wsRes.workspace;
+    events.value = eventsRes.events ?? [];
 
     if (isEditMode.value) {
       const taskRes = await getTask(workspaceId, taskId);
       const t = taskRes.task;
-      newTask.value = { 
-        title: t.title, 
-        body: t.body, 
-        assignee: t.assignee, 
+      newTask.value = {
+        title: t.title,
+        body: t.body,
+        assignee: t.assignee,
         cronSchedule: t.cronSchedule,
         allowAllCommands: t.allowAllCommands || false
       };
-      
+
       if (t.cronSchedule) {
         parseCronToUI(t.cronSchedule);
       }
     } else {
       // Default to workspace setting for new tasks
-      newTask.value.allowAllCommands = res.workspace.allowAllCommands || false;
+      newTask.value.allowAllCommands = wsRes.workspace.allowAllCommands || false;
     }
   } catch (err) {
     notifyError("Access Error: " + err.message);
@@ -449,9 +468,10 @@ async function submitHumanTask() {
   try {
     const status = scheduleType.value !== 'none' ? 'cron' : 'notstarted';
     await createTask(
-      workspaceId, newTask.value.title, newTask.value.body, 
+      workspaceId, newTask.value.title, newTask.value.body,
       newTask.value.assignee, newTaskAttachments.value,
-      status, newTask.value.cronSchedule, newTask.value.allowAllCommands
+      status, newTask.value.cronSchedule, newTask.value.allowAllCommands,
+      selectedEventId.value
     );
     notifySuccess('Task Created successfully');
     goBack(status === 'cron');

--- a/frontend/src/views/WorkspaceSettingsView.vue
+++ b/frontend/src/views/WorkspaceSettingsView.vue
@@ -639,6 +639,7 @@ const permissionsConfig = computed(() => ({
       `mcp__${serverName.value}__downloadAttachment`,
       `mcp__${serverName.value}__getTaskMessages`,
       `mcp__${serverName.value}__getNextTask`,
+      `mcp__${serverName.value}__publishEvent`,
     ]
   },
   enableAllProjectMcpServers: true,
@@ -670,6 +671,9 @@ approval_mode = "approve"
 approval_mode = "approve"
 
 [mcp_servers.${serverName.value}.tools.getNextTask]
+approval_mode = "approve"
+
+[mcp_servers.${serverName.value}.tools.publishEvent]
 approval_mode = "approve"`;
 });
 


### PR DESCRIPTION
- Event CRUD (name, payloadGuidelines) with ownership-scoped REST API
- EventTrigger CRUD: fan-out to workspaces on event publish, optional cron schedule, EmitEventID chaining with ownership validation
- publishEvent MCP tool: agents fire events by name with payload + FAQ
- Consumer (PubSubTopicEvents=3): renderTemplate substitutes {{EVENT_PAYLOAD}} / {{EVENT_FAQ}} in body; title is always static
- Agent instruction injection: createTask and event-consumer append [On completion: call publishEvent("name", "...")] + payload guidelines so agents know to publish explicitly with a meaningful payload
- PATCH /events/:id endpoint to update payloadGuidelines
- Remove auto-publish fallback (app.go) — agent is instructed instead
- Remove FAQ from event definition (FAQ is publish-time only)
- EmitEventID ownership check in CreateEventTrigger
- publishEvent added to workspace setup permissions config
- Event name sanitization on input (spaces→_, lowercase, strip invalid)
- Frontend: /events list + /events/:id detail with triggers CRUD, resulting tasks (load-more), consistent signal icon, header matches workspace sub-page convention (Events / name), pencil + trash icons in header, payload guidelines edit form on demand

Task: 0eCPoGZxPLl