### PR TITLE
🛡️ Sentinel: Harden Slack OAuth against CSRF

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -556,6 +556,7 @@ func New(cfg Config) (*App, error) {
 		Crud:       crudCtrl,
 		MCPManager: mcpManager,
 		PubSub:     pubsubSvc,
+		TokenSvc:   tokenSvc,
 		TokenKey:   cfg.Auth.WorkspaceTokenKey,
 		BaseURL:    cfg.App.BaseURL,
 	})
@@ -704,6 +705,7 @@ func New(cfg Config) (*App, error) {
 	handlerslack.New(handlerslack.Params{
 		SlackCtrl: slackCtrl,
 		SlackSvc:  slackSvc,
+		TokenSvc:  tokenSvc,
 		BaseURL:   cfg.App.BaseURL,
 		Mux:       mux,
 	})

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -18,6 +18,7 @@ import (
 	"github.com/agentrq/agentrq/backend/internal/repository/base"
 	"github.com/agentrq/agentrq/backend/internal/service/pubsub"
 	"github.com/agentrq/agentrq/backend/internal/service/security"
+	"github.com/agentrq/agentrq/backend/internal/service/auth"
 	slacksvc "github.com/agentrq/agentrq/backend/internal/service/slack"
 	"github.com/mustafaturan/monoflake"
 	zlog "github.com/rs/zerolog/log"
@@ -45,6 +46,7 @@ type Params struct {
 	Crud       CRUDRespondToTask
 	MCPManager MCPManager
 	PubSub     pubsub.Service
+	TokenSvc   auth.TokenService
 	TokenKey   string
 	BaseURL    string
 }
@@ -117,6 +119,7 @@ type controller struct {
 	crud     CRUDRespondToTask
 	mcp      MCPManager
 	pubsub   pubsub.Service
+	tokenSvc auth.TokenService
 	tokenKey string
 	baseURL  string
 }
@@ -129,6 +132,7 @@ func New(p Params) Controller {
 		crud:     p.Crud,
 		mcp:      p.MCPManager,
 		pubsub:   p.PubSub,
+		tokenSvc: p.TokenSvc,
 		tokenKey: p.TokenKey,
 		baseURL:  p.BaseURL,
 	}
@@ -370,11 +374,17 @@ func (c *controller) GetWorkspaceSlackConfig(ctx context.Context, workspaceID in
 
 	workspaceID62 := monoflake.ID(workspaceID).String()
 	redirectURI := fmt.Sprintf("%s/slack/oauth/callback", c.baseURL)
+
+	state, err := c.tokenSvc.CreateOAuthStateToken(redirectURI, "slack", workspaceID62)
+	if err != nil {
+		return nil, fmt.Errorf("slack: failed to generate oauth state: %w", err)
+	}
+
 	authURL := fmt.Sprintf(
 		"https://slack.com/oauth/v2/authorize?client_id=%s&scope=groups:write,groups:read,chat:write,app_mentions:read,commands&redirect_uri=%s&state=%s",
 		c.slack.ClientID(),
 		url.QueryEscape(redirectURI),
-		workspaceID62,
+		url.QueryEscape(state),
 	)
 
 	cfg := &entity.SlackConfig{

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -314,7 +314,7 @@ func (h *handler) rootLogin() fiber.Handler {
 func (h *handler) googleLogin() fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		redirectURL := h.sanitizeRedirectURL(c.Query("redirect_url", "/"))
-		state, err := h.tokenSvc.CreateOAuthStateToken(redirectURL, "google")
+		state, err := h.tokenSvc.CreateOAuthStateToken(redirectURL, "google", "")
 		if err != nil {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to generate state"})
 		}
@@ -387,7 +387,7 @@ func (h *handler) googleCallback() fiber.Handler {
 
 		redirectURL := "/"
 		if stateToken := c.Query("state"); stateToken != "" {
-			if rurl, err := h.tokenSvc.ValidateOAuthStateToken(stateToken, "google"); err == nil {
+			if rurl, _, err := h.tokenSvc.ValidateOAuthStateToken(stateToken, "google"); err == nil {
 				redirectURL = h.sanitizeRedirectURL(rurl)
 			}
 		}
@@ -402,7 +402,7 @@ func (h *handler) githubLogin() fiber.Handler {
 			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "github login disabled"})
 		}
 		redirectURL := h.sanitizeRedirectURL(c.Query("redirect_url", "/"))
-		state, err := h.tokenSvc.CreateOAuthStateToken(redirectURL, "github")
+		state, err := h.tokenSvc.CreateOAuthStateToken(redirectURL, "github", "")
 		if err != nil {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to generate state"})
 		}
@@ -467,7 +467,7 @@ func (h *handler) githubCallback() fiber.Handler {
 
 		redirectURL := "/"
 		if stateToken := c.Query("state"); stateToken != "" {
-			if rurl, err := h.tokenSvc.ValidateOAuthStateToken(stateToken, "github"); err == nil {
+			if rurl, _, err := h.tokenSvc.ValidateOAuthStateToken(stateToken, "github"); err == nil {
 				redirectURL = h.sanitizeRedirectURL(rurl)
 			}
 		}

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -42,12 +42,12 @@ func (m *mockTokenSvc) CreateMCPToken(userID, workspaceID, tokenType string) (st
 	return m.createMCPTokenFunc(userID, workspaceID, tokenType)
 }
 
-func (m *mockTokenSvc) CreateOAuthStateToken(redirectURL, provider string) (string, error) {
+func (m *mockTokenSvc) CreateOAuthStateToken(redirectURL, provider, workspaceID string) (string, error) {
 	return redirectURL, nil // passthrough for tests that don't need real JWT signing
 }
 
-func (m *mockTokenSvc) ValidateOAuthStateToken(tokenStr, provider string) (string, error) {
-	return tokenStr, nil // treat the raw value as the redirect URL in simple tests
+func (m *mockTokenSvc) ValidateOAuthStateToken(tokenStr, provider string) (string, string, error) {
+	return tokenStr, "", nil // treat the raw value as the redirect URL in simple tests
 }
 
 type mockCrudController struct {
@@ -108,7 +108,7 @@ func TestGoogleCallback_StateJWT(t *testing.T) {
 	}
 
 	t.Run("Valid JWT state redirects correctly", func(t *testing.T) {
-		state, _ := realTokenSvc.CreateOAuthStateToken("/workspaces", "google")
+		state, _ := realTokenSvc.CreateOAuthStateToken("/workspaces", "google", "")
 		req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state="+state, nil)
 		resp, _ := app.Test(req)
 		if resp.StatusCode != http.StatusFound {
@@ -132,7 +132,7 @@ func TestGoogleCallback_StateJWT(t *testing.T) {
 
 	t.Run("Wrong provider state falls back to /", func(t *testing.T) {
 		// State signed for github should be rejected by google callback
-		state, _ := realTokenSvc.CreateOAuthStateToken("/workspaces", "github")
+		state, _ := realTokenSvc.CreateOAuthStateToken("/workspaces", "github", "")
 		req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state="+state, nil)
 		resp, _ := app.Test(req)
 		if resp.StatusCode != http.StatusFound {

--- a/backend/internal/handler/slack/slack.go
+++ b/backend/internal/handler/slack/slack.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	slackctrl "github.com/agentrq/agentrq/backend/internal/controller/slack"
+	"github.com/agentrq/agentrq/backend/internal/service/auth"
 	slacksvc "github.com/agentrq/agentrq/backend/internal/service/slack"
 	zlog "github.com/rs/zerolog/log"
 )
@@ -20,6 +21,7 @@ import (
 type Params struct {
 	SlackCtrl slackctrl.Controller
 	SlackSvc  slacksvc.Service
+	TokenSvc  auth.TokenService
 	BaseURL   string
 	Mux       *http.ServeMux
 }
@@ -33,7 +35,7 @@ type Params struct {
 func New(p Params) {
 	p.Mux.Handle("/slack/events", eventsHandler(p.SlackSvc, p.SlackCtrl))
 	p.Mux.Handle("/slack/interactions", interactionsHandler(p.SlackSvc, p.SlackCtrl))
-	p.Mux.Handle("/slack/oauth/callback", oauthCallbackHandler(p.SlackSvc, p.SlackCtrl, p.BaseURL))
+	p.Mux.Handle("/slack/oauth/callback", oauthCallbackHandler(p.SlackSvc, p.SlackCtrl, p.TokenSvc, p.BaseURL))
 	p.Mux.Handle("/slack/commands", commandHandler(p.SlackSvc, p.SlackCtrl))
 }
 
@@ -174,7 +176,7 @@ func interactionsHandler(svc slacksvc.Service, ctrl slackctrl.Controller) http.H
 }
 
 // oauthCallbackHandler handles Slack's OAuth redirect callback.
-func oauthCallbackHandler(svc slacksvc.Service, ctrl slackctrl.Controller, baseURL string) http.Handler {
+func oauthCallbackHandler(svc slacksvc.Service, ctrl slackctrl.Controller, tokenSvc auth.TokenService, baseURL string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -182,7 +184,7 @@ func oauthCallbackHandler(svc slacksvc.Service, ctrl slackctrl.Controller, baseU
 		}
 
 		code := r.URL.Query().Get("code")
-		state := r.URL.Query().Get("state") // base62 workspace ID
+		state := r.URL.Query().Get("state")
 
 		if code == "" || state == "" {
 			zlog.Warn().Msg("[slack/oauth] missing code or state parameter")
@@ -190,18 +192,26 @@ func oauthCallbackHandler(svc slacksvc.Service, ctrl slackctrl.Controller, baseU
 			return
 		}
 
+		// Validate signed state token
+		_, workspaceID62, err := tokenSvc.ValidateOAuthStateToken(state, "slack")
+		if err != nil {
+			zlog.Error().Err(err).Msg("[slack/oauth] invalid state token")
+			http.Error(w, "invalid state token", http.StatusForbidden)
+			return
+		}
+
 		redirectURI := fmt.Sprintf("%s/slack/oauth/callback", baseURL)
-		err := ctrl.HandleOAuthCallback(r.Context(), state, code, redirectURI)
+		err = ctrl.HandleOAuthCallback(r.Context(), workspaceID62, code, redirectURI)
 		if err != nil {
 			zlog.Error().Err(err).Msg("[slack/oauth] HandleOAuthCallback error")
 			// Redirect back with a generic error query param to prevent information leakage
 			errorMsg := url.QueryEscape("failed to complete slack authorization")
-			http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack&slack_error=%s", baseURL, state, errorMsg), http.StatusTemporaryRedirect)
+			http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack&slack_error=%s", baseURL, workspaceID62, errorMsg), http.StatusTemporaryRedirect)
 			return
 		}
 
 		// Redirect back to settings page on success
-		http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack", baseURL, state), http.StatusTemporaryRedirect)
+		http.Redirect(w, r, fmt.Sprintf("%s/workspaces/%s/settings?tab=slack", baseURL, workspaceID62), http.StatusTemporaryRedirect)
 	})
 }
 

--- a/backend/internal/service/auth/jwt.go
+++ b/backend/internal/service/auth/jwt.go
@@ -30,15 +30,16 @@ type Claims struct {
 type StateClaims struct {
 	jwt.RegisteredClaims
 	RedirectURL string `json:"rurl,omitempty"`
+	WorkspaceID string `json:"wid,omitempty"`
 }
 
 type TokenService interface {
 	CreateToken(userID, email, name, picture string) (string, error)
 	CreateMCPToken(userID, workspaceID, tokenType string) (string, error)
 	CreateOAuthCodeToken(userID, workspaceID string) (string, error)
-	CreateOAuthStateToken(redirectURL, provider string) (string, error)
+	CreateOAuthStateToken(redirectURL, provider, workspaceID string) (string, error)
 	ValidateToken(tokenStr string) (*Claims, error)
-	ValidateOAuthStateToken(tokenStr, provider string) (redirectURL string, err error)
+	ValidateOAuthStateToken(tokenStr, provider string) (redirectURL string, workspaceID string, err error)
 }
 
 type tokenService struct {
@@ -128,7 +129,7 @@ func (s *tokenService) CreateOAuthCodeToken(userID, workspaceID string) (string,
 	return token.SignedString(s.secret)
 }
 
-func (s *tokenService) CreateOAuthStateToken(redirectURL, provider string) (string, error) {
+func (s *tokenService) CreateOAuthStateToken(redirectURL, provider, workspaceID string) (string, error) {
 	now := time.Now()
 	claims := StateClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
@@ -138,12 +139,13 @@ func (s *tokenService) CreateOAuthStateToken(redirectURL, provider string) (stri
 			NotBefore: jwt.NewNumericDate(now.Add(-2 * time.Second)),
 		},
 		RedirectURL: redirectURL,
+		WorkspaceID: workspaceID,
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	return token.SignedString(s.secret)
 }
 
-func (s *tokenService) ValidateOAuthStateToken(tokenStr, provider string) (string, error) {
+func (s *tokenService) ValidateOAuthStateToken(tokenStr, provider string) (string, string, error) {
 	token, err := jwt.ParseWithClaims(tokenStr, &StateClaims{}, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method")
@@ -151,14 +153,14 @@ func (s *tokenService) ValidateOAuthStateToken(tokenStr, provider string) (strin
 		return s.secret, nil
 	}, jwt.WithAudience(provider))
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	claims, ok := token.Claims.(*StateClaims)
 	if !ok || !token.Valid {
-		return "", errors.New("invalid state token")
+		return "", "", errors.New("invalid state token")
 	}
-	return claims.RedirectURL, nil
+	return claims.RedirectURL, claims.WorkspaceID, nil
 }
 
 func (s *tokenService) ValidateToken(tokenStr string) (*Claims, error) {

--- a/backend/internal/service/auth/jwt_test.go
+++ b/backend/internal/service/auth/jwt_test.go
@@ -144,41 +144,45 @@ func TestTokenService(t *testing.T) {
 	t.Run("CreateAndValidateOAuthStateToken", func(t *testing.T) {
 		redirectURL := "/dashboard"
 		provider := "google"
+		workspaceID := "ws_123"
 
-		token, err := s.CreateOAuthStateToken(redirectURL, provider)
+		token, err := s.CreateOAuthStateToken(redirectURL, provider, workspaceID)
 		if err != nil {
 			t.Fatalf("failed to create state token: %v", err)
 		}
 
-		got, err := s.ValidateOAuthStateToken(token, provider)
+		got, gotWS, err := s.ValidateOAuthStateToken(token, provider)
 		if err != nil {
 			t.Fatalf("failed to validate state token: %v", err)
 		}
 		if got != redirectURL {
 			t.Errorf("expected redirectURL %q, got %q", redirectURL, got)
 		}
+		if gotWS != workspaceID {
+			t.Errorf("expected workspaceID %q, got %q", workspaceID, gotWS)
+		}
 	})
 
 	t.Run("OAuthStateTokenWrongProvider", func(t *testing.T) {
-		token, err := s.CreateOAuthStateToken("/dashboard", "google")
+		token, err := s.CreateOAuthStateToken("/dashboard", "google", "")
 		if err != nil {
 			t.Fatalf("failed to create state token: %v", err)
 		}
 
-		_, err = s.ValidateOAuthStateToken(token, "github")
+		_, _, err = s.ValidateOAuthStateToken(token, "github")
 		if err == nil {
 			t.Error("expected error when validating with wrong provider, got nil")
 		}
 	})
 
 	t.Run("OAuthStateTokenExpiry", func(t *testing.T) {
-		token, err := s.CreateOAuthStateToken("/", "google")
+		token, err := s.CreateOAuthStateToken("/", "google", "")
 		if err != nil {
 			t.Fatalf("failed to create state token: %v", err)
 		}
 
 		// Should be valid immediately
-		_, err = s.ValidateOAuthStateToken(token, "google")
+		_, _, err = s.ValidateOAuthStateToken(token, "google")
 		if err != nil {
 			t.Errorf("expected valid token, got: %v", err)
 		}


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The Slack OAuth flow utilized a predictable base62-encoded `workspaceID` as the `state` parameter, providing no protection against Cross-Site Request Forgery (CSRF).
🎯 **Impact:** An attacker could exploit this to perform session fixation, tricking a workspace administrator into connecting their Slack workspace to an attacker-controlled AgentRQ workspace.
🔧 **Fix:** Hardened the OAuth flow by implementing signed JWT state tokens:
1. Updated `TokenService` to support optional workspace binding in `StateClaims`.
2. Modified the Slack controller to generate signed JWT state tokens containing the workspace ID.
3. Updated the Slack callback handler to verify the JWT signature, expiration, and provider audience before completing the link.
4. Consistent signature updates for Google and GitHub OAuth flows.
✅ **Verification:**
- Executed unit tests: `go test ./backend/internal/service/auth/... ./backend/internal/handler/api/... ./backend/internal/controller/slack/...`
- Verified successful backend compilation: `go build ./backend/...`
- Manual verification of Slack OAuth URL state parameter (now a long JWT string).

---
*PR created automatically by Jules for task [17546622732343782848](https://jules.google.com/task/17546622732343782848) started by @mustafaturan*