### PR TITLE
fix(scheduler): catch up missed minutes so drift cannot skip a firing

### DIFF
--- a/backend/internal/service/scheduler/scheduler.go
+++ b/backend/internal/service/scheduler/scheduler.go
@@ -27,7 +27,17 @@ type scheduler struct {
 	idgen  idgen.Service
 	bus    *eventbus.Bus
 	pubsub pubsub.Service
+
+	// lastProcessed is the most recent wall-clock minute the poller has evaluated. It is
+	// touched only by the single ticker goroutine (and directly in tests), so it needs no
+	// lock. It lets tick catch up any minutes skipped by ticker drift or scheduling latency
+	// so a scheduled minute is never silently missed.
+	lastProcessed time.Time
 }
+
+// maxCatchUpMinutes bounds how far back tick will catch up in one pass, so a long pause
+// (suspend, GC stall, clock jump) cannot spawn an unbounded backlog of tasks.
+const maxCatchUpMinutes = 120
 
 func New(repo base.Repository, idgen idgen.Service, bus *eventbus.Bus, ps pubsub.Service) Service {
 	return &scheduler{repo: repo, idgen: idgen, bus: bus, pubsub: ps}
@@ -53,31 +63,66 @@ func (s *scheduler) tick(ctx context.Context) {
 	crons, err := s.repo.SystemListTasksByStatus(ctx, "cron")
 	if err != nil {
 		zlog.Error().Err(err).Msg("scheduler: failed to list crons")
+		return // leave lastProcessed unchanged so the next tick catches up these minutes
+	}
+
+	now := time.Now().UTC().Truncate(time.Minute)
+	minutes := minutesToProcess(s.lastProcessed, now)
+	if len(minutes) == 0 {
 		return
 	}
 
 	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
-	now := time.Now().UTC().Truncate(time.Minute)
-
 	for _, c := range crons {
 		if c.CronSchedule == "" {
 			continue
 		}
-
 		sched, err := parser.Parse(c.CronSchedule)
 		if err != nil {
 			zlog.Warn().Err(err).Int64("task_id", c.ID).Str("schedule", c.CronSchedule).Msg("scheduler: invalid cron schedule")
 			continue
 		}
-
-		// Calculate the next run time from the last minute
-		// If the next calculated run time is EXACTLY this minute, we spawn.
-		next := sched.Next(now.Add(-1 * time.Second))
-
-		if next.Equal(now) {
-			s.spawn(ctx, c)
+		// Fire the schedule for every minute in the window that matches. Evaluating each
+		// elapsed minute (not just "now") means ticker drift or latency cannot skip a
+		// scheduled minute; lastProcessed advancing monotonically means none fires twice.
+		for _, minute := range minutes {
+			if sched.Next(minute.Add(-1 * time.Second)).Equal(minute) {
+				s.spawn(ctx, c)
+			}
 		}
 	}
+
+	s.lastProcessed = now
+}
+
+// minutesToProcess returns the minutes in (last, now] that tick should evaluate, each
+// truncated to the minute. On the first run (last is zero) it returns only the current
+// minute. It returns nil when no new full minute has elapsed (or the clock moved
+// backward), and caps the window at maxCatchUpMinutes ending at now.
+func minutesToProcess(last, now time.Time) []time.Time {
+	now = now.Truncate(time.Minute)
+	if now.IsZero() {
+		return nil
+	}
+
+	var start time.Time
+	if last.IsZero() {
+		start = now // first run: only the current minute
+	} else {
+		start = last.Truncate(time.Minute).Add(time.Minute)
+	}
+	if start.After(now) {
+		return nil // no new minute elapsed, or the clock went backward
+	}
+	if earliest := now.Add(-time.Duration(maxCatchUpMinutes-1) * time.Minute); start.Before(earliest) {
+		start = earliest
+	}
+
+	var minutes []time.Time
+	for m := start; !m.After(now); m = m.Add(time.Minute) {
+		minutes = append(minutes, m)
+	}
+	return minutes
 }
 
 func (s *scheduler) spawn(ctx context.Context, parent model.Task) {

--- a/backend/internal/service/scheduler/scheduler_catchup_test.go
+++ b/backend/internal/service/scheduler/scheduler_catchup_test.go
@@ -1,0 +1,112 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	"github.com/agentrq/agentrq/backend/internal/service/eventbus"
+	mock_idgen "github.com/agentrq/agentrq/backend/internal/service/mocks/idgen"
+	mock_pubsub "github.com/agentrq/agentrq/backend/internal/service/mocks/pubsub"
+	mock_repo "github.com/agentrq/agentrq/backend/internal/service/mocks/repository"
+	"github.com/agentrq/agentrq/backend/internal/service/pubsub"
+	"github.com/golang/mock/gomock"
+)
+
+func eqMinutes(a, b []time.Time) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !a[i].Equal(b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func TestMinutesToProcess(t *testing.T) {
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	min := func(offset int) time.Time { return base.Add(time.Duration(offset) * time.Minute) }
+
+	t.Run("first run returns only current minute", func(t *testing.T) {
+		if got := minutesToProcess(time.Time{}, base); !eqMinutes(got, []time.Time{base}) {
+			t.Fatalf("got %v", got)
+		}
+	})
+	t.Run("single elapsed minute", func(t *testing.T) {
+		if got := minutesToProcess(min(-1), base); !eqMinutes(got, []time.Time{base}) {
+			t.Fatalf("got %v", got)
+		}
+	})
+	t.Run("catches up a multi-minute gap in order", func(t *testing.T) {
+		want := []time.Time{min(-2), min(-1), base}
+		if got := minutesToProcess(min(-3), base); !eqMinutes(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+	t.Run("same minute returns nil", func(t *testing.T) {
+		if got := minutesToProcess(base, base); got != nil {
+			t.Fatalf("got %v, want nil", got)
+		}
+	})
+	t.Run("sub-minute advance returns nil (now truncates to same minute)", func(t *testing.T) {
+		if got := minutesToProcess(base, base.Add(30*time.Second)); got != nil {
+			t.Fatalf("got %v, want nil", got)
+		}
+	})
+	t.Run("clock moving backward returns nil", func(t *testing.T) {
+		if got := minutesToProcess(base, min(-5)); got != nil {
+			t.Fatalf("got %v, want nil", got)
+		}
+	})
+	t.Run("huge gap is capped to the most recent window", func(t *testing.T) {
+		got := minutesToProcess(min(-500), base)
+		if len(got) != maxCatchUpMinutes {
+			t.Fatalf("len = %d, want %d", len(got), maxCatchUpMinutes)
+		}
+		if !got[len(got)-1].Equal(base) {
+			t.Fatalf("last = %v, want %v", got[len(got)-1], base)
+		}
+		if want := base.Add(-time.Duration(maxCatchUpMinutes-1) * time.Minute); !got[0].Equal(want) {
+			t.Fatalf("first = %v, want %v", got[0], want)
+		}
+	})
+}
+
+// A gap of several minutes must fire an every-minute schedule once per missed minute,
+// rather than only once for "now".
+func TestTickCatchesUpMissedMinutes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRepo := mock_repo.NewMockRepository(ctrl)
+	mockIdgen := mock_idgen.NewMockService(ctrl)
+	mockPubSub := mock_pubsub.NewMockService(ctrl)
+	s := New(mockRepo, mockIdgen, eventbus.New(), mockPubSub).(*scheduler)
+
+	// Pretend the poller last ran two minutes ago (e.g. it drifted / stalled).
+	s.lastProcessed = time.Now().UTC().Truncate(time.Minute).Add(-2 * time.Minute)
+
+	task := model.Task{ID: 1, WorkspaceID: 10, UserID: 1, CronSchedule: "* * * * *"}
+	mockRepo.EXPECT().SystemListTasksByStatus(gomock.Any(), "cron").Return([]model.Task{task}, nil)
+	mockRepo.EXPECT().SystemCheckTaskExists(gomock.Any(), int64(10), int64(1), "notstarted").Return(false, nil).AnyTimes()
+	mockRepo.EXPECT().SystemCheckTaskExists(gomock.Any(), int64(10), int64(1), "ongoing").Return(false, nil).AnyTimes()
+	mockIdgen.EXPECT().NextID().Return(int64(2)).AnyTimes()
+	mockPubSub.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(&pubsub.PublishResponse{}, nil).AnyTimes()
+
+	// The gap spans at least two prior minutes plus the current one, so an every-minute
+	// schedule must spawn more than once (the old single-"now" logic spawned exactly once).
+	spawns := 0
+	mockRepo.EXPECT().CreateTask(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, task model.Task) (model.Task, error) {
+			spawns++
+			return model.Task{ID: 2}, nil
+		}).MinTimes(2)
+
+	s.tick(context.Background())
+
+	if spawns < 2 {
+		t.Fatalf("catch-up spawned %d times, want >= 2", spawns)
+	}
+}


### PR DESCRIPTION
Fixes #232.

The poller fired a schedule only when the current (truncated) minute matched. Ticker drift and scheduling latency could cause a wall-clock minute to never be observed, silently skipping that minute's scheduled tasks.

The consumer now tracks the last processed minute and evaluates every minute in `(last, now]` on each tick, so no scheduled minute is skipped. `lastProcessed` advances monotonically, so nothing fires twice. The catch-up window is capped (`maxCatchUpMinutes`) so a long pause or clock jump can't spawn an unbounded backlog. First run and backward/sub-minute clock movement are handled explicitly.

Tests: exhaustive `minutesToProcess` cases (first run, single/multi-minute gap, same minute, sub-minute, backward clock, capped huge gap) plus a mock-based tick catch-up.
