### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF in Slack OAuth Flow

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** The `ResizeBase64` service returned the original input string if the `data:image/` prefix was missing. The CRUD controller then stored this unsanitized string in the database. Since the frontend rendered some icons using `v-html`, this allowed for Stored XSS (e.g., using `javascript:` or malicious SVG).
 **Learning:** Fallback mechanisms that return unvalidated user input when processing fails are dangerous. If a service is designed to process/sanitize input, it must fail explicitly if the input doesn't meet the expected format.
 **Prevention:** Enforce strict input validation (e.g., prefix checks) and remove "fallback to original" logic in data processing services. Ensure that only successfully processed and sanitized data reaches the persistence layer.
+
+## 2024-05-23 - CSRF in Slack OAuth Flow
+**Vulnerability:** The Slack OAuth flow used the raw base62-encoded workspace ID as the `state` parameter without any cryptographic signature or session-bound nonce. This made the flow vulnerable to CSRF attacks, where an attacker could force a victim to link their AgentRQ workspace to the attacker's Slack workspace.
+**Learning:** OAuth `state` parameters must be unguessable and cryptographically tied to the user's session or signed by the server to prevent CSRF and ensure the integrity of the authorization flow.
+**Prevention:** Use a dedicated token service to generate and validate signed state tokens that include the intended resource ID and a purpose/provider claim. Extract the resource ID from the validated token instead of using raw URL parameters.

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -552,6 +552,7 @@ func New(cfg Config) (*App, error) {
 	slackCtrl := slackctrl.New(slackctrl.Params{
 		Repository: repo,
 		SlackSvc:   slackSvc,
+		TokenSvc:   tokenSvc,
 		Crud:       crudCtrl,
 		MCPManager: mcpManager,
 		PubSub:     pubsubSvc,
@@ -703,6 +704,7 @@ func New(cfg Config) (*App, error) {
 	handlerslack.New(handlerslack.Params{
 		SlackCtrl: slackCtrl,
 		SlackSvc:  slackSvc,
+		TokenSvc:  tokenSvc,
 		BaseURL:   cfg.App.BaseURL,
 		Mux:       mux,
 	})

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -16,6 +16,7 @@ import (
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	"github.com/agentrq/agentrq/backend/internal/data/model"
 	"github.com/agentrq/agentrq/backend/internal/repository/base"
+	"github.com/agentrq/agentrq/backend/internal/service/auth"
 	"github.com/agentrq/agentrq/backend/internal/service/pubsub"
 	"github.com/agentrq/agentrq/backend/internal/service/security"
 	slacksvc "github.com/agentrq/agentrq/backend/internal/service/slack"
@@ -42,6 +43,7 @@ type CRUDRespondToTask interface {
 type Params struct {
 	Repository base.Repository
 	SlackSvc   slacksvc.Service
+	TokenSvc   auth.TokenService
 	Crud       CRUDRespondToTask
 	MCPManager MCPManager
 	PubSub     pubsub.Service
@@ -114,6 +116,7 @@ type SlackBlockAction struct {
 type controller struct {
 	repo     base.Repository
 	slack    slacksvc.Service
+	tokenSvc auth.TokenService
 	crud     CRUDRespondToTask
 	mcp      MCPManager
 	pubsub   pubsub.Service
@@ -126,6 +129,7 @@ func New(p Params) Controller {
 	return &controller{
 		repo:     p.Repository,
 		slack:    p.SlackSvc,
+		tokenSvc: p.TokenSvc,
 		crud:     p.Crud,
 		mcp:      p.MCPManager,
 		pubsub:   p.PubSub,
@@ -369,12 +373,17 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 	installed := err == nil && link.AccessToken != ""
 
 	workspaceID62 := monoflake.ID(workspaceID).String()
+	state, err := c.tokenSvc.CreateOAuthStateToken(workspaceID62, "slack")
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate signed state: %w", err)
+	}
+
 	redirectURI := fmt.Sprintf("%s/slack/oauth/callback", c.baseURL)
 	authURL := fmt.Sprintf(
 		"https://slack.com/oauth/v2/authorize?client_id=%s&scope=groups:write,groups:read,chat:write,app_mentions:read,commands&redirect_uri=%s&state=%s",
 		c.slack.ClientID(),
 		url.QueryEscape(redirectURI),
-		workspaceID62,
+		url.QueryEscape(state),
 	)
 
 	cfg := &entity.SlackConfig{

--- a/backend/internal/handler/slack/slack.go
+++ b/backend/internal/handler/slack/slack.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	slackctrl "github.com/agentrq/agentrq/backend/internal/controller/slack"
+	"github.com/agentrq/agentrq/backend/internal/service/auth"
 	slacksvc "github.com/agentrq/agentrq/backend/internal/service/slack"
 	zlog "github.com/rs/zerolog/log"
 )
@@ -20,6 +21,7 @@ import (
 type Params struct {
 	SlackCtrl slackctrl.Controller
 	SlackSvc  slacksvc.Service
+	TokenSvc  auth.TokenService
 	BaseURL   string
 	Mux       *http.ServeMux
 }
@@ -33,7 +35,7 @@ type Params struct {
 func New(p Params) {
 	p.Mux.Handle("/slack/events", eventsHandler(p.SlackSvc, p.SlackCtrl))
 	p.Mux.Handle("/slack/interactions", interactionsHandler(p.SlackSvc, p.SlackCtrl))
-	p.Mux.Handle("/slack/oauth/callback", oauthCallbackHandler(p.SlackSvc, p.SlackCtrl, p.BaseURL))
+	p.Mux.Handle("/slack/oauth/callback", oauthCallbackHandler(p.SlackSvc, p.SlackCtrl, p.TokenSvc, p.BaseURL))
 	p.Mux.Handle("/slack/commands", commandHandler(p.SlackSvc, p.SlackCtrl))
 }
 
@@ -174,7 +176,7 @@ func interactionsHandler(svc slacksvc.Service, ctrl slackctrl.Controller) http.H
 }
 
 // oauthCallbackHandler handles Slack's OAuth redirect callback.
-func oauthCallbackHandler(svc slacksvc.Service, ctrl slackctrl.Controller, baseURL string) http.Handler {
+func oauthCallbackHandler(svc slacksvc.Service, ctrl slackctrl.Controller, tokenSvc auth.TokenService, baseURL string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -182,26 +184,33 @@ func oauthCallbackHandler(svc slacksvc.Service, ctrl slackctrl.Controller, baseU
 		}
 
 		code := r.URL.Query().Get("code")
-		state := r.URL.Query().Get("state") // base62 workspace ID
+		stateToken := r.URL.Query().Get("state")
 
-		if code == "" || state == "" {
+		if code == "" || stateToken == "" {
 			zlog.Warn().Msg("[slack/oauth] missing code or state parameter")
 			http.Error(w, "missing code or state parameter", http.StatusBadRequest)
 			return
 		}
 
+		workspaceID62, err := tokenSvc.ValidateOAuthStateToken(stateToken, "slack")
+		if err != nil {
+			zlog.Warn().Err(err).Msg("[slack/oauth] invalid state parameter")
+			http.Error(w, "invalid state parameter", http.StatusUnauthorized)
+			return
+		}
+
 		redirectURI := fmt.Sprintf("%s/slack/oauth/callback", baseURL)
-		err := ctrl.HandleOAuthCallback(r.Context(), state, code, redirectURI)
+		err = ctrl.HandleOAuthCallback(r.Context(), workspaceID62, code, redirectURI)
 		if err != nil {
 			zlog.Error().Err(err).Msg("[slack/oauth] HandleOAuthCallback error")
 			// Redirect back with a generic error query param to prevent information leakage
 			errorMsg := url.QueryEscape("failed to complete slack authorization")
-			http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack&slack_error=%s", baseURL, state, errorMsg), http.StatusTemporaryRedirect)
+			http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack&slack_error=%s", baseURL, workspaceID62, errorMsg), http.StatusTemporaryRedirect)
 			return
 		}
 
 		// Redirect back to settings page on success
-		http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack", baseURL, state), http.StatusTemporaryRedirect)
+		http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack", baseURL, workspaceID62), http.StatusTemporaryRedirect)
 	})
 }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The Slack OAuth flow was vulnerable to CSRF because it used a raw, unsigned workspace ID as the `state` parameter.
🎯 Impact: An attacker could potentially link their own Slack workspace to a victim's AgentRQ workspace.
🔧 Fix: Hardened the Slack OAuth flow by implementing cryptographically signed state tokens using the `TokenService`.
✅ Verification: Verified the implementation by manual code review and running the backend test suite.

---
*PR created automatically by Jules for task [3360655176834628550](https://jules.google.com/task/3360655176834628550) started by @mustafaturan*