### PR TITLE
feat(telemetry): record MCP connection events

### DIFF
--- a/backend/internal/controller/mcp/event.go
+++ b/backend/internal/controller/mcp/event.go
@@ -10,6 +10,7 @@ const (
 	ActionMCPToolCall Action = iota + 1
 	ActionMCPMethodCall
 	ActionMCPNotification
+	ActionMCPConnect
 )
 
 func (a Action) String() string {
@@ -20,6 +21,8 @@ func (a Action) String() string {
 		return "method_call"
 	case ActionMCPNotification:
 		return "notification"
+	case ActionMCPConnect:
+		return "connect"
 	}
 	return "unknown"
 }

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -337,6 +337,7 @@ func (ps *WorkspaceServer) Handler() http.Handler {
 					Type:    "agent.connected",
 					Payload: map[string]any{"connected": true, "workspaceId": ps.workspaceID},
 				})
+				ps.emitTelemetry(r.Context(), ActionMCPConnect, "connect")
 			}
 			defer func() {
 				if ps.agentConnections.Add(-1) == 0 {

--- a/backend/internal/controller/telemetry/telemetry.go
+++ b/backend/internal/controller/telemetry/telemetry.go
@@ -172,6 +172,8 @@ func (c *controller) recordMCP(event mcp.MCPEvent) {
 	switch event.Action {
 	case mcp.ActionMCPToolCall:
 		action = model.ActionIDMCPToolCall
+	case mcp.ActionMCPConnect:
+		action = model.ActionIDMCPConnect
 	case mcp.ActionMCPNotification:
 		switch event.Method {
 		case "permission_manual_allow":

--- a/backend/internal/controller/telemetry/telemetry_test.go
+++ b/backend/internal/controller/telemetry/telemetry_test.go
@@ -91,6 +91,14 @@ func TestTelemetryController(t *testing.T) {
 			Actor:       uint8(entity.ActorAgent),
 		}
 
+		// Send MCP Connect
+		mcpChan <- mcp.MCPEvent{
+			UserID:      1,
+			WorkspaceID: 10,
+			Action:      mcp.ActionMCPConnect,
+			Actor:       uint8(entity.ActorAgent),
+		}
+
 		// Send Rejection (Manual Task)
 		crudChan <- entity.CRUDEvent{
 			UserID:      1,
@@ -112,8 +120,8 @@ func TestTelemetryController(t *testing.T) {
 
 		var count int64
 		db.Model(&model.Telemetry{}).Count(&count)
-		if count != 6 {
-			t.Errorf("expected 6 telemetry records, got %d", count)
+		if count != 7 {
+			t.Errorf("expected 7 telemetry records, got %d", count)
 		}
 
 		var records []model.Telemetry
@@ -121,6 +129,7 @@ func TestTelemetryController(t *testing.T) {
 		manualFound := false
 		rejectFound := false
 		denyFound := false
+		connectFound := false
 		for _, r := range records {
 			if r.Action == model.ActionIDMCPPermissionManual {
 				manualFound = true
@@ -131,6 +140,9 @@ func TestTelemetryController(t *testing.T) {
 			if r.Action == model.ActionIDMCPPermissionDeny {
 				denyFound = true
 			}
+			if r.Action == model.ActionIDMCPConnect {
+				connectFound = true
+			}
 		}
 		if !manualFound {
 			t.Errorf("expected model.ActionIDMCPPermissionManual record, but not found")
@@ -140,6 +152,9 @@ func TestTelemetryController(t *testing.T) {
 		}
 		if !denyFound {
 			t.Errorf("expected model.ActionIDMCPPermissionDeny record, but not found")
+		}
+		if !connectFound {
+			t.Errorf("expected model.ActionIDMCPConnect record, but not found")
 		}
 	})
 

--- a/backend/internal/data/model/model.go
+++ b/backend/internal/data/model/model.go
@@ -167,4 +167,5 @@ const (
 	ActionIDTaskComplete
 	ActionIDTaskFromScheduled
 	ActionIDUserCreate
+	ActionIDMCPConnect
 )


### PR DESCRIPTION
Emit a telemetry event when an agent establishes an MCP connection to a workspace server (SSE stream, 0->1 transition). This makes the connect-agent step measurable — previously we could see tasks/tool-calls but had no signal for how many users actually got an agent connected.

- mcp: add ActionMCPConnect action ('connect')
- model: add ActionIDMCPConnect stored action code
- telemetry: map mcp.ActionMCPConnect -> model.ActionIDMCPConnect in recordMCP
- server: emit telemetry at the agent.connected 0->1 transition
- test: cover the connect mapping in TestTelemetryController