### PR TITLE
refactor(crud): reuse schedule.ValidateCronGranularity for event triggers

### DIFF
--- a/backend/internal/controller/crud/event.go
+++ b/backend/internal/controller/crud/event.go
@@ -3,15 +3,13 @@ package crud
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"strings"
 	"time"
 
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	"github.com/agentrq/agentrq/backend/internal/data/model"
 	mapper "github.com/agentrq/agentrq/backend/internal/mapper/api"
+	"github.com/agentrq/agentrq/backend/internal/service/schedule"
 	"github.com/mustafaturan/monoflake"
-	"github.com/robfig/cron/v3"
 )
 
 // EventController defines event operations.
@@ -126,7 +124,7 @@ func (c *controller) CreateEventTrigger(ctx context.Context, req entity.CreateEv
 	}
 
 	if req.CronSchedule != "" {
-		if err := validateEventTriggerCron(req.CronSchedule); err != nil {
+		if err := schedule.ValidateCronGranularity(req.CronSchedule); err != nil {
 			return nil, err
 		}
 	}
@@ -201,33 +199,6 @@ func (c *controller) ListTasksFromEvent(ctx context.Context, req entity.ListTask
 }
 
 // ── Validation helpers ────────────────────────────────────────────────────────
-
-// validateEventTriggerCron enforces the same cron rules as the MCP server:
-// - exactly 5 fields
-// - minute field must be a single fixed integer 0-59 (no wildcards, steps, ranges, or comma-lists)
-// - valid cron syntax overall
-func validateEventTriggerCron(schedule string) error {
-	fields := strings.Fields(schedule)
-	if len(fields) != 5 {
-		return fmt.Errorf("cron schedule must have exactly 5 fields (minute hour dom month dow)")
-	}
-	minuteField := fields[0]
-	if minuteField == "*" ||
-		strings.Contains(minuteField, "/") ||
-		strings.Contains(minuteField, "-") ||
-		strings.Contains(minuteField, ",") {
-		return fmt.Errorf("cron schedule granularity too fine: minute field must be a single fixed value (0-59), got %q", minuteField)
-	}
-	minute, err := strconv.Atoi(minuteField)
-	if err != nil || minute < 0 || minute > 59 {
-		return fmt.Errorf("cron schedule minute field must be a valid integer between 0 and 59, got %q", minuteField)
-	}
-	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
-	if _, err := parser.Parse(schedule); err != nil {
-		return fmt.Errorf("invalid cron schedule: %w", err)
-	}
-	return nil
-}
 
 func isValidEventName(name string) bool {
 	if len(name) == 0 || len(name) > 129 {

--- a/backend/internal/controller/crud/event_test.go
+++ b/backend/internal/controller/crud/event_test.go
@@ -2,6 +2,7 @@ package crud
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,36 +38,6 @@ func repeat(s string, n int) string {
 		out[i] = s[0]
 	}
 	return string(out)
-}
-
-// ── validateEventTriggerCron ──────────────────────────────────────────────────
-
-func TestValidateEventTriggerCron(t *testing.T) {
-	valid := []string{
-		"0 * * * *",    // every hour at :00
-		"30 * * * *",   // every hour at :30
-		"0 0 * * *",    // every day midnight
-		"30 14 25 4 *", // one-time
-	}
-	for _, s := range valid {
-		if err := validateEventTriggerCron(s); err != nil {
-			t.Errorf("expected %q to be valid, got %v", s, err)
-		}
-	}
-	invalid := []string{
-		"* * * * *",    // wildcard minute
-		"*/5 * * * *",  // step
-		"0-5 * * * *",  // range
-		"0,30 * * * *", // comma list
-		"60 * * * *",   // out of range
-		"abc * * * *",  // non-integer
-		"0 * * *",      // too few fields
-	}
-	for _, s := range invalid {
-		if err := validateEventTriggerCron(s); err == nil {
-			t.Errorf("expected %q to be invalid", s)
-		}
-	}
 }
 
 // ── CreateEvent ───────────────────────────────────────────────────────────────
@@ -112,7 +83,6 @@ func TestCreateEvent_EmptyName(t *testing.T) {
 		t.Error("expected error for empty name")
 	}
 }
-
 
 func TestCreateEvent_InvalidUserID(t *testing.T) {
 	e := newTestController(t)
@@ -281,7 +251,13 @@ func TestCreateEventTrigger_InvalidCron(t *testing.T) {
 		UserID:       testUserIDStr,
 	})
 	if err == nil {
-		t.Error("expected error for invalid cron schedule")
+		t.Fatal("expected error for invalid cron schedule")
+	}
+	// The trigger path delegates to the shared schedule.ValidateCronGranularity
+	// (same guardrail as the MCP server and task paths); assert we get its
+	// granularity error rather than any other validation failure.
+	if !strings.Contains(err.Error(), "granularity too fine") {
+		t.Errorf("expected granularity error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## What

`CreateEventTrigger` validated its cron schedule through a private
`validateEventTriggerCron` in `controller/crud/event.go` that was a
line-for-line copy of `schedule.ValidateCronGranularity` — the same
"minute must be a fixed 0-59, hourly-or-coarser" guardrail already used by
the MCP server (`controller/mcp/server.go`) and task creation
(`controller/crud/task.go`).

Three copies of the same rule invite drift: a future change to one path
silently diverges from the others, so an agent-created schedule and a
human/REST-created event trigger could start disagreeing about what's valid.

## Change

- `event.go`: drop the duplicate `validateEventTriggerCron`; call the shared
  `schedule.ValidateCronGranularity` directly (same import the sibling
  `task.go` already uses). Removes the now-unused `strconv` / `strings` /
  `robfig/cron` imports from the file.
- `event_test.go`: remove the redundant unit test (its valid/invalid cron
  table is already covered by `schedule.TestValidateCronGranularity`), and
  strengthen the existing `TestCreateEventTrigger_InvalidCron` to assert the
  shared validator's `"granularity too fine"` error — so the call site's
  delegation stays covered.

## Behavior

Unchanged, with one intentional consistency improvement: the granularity
rejection message on the event-trigger path now matches the shared
validator's wording (`".. not %q - only hourly or coarser schedules are
allowed"`), aligning it with the MCP and task paths.

## Tests

`cd backend && go test ./internal/...` — all pass. `go vet` and `gofmt`
clean.
