### PR TITLE
fix(tasks): atomic dequeue, MCP status validation, pubsub send-on-closed race

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -305,6 +305,14 @@ func New(cfg Config) (*App, error) {
 				if err != nil {
 					return model.Task{}, err
 				}
+				// Validate the transition with the same rules the REST path enforces, so an
+				// agent cannot persist an arbitrary status or mutate a cron template through MCP.
+				if !crud.IsValidTaskStatus(status) {
+					return model.Task{}, fmt.Errorf("invalid task status: %s", status)
+				}
+				if m.Status == "cron" {
+					return model.Task{}, fmt.Errorf("cannot change the status of a cron task template")
+				}
 				if m.Status == status {
 					return m, nil
 				}
@@ -380,7 +388,17 @@ func New(cfg Config) (*App, error) {
 			},
 			func(ctx context.Context) (model.Task, error) {
 				uid := monoflake.IDFromBase62(workspaceOwner).Int64()
-				return repo.GetNextTask(ctx, workspaceID, uid)
+				t, err := repo.ClaimNextTask(ctx, workspaceID, uid)
+				if err != nil {
+					return model.Task{}, err
+				}
+				// The task was atomically transitioned to "ongoing" as it was claimed;
+				// notify the human UI so the dashboard reflects that an agent picked it up.
+				bus.Publish(workspaceID, workspaceOwner, eventbus.Event{
+					Type:    "task.updated",
+					Payload: mapper.FromModelTaskToView(t),
+				})
+				return t, nil
 			},
 			func(ctx context.Context, chatID string, text string, attachments []entity.Attachment, metadata any) (int64, error) {
 				id := monoflake.IDFromBase62(chatID)

--- a/backend/internal/controller/crud/is_valid_task_status_test.go
+++ b/backend/internal/controller/crud/is_valid_task_status_test.go
@@ -1,0 +1,16 @@
+package crud
+
+import "testing"
+
+func TestIsValidTaskStatus(t *testing.T) {
+	for _, s := range []string{"notstarted", "ongoing", "completed", "rejected", "cron", "blocked"} {
+		if !IsValidTaskStatus(s) {
+			t.Errorf("expected %q to be valid", s)
+		}
+	}
+	for _, s := range []string{"", "garbage", "Ongoing", "done", "complete", "COMPLETED"} {
+		if IsValidTaskStatus(s) {
+			t.Errorf("expected %q to be invalid", s)
+		}
+	}
+}

--- a/backend/internal/controller/crud/task.go
+++ b/backend/internal/controller/crud/task.go
@@ -766,6 +766,11 @@ func isValidTaskStatus(status string) bool {
 	return false
 }
 
+// IsValidTaskStatus reports whether status is a recognized task status. It is the single
+// source of truth for status validation, exported so other entry points (e.g. the MCP tool
+// layer) enforce the same rule as the REST path rather than duplicating the list.
+func IsValidTaskStatus(status string) bool { return isValidTaskStatus(status) }
+
 func validateCronForContext(ctx context.Context, cronSchedule string) error {
 	if auth.ContextHasAudience(ctx, auth.ActorHumanAudience) {
 		return schedule.ValidateCronSyntax(cronSchedule)

--- a/backend/internal/repository/base/claim_next_task_test.go
+++ b/backend/internal/repository/base/claim_next_task_test.go
@@ -1,0 +1,151 @@
+package base
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func newTaskRepo(t *testing.T) (Repository, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.AutoMigrate(&model.Task{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return New(&mockDB{db: db}), db
+}
+
+func TestClaimNextTask_MarksOngoing(t *testing.T) {
+	repo, db := newTaskRepo(t)
+	ctx := context.Background()
+	ws, uid := int64(100), int64(1)
+	db.Create(&model.Task{ID: 10, WorkspaceID: ws, UserID: uid, Status: "notstarted", Assignee: "agent", CreatedAt: time.Now()})
+
+	got, err := repo.ClaimNextTask(ctx, ws, uid)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if got.ID != 10 {
+		t.Fatalf("claimed id = %d, want 10", got.ID)
+	}
+	if got.Status != "ongoing" {
+		t.Fatalf("returned status = %q, want ongoing", got.Status)
+	}
+	var reloaded model.Task
+	db.First(&reloaded, 10)
+	if reloaded.Status != "ongoing" {
+		t.Fatalf("persisted status = %q, want ongoing", reloaded.Status)
+	}
+}
+
+// A claimed task must not be handed out again; the queue drains exactly once and in
+// priority order (SortOrder asc, then CreatedAt, then id).
+func TestClaimNextTask_DrainsQueueInOrder(t *testing.T) {
+	repo, db := newTaskRepo(t)
+	ctx := context.Background()
+	ws, uid := int64(100), int64(1)
+	now := time.Now()
+	db.Create(&model.Task{ID: 10, WorkspaceID: ws, UserID: uid, Status: "notstarted", Assignee: "agent", SortOrder: 0, CreatedAt: now}) // fallback -> epoch(now), large
+	db.Create(&model.Task{ID: 11, WorkspaceID: ws, UserID: uid, Status: "notstarted", Assignee: "agent", SortOrder: 5, CreatedAt: now})
+	db.Create(&model.Task{ID: 12, WorkspaceID: ws, UserID: uid, Status: "notstarted", Assignee: "agent", SortOrder: 10, CreatedAt: now})
+
+	wantOrder := []int64{11, 12, 10} // 5 < 10 < epoch(now)
+	for i, want := range wantOrder {
+		got, err := repo.ClaimNextTask(ctx, ws, uid)
+		if err != nil {
+			t.Fatalf("claim %d: %v", i, err)
+		}
+		if got.ID != want {
+			t.Fatalf("claim %d = %d, want %d", i, got.ID, want)
+		}
+	}
+	if _, err := repo.ClaimNextTask(ctx, ws, uid); err != ErrNotFound {
+		t.Fatalf("empty queue: got %v, want ErrNotFound", err)
+	}
+}
+
+func TestClaimNextTask_RespectsFilters(t *testing.T) {
+	repo, db := newTaskRepo(t)
+	ctx := context.Background()
+	ws, uid := int64(100), int64(1)
+	db.Create(&model.Task{ID: 1, WorkspaceID: ws, UserID: uid, Status: "ongoing", Assignee: "agent"})     // wrong status
+	db.Create(&model.Task{ID: 2, WorkspaceID: ws, UserID: uid, Status: "notstarted", Assignee: "human"})  // wrong assignee
+	db.Create(&model.Task{ID: 3, WorkspaceID: 999, UserID: uid, Status: "notstarted", Assignee: "agent"}) // wrong workspace
+	db.Create(&model.Task{ID: 4, WorkspaceID: ws, UserID: 999, Status: "notstarted", Assignee: "agent"})  // wrong user
+
+	if _, err := repo.ClaimNextTask(ctx, ws, uid); err != ErrNotFound {
+		t.Fatalf("got %v, want ErrNotFound (no eligible task)", err)
+	}
+}
+
+// The core regression: many concurrent claimers must never receive the same task.
+func TestClaimNextTask_ConcurrentNoDoubleClaim(t *testing.T) {
+	dsn := "file:" + filepath.Join(t.TempDir(), "claim.db") + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	sqlDB, _ := db.DB()
+	defer sqlDB.Close() // release the file handle so TempDir cleanup can remove it on Windows
+	if err := db.AutoMigrate(&model.Task{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	repo := New(&mockDB{db: db})
+	ctx := context.Background()
+	ws, uid := int64(100), int64(1)
+
+	const tasks = 25
+	for i := 0; i < tasks; i++ {
+		db.Create(&model.Task{ID: int64(1000 + i), WorkspaceID: ws, UserID: uid, Status: "notstarted", Assignee: "agent", SortOrder: float64(i + 1)})
+	}
+
+	const goroutines = 40
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	claimed := map[int64]int{}
+	notFound := 0
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			got, err := repo.ClaimNextTask(ctx, ws, uid)
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case err == ErrNotFound:
+				notFound++
+			case err != nil:
+				t.Errorf("unexpected claim error: %v", err)
+			default:
+				claimed[got.ID]++
+			}
+		}()
+	}
+	wg.Wait()
+
+	if len(claimed) != tasks {
+		t.Errorf("distinct tasks claimed = %d, want %d", len(claimed), tasks)
+	}
+	for id, c := range claimed {
+		if c != 1 {
+			t.Errorf("task %d was claimed %d times (must be exactly once)", id, c)
+		}
+	}
+	if notFound != goroutines-tasks {
+		t.Errorf("ErrNotFound count = %d, want %d", notFound, goroutines-tasks)
+	}
+	var stillPending int64
+	db.Model(&model.Task{}).Where("status = ?", "notstarted").Count(&stillPending)
+	if stillPending != 0 {
+		t.Errorf("%d tasks left notstarted, want 0", stillPending)
+	}
+}

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -51,6 +51,7 @@ type Repository interface {
 	CreateUser(ctx context.Context, u model.User) (model.User, error)
 	UpdateUser(ctx context.Context, u model.User) (model.User, error)
 	GetNextTask(ctx context.Context, workspaceID int64, userID int64) (model.Task, error)
+	ClaimNextTask(ctx context.Context, workspaceID int64, userID int64) (model.Task, error)
 	GetGlobalTaskStats(ctx context.Context, userID int64) (entity.GlobalTaskStatsResponse, error)
 
 	// Slack integration
@@ -316,6 +317,55 @@ func (r *repository) GetNextTask(ctx context.Context, workspaceID int64, userID 
 		return model.Task{}, ErrNotFound
 	}
 	return t, err
+}
+
+// ClaimNextTask atomically dequeues the next notstarted, agent-assigned task in the
+// workspace and transitions it to "ongoing" in a single step, so two concurrent agents
+// (or the poller racing a getTask call) can never receive the same task. The claim is a
+// conditional UPDATE guarded by status = 'notstarted': for a given task exactly one caller
+// observes RowsAffected == 1; losers see 0 and retry with the next candidate. This is
+// atomic on both SQLite (writes are globally serialized) and PostgreSQL (row lock held for
+// the UPDATE), so it needs no dialect-specific FOR UPDATE / RETURNING clause.
+func (r *repository) ClaimNextTask(ctx context.Context, workspaceID int64, userID int64) (model.Task, error) {
+	dialect := r.conn(ctx).Dialector.Name()
+	var sortExpr string
+	if dialect == "sqlite" {
+		sortExpr = "(CASE WHEN sort_order > 0 THEN sort_order ELSE CAST(strftime('%s', created_at) AS REAL) END)"
+	} else {
+		// Assume Postgres
+		sortExpr = "(CASE WHEN sort_order > 0 THEN sort_order ELSE EXTRACT(EPOCH FROM created_at) END)"
+	}
+	order := fmt.Sprintf("%s ASC, id ASC", sortExpr)
+
+	// Bound the retry loop: a caller only loops when another caller claimed the same
+	// candidate first, which means the queue is draining, so this terminates quickly.
+	const maxAttempts = 128
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		var t model.Task
+		err := r.conn(ctx).
+			Where("workspace_id = ? AND user_id = ? AND status = ? AND assignee = ?", workspaceID, userID, "notstarted", "agent").
+			Order(order).
+			First(&t).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return model.Task{}, ErrNotFound
+		}
+		if err != nil {
+			return model.Task{}, err
+		}
+
+		res := r.conn(ctx).Model(&model.Task{}).
+			Where("id = ? AND status = ?", t.ID, "notstarted").
+			Updates(map[string]any{"status": "ongoing", "updated_at": time.Now()})
+		if res.Error != nil {
+			return model.Task{}, res.Error
+		}
+		if res.RowsAffected == 1 {
+			t.Status = "ongoing"
+			return t, nil
+		}
+		// Lost the race for this task; another caller claimed it first. Try the next one.
+	}
+	return model.Task{}, ErrNotFound
 }
 
 func (r *repository) UpdateTask(ctx context.Context, t model.Task) (model.Task, error) {

--- a/backend/internal/service/pubsub/pubsub.go
+++ b/backend/internal/service/pubsub/pubsub.go
@@ -238,25 +238,35 @@ func (c *service) publish(id int64, e any) (int, error) {
 	}
 
 	pubsub.mutex.RLock()
-	subscribers := make([]subscriber, len(pubsub.subscribers))
-	copy(subscribers, pubsub.subscribers)
+	n := len(pubsub.subscribers)
 	pubsub.mutex.RUnlock()
 
-	go func(e any, subscribers []subscriber) {
+	go func(e any) {
 		timeoutDuration := c.cfg.MaxDurationForSubscriberToReceive
 		opCtx, cancel := context.WithTimeout(context.Background(), timeoutDuration)
 		defer cancel()
+
+		// Hold the read lock for the whole fan-out. Unsubscribe and Delete take the write
+		// lock before they close a subscriber's channel, so while any publish holds the
+		// read lock no channel can be closed mid-send. This removes the send-on-closed data
+		// race; publishers still fan out concurrently since RWMutex permits many readers.
+		pubsub.mutex.RLock()
+		defer pubsub.mutex.RUnlock()
+
 		wg := sync.WaitGroup{}
-		for _, s := range subscribers {
+		for _, s := range pubsub.subscribers {
 			wg.Add(1)
 			go func(s subscriber) {
 				defer wg.Done()
 
+				// Defensive only: the read-lock discipline above already prevents a
+				// send-on-closed, but recovering keeps one bad subscriber from taking
+				// down the whole bus.
 				defer func() {
 					if r := recover(); r != nil {
 						zlog.Warn().
 							Int64("subscriber_id", s.id).
-							Msg(_logPrefix + "recovered from panic (likely send on closed channel)")
+							Msg(_logPrefix + "recovered from panic in subscriber send")
 					}
 				}()
 
@@ -268,9 +278,9 @@ func (c *service) publish(id int64, e any) (int, error) {
 			}(s)
 		}
 		wg.Wait()
-	}(e, subscribers)
+	}(e)
 
-	return len(subscribers), nil
+	return n, nil
 }
 
 // utility functions

--- a/backend/internal/service/pubsub/pubsub_concurrency_test.go
+++ b/backend/internal/service/pubsub/pubsub_concurrency_test.go
@@ -1,0 +1,141 @@
+package pubsub
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type fakeIDGen struct{ n int64 }
+
+func (f *fakeIDGen) NextID() int64 { return atomic.AddInt64(&f.n, 1) }
+
+func newTestPubSub() *service {
+	return &service{
+		cfg:   pubsubConfig{MaxDurationForSubscriberToReceive: 500 * time.Millisecond},
+		idgen: &fakeIDGen{},
+	}
+}
+
+func TestPubSub_Delivery(t *testing.T) {
+	svc := newTestPubSub()
+	ctx := context.Background()
+	cr, _ := svc.Create(ctx, CreatePubSubRequest{ID: 1})
+	sub, err := svc.Subscribe(ctx, SubscribeRequest{PubSubID: cr.ID})
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	if _, err := svc.Publish(ctx, PublishRequest{PubSubID: cr.ID, Event: "hello"}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	select {
+	case e := <-sub.Events:
+		if e != "hello" {
+			t.Fatalf("got %v, want hello", e)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no delivery within timeout")
+	}
+}
+
+func TestPubSub_UnsubscribeStopsDelivery(t *testing.T) {
+	svc := newTestPubSub()
+	ctx := context.Background()
+	svc.Create(ctx, CreatePubSubRequest{ID: 1})
+	subA, _ := svc.Subscribe(ctx, SubscribeRequest{PubSubID: 1})
+	subB, _ := svc.Subscribe(ctx, SubscribeRequest{PubSubID: 1})
+
+	if err := svc.Unsubscribe(ctx, UnsubscribeRequest{PubSubID: 1, ID: subA.ID}); err != nil {
+		t.Fatalf("unsubscribe: %v", err)
+	}
+
+	// Drain B so the fan-out can complete.
+	bGot := make(chan any, 1)
+	go func() { bGot <- <-subB.Events }()
+
+	if _, err := svc.Publish(ctx, PublishRequest{PubSubID: 1, Event: "x"}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	select {
+	case v := <-bGot:
+		if v != "x" {
+			t.Fatalf("B got %v, want x", v)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("remaining subscriber B did not receive")
+	}
+
+	// A was unsubscribed: it must not receive a value (its channel is closed).
+	select {
+	case _, ok := <-subA.Events:
+		if ok {
+			t.Fatal("unsubscribed subscriber A received a value")
+		}
+	case <-time.After(time.Second):
+		// No value delivered is also acceptable.
+	}
+}
+
+// Previously, publish sent on subscriber channels after releasing the lock, racing
+// Unsubscribe/Delete which close them (a send-on-closed panic, only masked by recover).
+// This churns publishes against subscribe/unsubscribe and must complete with no panic
+// and no deadlock.
+func TestPubSub_ConcurrentPublishUnsubscribe(t *testing.T) {
+	svc := newTestPubSub()
+	ctx := context.Background()
+	svc.Create(ctx, CreatePubSubRequest{ID: 1})
+
+	// A stable subscriber that always drains.
+	stable, _ := svc.Subscribe(ctx, SubscribeRequest{PubSubID: 1})
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			case <-stable.Events:
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for p := 0; p < 8; p++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				svc.Publish(ctx, PublishRequest{PubSubID: 1, Event: i})
+			}
+		}()
+	}
+	for c := 0; c < 8; c++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				s, err := svc.Subscribe(ctx, SubscribeRequest{PubSubID: 1})
+				if err != nil {
+					continue
+				}
+				// Drain until the channel is closed by Unsubscribe.
+				go func(ch chan any) {
+					for range ch {
+					}
+				}(s.Events)
+				svc.Unsubscribe(ctx, UnsubscribeRequest{PubSubID: 1, ID: s.ID})
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("deadlock: concurrent publish/unsubscribe did not finish")
+	}
+	close(stop)
+}


### PR DESCRIPTION
Fixes #229.

Three correctness bugs in the task-execution path:

1. **Atomic dequeue.** `getTask` (no id) used `GetNextTask`, a plain `SELECT ... First` that never changed status, so two agents (or the poller racing a `getTask`) got the same task. Adds `ClaimNextTask`: selects the next `notstarted` agent task and claims it with a conditional `UPDATE ... WHERE status='notstarted'`; exactly one caller gets `RowsAffected==1`, losers retry the next candidate. Atomic on both SQLite (serialized writes) and Postgres (row lock), no `FOR UPDATE`/`RETURNING` needed. `GetNextTask` (a pure read used elsewhere) is unchanged.

2. **MCP status validation.** The MCP `updateTaskStatus` callback wrote `params.Status` directly, unlike the REST path. It now rejects invalid statuses and cron-template mutation via the exported `crud.IsValidTaskStatus` (single source of truth).

3. **pubsub send-on-closed race.** `publish` copied subscribers, released the lock, then sent, while `Unsubscribe`/`Delete` closed those channels (panic, only masked by `recover`). `publish` now holds the read lock across the fan-out, so a channel cannot be closed mid-send; publishers still fan out concurrently.

**Tests:** `ClaimNextTask` (claim/ongoing, in-order drain, filters, 40-goroutine no-double-claim), pubsub delivery + unsubscribe + concurrent churn, and `IsValidTaskStatus`. Full `./internal/service/... ./internal/controller/... ./internal/repository/...` suite passes (pre-existing CGO-only telemetry test excluded).