### PR TITLE
test: fill three handler and Slack controller coverage gaps

### DIFF
--- a/backend/internal/controller/slack/slack_test.go
+++ b/backend/internal/controller/slack/slack_test.go
@@ -1110,6 +1110,7 @@ func TestHandleMCPPermission_Success_Allow(t *testing.T) {
 		ChannelID: "C123",
 		MessageTS: "12345678.90",
 		UserID:    "U_REVIEWER",
+		UserName:  "John Doe",
 	}
 
 	err = c.HandleMCPPermission(context.Background(), action)
@@ -1127,6 +1128,9 @@ func TestHandleMCPPermission_Success_Allow(t *testing.T) {
 	}
 	if uid, _ := meta["slack_user_id"].(string); uid != "U_REVIEWER" {
 		t.Errorf("expected slack_user_id='U_REVIEWER', got %q", uid)
+	}
+	if name, _ := meta["slack_user_name"].(string); name != "John Doe" {
+		t.Errorf("expected slack_user_name='John Doe', got %q", name)
 	}
 	if rid, _ := meta["request_id"].(string); rid != requestID {
 		t.Errorf("expected request_id=%q, got %q", requestID, rid)

--- a/backend/internal/controller/slack/slack_test.go
+++ b/backend/internal/controller/slack/slack_test.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -16,13 +17,18 @@ import (
 	"github.com/agentrq/agentrq/backend/internal/service/security"
 	"github.com/golang/mock/gomock"
 	slackapi "github.com/slack-go/slack"
+	"gorm.io/datatypes"
 )
+
+// Ensure future-permission-test imports are referenced.
+var _ = json.Marshal
+var _ datatypes.JSON
 
 // Thin stub for slacksvc.Service
 type stubSlackService struct{}
 
-func (s *stubSlackService) IsEnabled() bool    { return true }
-func (s *stubSlackService) ClientID() string   { return "test-client-id" }
+func (s *stubSlackService) IsEnabled() bool  { return true }
+func (s *stubSlackService) ClientID() string { return "test-client-id" }
 func (s *stubSlackService) CreatePrivateChannel(ctx context.Context, token, name string) (string, error) {
 	return "", nil
 }
@@ -47,8 +53,9 @@ func (s *stubSlackService) VerifyRequest(r *http.Request, body []byte) error {
 
 // Thin mock for CRUDRespondToTask
 type mockCRUD struct {
-	createTaskFunc  func(ctx context.Context, req entity.CreateTaskRequest) (*entity.CreateTaskResponse, error)
-	replyToTaskFunc func(ctx context.Context, req entity.ReplyToTaskRequest) (*entity.ReplyToTaskResponse, error)
+	createTaskFunc    func(ctx context.Context, req entity.CreateTaskRequest) (*entity.CreateTaskResponse, error)
+	replyToTaskFunc   func(ctx context.Context, req entity.ReplyToTaskRequest) (*entity.ReplyToTaskResponse, error)
+	respondToTaskFunc func(ctx context.Context, req entity.RespondToTaskRequest) (*entity.RespondToTaskResponse, error)
 }
 
 func (m *mockCRUD) CreateTask(ctx context.Context, req entity.CreateTaskRequest) (*entity.CreateTaskResponse, error) {
@@ -58,6 +65,9 @@ func (m *mockCRUD) CreateTask(ctx context.Context, req entity.CreateTaskRequest)
 	return &entity.CreateTaskResponse{}, nil
 }
 func (m *mockCRUD) RespondToTask(ctx context.Context, req entity.RespondToTaskRequest) (*entity.RespondToTaskResponse, error) {
+	if m.respondToTaskFunc != nil {
+		return m.respondToTaskFunc(ctx, req)
+	}
 	return nil, nil
 }
 func (m *mockCRUD) ReplyToTask(ctx context.Context, req entity.ReplyToTaskRequest) (*entity.ReplyToTaskResponse, error) {
@@ -70,13 +80,29 @@ func (m *mockCRUD) CheckWorkspaceAccess(ctx context.Context, id int64, userID st
 	return true, nil
 }
 
-type mockMCP struct{}
+type mockMCP struct {
+	capturedVerdict *struct {
+		workspaceID int64
+		userID      string
+		taskID      int64
+		requestID   string
+		behavior    string
+	}
+}
 
 func (m *mockMCP) SendPermissionVerdict(ctx context.Context, workspaceID int64, userID string, taskID int64, requestID, behavior string) error {
+	m.capturedVerdict = &struct {
+		workspaceID int64
+		userID      string
+		taskID      int64
+		requestID   string
+		behavior    string
+	}{workspaceID, userID, taskID, requestID, behavior}
 	return nil
 }
 
-func (m *mockMCP) SendChannelNotification(ctx context.Context, workspaceID int64, userID string, taskID int64, content string) {}
+func (m *mockMCP) SendChannelNotification(ctx context.Context, workspaceID int64, userID string, taskID int64, content string) {
+}
 
 func TestHandleSlashCommand_ChannelNotFound(t *testing.T) {
 	gomockCtrl := gomock.NewController(t)
@@ -615,11 +641,11 @@ func TestOnMessageCreated_HumanUserName(t *testing.T) {
 	}
 
 	msg := entity.Message{
-		ID:        1,
-		TaskID:    99,
-		UserID:    100,
-		Sender:    "human",
-		Text:      "Hello slack thread",
+		ID:     1,
+		TaskID: 99,
+		UserID: 100,
+		Sender: "human",
+		Text:   "Hello slack thread",
 	}
 
 	task := entity.Task{
@@ -673,6 +699,18 @@ func (s *stubSlackServiceWithUpdateTracking) UpdateMessage(ctx context.Context, 
 	s.capturedChannelID = channelID
 	s.capturedTS = ts
 	return nil
+}
+
+type stubSlackServiceWithPostTracking struct {
+	stubSlackService
+	postMessageCalled bool
+	capturedChannelID string
+}
+
+func (s *stubSlackServiceWithPostTracking) PostMessage(ctx context.Context, token, channelID string, blocks []slackapi.Block) (string, error) {
+	s.postMessageCalled = true
+	s.capturedChannelID = channelID
+	return "thread-ts-123", nil
 }
 
 func TestOnMessageUpdated_Success(t *testing.T) {
@@ -794,3 +832,71 @@ func TestOnMessageUpdated_SkippedIfDecidedInSlack(t *testing.T) {
 	}
 }
 
+func TestOnTaskCreated_Success(t *testing.T) {
+	gomockCtrl := gomock.NewController(t)
+	defer gomockCtrl.Finish()
+
+	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
+	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
+
+	stubSlack := &stubSlackServiceWithPostTracking{}
+
+	c := New(Params{
+		Repository: mockRepo,
+		SlackSvc:   stubSlack,
+		Crud:       &mockCRUD{},
+		MCPManager: &mockMCP{},
+		PubSub:     mockPubSub,
+		TokenKey:   "0123456789abcdef0123456789abcdef",
+		BaseURL:    "https://app.agentrq.com",
+	})
+
+	decToken := "xoxb-test-token"
+	encToken, nonce, err := security.Encrypt(decToken, "0123456789abcdef0123456789abcdef")
+	if err != nil {
+		t.Fatalf("failed to encrypt token: %v", err)
+	}
+
+	task := entity.Task{
+		ID:          1,
+		WorkspaceID: 42,
+		Title:       "Fix the bug",
+		Body:        "See issue #42",
+		Assignee:    "agent",
+		Status:      "notstarted",
+		CreatedBy:   "human",
+	}
+
+	mockRepo.EXPECT().
+		GetSlackWorkspaceLink(gomock.Any(), int64(42)).
+		Return(model.SlackWorkspaceLink{
+			WorkspaceID:    42,
+			AccessToken:    encToken,
+			TokenNonce:     nonce,
+			SlackChannelID: "C_PROJ",
+		}, nil)
+
+	var capturedThread model.SlackTaskThread
+	mockRepo.EXPECT().
+		UpsertSlackTaskThread(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, th model.SlackTaskThread) error {
+			capturedThread = th
+			return nil
+		})
+
+	err = c.OnTaskCreated(context.Background(), task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !stubSlack.postMessageCalled {
+		t.Error("expected PostMessage to be called")
+	}
+	if stubSlack.capturedChannelID != "C_PROJ" {
+		t.Errorf("expected channel 'C_PROJ', got %q", stubSlack.capturedChannelID)
+	}
+	if capturedThread.TaskID != 1 || capturedThread.WorkspaceID != 42 ||
+		capturedThread.SlackChannelID != "C_PROJ" || capturedThread.ThreadTS != "thread-ts-123" {
+		t.Errorf("unexpected SlackTaskThread: %+v", capturedThread)
+	}
+}

--- a/backend/internal/controller/slack/slack_test.go
+++ b/backend/internal/controller/slack/slack_test.go
@@ -21,10 +21,6 @@ import (
 	"gorm.io/datatypes"
 )
 
-// Ensure future-permission-test imports are referenced.
-var _ = json.Marshal
-var _ datatypes.JSON
-
 // Thin stub for slacksvc.Service
 type stubSlackService struct{}
 
@@ -1038,5 +1034,192 @@ func TestHandleTaskApproval_WorkspaceNotFound(t *testing.T) {
 	err := c.HandleTaskApproval(context.Background(), action)
 	if err == nil {
 		t.Fatal("expected error when workspace is not found")
+	}
+}
+
+func TestHandleMCPPermission_Success_Allow(t *testing.T) {
+	gomockCtrl := gomock.NewController(t)
+	defer gomockCtrl.Finish()
+
+	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
+	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
+	stubSlack := &stubSlackServiceWithUpdateTracking{}
+	mcp := &mockMCP{}
+
+	c := New(Params{
+		Repository: mockRepo,
+		SlackSvc:   stubSlack,
+		Crud:       &mockCRUD{},
+		MCPManager: mcp,
+		PubSub:     mockPubSub,
+		TokenKey:   "0123456789abcdef0123456789abcdef",
+		BaseURL:    "https://app.agentrq.com",
+	})
+
+	workspaceID := int64(42)
+	workspaceID62 := monoflake.ID(workspaceID).String()
+	taskID := int64(99)
+	taskID62 := monoflake.ID(taskID).String()
+	requestID := "req-abc-123"
+	ownerUserID := monoflake.ID(int64(100)).String()
+	actionID := "task_permission:" + workspaceID62 + ":" + taskID62 + ":" + requestID + ":allow"
+
+	decToken := "xoxb-test-token"
+	encToken, nonce, err := security.Encrypt(decToken, "0123456789abcdef0123456789abcdef")
+	if err != nil {
+		t.Fatalf("failed to encrypt token: %v", err)
+	}
+
+	metaBytes, _ := json.Marshal(map[string]any{
+		"type":       "permission_request",
+		"request_id": requestID,
+	})
+	permMsg := model.Message{
+		ID:       7,
+		TaskID:   taskID,
+		Metadata: datatypes.JSON(metaBytes),
+	}
+
+	mockRepo.EXPECT().
+		SystemGetWorkspace(gomock.Any(), workspaceID).
+		Return(model.Workspace{UserID: int64(100)}, nil)
+
+	mockRepo.EXPECT().
+		GetSlackWorkspaceLink(gomock.Any(), workspaceID).
+		Return(model.SlackWorkspaceLink{
+			WorkspaceID:    workspaceID,
+			AccessToken:    encToken,
+			TokenNonce:     nonce,
+			SlackChannelID: "C123",
+		}, nil)
+
+	mockRepo.EXPECT().
+		ListMessages(gomock.Any(), taskID).
+		Return([]model.Message{permMsg}, nil)
+
+	var capturedMeta []byte
+	mockRepo.EXPECT().
+		UpdateMessageMetadata(gomock.Any(), taskID, int64(7), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ int64, _ int64, b []byte) error {
+			capturedMeta = b
+			return nil
+		})
+
+	action := SlackBlockAction{
+		ActionID:  actionID,
+		ChannelID: "C123",
+		MessageTS: "12345678.90",
+		UserID:    "U_REVIEWER",
+	}
+
+	err = c.HandleMCPPermission(context.Background(), action)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Assert metadata-tagging: decided_in_slack, slack_user_id, request_id
+	var meta map[string]any
+	if err := json.Unmarshal(capturedMeta, &meta); err != nil {
+		t.Fatalf("failed to unmarshal captured metadata: %v", err)
+	}
+	if decided, _ := meta["decided_in_slack"].(bool); !decided {
+		t.Error("expected decided_in_slack=true in updated metadata")
+	}
+	if uid, _ := meta["slack_user_id"].(string); uid != "U_REVIEWER" {
+		t.Errorf("expected slack_user_id='U_REVIEWER', got %q", uid)
+	}
+	if rid, _ := meta["request_id"].(string); rid != requestID {
+		t.Errorf("expected request_id=%q, got %q", requestID, rid)
+	}
+
+	// Assert SendPermissionVerdict args via capturedVerdict
+	if mcp.capturedVerdict == nil {
+		t.Fatal("expected SendPermissionVerdict to be called")
+	}
+	if mcp.capturedVerdict.workspaceID != workspaceID {
+		t.Errorf("SendPermissionVerdict: expected workspaceID %d, got %d", workspaceID, mcp.capturedVerdict.workspaceID)
+	}
+	if mcp.capturedVerdict.userID != ownerUserID {
+		t.Errorf("SendPermissionVerdict: expected userID %q, got %q", ownerUserID, mcp.capturedVerdict.userID)
+	}
+	if mcp.capturedVerdict.taskID != taskID {
+		t.Errorf("SendPermissionVerdict: expected taskID %d, got %d", taskID, mcp.capturedVerdict.taskID)
+	}
+	if mcp.capturedVerdict.requestID != requestID {
+		t.Errorf("SendPermissionVerdict: expected requestID %q, got %q", requestID, mcp.capturedVerdict.requestID)
+	}
+	if mcp.capturedVerdict.behavior != "allow" {
+		t.Errorf("SendPermissionVerdict: expected behavior 'allow', got %q", mcp.capturedVerdict.behavior)
+	}
+	if !stubSlack.updateMessageCalled {
+		t.Error("expected UpdateMessage to be called after permission verdict")
+	}
+}
+
+func TestHandleMCPPermission_InvalidActionID(t *testing.T) {
+	c := New(Params{
+		TokenKey: "0123456789abcdef0123456789abcdef",
+		BaseURL:  "https://app.agentrq.com",
+	})
+
+	action := SlackBlockAction{ActionID: "task_permission:only:three:parts"}
+	err := c.HandleMCPPermission(context.Background(), action)
+	if err == nil {
+		t.Fatal("expected error for malformed action_id")
+	}
+	if !strings.Contains(err.Error(), "invalid task_permission action_id") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestHandleMCPPermission_NoMCPManager(t *testing.T) {
+	gomockCtrl := gomock.NewController(t)
+	defer gomockCtrl.Finish()
+
+	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
+	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
+
+	decToken := "xoxb-test-token"
+	encToken, nonce, err := security.Encrypt(decToken, "0123456789abcdef0123456789abcdef")
+	if err != nil {
+		t.Fatalf("failed to encrypt token: %v", err)
+	}
+
+	c := New(Params{
+		Repository: mockRepo,
+		SlackSvc:   &stubSlackServiceWithUpdateTracking{},
+		Crud:       &mockCRUD{},
+		MCPManager: nil,
+		PubSub:     mockPubSub,
+		TokenKey:   "0123456789abcdef0123456789abcdef",
+		BaseURL:    "https://app.agentrq.com",
+	})
+
+	workspaceID := int64(42)
+	workspaceID62 := monoflake.ID(workspaceID).String()
+	taskID := int64(99)
+	taskID62 := monoflake.ID(taskID).String()
+	actionID := "task_permission:" + workspaceID62 + ":" + taskID62 + ":req-xyz:allow"
+
+	mockRepo.EXPECT().
+		SystemGetWorkspace(gomock.Any(), workspaceID).
+		Return(model.Workspace{UserID: int64(100)}, nil)
+
+	mockRepo.EXPECT().
+		GetSlackWorkspaceLink(gomock.Any(), workspaceID).
+		Return(model.SlackWorkspaceLink{
+			WorkspaceID:    workspaceID,
+			AccessToken:    encToken,
+			TokenNonce:     nonce,
+			SlackChannelID: "C123",
+		}, nil)
+
+	action := SlackBlockAction{ActionID: actionID, ChannelID: "C123", MessageTS: "ts"}
+	err = c.HandleMCPPermission(context.Background(), action)
+	if err == nil {
+		t.Fatal("expected error when MCP manager is nil")
+	}
+	if !strings.Contains(err.Error(), "MCP manager not available") {
+		t.Errorf("unexpected error message: %v", err)
 	}
 }

--- a/backend/internal/controller/slack/slack_test.go
+++ b/backend/internal/controller/slack/slack_test.go
@@ -16,6 +16,7 @@ import (
 	mock_repo "github.com/agentrq/agentrq/backend/internal/service/mocks/repository"
 	"github.com/agentrq/agentrq/backend/internal/service/security"
 	"github.com/golang/mock/gomock"
+	"github.com/mustafaturan/monoflake"
 	slackapi "github.com/slack-go/slack"
 	"gorm.io/datatypes"
 )
@@ -898,5 +899,144 @@ func TestOnTaskCreated_Success(t *testing.T) {
 	if capturedThread.TaskID != 1 || capturedThread.WorkspaceID != 42 ||
 		capturedThread.SlackChannelID != "C_PROJ" || capturedThread.ThreadTS != "thread-ts-123" {
 		t.Errorf("unexpected SlackTaskThread: %+v", capturedThread)
+	}
+}
+
+func TestHandleTaskApproval_Success_Allow(t *testing.T) {
+	gomockCtrl := gomock.NewController(t)
+	defer gomockCtrl.Finish()
+
+	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
+	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
+	stubSlack := &stubSlackServiceWithUpdateTracking{}
+
+	workspaceID := int64(42)
+	taskID := int64(99)
+	ownerUserID := monoflake.ID(int64(100)).String()
+
+	var capturedReq entity.RespondToTaskRequest
+	var capturedOrigin entity.Origin
+	crud := &mockCRUD{
+		respondToTaskFunc: func(ctx context.Context, req entity.RespondToTaskRequest) (*entity.RespondToTaskResponse, error) {
+			capturedReq = req
+			capturedOrigin = entity.GetOrigin(ctx)
+			return &entity.RespondToTaskResponse{}, nil
+		},
+	}
+
+	c := New(Params{
+		Repository: mockRepo,
+		SlackSvc:   stubSlack,
+		Crud:       crud,
+		MCPManager: &mockMCP{},
+		PubSub:     mockPubSub,
+		TokenKey:   "0123456789abcdef0123456789abcdef",
+		BaseURL:    "https://app.agentrq.com",
+	})
+
+	workspaceID62 := monoflake.ID(workspaceID).String()
+	taskID62 := monoflake.ID(taskID).String()
+	actionID := "task_respond:" + workspaceID62 + ":" + taskID62 + ":allow"
+
+	decToken := "xoxb-test-token"
+	encToken, nonce, err := security.Encrypt(decToken, "0123456789abcdef0123456789abcdef")
+	if err != nil {
+		t.Fatalf("failed to encrypt token: %v", err)
+	}
+
+	mockRepo.EXPECT().
+		SystemGetWorkspace(gomock.Any(), workspaceID).
+		Return(model.Workspace{UserID: int64(100)}, nil)
+
+	mockRepo.EXPECT().
+		GetSlackWorkspaceLink(gomock.Any(), workspaceID).
+		Return(model.SlackWorkspaceLink{
+			WorkspaceID:    workspaceID,
+			AccessToken:    encToken,
+			TokenNonce:     nonce,
+			SlackChannelID: "C123",
+		}, nil)
+
+	action := SlackBlockAction{
+		ActionID:  actionID,
+		ChannelID: "C123",
+		MessageTS: "12345678.90",
+		UserID:    "U_REVIEWER",
+	}
+
+	err = c.HandleTaskApproval(context.Background(), action)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedReq.WorkspaceID != workspaceID {
+		t.Errorf("RespondToTask: expected workspaceID %d, got %d", workspaceID, capturedReq.WorkspaceID)
+	}
+	if capturedReq.TaskID != taskID {
+		t.Errorf("RespondToTask: expected taskID %d, got %d", taskID, capturedReq.TaskID)
+	}
+	if capturedReq.Action != "allow" {
+		t.Errorf("RespondToTask: expected action 'allow', got %q", capturedReq.Action)
+	}
+	if capturedReq.UserID != ownerUserID {
+		t.Errorf("RespondToTask: expected userID %q, got %q", ownerUserID, capturedReq.UserID)
+	}
+	if capturedOrigin != entity.OriginSlack {
+		t.Errorf("RespondToTask: expected OriginSlack in context, got %v", capturedOrigin)
+	}
+	if !stubSlack.updateMessageCalled {
+		t.Error("expected UpdateMessage to be called after approval")
+	}
+	if stubSlack.capturedTS != "12345678.90" {
+		t.Errorf("expected ts '12345678.90', got %q", stubSlack.capturedTS)
+	}
+}
+
+func TestHandleTaskApproval_InvalidActionID(t *testing.T) {
+	c := New(Params{
+		TokenKey: "0123456789abcdef0123456789abcdef",
+		BaseURL:  "https://app.agentrq.com",
+	})
+
+	action := SlackBlockAction{ActionID: "task_respond:only:two"}
+	err := c.HandleTaskApproval(context.Background(), action)
+	if err == nil {
+		t.Fatal("expected error for malformed action_id")
+	}
+	if !strings.Contains(err.Error(), "invalid task_respond action_id") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestHandleTaskApproval_WorkspaceNotFound(t *testing.T) {
+	gomockCtrl := gomock.NewController(t)
+	defer gomockCtrl.Finish()
+
+	mockRepo := mock_repo.NewMockRepository(gomockCtrl)
+	mockPubSub := mock_pubsub.NewMockService(gomockCtrl)
+
+	c := New(Params{
+		Repository: mockRepo,
+		SlackSvc:   &stubSlackService{},
+		Crud:       &mockCRUD{},
+		MCPManager: &mockMCP{},
+		PubSub:     mockPubSub,
+		TokenKey:   "0123456789abcdef0123456789abcdef",
+		BaseURL:    "https://app.agentrq.com",
+	})
+
+	workspaceID := int64(42)
+	workspaceID62 := monoflake.ID(workspaceID).String()
+	taskID62 := monoflake.ID(int64(99)).String()
+	actionID := "task_respond:" + workspaceID62 + ":" + taskID62 + ":allow"
+
+	mockRepo.EXPECT().
+		SystemGetWorkspace(gomock.Any(), workspaceID).
+		Return(model.Workspace{}, fmt.Errorf("not found"))
+
+	action := SlackBlockAction{ActionID: actionID, ChannelID: "C123", MessageTS: "ts"}
+	err := c.HandleTaskApproval(context.Background(), action)
+	if err == nil {
+		t.Fatal("expected error when workspace is not found")
 	}
 }

--- a/backend/internal/handler/api/event_test.go
+++ b/backend/internal/handler/api/event_test.go
@@ -27,6 +27,7 @@ type mockEventCrud struct {
 	listEventTriggersFunc  func(ctx context.Context, req entity.ListEventTriggersRequest) (*entity.ListEventTriggersResponse, error)
 	deleteEventTriggerFunc func(ctx context.Context, req entity.DeleteEventTriggerRequest) error
 	listTasksFromEventFunc func(ctx context.Context, req entity.ListTasksFromEventRequest) (*entity.ListTasksFromEventResponse, error)
+	updateEventFunc        func(ctx context.Context, req entity.UpdateEventRequest) (*entity.UpdateEventResponse, error)
 }
 
 func (m *mockEventCrud) CreateEvent(ctx context.Context, req entity.CreateEventRequest) (*entity.CreateEventResponse, error) {
@@ -53,6 +54,9 @@ func (m *mockEventCrud) DeleteEventTrigger(ctx context.Context, req entity.Delet
 func (m *mockEventCrud) ListTasksFromEvent(ctx context.Context, req entity.ListTasksFromEventRequest) (*entity.ListTasksFromEventResponse, error) {
 	return m.listTasksFromEventFunc(ctx, req)
 }
+func (m *mockEventCrud) UpdateEvent(ctx context.Context, req entity.UpdateEventRequest) (*entity.UpdateEventResponse, error) {
+	return m.updateEventFunc(ctx, req)
+}
 
 func newEventApp(ctrl *mockEventCrud) *fiber.App {
 	app := fiber.New()
@@ -72,6 +76,10 @@ func newEventApp(ctrl *mockEventCrud) *fiber.App {
 	app.Delete("/events/:id", func(c *fiber.Ctx) error {
 		c.Locals("user_id", "user1")
 		return h.deleteEvent()(c)
+	})
+	app.Patch("/events/:id", func(c *fiber.Ctx) error {
+		c.Locals("user_id", "user1")
+		return h.updateEvent()(c)
 	})
 	app.Post("/events/:id/triggers", func(c *fiber.Ctx) error {
 		c.Locals("user_id", "user1")
@@ -434,5 +442,82 @@ func TestListTasksFromEvent_InvalidEventID(t *testing.T) {
 
 	if resp.StatusCode != http.StatusUnprocessableEntity {
 		t.Errorf("expected 422, got %d", resp.StatusCode)
+	}
+}
+
+// ── updateEvent ───────────────────────────────────────────────────────────────
+
+func TestUpdateEvent_OK(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.updateEventFunc = func(_ context.Context, req entity.UpdateEventRequest) (*entity.UpdateEventResponse, error) {
+		return &entity.UpdateEventResponse{Event: entity.Event{ID: req.ID, PayloadGuidelines: req.PayloadGuidelines}}, nil
+	}
+	app := newEventApp(ctrl)
+
+	body := []byte(`{"payloadGuidelines":"describe what was deployed"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/events/"+testEventID, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestUpdateEvent_InvalidID(t *testing.T) {
+	app := newEventApp(&mockEventCrud{})
+
+	req := httptest.NewRequest(http.MethodPatch, "/events/!!!", bytes.NewReader([]byte(`{"payloadGuidelines":"x"}`)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d", resp.StatusCode)
+	}
+}
+
+func TestUpdateEvent_InvalidPayload(t *testing.T) {
+	app := newEventApp(&mockEventCrud{})
+
+	req := httptest.NewRequest(http.MethodPatch, "/events/"+testEventID, bytes.NewReader([]byte(`{bad json`)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d", resp.StatusCode)
+	}
+}
+
+func TestUpdateEvent_NotFound(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.updateEventFunc = func(_ context.Context, _ entity.UpdateEventRequest) (*entity.UpdateEventResponse, error) {
+		return nil, base.ErrNotFound
+	}
+	app := newEventApp(ctrl)
+
+	body := []byte(`{"payloadGuidelines":"x"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/events/"+testEventID, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestUpdateEvent_ControllerError(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.updateEventFunc = func(_ context.Context, _ entity.UpdateEventRequest) (*entity.UpdateEventResponse, error) {
+		return nil, errors.New("db unavailable")
+	}
+	app := newEventApp(ctrl)
+
+	body := []byte(`{"payloadGuidelines":"x"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/events/"+testEventID, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", resp.StatusCode)
 	}
 }


### PR DESCRIPTION
Hey folks 👋 — first contribution here, so please let me know if anything needs adjusting.

I was exploring the codebase and noticed three places where the implementation existed but the tests didn't quite cover the full contract. This PR fills those gaps.

## What's covered

**`updateEvent` handler** (`handler/api/event_test.go`)

The `PATCH /events/:id` handler had no tests at all — every sibling (create, list, get, delete) was covered, but update was missing. Added five cases: happy path (200), invalid base62 ID (422), malformed JSON body (422), not-found from the controller (404), and a generic controller error (500). Also extended `mockEventCrud` and `newEventApp` to support the PATCH route.

**`OnTaskCreated` success path** (`controller/slack/slack_test.go`)

The only existing `OnTaskCreated` test covered the `channel_not_found` failure. The happy path — where the task gets posted to Slack and the thread is upserted — was untested. The new test verifies that `PostMessage` is called on the right channel and that `UpsertSlackTaskThread` receives the correct `TaskID`, `WorkspaceID`, `SlackChannelID`, and `ThreadTS`.

**`HandleTaskApproval`** (`controller/slack/slack_test.go`)

No tests existed for this handler. Added three: a success case that asserts the full `RespondToTask` call (workspace, task, action, owner user ID, and that `OriginSlack` is set on the context), a malformed action_id case, and a workspace-not-found case.

**`HandleMCPPermission`** (`controller/slack/slack_test.go`)

Also untested. Added three: a success case that exercises the metadata-tagging path (verifying `decided_in_slack`, `slack_user_id`, and `slack_user_name` are written correctly) and asserts all five `SendPermissionVerdict` arguments; a malformed action_id case; and a nil-MCP-manager case.

## Scaffolding changes

To make the Slack tests work properly, `mockCRUD.RespondToTask` was changed from a hardcoded `return nil, nil` to a func-field dispatch (nil-safe, backward-compatible), and `mockMCP` was extended with a `capturedVerdict` field so tests can assert what `SendPermissionVerdict` actually received.

## Notes

- No production code touched — test files only
- `github.com/golang/mock@v1.6.0` doesn't have `gomock.MatchedBy`, so argument capture uses `DoAndReturn` closures instead
- All 21 test packages pass