### PR TITLE
Redact sensitive MCP request headers

### DIFF
--- a/backend/internal/handler/coremcp/coremcp.go
+++ b/backend/internal/handler/coremcp/coremcp.go
@@ -110,6 +110,15 @@ func getTokenVal(r *http.Request) string {
 	return ""
 }
 
+func loggedHeaderValue(name string, values []string) string {
+	switch strings.ToLower(name) {
+	case "authorization", "cookie", "set-cookie", "x-api-key", "x-auth-token":
+		return "[REDACTED]"
+	default:
+		return strings.Join(values, ", ")
+	}
+}
+
 func sendJSONRPCError(w http.ResponseWriter, message string, code int, httpStatus int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(httpStatus)
@@ -152,11 +161,7 @@ func (h *handler) streamableHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ev := zlog.Debug().Str("method", r.Method).Str("path", r.URL.Path).Str("remote", r.RemoteAddr)
 		for k, v := range r.Header {
-			if strings.ToLower(k) == "authorization" {
-				ev = ev.Str("h_"+strings.ToLower(k), "[REDACTED]")
-				continue
-			}
-			ev = ev.Str("h_"+strings.ToLower(k), strings.Join(v, ", "))
+			ev = ev.Str("h_"+strings.ToLower(k), loggedHeaderValue(k, v))
 		}
 		ev.Msg("CoreMCP call")
 

--- a/backend/internal/handler/coremcp/logging_test.go
+++ b/backend/internal/handler/coremcp/logging_test.go
@@ -1,0 +1,46 @@
+package coremcp
+
+import "testing"
+
+func TestLoggedHeaderValueRedactsSensitiveHeaders(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		values []string
+		want   string
+	}{
+		{
+			name:   "authorization",
+			header: "Authorization",
+			values: []string{"Bearer secret-token"},
+			want:   "[REDACTED]",
+		},
+		{
+			name:   "cookie",
+			header: "Cookie",
+			values: []string{"at=session-token; theme=light"},
+			want:   "[REDACTED]",
+		},
+		{
+			name:   "api key",
+			header: "X-Api-Key",
+			values: []string{"secret-key"},
+			want:   "[REDACTED]",
+		},
+		{
+			name:   "safe header",
+			header: "Mcp-Protocol-Version",
+			values: []string{"2024-11-05"},
+			want:   "2024-11-05",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := loggedHeaderValue(tt.header, tt.values)
+			if got != tt.want {
+				t.Fatalf("loggedHeaderValue(%q) = %q, want %q", tt.header, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/handler/mcp/logging_test.go
+++ b/backend/internal/handler/mcp/logging_test.go
@@ -1,0 +1,46 @@
+package mcp
+
+import "testing"
+
+func TestLoggedHeaderValueRedactsSensitiveHeaders(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		values []string
+		want   string
+	}{
+		{
+			name:   "authorization",
+			header: "Authorization",
+			values: []string{"Bearer secret-token"},
+			want:   "[REDACTED]",
+		},
+		{
+			name:   "cookie",
+			header: "Cookie",
+			values: []string{"at=session-token; theme=light"},
+			want:   "[REDACTED]",
+		},
+		{
+			name:   "api key",
+			header: "X-Api-Key",
+			values: []string{"secret-key"},
+			want:   "[REDACTED]",
+		},
+		{
+			name:   "safe header",
+			header: "Mcp-Protocol-Version",
+			values: []string{"2024-11-05"},
+			want:   "2024-11-05",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := loggedHeaderValue(tt.header, tt.values)
+			if got != tt.want {
+				t.Fatalf("loggedHeaderValue(%q) = %q, want %q", tt.header, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -116,6 +116,15 @@ func getTokenVal(r *http.Request) string {
 	return ""
 }
 
+func loggedHeaderValue(name string, values []string) string {
+	switch strings.ToLower(name) {
+	case "authorization", "cookie", "set-cookie", "x-api-key", "x-auth-token":
+		return "[REDACTED]"
+	default:
+		return strings.Join(values, ", ")
+	}
+}
+
 func sendJSONRPCError(w http.ResponseWriter, message string, code int, httpStatus int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(httpStatus)
@@ -168,11 +177,7 @@ func (h *handler) streamableHandler() http.Handler {
 		// Log all incoming MCP calls with headers
 		ev := zlog.Debug().Str("method", r.Method).Str("path", r.URL.Path).Str("remote", r.RemoteAddr)
 		for k, v := range r.Header {
-			if strings.ToLower(k) == "authorization" {
-				ev = ev.Str("h_"+strings.ToLower(k), "[REDACTED]")
-				continue
-			}
-			ev = ev.Str("h_"+strings.ToLower(k), strings.Join(v, ", "))
+			ev = ev.Str("h_"+strings.ToLower(k), loggedHeaderValue(k, v))
 		}
 		ev.Msg("MCP call")
 


### PR DESCRIPTION
## Summary
- Redact sensitive request headers in MCP and CoreMCP debug logs.
- Add regression tests for header redaction rules.

## Why
MCP handlers accept credentials through more than just the `Authorization` header. When debug logging is enabled, cookie-based sessions and API-key style headers could be written to structured logs. This keeps useful protocol headers visible while preventing credential disclosure.

## Validation
- `go test ./internal/handler/mcp ./internal/handler/coremcp`
- `make test`
- `go test ./...`
- `npm --prefix frontend run build`
- `git diff --check`
