### PR TITLE
perf(sqlite,tasks): enable WAL + busy_timeout, add composite dequeue index

### DIFF
--- a/backend/internal/data/model/model.go
+++ b/backend/internal/data/model/model.go
@@ -31,11 +31,14 @@ type (
 		CreatedAt time.Time
 		UpdatedAt time.Time
 
-		UserID      int64  `gorm:"index:idx_tasks_user_id"`
-		WorkspaceID int64  `gorm:"index:idx_tasks_workspace_id"`
-		CreatedBy   string `gorm:"type:varchar(16)"`    // "human" | "agent"
-		Assignee    string `gorm:"type:varchar(16)"`    // "human" | "agent"
-		Status      string `json:"status" gorm:"index"` // notstarted, ongoing, completed, rejected, cron, blocked
+		// idx_tasks_dequeue is a composite index matching the agent work-dequeue query
+		// (ClaimNextTask / GetNextTask): equality on workspace_id, user_id, status, assignee
+		// followed by the sort_order used for prioritization. Column order mirrors the query.
+		UserID      int64  `gorm:"index:idx_tasks_user_id;index:idx_tasks_dequeue,priority:2"`
+		WorkspaceID int64  `gorm:"index:idx_tasks_workspace_id;index:idx_tasks_dequeue,priority:1"`
+		CreatedBy   string `gorm:"type:varchar(16)"`                                       // "human" | "agent"
+		Assignee    string `gorm:"type:varchar(16);index:idx_tasks_dequeue,priority:4"`    // "human" | "agent"
+		Status      string `json:"status" gorm:"index;index:idx_tasks_dequeue,priority:3"` // notstarted, ongoing, completed, rejected, cron, blocked
 		Title       string `gorm:"type:varchar(255)"`
 		Body        string `gorm:"type:text"`
 		Response    string `gorm:"type:text"`
@@ -45,7 +48,7 @@ type (
 
 		CronSchedule     string  `gorm:"type:varchar(64)"`
 		ParentID         int64   `gorm:"index:idx_tasks_parent_id"`
-		SortOrder        float64 `gorm:"type:real;default:0"`
+		SortOrder        float64 `gorm:"type:real;default:0;index:idx_tasks_dequeue,priority:5"`
 		AllowAllCommands bool    `gorm:"default:false"`
 		TriggerID        int64   `gorm:"index:idx_tasks_trigger_id"` // event that caused this task
 		EventID          int64   `gorm:"index:idx_tasks_event_id"`   // event this task emits on completion
@@ -57,7 +60,7 @@ type (
 		ID                int64 `gorm:"primaryKey;autoIncrement:false"`
 		CreatedAt         time.Time
 		UpdatedAt         time.Time
-		UserID            int64          `gorm:"index:idx_events_user_id"`
+		UserID            int64  `gorm:"index:idx_events_user_id"`
 		Name              string `gorm:"type:varchar(140);uniqueIndex:idx_events_name_user_id"`
 		PayloadGuidelines string `gorm:"type:text"`
 	}

--- a/backend/internal/data/model/model.go
+++ b/backend/internal/data/model/model.go
@@ -31,13 +31,14 @@ type (
 		CreatedAt time.Time
 		UpdatedAt time.Time
 
-		// idx_tasks_dequeue is a composite index matching the agent work-dequeue query
-		// (ClaimNextTask / GetNextTask): equality on workspace_id, user_id, status, assignee
-		// followed by the sort_order used for prioritization. Column order mirrors the query.
+		// idx_tasks_dequeue is a composite index matching the equality prefix of the
+		// agent work-dequeue query (ClaimNextTask / GetNextTask): workspace_id, user_id,
+		// status. Column order mirrors the query. assignee and sort_order are left out
+		// deliberately to keep the index small.
 		UserID      int64  `gorm:"index:idx_tasks_user_id;index:idx_tasks_dequeue,priority:2"`
 		WorkspaceID int64  `gorm:"index:idx_tasks_workspace_id;index:idx_tasks_dequeue,priority:1"`
 		CreatedBy   string `gorm:"type:varchar(16)"`                                       // "human" | "agent"
-		Assignee    string `gorm:"type:varchar(16);index:idx_tasks_dequeue,priority:4"`    // "human" | "agent"
+		Assignee    string `gorm:"type:varchar(16)"`                                       // "human" | "agent"
 		Status      string `json:"status" gorm:"index;index:idx_tasks_dequeue,priority:3"` // notstarted, ongoing, completed, rejected, cron, blocked
 		Title       string `gorm:"type:varchar(255)"`
 		Body        string `gorm:"type:text"`
@@ -48,7 +49,7 @@ type (
 
 		CronSchedule     string  `gorm:"type:varchar(64)"`
 		ParentID         int64   `gorm:"index:idx_tasks_parent_id"`
-		SortOrder        float64 `gorm:"type:real;default:0;index:idx_tasks_dequeue,priority:5"`
+		SortOrder        float64 `gorm:"type:real;default:0"`
 		AllowAllCommands bool    `gorm:"default:false"`
 		TriggerID        int64   `gorm:"index:idx_tasks_trigger_id"` // event that caused this task
 		EventID          int64   `gorm:"index:idx_tasks_event_id"`   // event this task emits on completion

--- a/backend/internal/repository/base/dequeue_index_test.go
+++ b/backend/internal/repository/base/dequeue_index_test.go
@@ -1,0 +1,49 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+// The agent dequeue filters (workspace_id, user_id, status, assignee) and orders by
+// sort_order. Before this change assignee and sort_order were unindexed and there was no
+// composite index. Assert AutoMigrate creates idx_tasks_dequeue with the columns in the
+// order the query uses.
+func TestTaskDequeueCompositeIndex(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.AutoMigrate(&model.Task{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	rows, err := db.Raw("PRAGMA index_info('idx_tasks_dequeue')").Rows()
+	if err != nil {
+		t.Fatalf("index_info: %v", err)
+	}
+	defer rows.Close()
+
+	var cols []string
+	for rows.Next() {
+		var seqno, cid int
+		var name string
+		if err := rows.Scan(&seqno, &cid, &name); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		cols = append(cols, name)
+	}
+
+	want := []string{"workspace_id", "user_id", "status", "assignee", "sort_order"}
+	if len(cols) != len(want) {
+		t.Fatalf("idx_tasks_dequeue columns = %v, want %v (index missing or wrong shape)", cols, want)
+	}
+	for i := range want {
+		if cols[i] != want[i] {
+			t.Fatalf("idx_tasks_dequeue col[%d] = %q, want %q (full: %v)", i, cols[i], want[i], cols)
+		}
+	}
+}

--- a/backend/internal/repository/base/dequeue_index_test.go
+++ b/backend/internal/repository/base/dequeue_index_test.go
@@ -8,10 +8,9 @@ import (
 	"gorm.io/gorm"
 )
 
-// The agent dequeue filters (workspace_id, user_id, status, assignee) and orders by
-// sort_order. Before this change assignee and sort_order were unindexed and there was no
-// composite index. Assert AutoMigrate creates idx_tasks_dequeue with the columns in the
-// order the query uses.
+// The agent dequeue filters on workspace_id, user_id and status. Assert AutoMigrate
+// creates idx_tasks_dequeue covering that equality prefix in query order. assignee and
+// sort_order are deliberately left out to keep the index small.
 func TestTaskDequeueCompositeIndex(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	if err != nil {
@@ -37,7 +36,7 @@ func TestTaskDequeueCompositeIndex(t *testing.T) {
 		cols = append(cols, name)
 	}
 
-	want := []string{"workspace_id", "user_id", "status", "assignee", "sort_order"}
+	want := []string{"workspace_id", "user_id", "status"}
 	if len(cols) != len(want) {
 		t.Fatalf("idx_tasks_dequeue columns = %v, want %v (index missing or wrong shape)", cols, want)
 	}

--- a/backend/internal/repository/sqlite/sqlite.go
+++ b/backend/internal/repository/sqlite/sqlite.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	zlog "github.com/rs/zerolog/log"
@@ -50,7 +51,7 @@ func New(p Params) (dbconn.DBConn, error) {
 		return nil, nil
 	}
 
-	db, err := gorm.Open(sqlite.Open(cfg.DSN), &gorm.Config{TranslateError: true})
+	db, err := gorm.Open(sqlite.Open(withConcurrencyPragmas(cfg.DSN)), &gorm.Config{TranslateError: true})
 	if err != nil {
 		return nil, fmt.Errorf(_logPrefix+"failed to connect: %w", err)
 	}
@@ -73,6 +74,31 @@ func New(p Params) (dbconn.DBConn, error) {
 	}
 
 	return &repository{db: db}, nil
+}
+
+// withConcurrencyPragmas enables WAL journaling and a busy timeout on a file-backed SQLite
+// DSN. WAL lets readers and the single writer proceed concurrently (a bare DSN defaults to
+// "delete" journaling, where any reader blocks the writer and vice versa), and the busy
+// timeout makes contending writers wait rather than fail. It respects an operator that has
+// already configured pragmas, and leaves in-memory databases untouched.
+func withConcurrencyPragmas(dsn string) string {
+	if dsn == "" || strings.Contains(dsn, "_pragma=") {
+		return dsn // operator configured pragmas explicitly; do not override
+	}
+	if strings.Contains(dsn, ":memory:") {
+		return dsn // WAL is not meaningful for in-memory databases
+	}
+
+	base := dsn
+	if !strings.HasPrefix(base, "file:") {
+		// A file: scheme is required for the driver to parse query-string pragmas.
+		base = "file:" + base
+	}
+	sep := "?"
+	if strings.Contains(base, "?") {
+		sep = "&"
+	}
+	return base + sep + "_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)"
 }
 
 func (r *repository) Conn(ctx context.Context) *gorm.DB {

--- a/backend/internal/repository/sqlite/sqlite_pragmas_test.go
+++ b/backend/internal/repository/sqlite/sqlite_pragmas_test.go
@@ -1,0 +1,63 @@
+package sqlite
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestWithConcurrencyPragmas(t *testing.T) {
+	cases := []struct {
+		name          string
+		in            string
+		wantContains  []string
+		wantUnchanged bool
+	}{
+		{"bare path gets file scheme + pragmas", "./_storage/agentrq.db",
+			[]string{"file:./_storage/agentrq.db?", "_pragma=journal_mode(WAL)", "_pragma=busy_timeout(5000)"}, false},
+		{"existing query uses & separator", "file:./x.db?cache=shared",
+			[]string{"cache=shared", "&_pragma=journal_mode(WAL)"}, false},
+		{"explicit pragmas are respected", "file:./x.db?_pragma=journal_mode(DELETE)", nil, true},
+		{"in-memory untouched", ":memory:", nil, true},
+		{"empty untouched", "", nil, true},
+	}
+	for _, c := range cases {
+		got := withConcurrencyPragmas(c.in)
+		if c.wantUnchanged {
+			if got != c.in {
+				t.Errorf("%s: got %q, want unchanged %q", c.name, got, c.in)
+			}
+			continue
+		}
+		for _, w := range c.wantContains {
+			if !strings.Contains(got, w) {
+				t.Errorf("%s: %q missing %q", c.name, got, w)
+			}
+		}
+	}
+}
+
+// The produced DSN must actually put a real database into WAL mode with a busy timeout.
+func TestWithConcurrencyPragmas_EnablesWALOnRealDB(t *testing.T) {
+	dsn := withConcurrencyPragmas(filepath.Join(t.TempDir(), "wal.db"))
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	sqlDB, _ := db.DB()
+	defer sqlDB.Close()
+
+	var journal string
+	db.Raw("PRAGMA journal_mode").Scan(&journal)
+	if !strings.EqualFold(journal, "wal") {
+		t.Fatalf("journal_mode = %q, want wal", journal)
+	}
+	var busy int
+	db.Raw("PRAGMA busy_timeout").Scan(&busy)
+	if busy != 5000 {
+		t.Fatalf("busy_timeout = %d, want 5000", busy)
+	}
+}


### PR DESCRIPTION
Fixes #231.

1. **Concurrency pragmas.** The SQLite DSN now enables WAL journaling and a busy timeout for file-backed databases (`withConcurrencyPragmas`). WAL lets readers and the single writer proceed concurrently; a bare DSN defaulted to delete journaling, where readers and the writer block each other. Explicit config is respected and in-memory DBs are untouched.
2. **Dequeue index.** Adds composite index `idx_tasks_dequeue (workspace_id, user_id, status)` matching the equality prefix of the agent work-dequeue query. `assignee` and `sort_order` are left out to keep the index small (per review).

Tests cover the DSN behavior on a real DB (`journal_mode=wal`, `busy_timeout`) and the composite index shape.