### PR TITLE
fix: remove duplicate error log messages in getTask handler

### DIFF
--- a/backend/internal/handler/api/task.go
+++ b/backend/internal/handler/api/task.go
@@ -164,10 +164,6 @@ func (h *handler) getTask() fiber.Handler {
 		defer cancel()
 		rs, err := h.crud.GetTask(ctx, *rq)
 		if err != nil {
-			zlog.Error().Err(err).Msg("Failed to create task")
-			c.Set(_headerContentType, _mimeJSON)
-			zlog.Error().Err(err).Msg("Failed to list tasks")
-			c.Set(_headerContentType, _mimeJSON)
 			zlog.Error().Err(err).Msg("Failed to get task")
 			c.Set(_headerContentType, _mimeJSON)
 			e, status := mapper.FromErrorToHTTPResponse(err)


### PR DESCRIPTION
## Summary

Remove duplicate log messages and redundant `c.Set()` calls in the `getTask()` error handler.

### Problem

The `getTask()` handler was written with copy-paste code from `createTask()` and other handlers. When an error occurs during `GetTask()`, the code logs:
1. "Failed to create task" — **wrong**, this is `getTask`, not `createTask`
2. "Failed to list tasks" — **wrong**, this is `getTask`, not listing
3. "Failed to get task" — correct

Each also redundantly calls `c.Set(_headerContentType, _mimeJSON)` even though the header is already set at the top of the function.

### Fix

Remove the two incorrect log lines and their redundant `c.Set()` calls. Keep only a single log message and a single `c.Set()` call, matching the pattern used in other handlers.

### Verification
- [x] Code compiles: `go build ./...`
- [x] Tests pass: `go test ./internal/handler/api/...`