### PR TITLE
chore: bump patch version to v0.3.3

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.3.2"
+	_appVersion   = "v0.3.3"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,7 +55,7 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.3.2" {
+		if s.Version() != "v0.3.3" {
 			t.Errorf("Version mismatch: %s", s.Version())
 		}
 		if s.Env() != "development" {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "cron-parser": "^5.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
Changes since v0.3.2:

feat:
- add docs link near sidebar version (#202)
- record MCP connection events (telemetry) (#201)

fix:
- patch Dependabot vulnerabilities: vite 8.0.10->8.1.0, dompurify 3.4.10->3.4.11 (#203)

docs:
- add Simplified Chinese README + bilingual freshness note (#194)