### PR TITLE
fix(lifecycle): graceful shutdown, stop leaked goroutines, flush telemetry

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1,6 +1,14 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
 	zlog "github.com/rs/zerolog/log"
 
 	"github.com/agentrq/agentrq/backend/internal/app"
@@ -43,7 +51,25 @@ func main() {
 		zlog.Fatal().Err(err).Msg("init")
 	}
 
-	if err := a.Run(); err != nil {
-		zlog.Fatal().Err(err).Msg("run")
+	// Run the server in the background so we can react to termination signals and shut
+	// down gracefully (drain in-flight requests, flush telemetry) instead of exiting hard.
+	serverErr := make(chan error, 1)
+	go func() { serverErr <- a.Run() }()
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
+
+	select {
+	case err := <-serverErr:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			zlog.Fatal().Err(err).Msg("run")
+		}
+	case sig := <-stop:
+		zlog.Info().Str("signal", sig.String()).Msg("shutdown signal received; shutting down gracefully")
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		if err := a.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			zlog.Error().Err(err).Msg("graceful shutdown error")
+		}
 	}
 }

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -102,10 +102,11 @@ type (
 	}
 
 	App struct {
-		server server.Service
-		bus    *eventbus.Bus
-		pubsub pubsub.Service
-		cancel context.CancelFunc
+		server    server.Service
+		bus       *eventbus.Bus
+		pubsub    pubsub.Service
+		telemetry telemetry.Controller
+		cancel    context.CancelFunc
 	}
 )
 
@@ -224,7 +225,7 @@ func New(cfg Config) (*App, error) {
 		BatchSize: 1000,
 		Interval:  5 * time.Second,
 	})
-	if err := telemetryCtrl.Start(context.Background()); err != nil {
+	if err := telemetryCtrl.Start(appCtx); err != nil {
 		zlog.Error().Err(err).Msg("failed to start telemetry controller")
 	}
 
@@ -791,7 +792,7 @@ func New(cfg Config) (*App, error) {
 	}
 
 	cancelOnErr = nil // App takes ownership; defer must not cancel.
-	return &App{server: serverSvc, bus: bus, pubsub: pubsubSvc, cancel: appCancel}, nil
+	return &App{server: serverSvc, bus: bus, pubsub: pubsubSvc, telemetry: telemetryCtrl, cancel: appCancel}, nil
 }
 
 func pubStatsHandler(ctrl pub.StatsController) http.Handler {
@@ -893,4 +894,15 @@ func eventsHandler(ctrl crud.Controller, bus *eventbus.Bus, tokenSvc auth.TokenS
 func (a *App) Run() error {
 	defer a.cancel()
 	return a.server.Run()
+}
+
+// Shutdown gracefully stops the app: it cancels the app context (signaling background
+// consumers wired to it to stop), flushes buffered telemetry so nothing is lost, and
+// shuts the HTTP server down within ctx's deadline. Safe to call once on SIGINT/SIGTERM.
+func (a *App) Shutdown(ctx context.Context) error {
+	a.cancel()
+	if a.telemetry != nil {
+		a.telemetry.Close()
+	}
+	return a.server.Shutdown(ctx)
 }

--- a/backend/internal/controller/mcp/lifecycle_test.go
+++ b/backend/internal/controller/mcp/lifecycle_test.go
@@ -1,0 +1,43 @@
+package mcp
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+// Manager.Remove must Close the server so its background goroutines stop, rather than
+// just dropping the map entry and leaking them.
+func TestManagerRemoveClosesServer(t *testing.T) {
+	ws := &WorkspaceServer{done: make(chan struct{})}
+	m := NewManager(func(workspaceID int64, userID string) *WorkspaceServer { return ws })
+
+	m.Get(1, "user")
+	m.Remove(1)
+
+	select {
+	case <-ws.done:
+		// closed as expected
+	default:
+		t.Fatal("Remove did not Close the server (done channel not closed)")
+	}
+
+	ws.Close() // idempotent: must not panic on a second close
+}
+
+// Close must actually stop the StartPing ticker goroutine (previously it ran forever).
+func TestStartPingStopsOnClose(t *testing.T) {
+	ws := &WorkspaceServer{done: make(chan struct{})}
+
+	before := runtime.NumGoroutine()
+	ws.StartPing() // launches one ticker goroutine (60s tick; it will not fire in this test)
+	ws.Close()     // should cause the goroutine to return via <-ps.done
+
+	deadline := time.Now().Add(2 * time.Second)
+	for runtime.NumGoroutine() > before && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if runtime.NumGoroutine() > before {
+		t.Fatalf("StartPing goroutine did not exit after Close (before=%d, now=%d)", before, runtime.NumGoroutine())
+	}
+}

--- a/backend/internal/controller/mcp/manager.go
+++ b/backend/internal/controller/mcp/manager.go
@@ -21,7 +21,6 @@ func NewManager(newFn func(workspaceID int64, userID string) *WorkspaceServer) *
 	}
 }
 
-
 // Get returns an existing server or creates one lazily.
 func (m *Manager) Get(workspaceID int64, userID string) *WorkspaceServer {
 	m.mu.RLock()
@@ -42,12 +41,17 @@ func (m *Manager) Get(workspaceID int64, userID string) *WorkspaceServer {
 	return srv
 }
 
-// Remove tears down a workspace's MCP server.
+// Remove tears down a workspace's MCP server, stopping its background goroutines.
 func (m *Manager) Remove(workspaceID int64) {
 	m.mu.Lock()
+	srv := m.servers[workspaceID]
 	delete(m.servers, workspaceID)
 	m.mu.Unlock()
+	if srv != nil {
+		srv.Close() // stop StartPing/StartPoller so they don't leak
+	}
 }
+
 // IsAgentConnected returns true if any agent is currently connected to the workspace server.
 func (m *Manager) IsAgentConnected(workspaceID int64) bool {
 	m.mu.RLock()
@@ -86,4 +90,3 @@ func (m *Manager) SendChannelNotification(ctx context.Context, workspaceID int64
 		srv.SendChannelNotification(ctx, taskID, content)
 	}
 }
-

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -100,6 +100,21 @@ type WorkspaceServer struct {
 	archivedAt            *time.Time
 	lastUpdateCheckAt     time.Time
 	agentConnections      atomic.Int32
+
+	// done is closed by Close to stop the StartPing/StartPoller ticker goroutines, so a
+	// removed workspace server does not leak them for the lifetime of the process.
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+// Close stops the server's background goroutines (StartPing / StartPoller). It is
+// idempotent and safe to call more than once (e.g. from Manager.Remove).
+func (ps *WorkspaceServer) Close() {
+	ps.closeOnce.Do(func() {
+		if ps.done != nil {
+			close(ps.done)
+		}
+	})
 }
 
 // CreateTaskParams is the input to the create_task tool.
@@ -180,6 +195,7 @@ func NewWorkspaceServer(
 	ps := &WorkspaceServer{
 		workspaceID:           workspaceID,
 		userID:                userID,
+		done:                  make(chan struct{}),
 		createTask:            createTask,
 		updateStatus:          updateStatus,
 		getTask:               getTask,
@@ -415,7 +431,12 @@ func (ps *WorkspaceServer) StartPing() {
 	go func() {
 		ticker := time.NewTicker(60 * time.Second)
 		defer ticker.Stop()
-		for range ticker.C {
+		for {
+			select {
+			case <-ps.done:
+				return
+			case <-ticker.C:
+			}
 			for sess := range ps.mcpServer.Sessions() {
 				sess := sess // shadow for closure capture
 				go func() {
@@ -446,7 +467,12 @@ func (ps *WorkspaceServer) StartPoller(repo base.Repository) {
 	go func() {
 		ticker := time.NewTicker(60 * time.Second)
 		defer ticker.Stop()
-		for range ticker.C {
+		for {
+			select {
+			case <-ps.done:
+				return
+			case <-ticker.C:
+			}
 			ps.metadataMu.RLock()
 			isArchived := ps.archivedAt != nil
 			ps.metadataMu.RUnlock()

--- a/backend/internal/controller/telemetry/close_test.go
+++ b/backend/internal/controller/telemetry/close_test.go
@@ -1,0 +1,53 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+type memDBConn struct{ db *gorm.DB }
+
+func (m *memDBConn) Conn(ctx context.Context) *gorm.DB { return m.db }
+func (m *memDBConn) Close(ctx context.Context)         {}
+
+// Close must drain queued records and flush them, so shutdown does not silently drop
+// up to a batch interval of telemetry.
+func TestClose_DrainsAndFlushes(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.AutoMigrate(&model.Telemetry{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	c := &controller{
+		db:        &memDBConn{db: db},
+		queue:     make(chan model.Telemetry, 100),
+		stop:      make(chan struct{}),
+		batchSize: 1000,      // large, so only Close triggers the flush
+		interval:  time.Hour, // long, so the ticker never fires during the test
+	}
+	c.wg.Add(1)
+	go c.worker()
+
+	const n = 5
+	for i := 0; i < n; i++ {
+		c.queue <- model.Telemetry{UserID: 1, WorkspaceID: 10, OccurredAt: int64(i), Action: 1}
+	}
+
+	c.Close() // must block until the buffer (and anything still queued) is flushed
+
+	var count int64
+	db.Model(&model.Telemetry{}).Count(&count)
+	if count != n {
+		t.Fatalf("flushed %d telemetry rows, want %d (records lost on shutdown)", count, n)
+	}
+
+	c.Close() // idempotent: must not panic or hang
+}

--- a/backend/internal/controller/telemetry/telemetry.go
+++ b/backend/internal/controller/telemetry/telemetry.go
@@ -23,6 +23,7 @@ type (
 
 	Controller interface {
 		Start(ctx context.Context) error
+		Close()
 	}
 
 	controller struct {
@@ -30,6 +31,7 @@ type (
 		pubsub    pubsub.Service
 		queue     chan model.Telemetry
 		stop      chan struct{}
+		closeOnce sync.Once
 		wg        sync.WaitGroup
 		batchSize int
 		interval  time.Duration
@@ -225,8 +227,23 @@ func (c *controller) worker() {
 		case <-ticker.C:
 			flush()
 		case <-c.stop:
-			flush()
-			return
+			// Drain anything still queued so a shutdown flush loses nothing, then flush.
+			for {
+				select {
+				case record := <-c.queue:
+					buffer = append(buffer, record)
+				default:
+					flush()
+					return
+				}
+			}
 		}
 	}
+}
+
+// Close stops the worker, draining and flushing any buffered telemetry so shutdown does
+// not drop up to a batch interval of events. It is idempotent.
+func (c *controller) Close() {
+	c.closeOnce.Do(func() { close(c.stop) })
+	c.wg.Wait()
 }


### PR DESCRIPTION
Fixes #230.

1. **Graceful shutdown.** `main.go` handles SIGINT/SIGTERM and calls `App.Shutdown` (cancel app context, flush telemetry, `server.Shutdown` within a deadline) instead of exiting hard, so in-flight requests drain and buffered telemetry survives.
2. **Goroutine leaks.** `WorkspaceServer` gains a `done` channel and `Close()`; `StartPing`/`StartPoller` select on it and return. `Manager.Remove` calls `Close`, so a removed workspace no longer leaks its two ticker goroutines for the process lifetime. `Close` is idempotent and nil-safe.
3. **Telemetry flush.** `Telemetry.Close()` drains still-queued records and flushes before returning, so shutdown drops nothing. `telemetry.Start` now uses the app context so its consumers stop on shutdown.

Tests: telemetry drain-and-flush on `Close`, `Manager.Remove` closes the server, and the `StartPing` goroutine exits after `Close`.
