### PR TITLE
fix(scheduler): only treat both-fixed DOM+month crons as one-time (#225)

### DIFF
--- a/backend/internal/service/scheduler/scheduler.go
+++ b/backend/internal/service/scheduler/scheduler.go
@@ -141,9 +141,13 @@ func (s *scheduler) spawn(ctx context.Context, parent model.Task) {
 		Payload: mapper.FromModelTaskToView(created),
 	})
 
-	// If this is a one-time schedule, delete the parent template now that we've spawned it
+	// If this is a one-time schedule, delete the parent template now that we've spawned it.
+	// A schedule is one-time only when BOTH day-of-month and month are fixed (e.g.
+	// "0 9 1 1 *"), matching the frontend contract (useCron.js and the task-form
+	// generators). A fixed month with a wildcard day-of-month (e.g. "0 9 * 6 *" —
+	// every day in June) is recurring and must keep its parent template.
 	parts := strings.Fields(parent.CronSchedule)
-	if len(parts) == 5 && parts[3] != "*" {
+	if len(parts) == 5 && parts[2] != "*" && parts[3] != "*" {
 		err := s.repo.DeleteTask(ctx, parent.WorkspaceID, parent.ID, parent.UserID)
 		if err != nil {
 			zlog.Error().Err(err).Int64("cron_id", parent.ID).Msg("scheduler: failed to delete one-time parent task")

--- a/backend/internal/service/scheduler/scheduler_test.go
+++ b/backend/internal/service/scheduler/scheduler_test.go
@@ -81,6 +81,52 @@ func TestScheduler(t *testing.T) {
 		s.(*scheduler).tick(context.Background())
 	})
 
+	// A fixed-month schedule whose day-of-month is a wildcard (e.g. "9:00 every
+	// day in June") is a RECURRING schedule per the frontend contract
+	// (useCron.js / the task-form generators treat a cron as one-time only when
+	// BOTH day-of-month and month are specific). The scheduler must not delete
+	// the parent template after the first spawn.
+	t.Run("SpawnRecurringFixedMonthKeepsParent", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockRepo := mock_repo.NewMockRepository(ctrl)
+		mockIdgen := mock_idgen.NewMockService(ctrl)
+		mockPubSub := mock_pubsub.NewMockService(ctrl)
+		s := New(mockRepo, mockIdgen, bus, mockPubSub)
+
+		task := model.Task{ID: 1, WorkspaceID: 10, UserID: 1, CronSchedule: "0 9 * 6 *"}
+		mockRepo.EXPECT().SystemCheckTaskExists(gomock.Any(), int64(10), int64(1), "notstarted").Return(false, nil)
+		mockRepo.EXPECT().SystemCheckTaskExists(gomock.Any(), int64(10), int64(1), "ongoing").Return(false, nil)
+		mockIdgen.EXPECT().NextID().Return(int64(2))
+		mockRepo.EXPECT().CreateTask(gomock.Any(), gomock.Any()).Return(model.Task{ID: 2}, nil)
+		mockPubSub.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(&pubsub.PublishResponse{}, nil).AnyTimes()
+		// No DeleteTask expectation: gomock fails the test if spawn deletes the parent.
+
+		s.(*scheduler).spawn(context.Background(), task)
+	})
+
+	// A true one-time schedule has BOTH day-of-month and month specific (the
+	// shape the frontend emits for "run once at <datetime>"). The parent
+	// template must be deleted after it spawns its single run.
+	t.Run("SpawnOneTimeDeletesParent", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockRepo := mock_repo.NewMockRepository(ctrl)
+		mockIdgen := mock_idgen.NewMockService(ctrl)
+		mockPubSub := mock_pubsub.NewMockService(ctrl)
+		s := New(mockRepo, mockIdgen, bus, mockPubSub)
+
+		task := model.Task{ID: 1, WorkspaceID: 10, UserID: 1, CronSchedule: "0 9 1 1 *"}
+		mockRepo.EXPECT().SystemCheckTaskExists(gomock.Any(), int64(10), int64(1), "notstarted").Return(false, nil)
+		mockRepo.EXPECT().SystemCheckTaskExists(gomock.Any(), int64(10), int64(1), "ongoing").Return(false, nil)
+		mockIdgen.EXPECT().NextID().Return(int64(2))
+		mockRepo.EXPECT().CreateTask(gomock.Any(), gomock.Any()).Return(model.Task{ID: 2}, nil)
+		mockPubSub.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(&pubsub.PublishResponse{}, nil).AnyTimes()
+		mockRepo.EXPECT().DeleteTask(gomock.Any(), int64(10), int64(1), int64(1)).Return(nil)
+
+		s.(*scheduler).spawn(context.Background(), task)
+	})
+
 	t.Run("SpawnExists", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()


### PR DESCRIPTION
## Summary

Fixes #225.

The scheduler deleted a recurring task's parent template after the first run whenever the cron's **month** field was fixed — because it classified "one-time" as `parts[3] != "*"` (month only). That silently breaks fixed-month recurring schedules such as `0 9 * 6 *` ("9:00 every day in June"): the UI shows them as recurring, but they fire once and disappear.

This aligns the backend with the frontend's own definition of one-time, which requires **both** day-of-month and month to be fixed:

- `frontend/src/composables/useCron.js`: `parts[2] !== '*' && parts[3] !== '*'`
- `frontend/src/views/TaskFormView.vue` and `EventDetailView.vue` one-time generators emit `<min> <hour> <dom> <month> *` (both fixed); every recurring preset keeps month `*`.

## Change

```go
// scheduler.go, spawn()
-if len(parts) == 5 && parts[3] != "*" {
+if len(parts) == 5 && parts[2] != "*" && parts[3] != "*" {
```

This only changes behavior for the `* <fixed-month>` pattern (the bug). Genuine one-time schedules the UI emits (both DOM + month fixed, e.g. `0 9 1 1 *`) still delete their parent as before. The check can only ever err toward *keeping* a schedule, never wrongly deleting one.

## Tests

Added two regression subtests in `scheduler_test.go`:

- `SpawnRecurringFixedMonthKeepsParent` — `0 9 * 6 *` spawns a run but the parent is **not** deleted (fails on the old code: unexpected `DeleteTask`).
- `SpawnOneTimeDeletesParent` — `0 9 1 1 *` spawns its single run and the parent **is** deleted (guards against regressing one-time behavior).

`go test ./internal/...` is green across the suite.
