### PR TITLE
🛡️ Sentinel: [HIGH] Harden message and attachment access with BOLA protection

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -478,9 +478,9 @@ func New(cfg Config) (*App, error) {
 				}
 
 				b, _ := json.Marshal(existingMetadata)
-				err := repo.UpdateMessageMetadata(ctx, taskID, messageID, b)
+				uid := monoflake.IDFromBase62(workspaceOwner).Int64()
+				err := repo.UpdateMessageMetadata(ctx, taskID, messageID, uid, b)
 				if err == nil {
-					uid := monoflake.IDFromBase62(workspaceOwner).Int64()
 					latest, _ := repo.GetTask(ctx, workspaceID, taskID, uid)
 					bus.Publish(workspaceID, workspaceOwner, eventbus.Event{
 						Type:    "task.updated",
@@ -649,7 +649,8 @@ func New(cfg Config) (*App, error) {
 					t, err := repo.SystemGetTask(ctx, taskID)
 					if err == nil {
 						// Preload task messages
-						messages, err := repo.ListMessages(ctx, t.ID)
+						uid := monoflake.IDFromBase62(ownerID).Int64()
+						messages, err := repo.ListMessages(ctx, t.ID, uid)
 						if err == nil {
 							t.Messages = messages
 						}

--- a/backend/internal/controller/crud/task.go
+++ b/backend/internal/controller/crud/task.go
@@ -584,7 +584,7 @@ func (c *controller) UpdateMessageMetadata(ctx context.Context, req entity.Updat
 		return err
 	}
 
-	if err := c.repository.UpdateMessageMetadata(ctx, req.TaskID, req.MessageID, b); err != nil {
+	if err := c.repository.UpdateMessageMetadata(ctx, req.TaskID, req.MessageID, uid, b); err != nil {
 		return err
 	}
 	c.emitEvent(ctx, entity.CRUDEvent{

--- a/backend/internal/controller/crud/task_test.go
+++ b/backend/internal/controller/crud/task_test.go
@@ -717,7 +717,7 @@ func TestUpdateMessageMetadata_Success(t *testing.T) {
 	e := newTestController(t)
 
 	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(10), testUserID).Return(model.Task{}, nil)
-	e.repo.EXPECT().UpdateMessageMetadata(gomock.Any(), int64(10), int64(500), gomock.Any()).Return(nil)
+	e.repo.EXPECT().UpdateMessageMetadata(gomock.Any(), int64(10), int64(500), testUserID, gomock.Any()).Return(nil)
 
 	err := e.controller.UpdateMessageMetadata(context.Background(), entity.UpdateMessageMetadataRequest{
 		WorkspaceID: 1,

--- a/backend/internal/controller/crud/workspace.go
+++ b/backend/internal/controller/crud/workspace.go
@@ -99,7 +99,7 @@ func (c *controller) ListWorkspaces(ctx context.Context, req entity.ListWorkspac
 func (c *controller) DeleteWorkspace(ctx context.Context, req entity.DeleteWorkspaceRequest) error {
 	// 1. Get all task and message attachment IDs directly from DB
 	uid := monoflake.IDFromBase62(req.UserID).Int64()
-	attachmentIDs, _ := c.repository.GetWorkspaceAttachmentIDs(ctx, req.ID)
+	attachmentIDs, _ := c.repository.GetWorkspaceAttachmentIDs(ctx, req.ID, uid)
 
 	// 2. Delete from DB (repository handles cascaded DB delete)
 	if err := c.repository.DeleteWorkspace(ctx, req.ID, uid); err != nil {

--- a/backend/internal/controller/crud/workspace_test.go
+++ b/backend/internal/controller/crud/workspace_test.go
@@ -38,7 +38,7 @@ func TestCreateWorkspace_WithOptions(t *testing.T) {
 func TestDeleteWorkspace_Complex(t *testing.T) {
 	e := newTestController(t)
 
-	e.repo.EXPECT().GetWorkspaceAttachmentIDs(gomock.Any(), int64(1)).Return([]string{"att-1", "att-2"}, nil)
+	e.repo.EXPECT().GetWorkspaceAttachmentIDs(gomock.Any(), int64(1), testUserID).Return([]string{"att-1", "att-2"}, nil)
 	e.repo.EXPECT().DeleteWorkspace(gomock.Any(), int64(1), testUserID).Return(nil)
 	e.storage.EXPECT().Delete("att-1").Return(nil)
 	e.storage.EXPECT().Delete("att-2").Return(nil)

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -251,7 +251,7 @@ func (c *controller) OnMessageCreated(ctx context.Context, msg entity.Message, t
 				msg.Metadata = metaMap
 				b, marshalErr := json.Marshal(metaMap)
 				if marshalErr == nil {
-					if updateErr := c.repo.UpdateMessageMetadata(ctx, task.ID, msg.ID, b); updateErr != nil {
+					if updateErr := c.repo.UpdateMessageMetadata(ctx, task.ID, msg.ID, task.UserID, b); updateErr != nil {
 						zlog.Error().Err(updateErr).Int64("messageID", msg.ID).Msg("[slack] failed to update message metadata with slack details")
 					}
 				}
@@ -747,7 +747,7 @@ func (c *controller) HandleMCPPermission(ctx context.Context, action SlackBlockA
 
 	// Try to find the permission request message and save the slack decision flag in its metadata first,
 	// so that OnMessageUpdated can skip overwriting the slack-initiated UI update.
-	messages, listErr := c.repo.ListMessages(ctx, taskID)
+	messages, listErr := c.repo.ListMessages(ctx, taskID, ws.UserID)
 	if listErr == nil {
 		for _, m := range messages {
 			var metadata map[string]any
@@ -765,7 +765,7 @@ func (c *controller) HandleMCPPermission(ctx context.Context, action SlackBlockA
 					metadata["slack_user_name"] = action.UserName
 					b, marshalErr := json.Marshal(metadata)
 					if marshalErr == nil {
-						_ = c.repo.UpdateMessageMetadata(ctx, taskID, m.ID, b)
+						_ = c.repo.UpdateMessageMetadata(ctx, taskID, m.ID, ws.UserID, b)
 					}
 					break
 				}

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -33,9 +33,9 @@ type Repository interface {
 
 	// Message
 	CreateMessage(ctx context.Context, m model.Message) error
-	ListMessages(ctx context.Context, taskID int64) ([]model.Message, error)
-	UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte) error
-	GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64) ([]string, error)
+	ListMessages(ctx context.Context, taskID int64, userID int64) ([]model.Message, error)
+	UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, userID int64, metadata []byte) error
+	GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64, userID int64) ([]string, error)
 
 	SystemGetWorkspace(ctx context.Context, id int64) (model.Workspace, error)
 	SystemGetTask(ctx context.Context, id int64) (model.Task, error)
@@ -349,22 +349,31 @@ func (r *repository) CreateMessage(ctx context.Context, m model.Message) error {
 	return r.conn(ctx).Create(&m).Error
 }
 
-func (r *repository) ListMessages(ctx context.Context, taskID int64) ([]model.Message, error) {
+func (r *repository) ListMessages(ctx context.Context, taskID int64, userID int64) ([]model.Message, error) {
 	var msgs []model.Message
-	err := r.conn(ctx).Where("task_id = ?", taskID).Order("created_at asc").Find(&msgs).Error
+	err := r.conn(ctx).
+		Joins("JOIN tasks ON tasks.id = messages.task_id").
+		Where("messages.task_id = ? AND tasks.user_id = ?", taskID, userID).
+		Order("messages.created_at asc").
+		Find(&msgs).Error
 	return msgs, err
 }
 
-func (r *repository) UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte) error {
-	return r.conn(ctx).Model(&model.Message{}).Where("id = ? AND task_id = ?", messageID, taskID).Update("metadata", metadata).Error
+func (r *repository) UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, userID int64, metadata []byte) error {
+	// Use a subquery for BOLA protection.
+	return r.conn(ctx).Model(&model.Message{}).
+		Where("id = ? AND task_id = ? AND task_id IN (SELECT id FROM tasks WHERE user_id = ?)", messageID, taskID, userID).
+		Update("metadata", metadata).Error
 }
 
-func (r *repository) GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64) ([]string, error) {
+func (r *repository) GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64, userID int64) ([]string, error) {
 	var attachmentIDs []string
 
 	// 1. Get attachments from tasks
 	var taskAttachments []string
-	err := r.conn(ctx).Model(&model.Task{}).Where("workspace_id = ?", workspaceID).Pluck("attachments", &taskAttachments).Error
+	err := r.conn(ctx).Model(&model.Task{}).
+		Where("workspace_id = ? AND user_id = ?", workspaceID, userID).
+		Pluck("attachments", &taskAttachments).Error
 	if err == nil {
 		for _, ta := range taskAttachments {
 			if len(ta) > 0 {
@@ -384,7 +393,7 @@ func (r *repository) GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID 
 	var msgAttachments []string
 	err = r.conn(ctx).Model(&model.Message{}).
 		Joins("JOIN tasks ON tasks.id = messages.task_id").
-		Where("tasks.workspace_id = ?", workspaceID).
+		Where("tasks.workspace_id = ? AND tasks.user_id = ?", workspaceID, userID).
 		Pluck("messages.attachments", &msgAttachments).Error
 	if err == nil {
 		for _, ma := range msgAttachments {

--- a/backend/internal/repository/base/repository_test.go
+++ b/backend/internal/repository/base/repository_test.go
@@ -134,7 +134,7 @@ func TestRepository_UpdateMessageMetadata(t *testing.T) {
 		t.Fatalf("failed to connect database: %v", err)
 	}
 
-	_ = db.AutoMigrate(&model.Message{})
+	_ = db.AutoMigrate(&model.Task{}, &model.Message{})
 	repo := New(&mockDB{db: db})
 
 	ctx := context.Background()
@@ -147,8 +147,11 @@ func TestRepository_UpdateMessageMetadata(t *testing.T) {
 		Text:   "Initial text",
 	})
 
-	// Case 1: Success update with correct taskID
-	err = repo.UpdateMessageMetadata(ctx, taskID, messageID, []byte(`{"updated":true}`))
+	// Case 1: Success update with correct taskID and userID
+	userID := int64(1)
+	db.Create(&model.Task{ID: taskID, UserID: userID})
+
+	err = repo.UpdateMessageMetadata(ctx, taskID, messageID, userID, []byte(`{"updated":true}`))
 	if err != nil {
 		t.Errorf("expected nil error, got %v", err)
 	}
@@ -160,7 +163,7 @@ func TestRepository_UpdateMessageMetadata(t *testing.T) {
 	}
 
 	// Case 2: Update with WRONG taskID (IDOR)
-	err = repo.UpdateMessageMetadata(ctx, 999, messageID, []byte(`{"hacked":true}`))
+	err = repo.UpdateMessageMetadata(ctx, 999, messageID, userID, []byte(`{"hacked":true}`))
 	if err != nil {
 		t.Errorf("expected nil error (GORM Update doesn't return error on no rows), got %v", err)
 	}
@@ -168,6 +171,93 @@ func TestRepository_UpdateMessageMetadata(t *testing.T) {
 	db.First(&m, messageID)
 	if string(m.Metadata) == `{"hacked":true}` {
 		t.Error("vulnerability detected: metadata was updated with wrong taskID")
+	}
+
+	// Case 3: Update with WRONG userID (BOLA)
+	err = repo.UpdateMessageMetadata(ctx, taskID, messageID, 999, []byte(`{"bola":true}`))
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+
+	db.First(&m, messageID)
+	if string(m.Metadata) == `{"bola":true}` {
+		t.Error("vulnerability detected: metadata was updated with wrong userID")
+	}
+}
+
+func TestRepository_ListMessages_BOLA(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+
+	_ = db.AutoMigrate(&model.Task{}, &model.Message{})
+	repo := New(&mockDB{db: db})
+
+	ctx := context.Background()
+	taskID := int64(100)
+	userID := int64(1)
+	otherUserID := int64(2)
+
+	db.Create(&model.Task{ID: taskID, UserID: userID})
+	db.Create(&model.Message{ID: 1, TaskID: taskID, Text: "Secret message"})
+
+	// Case 1: Owner can list
+	msgs, err := repo.ListMessages(ctx, taskID, userID)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Errorf("expected 1 message, got %d", len(msgs))
+	}
+
+	// Case 2: Other user cannot list (BOLA)
+	msgs, err = repo.ListMessages(ctx, taskID, otherUserID)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("vulnerability detected: other user could list messages, got %d", len(msgs))
+	}
+}
+
+func TestRepository_GetWorkspaceAttachmentIDs_BOLA(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+
+	_ = db.AutoMigrate(&model.Task{}, &model.Message{})
+	repo := New(&mockDB{db: db})
+
+	ctx := context.Background()
+	workspaceID := int64(100)
+	userID := int64(1)
+	otherUserID := int64(2)
+
+	db.Create(&model.Task{
+		ID:          1,
+		WorkspaceID: workspaceID,
+		UserID:      userID,
+		Attachments: []byte(`[{"id":"att-1","filename":"test.txt"}]`),
+	})
+
+	// Case 1: Owner can get IDs
+	ids, err := repo.GetWorkspaceAttachmentIDs(ctx, workspaceID, userID)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "att-1" {
+		t.Errorf("expected [att-1], got %v", ids)
+	}
+
+	// Case 2: Other user cannot get IDs (BOLA)
+	ids, err = repo.GetWorkspaceAttachmentIDs(ctx, workspaceID, otherUserID)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("vulnerability detected: other user could get attachment IDs, got %v", ids)
 	}
 }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Potential Broken Object Level Authorization (BOLA/IDOR) in message and attachment endpoints.
🎯 Impact: An authenticated attacker could potentially list messages, update message metadata, or discover attachment IDs for tasks/workspaces they do not own by guessing or knowing the internal IDs.
🔧 Fix: Enforced user ownership checks at the repository level for `ListMessages`, `UpdateMessageMetadata`, and `GetWorkspaceAttachmentIDs`. The `Repository` interface now requires a `userID` for these operations, which is verified against the `tasks.user_id` or `workspaces.user_id` in the database.
✅ Verification: Added new unit tests in `repository_test.go` specifically targeting these methods with unauthorized user IDs to ensure they return no data or don't perform updates. Updated existing controller tests to maintain coverage. Verified all backend tests pass.

---
*PR created automatically by Jules for task [17659193505732872597](https://jules.google.com/task/17659193505732872597) started by @mustafaturan*