### PR TITLE
🛡️ Sentinel: Harden Slack OAuth CSRF Protection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** The `ResizeBase64` service returned the original input string if the `data:image/` prefix was missing. The CRUD controller then stored this unsanitized string in the database. Since the frontend rendered some icons using `v-html`, this allowed for Stored XSS (e.g., using `javascript:` or malicious SVG).
 **Learning:** Fallback mechanisms that return unvalidated user input when processing fails are dangerous. If a service is designed to process/sanitize input, it must fail explicitly if the input doesn't meet the expected format.
 **Prevention:** Enforce strict input validation (e.g., prefix checks) and remove "fallback to original" logic in data processing services. Ensure that only successfully processed and sanitized data reaches the persistence layer.
+
+## 2024-06-28 - Slack OAuth CSRF Vulnerability
+**Vulnerability:** The Slack OAuth integration used a raw, un-signed workspace ID as the `state` parameter. An attacker could initiate the OAuth flow and trick an administrator into completing it, linking the administrator's Slack workspace to an attacker-controlled AgentRQ workspace.
+**Learning:** Using raw IDs or predictable values in OAuth `state` parameters provides no CSRF protection. The `state` parameter must be session-bound and cryptographically signed to ensure that the OAuth response belongs to a flow initiated by the same user/session.
+**Prevention:** Use a signed JWT for all OAuth `state` parameters. Include a session-specific nonce or bind it to the target resource (like `workspaceID`) and verify both the signature and the claims (including `aud` for provider separation) upon callback.

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,6 +3,7 @@ module github.com/agentrq/agentrq/backend
 go 1.25.0
 
 require (
+	github.com/SherClockHolmes/webpush-go v1.4.0
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-acme/lego/v4 v4.35.2
 	github.com/gofiber/contrib/fiberzerolog v1.0.3
@@ -13,6 +14,7 @@ require (
 	github.com/mustafaturan/monoflake v1.2.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/zerolog v1.35.0
+	github.com/slack-go/slack v0.24.0
 	golang.org/x/image v0.39.0
 	golang.org/x/oauth2 v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -25,7 +27,6 @@ require (
 require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	filippo.io/edwards25519 v1.2.0 // indirect
-	github.com/SherClockHolmes/webpush-go v1.4.0 // indirect
 	github.com/andybalholm/brotli v1.1.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
@@ -53,7 +54,6 @@ require (
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
-	github.com/slack-go/slack v0.24.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.51.0 // indirect
 	github.com/valyala/tcplisten v1.0.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -25,6 +25,8 @@ github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9
 github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
+github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
+github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gofiber/contrib/fiberzerolog v1.0.3 h1:Z97hA5bNfThtZjEYG12g9YcT8I/cmCikNgmE4uzFk0U=
 github.com/gofiber/contrib/fiberzerolog v1.0.3/go.mod h1:0MD+NNFy0nZwiSo4dSVW7WwWVzOyuATNXwhJwgOP8uM=
 github.com/gofiber/fiber/v2 v2.52.13 h1:TOKP64iqC9b5P49VrBW5tHhUOvDyrtJ0xePEfzJbCbk=

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -555,6 +555,7 @@ func New(cfg Config) (*App, error) {
 		Crud:       crudCtrl,
 		MCPManager: mcpManager,
 		PubSub:     pubsubSvc,
+		TokenSvc:   tokenSvc,
 		TokenKey:   cfg.Auth.WorkspaceTokenKey,
 		BaseURL:    cfg.App.BaseURL,
 	})
@@ -703,6 +704,7 @@ func New(cfg Config) (*App, error) {
 	handlerslack.New(handlerslack.Params{
 		SlackCtrl: slackCtrl,
 		SlackSvc:  slackSvc,
+		TokenSvc:  tokenSvc,
 		BaseURL:   cfg.App.BaseURL,
 		Mux:       mux,
 	})

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -16,6 +16,7 @@ import (
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	"github.com/agentrq/agentrq/backend/internal/data/model"
 	"github.com/agentrq/agentrq/backend/internal/repository/base"
+	"github.com/agentrq/agentrq/backend/internal/service/auth"
 	"github.com/agentrq/agentrq/backend/internal/service/pubsub"
 	"github.com/agentrq/agentrq/backend/internal/service/security"
 	slacksvc "github.com/agentrq/agentrq/backend/internal/service/slack"
@@ -45,6 +46,7 @@ type Params struct {
 	Crud       CRUDRespondToTask
 	MCPManager MCPManager
 	PubSub     pubsub.Service
+	TokenSvc   auth.TokenService
 	TokenKey   string
 	BaseURL    string
 }
@@ -117,6 +119,7 @@ type controller struct {
 	crud     CRUDRespondToTask
 	mcp      MCPManager
 	pubsub   pubsub.Service
+	tokenSvc auth.TokenService
 	tokenKey string
 	baseURL  string
 }
@@ -129,6 +132,7 @@ func New(p Params) Controller {
 		crud:     p.Crud,
 		mcp:      p.MCPManager,
 		pubsub:   p.PubSub,
+		tokenSvc: p.TokenSvc,
 		tokenKey: p.TokenKey,
 		baseURL:  p.BaseURL,
 	}
@@ -369,12 +373,17 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 	installed := err == nil && link.AccessToken != ""
 
 	workspaceID62 := monoflake.ID(workspaceID).String()
+	state, err := c.tokenSvc.CreateOAuthStateToken("", workspaceID62, "slack")
+	if err != nil {
+		return nil, fmt.Errorf("slack: failed to generate state token: %w", err)
+	}
+
 	redirectURI := fmt.Sprintf("%s/slack/oauth/callback", c.baseURL)
 	authURL := fmt.Sprintf(
 		"https://slack.com/oauth/v2/authorize?client_id=%s&scope=groups:write,groups:read,chat:write,app_mentions:read,commands&redirect_uri=%s&state=%s",
 		c.slack.ClientID(),
 		url.QueryEscape(redirectURI),
-		workspaceID62,
+		state,
 	)
 
 	cfg := &entity.SlackConfig{

--- a/backend/internal/controller/slack/slack_test.go
+++ b/backend/internal/controller/slack/slack_test.go
@@ -11,6 +11,7 @@ import (
 
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	"github.com/agentrq/agentrq/backend/internal/data/model"
+	"github.com/agentrq/agentrq/backend/internal/service/auth"
 	mock_pubsub "github.com/agentrq/agentrq/backend/internal/service/mocks/pubsub"
 	mock_repo "github.com/agentrq/agentrq/backend/internal/service/mocks/repository"
 	"github.com/agentrq/agentrq/backend/internal/service/security"
@@ -46,6 +47,18 @@ func (s *stubSlackService) VerifyRequest(r *http.Request, body []byte) error {
 }
 
 // Thin mock for CRUDRespondToTask
+type mockTokenSvc struct {
+	auth.TokenService
+}
+
+func (m *mockTokenSvc) CreateOAuthStateToken(redirectURL, workspaceID, provider string) (string, error) {
+	return workspaceID, nil // simple mock
+}
+
+func (m *mockTokenSvc) ValidateOAuthStateToken(tokenStr, provider string) (string, string, error) {
+	return "", tokenStr, nil // simple mock
+}
+
 type mockCRUD struct {
 	createTaskFunc  func(ctx context.Context, req entity.CreateTaskRequest) (*entity.CreateTaskResponse, error)
 	replyToTaskFunc func(ctx context.Context, req entity.ReplyToTaskRequest) (*entity.ReplyToTaskResponse, error)
@@ -86,6 +99,7 @@ func TestHandleSlashCommand_ChannelNotFound(t *testing.T) {
 	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
 	crud := &mockCRUD{}
 	mcp := &mockMCP{}
+	tokenSvc := &mockTokenSvc{}
 
 	c := New(Params{
 		Repository: mockRepo,
@@ -93,6 +107,7 @@ func TestHandleSlashCommand_ChannelNotFound(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
+		TokenSvc:   tokenSvc,
 		TokenKey:   "test-key",
 		BaseURL:    "https://app.agentrq.com",
 	})
@@ -121,6 +136,7 @@ func TestHandleSlashCommand_WorkspaceNotFound(t *testing.T) {
 	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
 	crud := &mockCRUD{}
 	mcp := &mockMCP{}
+	tokenSvc := &mockTokenSvc{}
 
 	c := New(Params{
 		Repository: mockRepo,
@@ -128,6 +144,7 @@ func TestHandleSlashCommand_WorkspaceNotFound(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
+		TokenSvc:   tokenSvc,
 		TokenKey:   "test-key",
 		BaseURL:    "https://app.agentrq.com",
 	})
@@ -153,6 +170,7 @@ func TestHandleSlashCommand_Success_Unquoted(t *testing.T) {
 	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
 	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
 	mcp := &mockMCP{}
+	tokenSvc := &mockTokenSvc{}
 
 	var capturedReq entity.CreateTaskRequest
 	crud := &mockCRUD{
@@ -168,6 +186,7 @@ func TestHandleSlashCommand_Success_Unquoted(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
+		TokenSvc:   tokenSvc,
 		TokenKey:   "test-key",
 		BaseURL:    "https://app.agentrq.com",
 	})
@@ -220,6 +239,7 @@ func TestHandleSlashCommand_Success_QuotedBoth(t *testing.T) {
 	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
 	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
 	mcp := &mockMCP{}
+	tokenSvc := &mockTokenSvc{}
 
 	var capturedReq entity.CreateTaskRequest
 	crud := &mockCRUD{
@@ -235,6 +255,7 @@ func TestHandleSlashCommand_Success_QuotedBoth(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
+		TokenSvc:   tokenSvc,
 		TokenKey:   "test-key",
 		BaseURL:    "https://app.agentrq.com",
 	})
@@ -274,6 +295,7 @@ func TestHandleSlashCommand_Success_SmartQuotes(t *testing.T) {
 	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
 	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
 	mcp := &mockMCP{}
+	tokenSvc := &mockTokenSvc{}
 
 	var capturedReq entity.CreateTaskRequest
 	crud := &mockCRUD{
@@ -289,6 +311,7 @@ func TestHandleSlashCommand_Success_SmartQuotes(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
+		TokenSvc:   tokenSvc,
 		TokenKey:   "test-key",
 		BaseURL:    "https://app.agentrq.com",
 	})
@@ -329,6 +352,7 @@ func TestHandleSlashCommand_Success_Truncation(t *testing.T) {
 	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
 	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
 	mcp := &mockMCP{}
+	tokenSvc := &mockTokenSvc{}
 
 	var capturedReq entity.CreateTaskRequest
 	crud := &mockCRUD{
@@ -344,6 +368,7 @@ func TestHandleSlashCommand_Success_Truncation(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
+		TokenSvc:   tokenSvc,
 		TokenKey:   "test-key",
 		BaseURL:    "https://app.agentrq.com",
 	})
@@ -385,6 +410,7 @@ func TestProcessEvent_OriginSlack(t *testing.T) {
 	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
 	crud := &mockCRUD{}
 	mcp := &mockMCP{}
+	tokenSvc := &mockTokenSvc{}
 
 	c := New(Params{
 		Repository: mockRepo,
@@ -392,6 +418,7 @@ func TestProcessEvent_OriginSlack(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
+		TokenSvc:   tokenSvc,
 		TokenKey:   "test-key",
 		BaseURL:    "https://app.agentrq.com",
 	})
@@ -415,6 +442,7 @@ func TestHandleSlackEvent_WithFiles(t *testing.T) {
 	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
 	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
 	mcp := &mockMCP{}
+	tokenSvc := &mockTokenSvc{}
 
 	// Setup a mock HTTP test server to serve the private file download
 	fileContent := "hello from slack attachment"
@@ -442,6 +470,7 @@ func TestHandleSlackEvent_WithFiles(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
+		TokenSvc:   tokenSvc,
 		TokenKey:   "12345678901234567890123456789012",
 		BaseURL:    "https://app.agentrq.com",
 	})
@@ -537,6 +566,7 @@ func TestOnTaskCreated_ChannelNotFound(t *testing.T) {
 	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
 	crud := &mockCRUD{}
 	mcp := &mockMCP{}
+	tokenSvc := &mockTokenSvc{}
 
 	stubSlack := &stubSlackServiceChannelNotFound{}
 
@@ -546,6 +576,7 @@ func TestOnTaskCreated_ChannelNotFound(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
+		TokenSvc:   tokenSvc,
 		TokenKey:   "0123456789abcdef0123456789abcdef", // 32-byte key
 		BaseURL:    "https://app.agentrq.com",
 	})
@@ -595,6 +626,7 @@ func TestOnMessageCreated_HumanUserName(t *testing.T) {
 	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
 	crud := &mockCRUD{}
 	mcp := &mockMCP{}
+	tokenSvc := &mockTokenSvc{}
 
 	stubSlack := &stubSlackService{}
 
@@ -604,6 +636,7 @@ func TestOnMessageCreated_HumanUserName(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
+		TokenSvc:   tokenSvc,
 		TokenKey:   "0123456789abcdef0123456789abcdef", // 32-byte key
 		BaseURL:    "https://app.agentrq.com",
 	})
@@ -683,6 +716,7 @@ func TestOnMessageUpdated_Success(t *testing.T) {
 	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
 	crud := &mockCRUD{}
 	mcp := &mockMCP{}
+	tokenSvc := &mockTokenSvc{}
 
 	stubSlack := &stubSlackServiceWithUpdateTracking{}
 
@@ -692,6 +726,7 @@ func TestOnMessageUpdated_Success(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
+		TokenSvc:   tokenSvc,
 		TokenKey:   "0123456789abcdef0123456789abcdef", // 32-byte key
 		BaseURL:    "https://app.agentrq.com",
 	})
@@ -753,6 +788,7 @@ func TestOnMessageUpdated_SkippedIfDecidedInSlack(t *testing.T) {
 	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
 	crud := &mockCRUD{}
 	mcp := &mockMCP{}
+	tokenSvc := &mockTokenSvc{}
 
 	stubSlack := &stubSlackServiceWithUpdateTracking{}
 
@@ -762,6 +798,7 @@ func TestOnMessageUpdated_SkippedIfDecidedInSlack(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
+		TokenSvc:   tokenSvc,
 		TokenKey:   "0123456789abcdef0123456789abcdef", // 32-byte key
 		BaseURL:    "https://app.agentrq.com",
 	})

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -314,7 +314,7 @@ func (h *handler) rootLogin() fiber.Handler {
 func (h *handler) googleLogin() fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		redirectURL := h.sanitizeRedirectURL(c.Query("redirect_url", "/"))
-		state, err := h.tokenSvc.CreateOAuthStateToken(redirectURL, "google")
+		state, err := h.tokenSvc.CreateOAuthStateToken(redirectURL, "", "google")
 		if err != nil {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to generate state"})
 		}
@@ -387,7 +387,7 @@ func (h *handler) googleCallback() fiber.Handler {
 
 		redirectURL := "/"
 		if stateToken := c.Query("state"); stateToken != "" {
-			if rurl, err := h.tokenSvc.ValidateOAuthStateToken(stateToken, "google"); err == nil {
+			if rurl, _, err := h.tokenSvc.ValidateOAuthStateToken(stateToken, "google"); err == nil {
 				redirectURL = h.sanitizeRedirectURL(rurl)
 			}
 		}
@@ -402,7 +402,7 @@ func (h *handler) githubLogin() fiber.Handler {
 			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "github login disabled"})
 		}
 		redirectURL := h.sanitizeRedirectURL(c.Query("redirect_url", "/"))
-		state, err := h.tokenSvc.CreateOAuthStateToken(redirectURL, "github")
+		state, err := h.tokenSvc.CreateOAuthStateToken(redirectURL, "", "github")
 		if err != nil {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to generate state"})
 		}
@@ -467,7 +467,7 @@ func (h *handler) githubCallback() fiber.Handler {
 
 		redirectURL := "/"
 		if stateToken := c.Query("state"); stateToken != "" {
-			if rurl, err := h.tokenSvc.ValidateOAuthStateToken(stateToken, "github"); err == nil {
+			if rurl, _, err := h.tokenSvc.ValidateOAuthStateToken(stateToken, "github"); err == nil {
 				redirectURL = h.sanitizeRedirectURL(rurl)
 			}
 		}

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -42,12 +42,12 @@ func (m *mockTokenSvc) CreateMCPToken(userID, workspaceID, tokenType string) (st
 	return m.createMCPTokenFunc(userID, workspaceID, tokenType)
 }
 
-func (m *mockTokenSvc) CreateOAuthStateToken(redirectURL, provider string) (string, error) {
+func (m *mockTokenSvc) CreateOAuthStateToken(redirectURL, workspaceID, provider string) (string, error) {
 	return redirectURL, nil // passthrough for tests that don't need real JWT signing
 }
 
-func (m *mockTokenSvc) ValidateOAuthStateToken(tokenStr, provider string) (string, error) {
-	return tokenStr, nil // treat the raw value as the redirect URL in simple tests
+func (m *mockTokenSvc) ValidateOAuthStateToken(tokenStr, provider string) (string, string, error) {
+	return tokenStr, "", nil // treat the raw value as the redirect URL in simple tests
 }
 
 type mockCrudController struct {
@@ -108,7 +108,7 @@ func TestGoogleCallback_StateJWT(t *testing.T) {
 	}
 
 	t.Run("Valid JWT state redirects correctly", func(t *testing.T) {
-		state, _ := realTokenSvc.CreateOAuthStateToken("/workspaces", "google")
+		state, _ := realTokenSvc.CreateOAuthStateToken("/workspaces", "", "google")
 		req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state="+state, nil)
 		resp, _ := app.Test(req)
 		if resp.StatusCode != http.StatusFound {
@@ -132,7 +132,7 @@ func TestGoogleCallback_StateJWT(t *testing.T) {
 
 	t.Run("Wrong provider state falls back to /", func(t *testing.T) {
 		// State signed for github should be rejected by google callback
-		state, _ := realTokenSvc.CreateOAuthStateToken("/workspaces", "github")
+		state, _ := realTokenSvc.CreateOAuthStateToken("/workspaces", "", "github")
 		req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state="+state, nil)
 		resp, _ := app.Test(req)
 		if resp.StatusCode != http.StatusFound {

--- a/backend/internal/handler/slack/slack.go
+++ b/backend/internal/handler/slack/slack.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	slackctrl "github.com/agentrq/agentrq/backend/internal/controller/slack"
+	"github.com/agentrq/agentrq/backend/internal/service/auth"
 	slacksvc "github.com/agentrq/agentrq/backend/internal/service/slack"
 	zlog "github.com/rs/zerolog/log"
 )
@@ -20,6 +21,7 @@ import (
 type Params struct {
 	SlackCtrl slackctrl.Controller
 	SlackSvc  slacksvc.Service
+	TokenSvc  auth.TokenService
 	BaseURL   string
 	Mux       *http.ServeMux
 }
@@ -33,7 +35,7 @@ type Params struct {
 func New(p Params) {
 	p.Mux.Handle("/slack/events", eventsHandler(p.SlackSvc, p.SlackCtrl))
 	p.Mux.Handle("/slack/interactions", interactionsHandler(p.SlackSvc, p.SlackCtrl))
-	p.Mux.Handle("/slack/oauth/callback", oauthCallbackHandler(p.SlackSvc, p.SlackCtrl, p.BaseURL))
+	p.Mux.Handle("/slack/oauth/callback", oauthCallbackHandler(p.SlackSvc, p.SlackCtrl, p.TokenSvc, p.BaseURL))
 	p.Mux.Handle("/slack/commands", commandHandler(p.SlackSvc, p.SlackCtrl))
 }
 
@@ -174,7 +176,7 @@ func interactionsHandler(svc slacksvc.Service, ctrl slackctrl.Controller) http.H
 }
 
 // oauthCallbackHandler handles Slack's OAuth redirect callback.
-func oauthCallbackHandler(svc slacksvc.Service, ctrl slackctrl.Controller, baseURL string) http.Handler {
+func oauthCallbackHandler(svc slacksvc.Service, ctrl slackctrl.Controller, tokenSvc auth.TokenService, baseURL string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -182,26 +184,33 @@ func oauthCallbackHandler(svc slacksvc.Service, ctrl slackctrl.Controller, baseU
 		}
 
 		code := r.URL.Query().Get("code")
-		state := r.URL.Query().Get("state") // base62 workspace ID
+		stateToken := r.URL.Query().Get("state")
 
-		if code == "" || state == "" {
+		if code == "" || stateToken == "" {
 			zlog.Warn().Msg("[slack/oauth] missing code or state parameter")
 			http.Error(w, "missing code or state parameter", http.StatusBadRequest)
 			return
 		}
 
+		_, workspaceID62, err := tokenSvc.ValidateOAuthStateToken(stateToken, "slack")
+		if err != nil {
+			zlog.Warn().Err(err).Msg("[slack/oauth] invalid state token")
+			http.Error(w, "forbidden: invalid state token", http.StatusForbidden)
+			return
+		}
+
 		redirectURI := fmt.Sprintf("%s/slack/oauth/callback", baseURL)
-		err := ctrl.HandleOAuthCallback(r.Context(), state, code, redirectURI)
+		err = ctrl.HandleOAuthCallback(r.Context(), workspaceID62, code, redirectURI)
 		if err != nil {
 			zlog.Error().Err(err).Msg("[slack/oauth] HandleOAuthCallback error")
 			// Redirect back with a generic error query param to prevent information leakage
 			errorMsg := url.QueryEscape("failed to complete slack authorization")
-			http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack&slack_error=%s", baseURL, state, errorMsg), http.StatusTemporaryRedirect)
+			http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack&slack_error=%s", baseURL, workspaceID62, errorMsg), http.StatusTemporaryRedirect)
 			return
 		}
 
 		// Redirect back to settings page on success
-		http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack", baseURL, state), http.StatusTemporaryRedirect)
+		http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack", baseURL, workspaceID62), http.StatusTemporaryRedirect)
 	})
 }
 

--- a/backend/internal/service/auth/jwt.go
+++ b/backend/internal/service/auth/jwt.go
@@ -30,15 +30,16 @@ type Claims struct {
 type StateClaims struct {
 	jwt.RegisteredClaims
 	RedirectURL string `json:"rurl,omitempty"`
+	WorkspaceID string `json:"wid,omitempty"`
 }
 
 type TokenService interface {
 	CreateToken(userID, email, name, picture string) (string, error)
 	CreateMCPToken(userID, workspaceID, tokenType string) (string, error)
 	CreateOAuthCodeToken(userID, workspaceID string) (string, error)
-	CreateOAuthStateToken(redirectURL, provider string) (string, error)
+	CreateOAuthStateToken(redirectURL, workspaceID, provider string) (string, error)
 	ValidateToken(tokenStr string) (*Claims, error)
-	ValidateOAuthStateToken(tokenStr, provider string) (redirectURL string, err error)
+	ValidateOAuthStateToken(tokenStr, provider string) (redirectURL, workspaceID string, err error)
 }
 
 type tokenService struct {
@@ -128,7 +129,7 @@ func (s *tokenService) CreateOAuthCodeToken(userID, workspaceID string) (string,
 	return token.SignedString(s.secret)
 }
 
-func (s *tokenService) CreateOAuthStateToken(redirectURL, provider string) (string, error) {
+func (s *tokenService) CreateOAuthStateToken(redirectURL, workspaceID, provider string) (string, error) {
 	now := time.Now()
 	claims := StateClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
@@ -138,12 +139,13 @@ func (s *tokenService) CreateOAuthStateToken(redirectURL, provider string) (stri
 			NotBefore: jwt.NewNumericDate(now.Add(-2 * time.Second)),
 		},
 		RedirectURL: redirectURL,
+		WorkspaceID: workspaceID,
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	return token.SignedString(s.secret)
 }
 
-func (s *tokenService) ValidateOAuthStateToken(tokenStr, provider string) (string, error) {
+func (s *tokenService) ValidateOAuthStateToken(tokenStr, provider string) (string, string, error) {
 	token, err := jwt.ParseWithClaims(tokenStr, &StateClaims{}, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method")
@@ -151,14 +153,14 @@ func (s *tokenService) ValidateOAuthStateToken(tokenStr, provider string) (strin
 		return s.secret, nil
 	}, jwt.WithAudience(provider))
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	claims, ok := token.Claims.(*StateClaims)
 	if !ok || !token.Valid {
-		return "", errors.New("invalid state token")
+		return "", "", errors.New("invalid state token")
 	}
-	return claims.RedirectURL, nil
+	return claims.RedirectURL, claims.WorkspaceID, nil
 }
 
 func (s *tokenService) ValidateToken(tokenStr string) (*Claims, error) {

--- a/backend/internal/service/auth/jwt_test.go
+++ b/backend/internal/service/auth/jwt_test.go
@@ -143,42 +143,46 @@ func TestTokenService(t *testing.T) {
 
 	t.Run("CreateAndValidateOAuthStateToken", func(t *testing.T) {
 		redirectURL := "/dashboard"
+		workspaceID := "w123"
 		provider := "google"
 
-		token, err := s.CreateOAuthStateToken(redirectURL, provider)
+		token, err := s.CreateOAuthStateToken(redirectURL, workspaceID, provider)
 		if err != nil {
 			t.Fatalf("failed to create state token: %v", err)
 		}
 
-		got, err := s.ValidateOAuthStateToken(token, provider)
+		gotURL, gotWS, err := s.ValidateOAuthStateToken(token, provider)
 		if err != nil {
 			t.Fatalf("failed to validate state token: %v", err)
 		}
-		if got != redirectURL {
-			t.Errorf("expected redirectURL %q, got %q", redirectURL, got)
+		if gotURL != redirectURL {
+			t.Errorf("expected redirectURL %q, got %q", redirectURL, gotURL)
+		}
+		if gotWS != workspaceID {
+			t.Errorf("expected workspaceID %q, got %q", workspaceID, gotWS)
 		}
 	})
 
 	t.Run("OAuthStateTokenWrongProvider", func(t *testing.T) {
-		token, err := s.CreateOAuthStateToken("/dashboard", "google")
+		token, err := s.CreateOAuthStateToken("/dashboard", "", "google")
 		if err != nil {
 			t.Fatalf("failed to create state token: %v", err)
 		}
 
-		_, err = s.ValidateOAuthStateToken(token, "github")
+		_, _, err = s.ValidateOAuthStateToken(token, "github")
 		if err == nil {
 			t.Error("expected error when validating with wrong provider, got nil")
 		}
 	})
 
 	t.Run("OAuthStateTokenExpiry", func(t *testing.T) {
-		token, err := s.CreateOAuthStateToken("/", "google")
+		token, err := s.CreateOAuthStateToken("/", "", "google")
 		if err != nil {
 			t.Fatalf("failed to create state token: %v", err)
 		}
 
 		// Should be valid immediately
-		_, err = s.ValidateOAuthStateToken(token, "google")
+		_, _, err = s.ValidateOAuthStateToken(token, "google")
 		if err != nil {
 			t.Errorf("expected valid token, got: %v", err)
 		}


### PR DESCRIPTION
Implemented CSRF protection for Slack OAuth by using signed JWT state tokens, including audience validation and workspace binding. Verified with unit tests and backend build.

---
*PR created automatically by Jules for task [12338341809731593216](https://jules.google.com/task/12338341809731593216) started by @mustafaturan*