### PR TITLE
fix: reject invalid workspace ids when listing tasks

### DIFF
--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -192,6 +192,76 @@ func (m *mockCrudTaskCounts) GetWorkspaceTaskCounts(ctx context.Context, req ent
 	return m.getWorkspaceTaskCountsFunc(ctx, req)
 }
 
+type mockCrudListTasks struct {
+	crud.Controller
+	listTasksFunc func(ctx context.Context, req entity.ListTasksRequest) (*entity.ListTasksResponse, error)
+}
+
+func (m *mockCrudListTasks) ListTasks(ctx context.Context, req entity.ListTasksRequest) (*entity.ListTasksResponse, error) {
+	return m.listTasksFunc(ctx, req)
+}
+
+func TestListTasks_InvalidWorkspaceID(t *testing.T) {
+	app := fiber.New()
+	crudCtrl := &mockCrudListTasks{}
+	called := false
+
+	h := &handler{
+		crud: crudCtrl,
+	}
+
+	app.Get("/api/v1/workspaces/:id/tasks", func(c *fiber.Ctx) error {
+		c.Locals("user_id", "user1")
+		return h.listTasks()(c)
+	})
+
+	crudCtrl.listTasksFunc = func(ctx context.Context, req entity.ListTasksRequest) (*entity.ListTasksResponse, error) {
+		called = true
+		return &entity.ListTasksResponse{}, nil
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/workspaces/!/tasks", nil)
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("Expected status 422, got %d", resp.StatusCode)
+	}
+	if called {
+		t.Fatal("ListTasks should not be called for invalid workspace IDs")
+	}
+}
+
+func TestListTasks_GlobalRouteAllowsMissingWorkspaceID(t *testing.T) {
+	app := fiber.New()
+	crudCtrl := &mockCrudListTasks{}
+
+	h := &handler{
+		crud: crudCtrl,
+	}
+
+	app.Get("/api/v1/tasks", func(c *fiber.Ctx) error {
+		c.Locals("user_id", "user1")
+		return h.listTasks()(c)
+	})
+
+	crudCtrl.listTasksFunc = func(ctx context.Context, req entity.ListTasksRequest) (*entity.ListTasksResponse, error) {
+		if req.WorkspaceID != 0 {
+			t.Fatalf("expected global task list workspace ID 0, got %d", req.WorkspaceID)
+		}
+		if req.UserID != "user1" {
+			t.Fatalf("expected user ID user1, got %s", req.UserID)
+		}
+		return &entity.ListTasksResponse{}, nil
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/tasks", nil)
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+}
+
 func TestGetWorkspaceTaskCounts(t *testing.T) {
 	app := fiber.New()
 	crudCtrl := &mockCrudTaskCounts{}

--- a/backend/internal/mapper/api/task.go
+++ b/backend/internal/mapper/api/task.go
@@ -35,15 +35,15 @@ func FromHTTPRequestToCreateTaskRequestEntity(c *fiber.Ctx) *entity.CreateTaskRe
 
 	return &entity.CreateTaskRequest{
 		Task: entity.Task{
-			WorkspaceID:  workspaceID,
-			CreatedBy:    payload.Task.CreatedBy,
-			Assignee:     payload.Task.Assignee,
-			Title:        payload.Task.Title,
-			Body:         payload.Task.Body,
-			Status:       payload.Task.Status,
-			Attachments:  entityAttachments,
-			CronSchedule: payload.Task.CronSchedule,
-			SortOrder:    payload.Task.SortOrder,
+			WorkspaceID:      workspaceID,
+			CreatedBy:        payload.Task.CreatedBy,
+			Assignee:         payload.Task.Assignee,
+			Title:            payload.Task.Title,
+			Body:             payload.Task.Body,
+			Status:           payload.Task.Status,
+			Attachments:      entityAttachments,
+			CronSchedule:     payload.Task.CronSchedule,
+			SortOrder:        payload.Task.SortOrder,
 			AllowAllCommands: payload.Task.AllowAllCommands,
 		},
 	}
@@ -69,7 +69,13 @@ func FromGetTaskResponseEntityToHTTPResponse(rs *entity.GetTaskResponse) []byte 
 }
 
 func FromHTTPRequestToListTasksRequestEntity(c *fiber.Ctx) *entity.ListTasksRequest {
-	workspaceID := monoflake.IDFromBase62(c.Params("id")).Int64()
+	var workspaceID int64
+	if idParam := c.Params("id"); idParam != "" {
+		workspaceID = monoflake.IDFromBase62(idParam).Int64()
+		if workspaceID == 0 {
+			return nil
+		}
+	}
 
 	statusStr := c.Query("status")
 	var status []string
@@ -280,21 +286,21 @@ func FromEntityTaskToView(t entity.Task) view.Task {
 		workspaceID = monoflake.ID(t.WorkspaceID).String()
 	}
 	res := view.Task{
-		ID:           monoflake.ID(t.ID).String(),
-		CreatedAt:    t.CreatedAt,
-		UpdatedAt:    t.UpdatedAt,
-		WorkspaceID:  workspaceID,
-		CreatedBy:    t.CreatedBy,
-		Assignee:     t.Assignee,
-		Status:       t.Status,
-		Title:        t.Title,
-		Body:         t.Body,
-		Response:     t.Response,
-		ReplyText:    t.ReplyText,
-		Attachments:  fromEntityAttachmentsToView(t.Attachments),
-		Messages:     fromEntityMessagesToView(t.Messages),
-		CronSchedule: t.CronSchedule,
-		SortOrder:    t.SortOrder,
+		ID:               monoflake.ID(t.ID).String(),
+		CreatedAt:        t.CreatedAt,
+		UpdatedAt:        t.UpdatedAt,
+		WorkspaceID:      workspaceID,
+		CreatedBy:        t.CreatedBy,
+		Assignee:         t.Assignee,
+		Status:           t.Status,
+		Title:            t.Title,
+		Body:             t.Body,
+		Response:         t.Response,
+		ReplyText:        t.ReplyText,
+		Attachments:      fromEntityAttachmentsToView(t.Attachments),
+		Messages:         fromEntityMessagesToView(t.Messages),
+		CronSchedule:     t.CronSchedule,
+		SortOrder:        t.SortOrder,
 		AllowAllCommands: t.AllowAllCommands,
 	}
 	if t.ParentID != 0 {
@@ -366,21 +372,21 @@ func FromModelTaskToView(t model.Task) view.Task {
 	}
 
 	res := view.Task{
-		ID:           monoflake.ID(t.ID).String(),
-		CreatedAt:    t.CreatedAt,
-		UpdatedAt:    t.UpdatedAt,
-		WorkspaceID:  workspaceID,
-		CreatedBy:    t.CreatedBy,
-		Assignee:     t.Assignee,
-		Status:       t.Status,
-		Title:        t.Title,
-		Body:         t.Body,
-		Response:     t.Response,
-		ReplyText:    t.ReplyText,
-		Attachments:  atts,
-		Messages:     msgs,
-		CronSchedule: t.CronSchedule,
-		SortOrder:    t.SortOrder,
+		ID:               monoflake.ID(t.ID).String(),
+		CreatedAt:        t.CreatedAt,
+		UpdatedAt:        t.UpdatedAt,
+		WorkspaceID:      workspaceID,
+		CreatedBy:        t.CreatedBy,
+		Assignee:         t.Assignee,
+		Status:           t.Status,
+		Title:            t.Title,
+		Body:             t.Body,
+		Response:         t.Response,
+		ReplyText:        t.ReplyText,
+		Attachments:      atts,
+		Messages:         msgs,
+		CronSchedule:     t.CronSchedule,
+		SortOrder:        t.SortOrder,
 		AllowAllCommands: t.AllowAllCommands,
 	}
 	if t.ParentID != 0 {
@@ -399,12 +405,12 @@ func FromHTTPRequestToUpdateScheduledTaskRequestEntity(c *fiber.Ctx) *entity.Upd
 		return nil
 	}
 	return &entity.UpdateScheduledTaskRequest{
-		WorkspaceID:  workspaceID,
-		TaskID:       taskID,
-		Title:        payload.Task.Title,
-		Body:         payload.Task.Body,
-		Assignee:     payload.Task.Assignee,
-		CronSchedule: payload.Task.CronSchedule,
+		WorkspaceID:      workspaceID,
+		TaskID:           taskID,
+		Title:            payload.Task.Title,
+		Body:             payload.Task.Body,
+		Assignee:         payload.Task.Assignee,
+		CronSchedule:     payload.Task.CronSchedule,
 		AllowAllCommands: payload.Task.AllowAllCommands,
 	}
 }


### PR DESCRIPTION
Task: #192

## Summary

- Reject invalid workspace IDs for `GET /workspaces/:id/tasks`
- Preserve global task listing behavior for `GET /tasks`
- Add handler tests for invalid workspace-scoped list requests and global task listing

## Tests

```bash
go test ./internal/mapper/api ./internal/handler/api