### PR TITLE
fix: stop self-learning loop note from accumulating in task bodies

### DIFF
--- a/backend/internal/controller/crud/task.go
+++ b/backend/internal/controller/crud/task.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
@@ -14,6 +15,22 @@ import (
 	"github.com/mustafaturan/monoflake"
 	"gorm.io/datatypes"
 )
+
+// appendSelfLearningNote appends the workspace's self-learning loop note to an
+// agent task body. It is idempotent: if the note is empty or the body already
+// contains it, the body is returned unchanged. This prevents the note from
+// accumulating multiple times when a body that already carries it is re-submitted
+// (e.g. self-improving loop tasks, copied bodies, or repeated human→agent
+// reassignment) — which would otherwise be returned repeatedly by the getTask tool.
+func appendSelfLearningNote(body, note string) string {
+	if note == "" || strings.Contains(body, note) {
+		return body
+	}
+	if body != "" {
+		return body + "\n\n" + note
+	}
+	return note
+}
 
 func (c *controller) ensureActiveWorkspace(ctx context.Context, id int64, userID string) (model.Workspace, error) {
 	uid := monoflake.IDFromBase62(userID).Int64()
@@ -85,12 +102,8 @@ func (c *controller) CreateTask(ctx context.Context, req entity.CreateTaskReques
 		allowAll = w.AllowAllCommands
 	}
 
-	if req.Task.Assignee == "agent" && w.SelfLearningLoopNote != "" {
-		if req.Task.Body != "" {
-			req.Task.Body += "\n\n" + w.SelfLearningLoopNote
-		} else {
-			req.Task.Body = w.SelfLearningLoopNote
-		}
+	if req.Task.Assignee == "agent" {
+		req.Task.Body = appendSelfLearningNote(req.Task.Body, w.SelfLearningLoopNote)
 	}
 
 	m := model.Task{
@@ -373,13 +386,7 @@ func (c *controller) UpdateTaskAssignee(ctx context.Context, req entity.UpdateTa
 	}
 
 	if req.Assignee == "agent" && m.Assignee != "agent" {
-		if w.SelfLearningLoopNote != "" {
-			if m.Body != "" {
-				m.Body += "\n\n" + w.SelfLearningLoopNote
-			} else {
-				m.Body = w.SelfLearningLoopNote
-			}
-		}
+		m.Body = appendSelfLearningNote(m.Body, w.SelfLearningLoopNote)
 	}
 
 	m.Assignee = req.Assignee

--- a/backend/internal/controller/crud/task_test.go
+++ b/backend/internal/controller/crud/task_test.go
@@ -136,6 +136,41 @@ func TestCreateTask_AgentAppendLoopNote(t *testing.T) {
 	}
 }
 
+// TestCreateTask_AgentLoopNoteIdempotent ensures the self-learning loop note is
+// not appended a second time when the submitted body already contains it (e.g.
+// a self-improving loop re-submitting a prior task body). Otherwise the note
+// would accumulate and be returned multiple times by the getTask tool.
+func TestCreateTask_AgentLoopNoteIdempotent(t *testing.T) {
+	e := newTestController(t)
+
+	ws := activeWorkspace()
+	ws.SelfLearningLoopNote = "Be concise."
+
+	bodyWithNote := "Hello world.\n\nBe concise."
+	created := model.Task{ID: 46, WorkspaceID: 1, Assignee: "agent", Body: bodyWithNote}
+
+	e.repo.EXPECT().GetWorkspace(gomock.Any(), int64(1), testUserID).Return(ws, nil)
+	e.idgen.EXPECT().NextID().Return(int64(46))
+	e.repo.EXPECT().CreateTask(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, m model.Task) (model.Task, error) {
+		if m.Body != bodyWithNote {
+			return model.Task{}, fmt.Errorf("expected note to NOT be duplicated, got %q", m.Body)
+		}
+		return created, nil
+	})
+
+	resp, err := e.controller.CreateTask(context.Background(), entity.CreateTaskRequest{
+		UserID: testUserIDStr,
+		Task:   entity.Task{WorkspaceID: 1, Title: "Agent Task", Body: bodyWithNote, Assignee: "agent"},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Task.Body != bodyWithNote {
+		t.Errorf("expected body unchanged (note not duplicated), got %q", resp.Task.Body)
+	}
+}
+
 func TestCreateTask_EmptyTitle(t *testing.T) {
 	e := newTestController(t)
 
@@ -585,6 +620,38 @@ func TestUpdateTaskAssignee_AgentAppendLoopNote(t *testing.T) {
 	}
 	if resp.Task.Body != "Original body.\n\nBe concise." {
 		t.Errorf("expected task body to be updated")
+	}
+}
+
+// TestUpdateTaskAssignee_LoopNoteIdempotent ensures reassigning a task to the
+// agent does not append the loop note again when the body already contains it.
+func TestUpdateTaskAssignee_LoopNoteIdempotent(t *testing.T) {
+	e := newTestController(t)
+
+	ws := activeWorkspace()
+	ws.SelfLearningLoopNote = "Be concise."
+
+	bodyWithNote := "Original body.\n\nBe concise."
+	task := model.Task{ID: 11, WorkspaceID: 1, Assignee: "human", Body: bodyWithNote}
+	updated := model.Task{ID: 11, WorkspaceID: 1, Assignee: "agent", Body: bodyWithNote}
+
+	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(11), testUserID).Return(task, nil)
+	e.repo.EXPECT().GetWorkspace(gomock.Any(), int64(1), testUserID).Return(ws, nil)
+	e.repo.EXPECT().UpdateTask(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, m model.Task) (model.Task, error) {
+		if m.Body != bodyWithNote {
+			return model.Task{}, fmt.Errorf("expected note to NOT be duplicated, got %q", m.Body)
+		}
+		return updated, nil
+	})
+
+	resp, err := e.controller.UpdateTaskAssignee(context.Background(), entity.UpdateTaskAssigneeRequest{
+		WorkspaceID: 1, TaskID: 11, Assignee: "agent", UserID: testUserIDStr,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Task.Body != bodyWithNote {
+		t.Errorf("expected body unchanged (note not duplicated), got %q", resp.Task.Body)
 	}
 }
 


### PR DESCRIPTION
The self-learning loop note was appended to an agent task's body without checking whether the body already contained it, in both CreateTask and UpdateTaskAssignee. A body that already carried the note (e.g. a self-improving loop re-submitting a prior task body, or repeated human->agent reassignment) would get the note appended again, so it accumulated and was returned multiple times by the getTask tool (most visibly via getTask with no taskId, which dequeues these loop tasks).

Make the append idempotent via a shared appendSelfLearningNote helper that only appends the note when it is non-empty and not already present. The getTask read path is unchanged — it returns the stored body as-is — so deduplicating at write time is sufficient.

Task: 0eUHBKamma9