### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF in Slack OAuth flow

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** The `ResizeBase64` service returned the original input string if the `data:image/` prefix was missing. The CRUD controller then stored this unsanitized string in the database. Since the frontend rendered some icons using `v-html`, this allowed for Stored XSS (e.g., using `javascript:` or malicious SVG).
 **Learning:** Fallback mechanisms that return unvalidated user input when processing fails are dangerous. If a service is designed to process/sanitize input, it must fail explicitly if the input doesn't meet the expected format.
 **Prevention:** Enforce strict input validation (e.g., prefix checks) and remove "fallback to original" logic in data processing services. Ensure that only successfully processed and sanitized data reaches the persistence layer.
+
+## 2025-05-23 - CSRF in Slack OAuth Flow
+**Vulnerability:** The Slack OAuth flow used a predictable base62 workspace ID as the `state` parameter. This lacked cryptographic integrity and session binding, making it vulnerable to CSRF attacks where an attacker could force a user to link their Slack workspace to an arbitrary AgentRQ workspace.
+**Learning:** The `state` parameter in OAuth2 is intended to be a non-guessable, session-bound value to prevent CSRF. Using a resource ID directly is insufficient.
+**Prevention:** Always use cryptographically signed tokens or high-entropy random nonces for the OAuth `state` parameter. In this project, `TokenService.CreateOAuthStateToken` provides a secure, signed JWT that can carry payload (like workspace ID) while ensuring origin and integrity.

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -555,6 +555,7 @@ func New(cfg Config) (*App, error) {
 		Crud:       crudCtrl,
 		MCPManager: mcpManager,
 		PubSub:     pubsubSvc,
+		TokenSvc:   tokenSvc,
 		TokenKey:   cfg.Auth.WorkspaceTokenKey,
 		BaseURL:    cfg.App.BaseURL,
 	})
@@ -703,6 +704,7 @@ func New(cfg Config) (*App, error) {
 	handlerslack.New(handlerslack.Params{
 		SlackCtrl: slackCtrl,
 		SlackSvc:  slackSvc,
+		TokenSvc:  tokenSvc,
 		BaseURL:   cfg.App.BaseURL,
 		Mux:       mux,
 	})

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -16,6 +16,7 @@ import (
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	"github.com/agentrq/agentrq/backend/internal/data/model"
 	"github.com/agentrq/agentrq/backend/internal/repository/base"
+	"github.com/agentrq/agentrq/backend/internal/service/auth"
 	"github.com/agentrq/agentrq/backend/internal/service/pubsub"
 	"github.com/agentrq/agentrq/backend/internal/service/security"
 	slacksvc "github.com/agentrq/agentrq/backend/internal/service/slack"
@@ -45,6 +46,7 @@ type Params struct {
 	Crud       CRUDRespondToTask
 	MCPManager MCPManager
 	PubSub     pubsub.Service
+	TokenSvc   auth.TokenService
 	TokenKey   string
 	BaseURL    string
 }
@@ -117,6 +119,7 @@ type controller struct {
 	crud     CRUDRespondToTask
 	mcp      MCPManager
 	pubsub   pubsub.Service
+	tokenSvc auth.TokenService
 	tokenKey string
 	baseURL  string
 }
@@ -129,6 +132,7 @@ func New(p Params) Controller {
 		crud:     p.Crud,
 		mcp:      p.MCPManager,
 		pubsub:   p.PubSub,
+		tokenSvc: p.TokenSvc,
 		tokenKey: p.TokenKey,
 		baseURL:  p.BaseURL,
 	}
@@ -369,12 +373,18 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 	installed := err == nil && link.AccessToken != ""
 
 	workspaceID62 := monoflake.ID(workspaceID).String()
+	state, err := c.tokenSvc.CreateOAuthStateToken(workspaceID62, "slack")
+	if err != nil {
+		zlog.Error().Err(err).Int64("workspaceID", workspaceID).Msg("[slack] failed to generate oauth state token")
+		return nil, fmt.Errorf("failed to generate oauth state")
+	}
+
 	redirectURI := fmt.Sprintf("%s/slack/oauth/callback", c.baseURL)
 	authURL := fmt.Sprintf(
 		"https://slack.com/oauth/v2/authorize?client_id=%s&scope=groups:write,groups:read,chat:write,app_mentions:read,commands&redirect_uri=%s&state=%s",
 		c.slack.ClientID(),
 		url.QueryEscape(redirectURI),
-		workspaceID62,
+		url.QueryEscape(state),
 	)
 
 	cfg := &entity.SlackConfig{

--- a/backend/internal/controller/slack/slack_test.go
+++ b/backend/internal/controller/slack/slack_test.go
@@ -11,6 +11,7 @@ import (
 
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	"github.com/agentrq/agentrq/backend/internal/data/model"
+	"github.com/agentrq/agentrq/backend/internal/service/auth"
 	mock_pubsub "github.com/agentrq/agentrq/backend/internal/service/mocks/pubsub"
 	mock_repo "github.com/agentrq/agentrq/backend/internal/service/mocks/repository"
 	"github.com/agentrq/agentrq/backend/internal/service/security"
@@ -78,6 +79,18 @@ func (m *mockMCP) SendPermissionVerdict(ctx context.Context, workspaceID int64, 
 
 func (m *mockMCP) SendChannelNotification(ctx context.Context, workspaceID int64, userID string, taskID int64, content string) {}
 
+type mockTokenSvc struct {
+	auth.TokenService
+}
+
+func (m *mockTokenSvc) CreateOAuthStateToken(redirectURL, provider string) (string, error) {
+	return redirectURL, nil
+}
+
+func (m *mockTokenSvc) ValidateOAuthStateToken(tokenStr, provider string) (string, error) {
+	return tokenStr, nil
+}
+
 func TestHandleSlashCommand_ChannelNotFound(t *testing.T) {
 	gomockCtrl := gomock.NewController(t)
 	defer gomockCtrl.Finish()
@@ -93,7 +106,7 @@ func TestHandleSlashCommand_ChannelNotFound(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenKey:   "test-key",
+		TokenSvc:   &mockTokenSvc{}, TokenKey:   "test-key",
 		BaseURL:    "https://app.agentrq.com",
 	})
 
@@ -128,7 +141,7 @@ func TestHandleSlashCommand_WorkspaceNotFound(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenKey:   "test-key",
+		TokenSvc:   &mockTokenSvc{}, TokenKey:   "test-key",
 		BaseURL:    "https://app.agentrq.com",
 	})
 
@@ -168,7 +181,7 @@ func TestHandleSlashCommand_Success_Unquoted(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenKey:   "test-key",
+		TokenSvc:   &mockTokenSvc{}, TokenKey:   "test-key",
 		BaseURL:    "https://app.agentrq.com",
 	})
 
@@ -235,7 +248,7 @@ func TestHandleSlashCommand_Success_QuotedBoth(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenKey:   "test-key",
+		TokenSvc:   &mockTokenSvc{}, TokenKey:   "test-key",
 		BaseURL:    "https://app.agentrq.com",
 	})
 
@@ -289,7 +302,7 @@ func TestHandleSlashCommand_Success_SmartQuotes(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenKey:   "test-key",
+		TokenSvc:   &mockTokenSvc{}, TokenKey:   "test-key",
 		BaseURL:    "https://app.agentrq.com",
 	})
 
@@ -344,7 +357,7 @@ func TestHandleSlashCommand_Success_Truncation(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenKey:   "test-key",
+		TokenSvc:   &mockTokenSvc{}, TokenKey:   "test-key",
 		BaseURL:    "https://app.agentrq.com",
 	})
 
@@ -392,7 +405,7 @@ func TestProcessEvent_OriginSlack(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenKey:   "test-key",
+		TokenSvc:   &mockTokenSvc{}, TokenKey:   "test-key",
 		BaseURL:    "https://app.agentrq.com",
 	})
 
@@ -442,7 +455,7 @@ func TestHandleSlackEvent_WithFiles(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenKey:   "12345678901234567890123456789012",
+		TokenSvc:   &mockTokenSvc{}, TokenKey:   "12345678901234567890123456789012",
 		BaseURL:    "https://app.agentrq.com",
 	})
 
@@ -546,7 +559,7 @@ func TestOnTaskCreated_ChannelNotFound(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenKey:   "0123456789abcdef0123456789abcdef", // 32-byte key
+		TokenSvc:   &mockTokenSvc{}, TokenKey:   "0123456789abcdef0123456789abcdef", // 32-byte key
 		BaseURL:    "https://app.agentrq.com",
 	})
 
@@ -604,7 +617,7 @@ func TestOnMessageCreated_HumanUserName(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenKey:   "0123456789abcdef0123456789abcdef", // 32-byte key
+		TokenSvc:   &mockTokenSvc{}, TokenKey:   "0123456789abcdef0123456789abcdef", // 32-byte key
 		BaseURL:    "https://app.agentrq.com",
 	})
 
@@ -692,7 +705,7 @@ func TestOnMessageUpdated_Success(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenKey:   "0123456789abcdef0123456789abcdef", // 32-byte key
+		TokenSvc:   &mockTokenSvc{}, TokenKey:   "0123456789abcdef0123456789abcdef", // 32-byte key
 		BaseURL:    "https://app.agentrq.com",
 	})
 
@@ -762,7 +775,7 @@ func TestOnMessageUpdated_SkippedIfDecidedInSlack(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenKey:   "0123456789abcdef0123456789abcdef", // 32-byte key
+		TokenSvc:   &mockTokenSvc{}, TokenKey:   "0123456789abcdef0123456789abcdef", // 32-byte key
 		BaseURL:    "https://app.agentrq.com",
 	})
 

--- a/backend/internal/handler/slack/slack.go
+++ b/backend/internal/handler/slack/slack.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	slackctrl "github.com/agentrq/agentrq/backend/internal/controller/slack"
+	"github.com/agentrq/agentrq/backend/internal/service/auth"
 	slacksvc "github.com/agentrq/agentrq/backend/internal/service/slack"
 	zlog "github.com/rs/zerolog/log"
 )
@@ -20,6 +21,7 @@ import (
 type Params struct {
 	SlackCtrl slackctrl.Controller
 	SlackSvc  slacksvc.Service
+	TokenSvc  auth.TokenService
 	BaseURL   string
 	Mux       *http.ServeMux
 }
@@ -33,7 +35,7 @@ type Params struct {
 func New(p Params) {
 	p.Mux.Handle("/slack/events", eventsHandler(p.SlackSvc, p.SlackCtrl))
 	p.Mux.Handle("/slack/interactions", interactionsHandler(p.SlackSvc, p.SlackCtrl))
-	p.Mux.Handle("/slack/oauth/callback", oauthCallbackHandler(p.SlackSvc, p.SlackCtrl, p.BaseURL))
+	p.Mux.Handle("/slack/oauth/callback", oauthCallbackHandler(p.SlackSvc, p.SlackCtrl, p.TokenSvc, p.BaseURL))
 	p.Mux.Handle("/slack/commands", commandHandler(p.SlackSvc, p.SlackCtrl))
 }
 
@@ -174,7 +176,7 @@ func interactionsHandler(svc slacksvc.Service, ctrl slackctrl.Controller) http.H
 }
 
 // oauthCallbackHandler handles Slack's OAuth redirect callback.
-func oauthCallbackHandler(svc slacksvc.Service, ctrl slackctrl.Controller, baseURL string) http.Handler {
+func oauthCallbackHandler(svc slacksvc.Service, ctrl slackctrl.Controller, tokenSvc auth.TokenService, baseURL string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -182,26 +184,34 @@ func oauthCallbackHandler(svc slacksvc.Service, ctrl slackctrl.Controller, baseU
 		}
 
 		code := r.URL.Query().Get("code")
-		state := r.URL.Query().Get("state") // base62 workspace ID
+		stateToken := r.URL.Query().Get("state") // JWT state token
 
-		if code == "" || state == "" {
+		if code == "" || stateToken == "" {
 			zlog.Warn().Msg("[slack/oauth] missing code or state parameter")
 			http.Error(w, "missing code or state parameter", http.StatusBadRequest)
 			return
 		}
 
+		// Validate state token and retrieve workspaceID62
+		workspaceID62, err := tokenSvc.ValidateOAuthStateToken(stateToken, "slack")
+		if err != nil {
+			zlog.Warn().Err(err).Msg("[slack/oauth] invalid state token")
+			http.Error(w, "invalid state parameter", http.StatusUnauthorized)
+			return
+		}
+
 		redirectURI := fmt.Sprintf("%s/slack/oauth/callback", baseURL)
-		err := ctrl.HandleOAuthCallback(r.Context(), state, code, redirectURI)
+		err = ctrl.HandleOAuthCallback(r.Context(), workspaceID62, code, redirectURI)
 		if err != nil {
 			zlog.Error().Err(err).Msg("[slack/oauth] HandleOAuthCallback error")
 			// Redirect back with a generic error query param to prevent information leakage
 			errorMsg := url.QueryEscape("failed to complete slack authorization")
-			http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack&slack_error=%s", baseURL, state, errorMsg), http.StatusTemporaryRedirect)
+			http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack&slack_error=%s", baseURL, workspaceID62, errorMsg), http.StatusTemporaryRedirect)
 			return
 		}
 
 		// Redirect back to settings page on success
-		http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack", baseURL, state), http.StatusTemporaryRedirect)
+		http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack", baseURL, workspaceID62), http.StatusTemporaryRedirect)
 	})
 }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: CSRF in Slack OAuth flow due to predictable `state` parameter.
🎯 Impact: Attacker could force a user to link their Slack workspace to an attacker-controlled or arbitrary AgentRQ workspace.
🔧 Fix: Used cryptographically signed JWTs for the OAuth `state` parameter via `TokenService`.
✅ Verification: Verified with unit tests and code review. Full test suite passing.

---
*PR created automatically by Jules for task [7261875578559758153](https://jules.google.com/task/7261875578559758153) started by @mustafaturan*