### PR TITLE
🛡️ Sentinel: Fix [CSRF in Google OAuth Flow]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** The `ResizeBase64` service returned the original input string if the `data:image/` prefix was missing. The CRUD controller then stored this unsanitized string in the database. Since the frontend rendered some icons using `v-html`, this allowed for Stored XSS (e.g., using `javascript:` or malicious SVG).
 **Learning:** Fallback mechanisms that return unvalidated user input when processing fails are dangerous. If a service is designed to process/sanitize input, it must fail explicitly if the input doesn't meet the expected format.
 **Prevention:** Enforce strict input validation (e.g., prefix checks) and remove "fallback to original" logic in data processing services. Ensure that only successfully processed and sanitized data reaches the persistence layer.
+
+## 2026-06-22 - CSRF in Google OAuth Flow
+**Vulnerability:** The Google OAuth flow was susceptible to CSRF attacks because it used a static or user-provided `state` parameter without verifying its integrity or binding it to the user's session.
+**Learning:** Standard OAuth2 flows require a `state` parameter to prevent CSRF. Simply passing a value isn't enough; it must be cryptographically bound to the session and verified upon callback.
+**Prevention:** Implement a double-submit cookie pattern combined with HMAC signing. Generate a random nonce, store it in a secure cookie, and include it in a signed `state` parameter (`payload:nonce.signature`). Verify both the signature and the nonce matching the cookie during the callback.

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -295,14 +295,90 @@ func (h *handler) rootLogin() fiber.Handler {
 
 func (h *handler) googleLogin() fiber.Handler {
 	return func(c *fiber.Ctx) error {
-		state := c.Query("redirect_url", "state")
-		return c.Redirect(h.auth.GetAuthURL(state))
+		redirectURL := c.Query("redirect_url", "/")
+
+		// Security: generate a random nonce for CSRF protection
+		nonce, err := security.GenerateSecret(16)
+		if err != nil {
+			zlog.Error().Err(err).Msg("Failed to generate oauth state nonce")
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		}
+
+		// Security: sign the state data to prevent tampering
+		stateData := fmt.Sprintf("%s:%s", redirectURL, nonce)
+		stateSignature := security.Sign(stateData, h.tokenKey)
+		signedState := fmt.Sprintf("%s.%s", stateData, stateSignature)
+
+		// Store nonce in a secure cookie
+		cookie := &fiber.Cookie{
+			Name:     "oauth_state",
+			Value:    nonce,
+			Expires:  time.Now().Add(15 * time.Minute),
+			HTTPOnly: true,
+			Secure:   h.sslEnabled,
+			SameSite: "Lax",
+			Path:     "/",
+		}
+		if h.domain != "" && !strings.HasPrefix(h.domain, "localhost") {
+			cookie.Domain = "." + h.domain
+		}
+		c.Cookie(cookie)
+
+		return c.Redirect(h.auth.GetAuthURL(signedState))
 	}
 }
 
 func (h *handler) googleCallback() fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		code := c.Query("code")
+		state := c.Query("state")
+
+		// Security: verify signed state and nonce to prevent CSRF
+		if state == "" {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "missing state parameter"})
+		}
+
+		lastDot := strings.LastIndex(state, ".")
+		if lastDot == -1 {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid state format"})
+		}
+
+		stateData := state[:lastDot]
+		stateSignature := state[lastDot+1:]
+
+		if !security.Verify(stateData, stateSignature, h.tokenKey) {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid state signature"})
+		}
+
+		lastColon := strings.LastIndex(stateData, ":")
+		if lastColon == -1 {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid state data"})
+		}
+
+		redirectURLParam := stateData[:lastColon]
+		nonceParam := stateData[lastColon+1:]
+
+		cookieNonce := c.Cookies("oauth_state")
+
+		// Clear cookie immediately
+		clearCookie := &fiber.Cookie{
+			Name:     "oauth_state",
+			Value:    "",
+			Expires:  time.Now().Add(-1 * time.Hour),
+			HTTPOnly: true,
+			Secure:   h.sslEnabled,
+			SameSite: "Lax",
+			Path:     "/",
+		}
+		if h.domain != "" && !strings.HasPrefix(h.domain, "localhost") {
+			clearCookie.Domain = "." + h.domain
+		}
+		c.Cookie(clearCookie)
+
+		if cookieNonce == "" || !security.SecureCompare(nonceParam, cookieNonce) {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid oauth state (CSRF detected or expired)"})
+		}
+
 		ctx, cancel := newContext(c)
 		defer cancel()
 
@@ -363,18 +439,17 @@ func (h *handler) googleCallback() fiber.Handler {
 		}
 		c.Cookie(cookie)
 
-		state := c.Query("state")
 		redirectURL := "/"
 		// Situational security: validate redirect URL to prevent open redirect
-		if state != "" && state != "state" {
-			if strings.HasPrefix(state, "/") && !strings.HasPrefix(state, "//") && !strings.HasPrefix(state, "/\\") {
-				redirectURL = state
+		if redirectURLParam != "" {
+			if strings.HasPrefix(redirectURLParam, "/") && !strings.HasPrefix(redirectURLParam, "//") && !strings.HasPrefix(redirectURLParam, "/\\") {
+				redirectURL = redirectURLParam
 			} else {
 				// Parse absolute URL and validate against baseURL
-				if pRedirect, err := url.Parse(state); err == nil && pRedirect.IsAbs() {
+				if pRedirect, err := url.Parse(redirectURLParam); err == nil && pRedirect.IsAbs() {
 					if pBase, err := url.Parse(h.baseURL); err == nil {
 						if pRedirect.Host == pBase.Host && pRedirect.Scheme == pBase.Scheme {
-							redirectURL = state
+							redirectURL = redirectURLParam
 						}
 					}
 				}

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	"github.com/agentrq/agentrq/backend/internal/repository/base"
 	"github.com/agentrq/agentrq/backend/internal/service/auth"
+	"github.com/agentrq/agentrq/backend/internal/service/security"
 	"github.com/gofiber/fiber/v2"
 	"github.com/mustafaturan/monoflake"
 )
@@ -56,12 +58,14 @@ func TestGoogleCallback_OpenRedirectPrevention(t *testing.T) {
 	authSvc := &mockAuthService{}
 	tokenSvc := &mockTokenSvc{}
 	crudCtrl := &mockCrudController{}
+	tokenKey := "test-token-key-1234567890123456"
 
 	h := &handler{
 		auth:     authSvc,
 		tokenSvc: tokenSvc,
 		crud:     crudCtrl,
 		baseURL:  "http://localhost:3000",
+		tokenKey: tokenKey,
 	}
 
 	app.Get("/google/callback", h.googleCallback())
@@ -80,39 +84,45 @@ func TestGoogleCallback_OpenRedirectPrevention(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		state       string
+		redirectURL string
 		expectedLoc string
 	}{
 		{
 			name:        "Safe local redirect",
-			state:       "/workspaces",
+			redirectURL: "/workspaces",
 			expectedLoc: "/workspaces",
 		},
 		{
 			name:        "Malicious absolute redirect",
-			state:       "http://localhost:3000.evil.com",
+			redirectURL: "http://localhost:3000.evil.com",
 			expectedLoc: "/",
 		},
 		{
 			name:        "Malicious relative redirect //",
-			state:       "//evil.com",
+			redirectURL: "//evil.com",
 			expectedLoc: "/",
 		},
 		{
 			name:        "Malicious relative redirect /\\",
-			state:       "/\\evil.com",
+			redirectURL: "/\\evil.com",
 			expectedLoc: "/",
 		},
 		{
 			name:        "Safe absolute redirect",
-			state:       "http://localhost:3000/safe",
+			redirectURL: "http://localhost:3000/safe",
 			expectedLoc: "http://localhost:3000/safe",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state="+tt.state, nil)
+			nonce := "testnonce1234567"
+			stateData := fmt.Sprintf("%s:%s", tt.redirectURL, nonce)
+			sig := security.Sign(stateData, tokenKey)
+			signedState := fmt.Sprintf("%s.%s", stateData, sig)
+
+			req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state="+signedState, nil)
+			req.AddCookie(&http.Cookie{Name: "oauth_state", Value: nonce})
 			resp, _ := app.Test(req)
 
 			if resp.StatusCode != http.StatusFound {

--- a/backend/internal/service/security/security.go
+++ b/backend/internal/service/security/security.go
@@ -3,7 +3,9 @@ package security
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
@@ -91,4 +93,19 @@ func GenerateSecret(n int) (string, error) {
 // It wraps crypto/subtle.ConstantTimeCompare to mitigate timing attacks.
 func SecureCompare(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+// Sign generates an HMAC-SHA256 signature for the given data using the provided key.
+// It returns the hex-encoded signature.
+func Sign(data, key string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(data))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// Verify validates an HMAC-SHA256 signature for the given data using the provided key.
+// It returns true if the signature is valid.
+func Verify(data, signature, key string) bool {
+	expected := Sign(data, key)
+	return SecureCompare(signature, expected)
 }

--- a/backend/internal/service/security/security_test.go
+++ b/backend/internal/service/security/security_test.go
@@ -89,4 +89,24 @@ func TestSecurity(t *testing.T) {
 			t.Error("expected true for empty strings")
 		}
 	})
+
+	t.Run("SignVerify", func(t *testing.T) {
+		data := "some data to sign"
+		sig := Sign(data, key)
+		if sig == "" {
+			t.Fatal("expected signature, got empty string")
+		}
+		if !Verify(data, sig, key) {
+			t.Error("expected true for valid signature")
+		}
+		if Verify(data, "invalid signature", key) {
+			t.Error("expected false for invalid signature")
+		}
+		if Verify("different data", sig, key) {
+			t.Error("expected false for different data")
+		}
+		if Verify(data, sig, "different key 123456789012345678") {
+			t.Error("expected false for different key")
+		}
+	})
 }


### PR DESCRIPTION
Hardened the Google OAuth flow against CSRF by implementing session-bound nonces and HMAC-signed state parameters. Added Sign and Verify functions to the security service. Updated API handler tests to verify the fix.

---
*PR created automatically by Jules for task [600929478421949167](https://jules.google.com/task/600929478421949167) started by @mustafaturan*