### PR TITLE
fix(events): cap event fan-out to break runaway trigger chains

### DIFF
--- a/backend/internal/controller/event/event.go
+++ b/backend/internal/controller/event/event.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
@@ -15,6 +16,16 @@ import (
 	"github.com/agentrq/agentrq/backend/internal/service/pubsub"
 	"github.com/mustafaturan/monoflake"
 	zlog "github.com/rs/zerolog/log"
+)
+
+// Event fan-out is throttled per event to contain runaway trigger chains. Triggers can
+// chain (EmitEventID) and two events can reference each other, so an agent completing
+// tasks could drive an unbounded A -> B -> A -> ... task-creation loop. If an event fires
+// more than eventFireBurst times within eventFireWindow it is dropped and logged, which
+// breaks such loops while leaving normal usage (well under the cap) unaffected.
+const (
+	eventFireWindow = time.Minute
+	eventFireBurst  = 30
 )
 
 type (
@@ -34,16 +45,45 @@ type (
 		pubsub pubsub.Service
 		ids    idgen.Service
 		bus    *eventbus.Bus
+
+		fireMu    sync.Mutex
+		fireTimes map[int64][]time.Time // eventID -> recent fire timestamps (sliding window)
 	}
 )
 
 func New(p Params) Controller {
 	return &controller{
-		repo:   p.Repository,
-		pubsub: p.PubSub,
-		ids:    p.IDGen,
-		bus:    p.Bus,
+		repo:      p.Repository,
+		pubsub:    p.PubSub,
+		ids:       p.IDGen,
+		bus:       p.Bus,
+		fireTimes: make(map[int64][]time.Time),
 	}
+}
+
+// allowFire records a fire of eventID at now and reports whether it is within the
+// per-event burst budget. It prunes timestamps older than eventFireWindow, so the map
+// stays bounded to at most eventFireBurst entries per active event.
+func (c *controller) allowFire(eventID int64, now time.Time) bool {
+	c.fireMu.Lock()
+	defer c.fireMu.Unlock()
+
+	if c.fireTimes == nil {
+		c.fireTimes = make(map[int64][]time.Time)
+	}
+	cutoff := now.Add(-eventFireWindow)
+	recent := c.fireTimes[eventID][:0]
+	for _, ts := range c.fireTimes[eventID] {
+		if ts.After(cutoff) {
+			recent = append(recent, ts)
+		}
+	}
+	if len(recent) >= eventFireBurst {
+		c.fireTimes[eventID] = recent
+		return false
+	}
+	c.fireTimes[eventID] = append(recent, now)
+	return true
 }
 
 func (c *controller) Start(ctx context.Context) error {
@@ -77,6 +117,16 @@ func (c *controller) Start(ctx context.Context) error {
 }
 
 func (c *controller) processEvent(ctx context.Context, ev entity.EventPublishedPayload) {
+	if !c.allowFire(ev.EventID, time.Now()) {
+		zlog.Warn().
+			Int64("eventID", ev.EventID).
+			Str("name", ev.Name).
+			Int("burst", eventFireBurst).
+			Dur("window", eventFireWindow).
+			Msg("[event-consumer] event fan-out rate exceeded; dropping (likely a trigger cycle)")
+		return
+	}
+
 	triggers, err := c.repo.SystemListEventTriggersByEventID(ctx, ev.EventID)
 	if err != nil || len(triggers) == 0 {
 		return

--- a/backend/internal/controller/event/fire_limit_test.go
+++ b/backend/internal/controller/event/fire_limit_test.go
@@ -1,0 +1,71 @@
+package event
+
+import (
+	"testing"
+	"time"
+)
+
+func newFireController() *controller {
+	return &controller{fireTimes: make(map[int64][]time.Time)}
+}
+
+func TestAllowFire_BurstThenBlock(t *testing.T) {
+	c := newFireController()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	for i := 0; i < eventFireBurst; i++ {
+		if !c.allowFire(1, now) {
+			t.Fatalf("fire %d within burst should be allowed", i)
+		}
+	}
+	if c.allowFire(1, now) {
+		t.Fatal("fire beyond the burst budget must be blocked (breaks runaway chains)")
+	}
+}
+
+func TestAllowFire_WindowResets(t *testing.T) {
+	c := newFireController()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	for i := 0; i < eventFireBurst; i++ {
+		c.allowFire(1, now)
+	}
+	if c.allowFire(1, now) {
+		t.Fatal("should be blocked while the window is saturated")
+	}
+
+	later := now.Add(eventFireWindow + time.Second)
+	if !c.allowFire(1, later) {
+		t.Fatal("should be allowed again once the window has elapsed")
+	}
+}
+
+func TestAllowFire_IndependentPerEvent(t *testing.T) {
+	c := newFireController()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	for i := 0; i < eventFireBurst; i++ {
+		c.allowFire(1, now)
+	}
+	if !c.allowFire(2, now) {
+		t.Fatal("a different event must have its own independent budget")
+	}
+}
+
+// Pruning must keep the sliding window bounded: old timestamps drop out so a steady,
+// under-cap rate never trips the breaker.
+func TestAllowFire_SteadyRateNeverBlocks(t *testing.T) {
+	c := newFireController()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// One fire every half-window for many iterations: always well under the burst.
+	step := eventFireWindow / 2
+	for i := 0; i < 100; i++ {
+		if !c.allowFire(1, now) {
+			t.Fatalf("steady under-cap fire %d should be allowed", i)
+		}
+		now = now.Add(step)
+	}
+	if got := len(c.fireTimes[1]); got > eventFireBurst {
+		t.Fatalf("window not pruned: %d timestamps retained", got)
+	}
+}


### PR DESCRIPTION
Fixes #233.

Triggers chain through `EmitEventID`, and two events can reference each other, so completing tasks could drive an unbounded A -> B -> A task-creation loop. The consumer had no cycle, depth, or rate guard.

Sliding-window breaker: if an event fires more than `eventFireBurst` times within `eventFireWindow`, the fan-out is dropped and logged. That breaks the loop while leaving normal usage (well under the cap) untouched. The window is pruned so the map stays bounded, and `allowFire` is nil-safe.

Tests: burst-then-block, window reset, per-event independence, and steady under-cap rate with pruning.

The AGENTS.md docs correction that used to ride along here now lives in #253, so this PR is the cycle guard alone.
