### PR TITLE
docs: clarify Codex Gateway Windows startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,14 @@ codex-gateway
 codex-gateway -- codex app-server
 ```
 
+> **Windows PowerShell:** `codex-gateway -- codex app-server` may fail with `spawn codex ENOENT` when Codex is installed through npm. Until [agentrq/codex-gateway#2](https://github.com/agentrq/codex-gateway/issues/2) is fixed, pass the absolute Codex executable path:
+
+```powershell
+& "$env:APPDATA\npm\codex-gateway.cmd" -- "$env:APPDATA\npm\node_modules\@openai\codex\node_modules\@openai\codex-win32-x64\vendor\x86_64-pc-windows-msvc\bin\codex.exe" app-server
+```
+
+If your npm global directory or Codex package path differs, replace those paths with the locations on your machine.
+
 ## 👑 Supervisor (CoreMCP)
 
 While individual workspaces provide a scoped view for specific projects, the **Supervisor (CoreMCP)** is a global MCP server that grants an agent bird's-eye view and management capabilities across your entire AgentRQ account.

--- a/frontend/src/views/WorkspaceSettingsView.vue
+++ b/frontend/src/views/WorkspaceSettingsView.vue
@@ -146,6 +146,10 @@
                             {{ copiedState.codexStart ? 'Copied!' : 'Copy' }}
                           </button>
                         </div>
+                        <p class="text-[10px] text-amber-700 dark:text-amber-400 font-semibold leading-relaxed">
+                          Windows PowerShell users may see <code class="font-mono">spawn codex ENOENT</code>. See:
+                          <a href="https://github.com/agentrq/codex-gateway/issues/2" target="_blank" rel="noopener noreferrer" class="underline decoration-amber-300 underline-offset-2">agentrq/codex-gateway#2</a>.
+                        </p>
                       </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- add a Windows PowerShell note to the Codex Gateway README usage section
- link the Setup UI Codex tab to the tracked codex-gateway Windows launch issue
- keep the existing setup command unchanged while warning about the known Windows failure mode

## Testing
- npm run build
- git diff --check

Closes #207