### PR TITLE
Harden OAuth and attachment handling

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -1,0 +1,330 @@
+# AgentRQ ── 에이전트-휴먼 협업 플랫폼
+
+<p align="center">
+  <a href="README.md">English</a> | <a href="README.zh-CN.md">简体中文</a>
+  <br />
+  <br />
+  <a href="https://www.youtube.com/watch?v=GBAoSpuCzrU">YouTube에서 HD로 보기</a>
+  <br />
+  <br />
+  <a href="https://discord.gg/xFSMaEA2b2">
+    <img src="https://img.shields.io/badge/Discord-Join%20Community-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" />
+  </a>
+</p>
+
+AgentRQ는 휴먼 오퍼레이터와 AI 에이전트가 매끄럽게 협업하도록 설계된 현대적인 고성능 플랫폼입니다. **Model Context Protocol(MCP)** 을 활용해 Claude 같은 AI 모델이 워크스페이스의 태스크 관리 시스템과 직접 상호작용할 수 있게 합니다.
+
+## 🚀 개요
+
+AgentRQ는 사람과 AI 에이전트가 함께 일하는 공유 작업 공간이라고 생각하면 됩니다. 복잡한 목표를 관리 가능한 태스크로 나누고, 그 작업을 AI 에이전트에게 직접 위임할 수 있습니다.
+
+에이전트는 MCP를 통해 워크스페이스 상태를 "볼" 수 있으므로, 자신에게 할당된 태스크를 가져오고, 상태를 갱신하고, 민감한 작업에 대한 권한을 요청하고, 사용자와 소통할 수 있습니다. 이 모든 내용은 플랫폼 전체에 실시간으로 동기화됩니다.
+
+## 🏛 아키텍처
+
+AgentRQ는 분리된 서비스 지향 아키텍처를 따릅니다.
+
+### 백엔드(Go / Fiber)
+- **API 서버**: 워크스페이스와 태스크 관리를 위한 Fiber 기반 REST API입니다.
+- **MCP 서버**: AI 모델에 도구와 리소스를 노출하는 통합 `mcp-go` SSE 서버입니다.
+- **CoreMCP(Supervisor)**: 전체 플랫폼의 모든 워크스페이스, 태스크, 통계를 에이전트가 관리할 수 있게 하는 전역 MCP 서버입니다.
+- **데이터 계층**: 사용자 범위의 영속 저장소를 위해 GORM과 SQLite를 사용합니다.
+- **인증**: Google OAuth2 연동과 JWT 기반 세션 관리를 사용합니다.
+- **이벤트 버스**: 실시간 SSE 알림을 위한 내부 pub/sub 시스템입니다.
+
+### 프론트엔드(Vue.js 3 / Vite)
+- **현대적인 UI**: Vue 3, Pinia, Tailwind CSS로 구성되어 있습니다.
+- **글래스모피즘**: 부드러운 전환과 실시간 업데이트를 갖춘 세련된 디자인 언어를 사용합니다.
+- **반응형 상태**: SSE 이벤트를 통해 백엔드와 동기화됩니다.
+
+## 🛠 시작하기
+
+### 사전 요구 사항
+- **Go** 1.21 이상
+- **Node.js** 18 이상(npm 포함)
+- **Google Cloud Console**: OAuth2 Client ID와 Secret
+
+### 설정
+1. `backend` 디렉터리에 `_config/base.yaml` 또는 `development.yaml`을 만듭니다.
+2. Google OAuth2 자격 증명을 입력합니다.
+
+```yaml
+auth:
+  google:
+    client_id: "your-google-client-id"
+    client_secret: "your-google-client-secret"
+```
+
+### 로컬 실행
+제공된 `Makefile`로 전체 스택을 실행합니다.
+
+```bash
+# 1. 모든 의존성 설치
+make install
+
+# 2. 프론트엔드와 백엔드 실행
+make dev
+```
+
+프론트엔드는 `http://localhost:5173`에서 사용할 수 있습니다.
+
+### 셀프 호스팅(Docker)
+미리 빌드된 Docker 이미지로 프로덕션 또는 개발 스택을 실행하려면 [셀프 호스팅 설정 가이드](SETUP.md)를 참고하세요.
+
+> [!NOTE]
+> **에이전트 / AI 어시스턴트:** Docker로 로컬 셀프 호스팅 AgentRQ 인스턴스를 설정, 구성, 실행, 진단해야 한다면 [SETUP.md](SETUP.md)를 참고하세요. 단계별 절차, Docker 실행 명령, 환경 변수 구성이 포함되어 있습니다.
+
+## 🤖 Claude Code 및 AI 연동
+
+AgentRQ는 **Claude Channel**로 매끄럽게 연동되도록 설계되었습니다. AI 에이전트는 자신에게 할당된 태스크를 보고 Claude 세션 안에서 직접 응답할 수 있습니다.
+
+각 워크스페이스는 자체 MCP URL과 토큰을 가집니다. 이 정보는 워크스페이스 설정 모달에서 확인할 수 있습니다. 프로덕션에서는 `https://WORKSPACE_ID.mcp.agentrq.com/` 형식을 따릅니다.
+
+### Step 1 — `.mcp.json`
+
+로컬 프로젝트 디렉터리에 `.mcp.json` 파일을 만듭니다. 앞의 점은 필요합니다. 프로젝트마다 자체 파일을 사용하므로 Claude 인스턴스가 워크스페이스별로 격리됩니다. 아래의 `YOUR_MCP_URL`을 설정 모달에 표시되는 전체 URL로 바꿉니다. 예: `https://WORKSPACE_ID.mcp.agentrq.com/?token=TOKEN`
+
+```json
+{
+  "mcpServers": {
+    "agentrq-WORKSPACE_ID": {
+      "type": "http",
+      "url": "YOUR_MCP_URL"
+    }
+  }
+}
+```
+
+### Step 2 — `.claude/settings.local.json`
+
+같은 프로젝트 디렉터리에 `.claude/settings.local.json` 파일을 추가해 AgentRQ 도구를 미리 승인하면, 매 작업마다 권한 프롬프트가 뜨는 것을 줄일 수 있습니다.
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__agentrq-WORKSPACE_ID__updateTaskStatus",
+      "mcp__agentrq-WORKSPACE_ID__getWorkspace",
+      "mcp__agentrq-WORKSPACE_ID__reply",
+      "mcp__agentrq-WORKSPACE_ID__createTask",
+      "mcp__agentrq-WORKSPACE_ID__downloadAttachment",
+      "mcp__agentrq-WORKSPACE_ID__getTaskMessages",
+      "mcp__agentrq-WORKSPACE_ID__getNextTask"
+    ]
+  },
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": ["agentrq-WORKSPACE_ID"]
+}
+```
+
+### Step 3 — Claude 시작
+
+두 파일을 준비한 뒤 해당 프로젝트 디렉터리에서 Claude Code를 실행합니다.
+
+```bash
+claude --dangerously-load-development-channels server:agentrq-WORKSPACE_ID
+```
+
+> **팁:** 워크스페이스 ID, 토큰이 포함된 전체 MCP URL, 바로 붙여 넣을 수 있는 설정 조각은 각 AgentRQ 워크스페이스의 **Setup** 모달에서 확인할 수 있습니다.
+
+### 사용 가능한 MCP 도구
+연결되면 AI 에이전트는 다음 도구를 사용할 수 있습니다.
+- `createTask`: 휴먼 사용자에게 태스크를 할당합니다. 반복 작업용 `cron_schedule`도 선택적으로 지원합니다.
+- `updateTaskStatus`: 태스크 상태를 `notstarted`, `ongoing`, `blocked`, `completed` 사이에서 변경합니다.
+- `reply`: AgentRQ 대시보드로 메시지를 실시간 전송합니다.
+- `getWorkspace`: 워크스페이스 이름, 미션 설명, 태스크 통계를 가져옵니다.
+- `getTaskMessages`: 커서 기반 페이지네이션으로 태스크 채팅 기록을 읽습니다.
+- `getNextTask`: 에이전트에게 할당된 다음 "not started" 태스크를 효율적으로 가져옵니다.
+- `downloadAttachment`: ID로 첨부파일을 가져옵니다.
+- **실시간 알림**: 휴먼이 태스크와 상호작용할 때마다 에이전트는 `notifications/claude/channel` 프로토콜로 알림을 받습니다.
+
+## 🌉 ACP Gateway(ACP 에이전트용 브리지)
+
+Claude Code는 `claude/notifications`를 네이티브로 지원하지만, **Gemini CLI** 같은 다른 에이전트는 AgentRQ의 실시간 태스크 알림을 받기 위해 브리지가 필요합니다. `@agentrq/acp-gateway`는 [Agent Client Protocol(ACP)](https://agentclientprotocol.com)과 MCP를 연결합니다.
+
+### 설치
+
+```bash
+npm install -g @agentrq/acp-gateway
+```
+
+### 사용법
+
+1. 프로젝트 루트에 [`.mcp.json`](#step-1--mcpjson)이 있는지 확인합니다.
+2. 게이트웨이 뒤에 에이전트의 ACP 명령을 붙여 실행합니다.
+
+```bash
+# Gemini CLI 사용 예
+acp-gateway -- gemini --acp
+```
+
+게이트웨이는 자동으로 다음 작업을 수행합니다.
+- `.mcp.json`의 URL로 AgentRQ 워크스페이스에 연결합니다.
+- 에이전트 하위 프로세스를 실행하고 표준 입출력을 브리지합니다.
+- 태스크 할당, 메시지, 권한 요청을 실시간으로 전달합니다.
+
+## 🌌 Codex Gateway(OpenAI Codex용 브리지)
+
+ACP Gateway와 비슷하게 `@agentrq/codex-gateway`는 Model Context Protocol(MCP)과 Codex app-server 프로토콜을 브리지해 [OpenAI Codex](https://github.com/openai/codex)를 AgentRQ 워크스페이스에 연결합니다.
+
+### 설치
+
+```bash
+npm install -g @agentrq/codex-gateway@latest
+```
+
+### 설정
+
+**1. Codex용 agentrq MCP 서버 설정(프로젝트 단위)**
+
+Codex는 프로젝트 단위 MCP 서버 설정을 `.codex/config.toml`에서 읽습니다. 이 파일을 만들어 Codex 에이전트가 작업 실행 중 agentrq 도구를 직접 사용할 수 있게 합니다. `<WORKSPACEID>`와 `<TOKEN>`은 agentrq 대시보드의 값으로 바꿉니다.
+
+```bash
+mkdir -p .codex
+cat >> .codex/config.toml << 'EOF'
+
+[mcp_servers.agentrq-workspace]
+url = "https://<WORKSPACEID>.mcp.agentrq.com/?token=<TOKEN>"
+
+[mcp_servers.agentrq-<ID>.tools.updateTaskStatus]
+approval_mode = "approve"
+
+[mcp_servers.agentrq-<ID>.tools.getWorkspace]
+approval_mode = "approve"
+
+[mcp_servers.agentrq-<ID>.tools.reply]
+approval_mode = "approve"
+
+[mcp_servers.agentrq-<ID>.tools.createTask]
+approval_mode = "approve"
+
+[mcp_servers.agentrq-<ID>.tools.downloadAttachment]
+approval_mode = "approve"
+
+[mcp_servers.agentrq-<ID>.tools.getTaskMessages]
+approval_mode = "approve"
+
+[mcp_servers.agentrq-<ID>.tools.getNextTask]
+approval_mode = "approve"
+EOF
+```
+
+**2. 게이트웨이의 agentrq 연결 설정**
+
+`codex-gateway`가 같은 agentrq 워크스페이스에 연결할 수 있도록 프로젝트 루트에 `.mcp.json`을 만듭니다.
+
+```json
+{
+  "mcpServers": {
+    "agentrq": {
+      "type": "http",
+      "url": "https://<WORKSPACEID>.mcp.agentrq.com/mcp?token=<TOKEN>"
+    }
+  }
+}
+```
+
+> **참고:** `.mcp.json`은 `codex-gateway`가 태스크를 받기 위해 사용합니다. `.codex/config.toml`은 Codex 에이전트가 실행 중 `reply`, `updateTaskStatus` 같은 agentrq 도구를 호출하는 데 사용합니다.
+
+### 사용법
+
+`.mcp.json`이 있는 agentrq 워크스페이스 루트에서 `codex-gateway`를 실행합니다.
+
+```bash
+# 기본값: `codex app-server` 실행
+codex-gateway
+
+# 사용자 지정 codex 명령
+codex-gateway -- codex app-server
+```
+
+## 👑 Supervisor(CoreMCP)
+
+개별 워크스페이스가 특정 프로젝트에 대한 범위 제한 뷰를 제공한다면, **Supervisor(CoreMCP)** 는 전체 AgentRQ 계정에 대한 조감도와 관리 기능을 에이전트에게 제공하는 전역 MCP 서버입니다.
+
+Supervisor는 `https://mcp.agentrq.com/mcp`에서 접근할 수 있습니다. 최신 AI 도구가 안전하게 연결할 수 있도록 **OAuth2** 인증을 사용합니다.
+
+### Supervisor를 사용하는 이유
+- **다중 워크스페이스 관리**: 워크스페이스를 나열하고, 만들고, 갱신합니다.
+- **전역 태스크 보기**: `listAllTasks` 한 번으로 모든 워크스페이스의 태스크를 가져옵니다.
+- **관리 제어**: 태스크 할당, 상태, 우선순위를 전역으로 관리합니다.
+- **통합 통계**: 모든 워크스페이스의 상세 통계와 상태 지표에 접근합니다.
+
+### 사용 가능한 Supervisor 도구
+Supervisor는 전역 관리를 위한 포괄적인 도구를 제공합니다. 필요한 경우 `workspaceId` 파라미터를 사용합니다.
+
+**워크스페이스 관리**
+- `listWorkspaces`: 활성 및 보관된 모든 워크스페이스 개요입니다.
+- `createWorkspace`: 새 프로젝트 환경을 시작합니다.
+- `getWorkspace`: ID로 특정 워크스페이스 상세 정보를 가져옵니다.
+- `updateWorkspace`: 워크스페이스 설정과 메타데이터를 수정합니다.
+- `getWorkspaceStats`: 워크스페이스의 상위 분석 및 성능 데이터를 가져옵니다.
+
+**태스크 관리**
+- `listAllTasks`: 전체 플랫폼의 태스크를 검색하고 필터링합니다.
+- `listTasks`: 특정 워크스페이스의 태스크를 나열합니다.
+- `createTask`: 특정 워크스페이스에 새 태스크를 만듭니다.
+- `getTask`: 특정 태스크의 상세 정보를 가져옵니다.
+- `updateTaskStatus`: 태스크 상태를 변경합니다.
+- `updateTaskOrder`: 목록에서 태스크 순서를 변경합니다.
+- `updateTaskAssignee`: 태스크 담당자를 변경합니다.
+- `updateTaskAllowAll`: 태스크의 `allow_all_commands` 권한을 토글합니다.
+- `updateScheduledTask`: 예약/cron 태스크를 수정합니다.
+
+**커뮤니케이션 및 파일**
+- `replyToTask`: 태스크 채팅 스레드에 메시지를 게시합니다.
+- `respondToTask`: 권한 요청에 대한 allow/deny 판단을 제출합니다.
+- `getAttachment`: 특정 첨부파일의 데이터와 메타데이터를 base64로 가져옵니다.
+
+### Supervisor에 연결하기(Claude Code)
+Supervisor는 OAuth2를 사용하므로 `~/.mcp.json`에 다음 설정으로 연결할 수 있습니다.
+
+```json
+{
+  "mcpServers": {
+    "agentrq": {
+      "type": "http",
+      "url": "https://mcp.agentrq.com/mcp"
+    }
+  }
+}
+```
+
+이 서버로 Claude를 처음 실행하면 브라우저에서 인증할 수 있는 링크가 제공됩니다.
+
+## 🧩 공식 확장
+
+AgentRQ는 주요 AI 에이전트 CLI 도구에서 Supervisor MCP 설정과 연동을 단순화하기 위한 공식 확장을 제공합니다. 하위 에이전트 MCP는 각자의 워크스페이스별 MCP 서버 URL을 사용해야 합니다.
+
+### 🍊 Claude Code
+Claude Code용 AgentRQ 플러그인은 공식 마켓플레이스를 통해 배포됩니다. 내장 스킬과 사전 설정된 MCP 접근을 제공합니다.
+
+**설치:**
+```bash
+/plugin marketplace add https://github.com/agentrq/agentrq-claude-extension
+/plugin install agentrq@agentrq
+```
+
+### ♊ Gemini CLI
+Gemini CLI 확장을 사용하면 Google Gemini 모델로 터미널에서 직접 AgentRQ 워크스페이스와 태스크를 관리할 수 있습니다.
+
+> **팁:** Gemini에서 실시간 태스크 알림을 활성화하려면 [ACP Gateway](#-acp-gatewayacp-에이전트용-브리지)를 사용하세요.
+
+**설치:**
+```bash
+gemini extensions install https://github.com/agentrq/agentrq-gemini-extension
+```
+
+## 🔌 연동
+
+### Slack 연동
+AgentRQ는 실시간 태스크 생성, 스레드 답글 동기화, 에이전트 권한 요청을 위한 멀티테넌트 Slack 연동을 지원합니다.
+- [Slack 연동 설정 및 사용 가이드](integrations/slack/README.md)
+
+## 🤝 크레딧
+
+- [AgentRQ](https://agentrq.com) — 공식 에이전트-휴먼 협업 플랫폼입니다.
+- [HasMCP](https://hasmcp.com) — API와 에이전트 사이의 간극을 연결합니다.
+
+## 📝 라이선스
+Apache-2.0

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -109,10 +109,19 @@ type (
 	}
 )
 
+const (
+	defaultJWTSecret         = "agentrq-secret-change-me"
+	defaultRootAccessToken   = "agentrq"
+	defaultWorkspaceTokenKey = "agentrq-token-key-change-me-32by"
+)
+
 func New(cfg Config) (*App, error) {
 	cfg.App.BaseURL = strings.TrimSuffix(cfg.App.BaseURL, "/")
 	if cfg.App.BaseURL == "" {
 		cfg.App.BaseURL = fmt.Sprintf("http://localhost:%d", cfg.App.Port)
+	}
+	if err := validateDeploymentSecrets(cfg); err != nil {
+		return nil, err
 	}
 
 	appCtx, appCancel := context.WithCancel(context.Background())
@@ -555,6 +564,7 @@ func New(cfg Config) (*App, error) {
 		Crud:       crudCtrl,
 		MCPManager: mcpManager,
 		PubSub:     pubsubSvc,
+		TokenSvc:   tokenSvc,
 		TokenKey:   cfg.Auth.WorkspaceTokenKey,
 		BaseURL:    cfg.App.BaseURL,
 	})
@@ -792,6 +802,26 @@ func New(cfg Config) (*App, error) {
 
 	cancelOnErr = nil // App takes ownership; defer must not cancel.
 	return &App{server: serverSvc, bus: bus, pubsub: pubsubSvc, cancel: appCancel}, nil
+}
+
+func validateDeploymentSecrets(cfg Config) error {
+	env := "development"
+	if cfg.ConfigSvc != nil {
+		env = cfg.ConfigSvc.Env()
+	}
+	if env == "" || env == "development" {
+		return nil
+	}
+	if cfg.Auth.JWTSecret == "" || cfg.Auth.JWTSecret == defaultJWTSecret {
+		return errors.New("insecure auth.jwtSecret: set AGENTRQ_AUTH_JWT_SECRET to a production secret")
+	}
+	if cfg.Auth.WorkspaceTokenKey == "" || cfg.Auth.WorkspaceTokenKey == defaultWorkspaceTokenKey || len(cfg.Auth.WorkspaceTokenKey) != 32 {
+		return errors.New("insecure auth.workspaceTokenKey: set AGENTRQ_AUTH_WORKSPACE_TOKEN_KEY to an exact 32-byte production key")
+	}
+	if cfg.Auth.RootLoginEnabled && (cfg.Auth.RootAccessToken == "" || cfg.Auth.RootAccessToken == defaultRootAccessToken) {
+		return errors.New("insecure auth.rootAccessToken: set AGENTRQ_AUTH_ROOT_ACCESS_TOKEN before enabling root login")
+	}
+	return nil
 }
 
 func pubStatsHandler(ctrl pub.StatsController) http.Handler {

--- a/backend/internal/app/security_config_test.go
+++ b/backend/internal/app/security_config_test.go
@@ -1,0 +1,48 @@
+package app
+
+import "testing"
+
+type testConfigSvc struct {
+	env string
+}
+
+func (s testConfigSvc) Populate(key string, cfg any) error { return nil }
+func (s testConfigSvc) Env() string                        { return s.env }
+func (s testConfigSvc) App() string                        { return "AgentRQ" }
+func (s testConfigSvc) AppShortName() string               { return "agentrq" }
+func (s testConfigSvc) Version() string                    { return "test" }
+
+func TestValidateDeploymentSecrets_AllowsDevelopmentDefaults(t *testing.T) {
+	var cfg Config
+	cfg.ConfigSvc = testConfigSvc{env: "development"}
+	cfg.Auth.JWTSecret = defaultJWTSecret
+	cfg.Auth.WorkspaceTokenKey = defaultWorkspaceTokenKey
+	cfg.Auth.RootLoginEnabled = true
+	cfg.Auth.RootAccessToken = defaultRootAccessToken
+
+	if err := validateDeploymentSecrets(cfg); err != nil {
+		t.Fatalf("development defaults should be allowed, got %v", err)
+	}
+}
+
+func TestValidateDeploymentSecrets_RejectsProductionDefaults(t *testing.T) {
+	var cfg Config
+	cfg.ConfigSvc = testConfigSvc{env: "production"}
+	cfg.Auth.JWTSecret = defaultJWTSecret
+	cfg.Auth.WorkspaceTokenKey = "0123456789abcdef0123456789abcdef"
+
+	if err := validateDeploymentSecrets(cfg); err == nil {
+		t.Fatal("expected production default JWT secret to be rejected")
+	}
+}
+
+func TestValidateDeploymentSecrets_RejectsInvalidWorkspaceKey(t *testing.T) {
+	var cfg Config
+	cfg.ConfigSvc = testConfigSvc{env: "production"}
+	cfg.Auth.JWTSecret = "not-the-default-secret"
+	cfg.Auth.WorkspaceTokenKey = "short"
+
+	if err := validateDeploymentSecrets(cfg); err == nil {
+		t.Fatal("expected invalid workspace token key to be rejected")
+	}
+}

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -16,6 +16,7 @@ import (
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	"github.com/agentrq/agentrq/backend/internal/data/model"
 	"github.com/agentrq/agentrq/backend/internal/repository/base"
+	"github.com/agentrq/agentrq/backend/internal/service/auth"
 	"github.com/agentrq/agentrq/backend/internal/service/pubsub"
 	"github.com/agentrq/agentrq/backend/internal/service/security"
 	slacksvc "github.com/agentrq/agentrq/backend/internal/service/slack"
@@ -45,6 +46,7 @@ type Params struct {
 	Crud       CRUDRespondToTask
 	MCPManager MCPManager
 	PubSub     pubsub.Service
+	TokenSvc   auth.TokenService
 	TokenKey   string
 	BaseURL    string
 }
@@ -65,7 +67,7 @@ type Controller interface {
 	GetWorkspaceSlackConfig(ctx context.Context, workspaceID int64) (*entity.SlackConfig, error)
 
 	// OAuth callback
-	HandleOAuthCallback(ctx context.Context, workspaceID62 string, code string, redirectURI string) error
+	HandleOAuthCallback(ctx context.Context, state string, code string, redirectURI string) (workspaceID62 string, err error)
 
 	// Inbound Slack events
 	HandleSlackEvent(ctx context.Context, payload SlackEventPayload) error
@@ -117,6 +119,7 @@ type controller struct {
 	crud     CRUDRespondToTask
 	mcp      MCPManager
 	pubsub   pubsub.Service
+	tokenSvc auth.TokenService
 	tokenKey string
 	baseURL  string
 }
@@ -129,6 +132,7 @@ func New(p Params) Controller {
 		crud:     p.Crud,
 		mcp:      p.MCPManager,
 		pubsub:   p.PubSub,
+		tokenSvc: p.TokenSvc,
 		tokenKey: p.TokenKey,
 		baseURL:  p.BaseURL,
 	}
@@ -369,12 +373,19 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 	installed := err == nil && link.AccessToken != ""
 
 	workspaceID62 := monoflake.ID(workspaceID).String()
+	if c.tokenSvc == nil {
+		return nil, fmt.Errorf("slack: token service not configured")
+	}
+	state, err := c.tokenSvc.CreateOAuthStateToken(workspaceID62, "slack")
+	if err != nil {
+		return nil, fmt.Errorf("slack: failed to create oauth state: %w", err)
+	}
 	redirectURI := fmt.Sprintf("%s/slack/oauth/callback", c.baseURL)
 	authURL := fmt.Sprintf(
 		"https://slack.com/oauth/v2/authorize?client_id=%s&scope=groups:write,groups:read,chat:write,app_mentions:read,commands&redirect_uri=%s&state=%s",
 		c.slack.ClientID(),
 		url.QueryEscape(redirectURI),
-		workspaceID62,
+		url.QueryEscape(state),
 	)
 
 	cfg := &entity.SlackConfig{
@@ -395,25 +406,32 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 // HandleOAuthCallback handles the dynamic Slack OAuth v2 redirect code exchange.
 // It exchanges the temporary code, encrypts the access token, auto-provisions a private channel,
 // and saves the credentials into GORM.
-func (c *controller) HandleOAuthCallback(ctx context.Context, workspaceID62 string, code string, redirectURI string) error {
+func (c *controller) HandleOAuthCallback(ctx context.Context, state string, code string, redirectURI string) (string, error) {
+	if c.tokenSvc == nil {
+		return "", fmt.Errorf("slack: token service not configured")
+	}
+	workspaceID62, err := c.tokenSvc.ValidateOAuthStateToken(state, "slack")
+	if err != nil {
+		return "", fmt.Errorf("slack: invalid oauth state: %w", err)
+	}
 	workspaceID := monoflake.IDFromBase62(workspaceID62).Int64()
 	if workspaceID == 0 {
-		return fmt.Errorf("slack: invalid workspace ID state: %s", workspaceID62)
+		return "", fmt.Errorf("slack: invalid workspace ID state: %s", workspaceID62)
 	}
 
 	ws, err := c.repo.SystemGetWorkspace(ctx, workspaceID)
 	if err != nil {
-		return fmt.Errorf("slack: workspace not found: %w", err)
+		return "", fmt.Errorf("slack: workspace not found: %w", err)
 	}
 
 	token, teamID, botUserID, authedUserID, err := c.slack.ExchangeCode(ctx, code, redirectURI)
 	if err != nil {
-		return fmt.Errorf("slack: oauth exchange failed: %w", err)
+		return "", fmt.Errorf("slack: oauth exchange failed: %w", err)
 	}
 
 	encToken, nonce, err := security.Encrypt(token, c.tokenKey)
 	if err != nil {
-		return fmt.Errorf("slack: failed to encrypt token: %w", err)
+		return "", fmt.Errorf("slack: failed to encrypt token: %w", err)
 	}
 
 	// Resolve existing link to preserve manual channel configurations if any
@@ -432,7 +450,7 @@ func (c *controller) HandleOAuthCallback(ctx context.Context, workspaceID62 stri
 		channelName := slacksvc.BuildChannelNameFromWorkspace(ws.Name, workspaceID)
 		channelID, err := c.slack.CreatePrivateChannel(ctx, token, channelName)
 		if err != nil {
-			return fmt.Errorf("slack: failed to auto-provision channel: %w", err)
+			return "", fmt.Errorf("slack: failed to auto-provision channel: %w", err)
 		}
 		link.SlackChannelID = channelID
 		link.SlackChannelName = channelName
@@ -447,11 +465,11 @@ func (c *controller) HandleOAuthCallback(ctx context.Context, workspaceID62 stri
 	}
 
 	if err := c.repo.UpsertSlackWorkspaceLink(ctx, link); err != nil {
-		return fmt.Errorf("slack: failed to save workspace link: %w", err)
+		return "", fmt.Errorf("slack: failed to save workspace link: %w", err)
 	}
 
 	zlog.Info().Int64("workspaceID", workspaceID).Str("channel", link.SlackChannelName).Msg("[slack] successfully completed dynamic multi-tenant installation")
-	return nil
+	return workspaceID62, nil
 }
 
 // ─── Inbound Slack events ──────────────────────────────────────────────────────
@@ -1055,4 +1073,3 @@ func formatSlackAttachments(atts []entity.Attachment) string {
 	}
 	return "Attachments:\n" + strings.Join(parts, "\n")
 }
-

--- a/backend/internal/handler/api/attachment_security_test.go
+++ b/backend/internal/handler/api/attachment_security_test.go
@@ -1,0 +1,33 @@
+package api
+
+import "testing"
+
+func TestSafeAttachmentContentType(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "html becomes opaque", in: "text/html", want: "application/octet-stream"},
+		{name: "javascript becomes opaque", in: "application/javascript", want: "application/octet-stream"},
+		{name: "png allowed", in: "image/png", want: "image/png"},
+		{name: "parameters stripped", in: "text/plain; charset=utf-8", want: "text/plain"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := safeAttachmentContentType(tt.in); got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestIsInlineAttachmentType(t *testing.T) {
+	if isInlineAttachmentType("application/octet-stream") {
+		t.Fatal("opaque attachments must not be inline")
+	}
+	if !isInlineAttachmentType("image/png") {
+		t.Fatal("safe image type should be inline")
+	}
+}

--- a/backend/internal/handler/api/middleware/clientip/clientip.go
+++ b/backend/internal/handler/api/middleware/clientip/clientip.go
@@ -1,0 +1,45 @@
+package clientip
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// Extract returns the client IP for rate limiting. Forwarded headers are only
+// trusted when the direct peer is a local/private reverse proxy.
+func Extract(r *http.Request) string {
+	remote := remoteIP(r.RemoteAddr)
+	if !isTrustedProxyPeer(remote) {
+		return remote
+	}
+
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		for _, part := range strings.Split(xff, ",") {
+			ip := strings.TrimSpace(part)
+			if net.ParseIP(ip) != nil {
+				return ip
+			}
+		}
+	}
+	if xri := strings.TrimSpace(r.Header.Get("X-Real-IP")); xri != "" && net.ParseIP(xri) != nil {
+		return xri
+	}
+	return remote
+}
+
+func remoteIP(remoteAddr string) string {
+	ip, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return remoteAddr
+	}
+	return ip
+}
+
+func isTrustedProxyPeer(ipStr string) bool {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback() || ip.IsPrivate()
+}

--- a/backend/internal/handler/api/middleware/clientip/clientip_test.go
+++ b/backend/internal/handler/api/middleware/clientip/clientip_test.go
@@ -1,0 +1,32 @@
+package clientip
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestExtract_IgnoresForwardedHeadersFromUntrustedPeer(t *testing.T) {
+	r := &http.Request{
+		RemoteAddr: "203.0.113.10:12345",
+		Header: http.Header{
+			"X-Forwarded-For": []string{"198.51.100.99"},
+		},
+	}
+
+	if got := Extract(r); got != "203.0.113.10" {
+		t.Fatalf("expected direct peer IP, got %q", got)
+	}
+}
+
+func TestExtract_UsesForwardedHeadersFromTrustedPeer(t *testing.T) {
+	r := &http.Request{
+		RemoteAddr: "127.0.0.1:12345",
+		Header: http.Header{
+			"X-Forwarded-For": []string{"198.51.100.99, 10.0.0.2"},
+		},
+	}
+
+	if got := Extract(r); got != "198.51.100.99" {
+		t.Fatalf("expected forwarded client IP, got %q", got)
+	}
+}

--- a/backend/internal/handler/api/middleware/ddos/ddos.go
+++ b/backend/internal/handler/api/middleware/ddos/ddos.go
@@ -2,12 +2,11 @@ package ddos
 
 import (
 	"encoding/json"
-	"net"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
+	"github.com/agentrq/agentrq/backend/internal/handler/api/middleware/clientip"
 	zlog "github.com/rs/zerolog/log"
 )
 
@@ -49,20 +48,7 @@ func New(enabled bool, maxRequestsPerSecond int, blockDuration time.Duration) fu
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Extract IP
-			ip, _, err := net.SplitHostPort(r.RemoteAddr)
-			if err != nil {
-				ip = r.RemoteAddr
-			}
-			// Handle proxies
-			if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-				ips := strings.Split(xff, ",")
-				if len(ips) > 0 {
-					ip = strings.TrimSpace(ips[0])
-				}
-			} else if xri := r.Header.Get("X-Real-IP"); xri != "" {
-				ip = xri
-			}
+			ip := clientip.Extract(r)
 
 			now := time.Now()
 

--- a/backend/internal/handler/api/middleware/ratelimit/ratelimit.go
+++ b/backend/internal/handler/api/middleware/ratelimit/ratelimit.go
@@ -2,13 +2,13 @@ package ratelimit
 
 import (
 	"encoding/json"
-	"net"
 	"net/http"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/agentrq/agentrq/backend/internal/handler/api/middleware/clientip"
 	"github.com/agentrq/agentrq/backend/internal/service/auth"
 	zlog "github.com/rs/zerolog/log"
 )
@@ -51,19 +51,7 @@ func New(enabled bool, maxPerIP int, maxPerUser int, window time.Duration, token
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Always extract IP
-			ip, _, err := net.SplitHostPort(r.RemoteAddr)
-			if err != nil {
-				ip = r.RemoteAddr
-			}
-			if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-				ips := strings.Split(xff, ",")
-				if len(ips) > 0 {
-					ip = strings.TrimSpace(ips[0])
-				}
-			} else if xri := r.Header.Get("X-Real-IP"); xri != "" {
-				ip = xri
-			}
+			ip := clientip.Extract(r)
 			ipKey := "ip:" + ip
 
 			// Extract User ID if authenticated
@@ -168,22 +156,22 @@ func New(enabled bool, maxPerIP int, maxPerUser int, window time.Duration, token
 
 			// Set rate limit headers
 			w.Header().Set("X-RateLimit-Limit-IP", strconv.Itoa(maxPerIP))
-			w.Header().Set("X-RateLimit-Remaining-IP", strconv.Itoa(maxPerIP - ipInfo.requestCount))
+			w.Header().Set("X-RateLimit-Remaining-IP", strconv.Itoa(maxPerIP-ipInfo.requestCount))
 			w.Header().Set("X-RateLimit-Reset-IP", strconv.FormatInt(ipInfo.windowStart.Add(window).Unix(), 10))
 
 			if userKey != "" {
 				w.Header().Set("X-RateLimit-Limit-User", strconv.Itoa(maxPerUser))
-				w.Header().Set("X-RateLimit-Remaining-User", strconv.Itoa(maxPerUser - userInfo.requestCount))
+				w.Header().Set("X-RateLimit-Remaining-User", strconv.Itoa(maxPerUser-userInfo.requestCount))
 				w.Header().Set("X-RateLimit-Reset-User", strconv.FormatInt(userInfo.windowStart.Add(window).Unix(), 10))
 
 				// Set primary headers to User limits since it's the more specific limit
 				w.Header().Set("X-RateLimit-Limit", strconv.Itoa(maxPerUser))
-				w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(maxPerUser - userInfo.requestCount))
+				w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(maxPerUser-userInfo.requestCount))
 				w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(userInfo.windowStart.Add(window).Unix(), 10))
 			} else {
 				// Set primary headers to IP limits
 				w.Header().Set("X-RateLimit-Limit", strconv.Itoa(maxPerIP))
-				w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(maxPerIP - ipInfo.requestCount))
+				w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(maxPerIP-ipInfo.requestCount))
 				w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(ipInfo.windowStart.Add(window).Unix(), 10))
 			}
 

--- a/backend/internal/handler/api/task.go
+++ b/backend/internal/handler/api/task.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -505,9 +507,34 @@ func (h *handler) getAttachment() fiber.Handler {
 			return c.Send(e)
 		}
 
-		c.Set("Content-Type", res.MimeType)
-		c.Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", res.Filename))
+		contentType := safeAttachmentContentType(res.MimeType)
+		c.Set("Content-Type", contentType)
+		c.Set("X-Content-Type-Options", "nosniff")
+		disposition := "attachment"
+		if isInlineAttachmentType(contentType) {
+			disposition = "inline"
+		}
+		c.Set("Content-Disposition", fmt.Sprintf("%s; filename=%s", disposition, strconv.Quote(filepath.Base(res.Filename))))
 		return c.Send(res.Data)
+	}
+}
+
+func safeAttachmentContentType(mimeType string) string {
+	mimeType = strings.ToLower(strings.TrimSpace(strings.Split(mimeType, ";")[0]))
+	switch mimeType {
+	case "image/png", "image/jpeg", "image/gif", "image/webp", "image/svg+xml", "application/pdf", "text/plain":
+		return mimeType
+	default:
+		return "application/octet-stream"
+	}
+}
+
+func isInlineAttachmentType(mimeType string) bool {
+	switch mimeType {
+	case "image/png", "image/jpeg", "image/gif", "image/webp", "application/pdf", "text/plain":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/backend/internal/handler/coremcp/server.go
+++ b/backend/internal/handler/coremcp/server.go
@@ -220,6 +220,7 @@ type UpdateScheduledTaskParams struct {
 
 type GetAttachmentParams struct {
 	WorkspaceID  string `json:"workspaceId"`
+	TaskID       string `json:"taskId"`
 	AttachmentID string `json:"attachmentId"`
 }
 
@@ -600,6 +601,7 @@ func (s *WorkspaceServer) handleGetAttachment(ctx context.Context, req *mcp.Call
 	res, err := s.crud.GetAttachment(ctx, entity.GetAttachmentRequest{
 		UserID:       userID,
 		WorkspaceID:  parseID(args.WorkspaceID),
+		TaskID:       parseID(args.TaskID),
 		AttachmentID: args.AttachmentID,
 	})
 	if err != nil {

--- a/backend/internal/handler/coremcp/server_attachment_test.go
+++ b/backend/internal/handler/coremcp/server_attachment_test.go
@@ -1,0 +1,49 @@
+package coremcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agentrq/agentrq/backend/internal/controller/crud"
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/mustafaturan/monoflake"
+)
+
+type attachmentCrud struct {
+	crud.Controller
+	got entity.GetAttachmentRequest
+}
+
+func (c *attachmentCrud) GetAttachment(ctx context.Context, req entity.GetAttachmentRequest) (*entity.GetAttachmentResponse, error) {
+	c.got = req
+	return &entity.GetAttachmentResponse{
+		Data:     []byte("hello"),
+		Filename: "hello.txt",
+		MimeType: "text/plain",
+	}, nil
+}
+
+func TestHandleGetAttachmentPassesTaskID(t *testing.T) {
+	crudCtrl := &attachmentCrud{}
+	srv := &WorkspaceServer{crud: crudCtrl}
+	ctx := context.WithValue(context.Background(), "user_id", "user-1")
+
+	_, _, err := srv.handleGetAttachment(ctx, nil, GetAttachmentParams{
+		WorkspaceID:  monoflake.ID(1).String(),
+		TaskID:       monoflake.ID(2).String(),
+		AttachmentID: "att-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if crudCtrl.got.WorkspaceID != 1 {
+		t.Fatalf("expected workspace ID 1, got %d", crudCtrl.got.WorkspaceID)
+	}
+	if crudCtrl.got.TaskID != 2 {
+		t.Fatalf("expected task ID 2, got %d", crudCtrl.got.TaskID)
+	}
+	if crudCtrl.got.AttachmentID != "att-1" {
+		t.Fatalf("expected attachment att-1, got %q", crudCtrl.got.AttachmentID)
+	}
+}

--- a/backend/internal/handler/slack/slack.go
+++ b/backend/internal/handler/slack/slack.go
@@ -191,17 +191,17 @@ func oauthCallbackHandler(svc slacksvc.Service, ctrl slackctrl.Controller, baseU
 		}
 
 		redirectURI := fmt.Sprintf("%s/slack/oauth/callback", baseURL)
-		err := ctrl.HandleOAuthCallback(r.Context(), state, code, redirectURI)
+		workspaceID62, err := ctrl.HandleOAuthCallback(r.Context(), state, code, redirectURI)
 		if err != nil {
 			zlog.Error().Err(err).Msg("[slack/oauth] HandleOAuthCallback error")
 			// Redirect back with a generic error query param to prevent information leakage
 			errorMsg := url.QueryEscape("failed to complete slack authorization")
-			http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack&slack_error=%s", baseURL, state, errorMsg), http.StatusTemporaryRedirect)
+			http.Redirect(w, r, fmt.Sprintf("%s/workspaces?tab=slack&slack_error=%s", baseURL, errorMsg), http.StatusTemporaryRedirect)
 			return
 		}
 
 		// Redirect back to settings page on success
-		http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack", baseURL, state), http.StatusTemporaryRedirect)
+		http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack", baseURL, workspaceID62), http.StatusTemporaryRedirect)
 	})
 }
 


### PR DESCRIPTION
## Changes

- Sign and validate Slack OAuth callback state using the existing OAuth state token flow
- Redirect Slack OAuth failures to `/workspaces?tab=slack` instead of using an unverified workspace ID in the redirect path
- Harden attachment responses by tightening MIME handling and Content-Disposition to reduce inline XSS risk
- Add a production guard that rejects default JWT/root/workspace token secrets
- Only trust forwarded IP headers in rate limit/DDoS middleware when the request comes from a trusted proxy peer
- Pass the missing `taskId` through CoreMCP `getAttachment`
- Add Korean translation in `README-ko.md`

## Validation

- Focused backend tests pass
- The go test ./... command fails during the controller package setup due to missing mock files and the lack of a mockgen installation. This requirement was missing from SETUP.md. Installing mockgen and generating the mocks resolved the failure