### PR TITLE
🛡️ Sentinel: [HIGH] Fix IDOR/BOLA in repository methods

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** The Slack OAuth flow used a predictable base62 workspace ID as the `state` parameter. This lacked cryptographic integrity and session binding, making it vulnerable to CSRF attacks where an attacker could force a user to link their Slack workspace to an arbitrary AgentRQ workspace.
 **Learning:** The `state` parameter in OAuth2 is intended to be a non-guessable, session-bound value to prevent CSRF. Using a resource ID directly is insufficient.
 **Prevention:** Always use cryptographically signed tokens or high-entropy random nonces for the OAuth `state` parameter. In this project, `TokenService.CreateOAuthStateToken` provides a secure, signed JWT that can carry payload (like workspace ID) while ensuring origin and integrity.
+
+## 2026-07-06 - BOLA/IDOR in Repository Layer
+**Vulnerability:** Several repository methods (ListMessages, UpdateMessageMetadata, GetWorkspaceAttachmentIDs) fetched or modified data based solely on resource IDs without verifying the userID of the owner.
+**Learning:** Even if controllers or handlers perform an initial check, the repository layer should ideally enforce authorization by including ownership criteria in its queries to prevent BOLA/IDOR if a caller fails to perform the check.
+**Prevention:** Always include a userID parameter in repository methods that access user-specific resources and enforce it in the SQL query (e.g., WHERE id = ? AND user_id = ?).

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -478,10 +478,10 @@ func New(cfg Config) (*App, error) {
 					existingMetadata[k] = v
 				}
 
+				uid := monoflake.IDFromBase62(workspaceOwner).Int64()
 				b, _ := json.Marshal(existingMetadata)
-				err := repo.UpdateMessageMetadata(ctx, taskID, messageID, b)
+				err := repo.UpdateMessageMetadata(ctx, taskID, messageID, uid, b)
 				if err == nil {
-					uid := monoflake.IDFromBase62(workspaceOwner).Int64()
 					latest, _ := repo.GetTask(ctx, workspaceID, taskID, uid)
 					bus.Publish(workspaceID, workspaceOwner, eventbus.Event{
 						Type:    "task.updated",
@@ -651,7 +651,7 @@ func New(cfg Config) (*App, error) {
 					t, err := repo.SystemGetTask(ctx, taskID)
 					if err == nil {
 						// Preload task messages
-						messages, err := repo.ListMessages(ctx, t.ID)
+						messages, err := repo.ListMessages(ctx, t.ID, t.UserID)
 						if err == nil {
 							t.Messages = messages
 						}

--- a/backend/internal/controller/crud/task.go
+++ b/backend/internal/controller/crud/task.go
@@ -591,7 +591,7 @@ func (c *controller) UpdateMessageMetadata(ctx context.Context, req entity.Updat
 		return err
 	}
 
-	if err := c.repository.UpdateMessageMetadata(ctx, req.TaskID, req.MessageID, b); err != nil {
+	if err := c.repository.UpdateMessageMetadata(ctx, req.TaskID, req.MessageID, uid, b); err != nil {
 		return err
 	}
 	c.emitEvent(ctx, entity.CRUDEvent{

--- a/backend/internal/controller/crud/task_test.go
+++ b/backend/internal/controller/crud/task_test.go
@@ -784,7 +784,7 @@ func TestUpdateMessageMetadata_Success(t *testing.T) {
 	e := newTestController(t)
 
 	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(10), testUserID).Return(model.Task{}, nil)
-	e.repo.EXPECT().UpdateMessageMetadata(gomock.Any(), int64(10), int64(500), gomock.Any()).Return(nil)
+	e.repo.EXPECT().UpdateMessageMetadata(gomock.Any(), int64(10), int64(500), testUserID, gomock.Any()).Return(nil)
 
 	err := e.controller.UpdateMessageMetadata(context.Background(), entity.UpdateMessageMetadataRequest{
 		WorkspaceID: 1,

--- a/backend/internal/controller/crud/workspace.go
+++ b/backend/internal/controller/crud/workspace.go
@@ -99,7 +99,7 @@ func (c *controller) ListWorkspaces(ctx context.Context, req entity.ListWorkspac
 func (c *controller) DeleteWorkspace(ctx context.Context, req entity.DeleteWorkspaceRequest) error {
 	// 1. Get all task and message attachment IDs directly from DB
 	uid := monoflake.IDFromBase62(req.UserID).Int64()
-	attachmentIDs, _ := c.repository.GetWorkspaceAttachmentIDs(ctx, req.ID)
+	attachmentIDs, _ := c.repository.GetWorkspaceAttachmentIDs(ctx, req.ID, uid)
 
 	// 2. Delete from DB (repository handles cascaded DB delete)
 	if err := c.repository.DeleteWorkspace(ctx, req.ID, uid); err != nil {

--- a/backend/internal/controller/crud/workspace_test.go
+++ b/backend/internal/controller/crud/workspace_test.go
@@ -38,7 +38,7 @@ func TestCreateWorkspace_WithOptions(t *testing.T) {
 func TestDeleteWorkspace_Complex(t *testing.T) {
 	e := newTestController(t)
 
-	e.repo.EXPECT().GetWorkspaceAttachmentIDs(gomock.Any(), int64(1)).Return([]string{"att-1", "att-2"}, nil)
+	e.repo.EXPECT().GetWorkspaceAttachmentIDs(gomock.Any(), int64(1), testUserID).Return([]string{"att-1", "att-2"}, nil)
 	e.repo.EXPECT().DeleteWorkspace(gomock.Any(), int64(1), testUserID).Return(nil)
 	e.storage.EXPECT().Delete("att-1").Return(nil)
 	e.storage.EXPECT().Delete("att-2").Return(nil)

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -255,7 +255,7 @@ func (c *controller) OnMessageCreated(ctx context.Context, msg entity.Message, t
 				msg.Metadata = metaMap
 				b, marshalErr := json.Marshal(metaMap)
 				if marshalErr == nil {
-					if updateErr := c.repo.UpdateMessageMetadata(ctx, task.ID, msg.ID, b); updateErr != nil {
+					if updateErr := c.repo.UpdateMessageMetadata(ctx, task.ID, msg.ID, task.UserID, b); updateErr != nil {
 						zlog.Error().Err(updateErr).Int64("messageID", msg.ID).Msg("[slack] failed to update message metadata with slack details")
 					}
 				}
@@ -757,7 +757,8 @@ func (c *controller) HandleMCPPermission(ctx context.Context, action SlackBlockA
 
 	// Try to find the permission request message and save the slack decision flag in its metadata first,
 	// so that OnMessageUpdated can skip overwriting the slack-initiated UI update.
-	messages, listErr := c.repo.ListMessages(ctx, taskID)
+	uid := monoflake.IDFromBase62(ownerID).Int64()
+	messages, listErr := c.repo.ListMessages(ctx, taskID, uid)
 	if listErr == nil {
 		for _, m := range messages {
 			var metadata map[string]any
@@ -775,7 +776,7 @@ func (c *controller) HandleMCPPermission(ctx context.Context, action SlackBlockA
 					metadata["slack_user_name"] = action.UserName
 					b, marshalErr := json.Marshal(metadata)
 					if marshalErr == nil {
-						_ = c.repo.UpdateMessageMetadata(ctx, taskID, m.ID, b)
+						_ = c.repo.UpdateMessageMetadata(ctx, taskID, m.ID, uid, b)
 					}
 					break
 				}

--- a/backend/internal/controller/slack/slack_test.go
+++ b/backend/internal/controller/slack/slack_test.go
@@ -1106,14 +1106,15 @@ func TestHandleMCPPermission_Success_Allow(t *testing.T) {
 			SlackChannelID: "C123",
 		}, nil)
 
+	uid := monoflake.IDFromBase62(ownerUserID).Int64()
 	mockRepo.EXPECT().
-		ListMessages(gomock.Any(), taskID).
+		ListMessages(gomock.Any(), taskID, uid).
 		Return([]model.Message{permMsg}, nil)
 
 	var capturedMeta []byte
 	mockRepo.EXPECT().
-		UpdateMessageMetadata(gomock.Any(), taskID, int64(7), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ int64, _ int64, b []byte) error {
+		UpdateMessageMetadata(gomock.Any(), taskID, int64(7), uid, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ int64, _ int64, _ int64, b []byte) error {
 			capturedMeta = b
 			return nil
 		})

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -33,9 +33,9 @@ type Repository interface {
 
 	// Message
 	CreateMessage(ctx context.Context, m model.Message) error
-	ListMessages(ctx context.Context, taskID int64) ([]model.Message, error)
-	UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte) error
-	GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64) ([]string, error)
+	ListMessages(ctx context.Context, taskID int64, userID int64) ([]model.Message, error)
+	UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, userID int64, metadata []byte) error
+	GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64, userID int64) ([]string, error)
 
 	SystemGetWorkspace(ctx context.Context, id int64) (model.Workspace, error)
 	SystemGetTask(ctx context.Context, id int64) (model.Task, error)
@@ -349,22 +349,22 @@ func (r *repository) CreateMessage(ctx context.Context, m model.Message) error {
 	return r.conn(ctx).Create(&m).Error
 }
 
-func (r *repository) ListMessages(ctx context.Context, taskID int64) ([]model.Message, error) {
+func (r *repository) ListMessages(ctx context.Context, taskID int64, userID int64) ([]model.Message, error) {
 	var msgs []model.Message
-	err := r.conn(ctx).Where("task_id = ?", taskID).Order("created_at asc").Find(&msgs).Error
+	err := r.conn(ctx).Where("task_id = ? AND user_id = ?", taskID, userID).Order("created_at asc").Find(&msgs).Error
 	return msgs, err
 }
 
-func (r *repository) UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte) error {
-	return r.conn(ctx).Model(&model.Message{}).Where("id = ? AND task_id = ?", messageID, taskID).Update("metadata", metadata).Error
+func (r *repository) UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, userID int64, metadata []byte) error {
+	return r.conn(ctx).Model(&model.Message{}).Where("id = ? AND task_id = ? AND user_id = ?", messageID, taskID, userID).Update("metadata", metadata).Error
 }
 
-func (r *repository) GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64) ([]string, error) {
+func (r *repository) GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64, userID int64) ([]string, error) {
 	var attachmentIDs []string
 
 	// 1. Get attachments from tasks
 	var taskAttachments []string
-	err := r.conn(ctx).Model(&model.Task{}).Where("workspace_id = ?", workspaceID).Pluck("attachments", &taskAttachments).Error
+	err := r.conn(ctx).Model(&model.Task{}).Where("workspace_id = ? AND user_id = ?", workspaceID, userID).Pluck("attachments", &taskAttachments).Error
 	if err == nil {
 		for _, ta := range taskAttachments {
 			if len(ta) > 0 {
@@ -384,7 +384,7 @@ func (r *repository) GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID 
 	var msgAttachments []string
 	err = r.conn(ctx).Model(&model.Message{}).
 		Joins("JOIN tasks ON tasks.id = messages.task_id").
-		Where("tasks.workspace_id = ?", workspaceID).
+		Where("tasks.workspace_id = ? AND tasks.user_id = ?", workspaceID, userID).
 		Pluck("messages.attachments", &msgAttachments).Error
 	if err == nil {
 		for _, ma := range msgAttachments {

--- a/backend/internal/repository/base/repository_test.go
+++ b/backend/internal/repository/base/repository_test.go
@@ -144,11 +144,12 @@ func TestRepository_UpdateMessageMetadata(t *testing.T) {
 	db.Create(&model.Message{
 		ID:     messageID,
 		TaskID: taskID,
+		UserID: 1,
 		Text:   "Initial text",
 	})
 
-	// Case 1: Success update with correct taskID
-	err = repo.UpdateMessageMetadata(ctx, taskID, messageID, []byte(`{"updated":true}`))
+	// Case 1: Success update with correct taskID and userID
+	err = repo.UpdateMessageMetadata(ctx, taskID, messageID, 1, []byte(`{"updated":true}`))
 	if err != nil {
 		t.Errorf("expected nil error, got %v", err)
 	}
@@ -160,7 +161,7 @@ func TestRepository_UpdateMessageMetadata(t *testing.T) {
 	}
 
 	// Case 2: Update with WRONG taskID (IDOR)
-	err = repo.UpdateMessageMetadata(ctx, 999, messageID, []byte(`{"hacked":true}`))
+	err = repo.UpdateMessageMetadata(ctx, 999, messageID, 1, []byte(`{"hacked":true}`))
 	if err != nil {
 		t.Errorf("expected nil error (GORM Update doesn't return error on no rows), got %v", err)
 	}
@@ -198,6 +199,7 @@ func TestRepository_ListTasks_PreloadMessages(t *testing.T) {
 		db.Create(&model.Message{
 			ID:     100 + i,
 			TaskID: i,
+			UserID: userID,
 			Text:   "Initial msg for task",
 		})
 	}
@@ -222,6 +224,24 @@ func TestRepository_ListTasks_PreloadMessages(t *testing.T) {
 		if len(task.Messages) != 1 {
 			t.Errorf("expected 1 preloaded message for task %d, got %d", task.ID, len(task.Messages))
 		}
+	}
+
+	// Case 2: ListMessages with userID
+	msgs, err := repo.ListMessages(ctx, 1, userID)
+	if err != nil {
+		t.Fatalf("ListMessages failed: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Errorf("expected 1 message, got %d", len(msgs))
+	}
+
+	// Case 3: ListMessages with WRONG userID (IDOR)
+	msgs, err = repo.ListMessages(ctx, 1, 999)
+	if err != nil {
+		t.Fatalf("ListMessages (wrong user) failed: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("vulnerability: expected 0 messages for wrong user, got %d", len(msgs))
 	}
 }
 
@@ -260,6 +280,7 @@ func TestRepository_GetWorkspaceTaskCountsByCategory(t *testing.T) {
 	db.Create(&model.Message{
 		ID:        901,
 		TaskID:    9,
+		UserID:    userID,
 		CreatedAt: time.Now(),
 		Metadata:  []byte(`{"type":"permission_request","status":"pending"}`),
 	})
@@ -283,6 +304,39 @@ func TestRepository_GetWorkspaceTaskCountsByCategory(t *testing.T) {
 	}
 	if counts["pending"] != 1 { // ID 9
 		t.Errorf("expected 1 pending tasks, got %d", counts["pending"])
+	}
+
+	// Test GetWorkspaceAttachmentIDs
+	_ = db.AutoMigrate(&model.Task{}, &model.Message{})
+	_ = db.Create(&model.Task{
+		ID:          100,
+		WorkspaceID: 1,
+		UserID:      10,
+		Attachments: []byte(`[{"id":"att-task-1","filename":"test.txt"}]`),
+	})
+	_ = db.Create(&model.Message{
+		ID:        200,
+		TaskID:    100,
+		UserID:    10,
+		Attachments: []byte(`[{"id":"att-msg-1","filename":"test2.txt"}]`),
+	})
+
+	// Correct user
+	attIDs, err := repo.GetWorkspaceAttachmentIDs(ctx, 1, 10)
+	if err != nil {
+		t.Fatalf("GetWorkspaceAttachmentIDs failed: %v", err)
+	}
+	if len(attIDs) != 2 {
+		t.Errorf("expected 2 attachments, got %d", len(attIDs))
+	}
+
+	// Wrong user
+	attIDs, err = repo.GetWorkspaceAttachmentIDs(ctx, 1, 999)
+	if err != nil {
+		t.Fatalf("GetWorkspaceAttachmentIDs failed: %v", err)
+	}
+	if len(attIDs) != 0 {
+		t.Errorf("vulnerability: expected 0 attachments for wrong user, got %d", len(attIDs))
 	}
 }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Insecure Direct Object Reference (IDOR) / Broken Object Level Authorization (BOLA) in repository layer.
🎯 Impact: Authenticated users could potentially read or modify messages and retrieve attachment IDs belonging to other users' workspaces by iterating through sequential or guessable IDs.
🔧 Fix: Hardened the repository layer by requiring a `userID` parameter for `ListMessages`, `UpdateMessageMetadata`, and `GetWorkspaceAttachmentIDs`. Added `WHERE user_id = ?` or ownership joins to the database queries to strictly enforce authorization at the data access level. Updated all calling controllers and background processes to resolve and pass the correct user ID.
✅ Verification:
- Updated `backend/internal/repository/base/repository_test.go` with new test cases specifically checking for IDOR prevention (wrong userID should return empty results).
- Updated all mock-based unit tests in CRUD and Slack controllers.
- Verified all backend tests pass with `cd backend && go test ./...`.
- Verified successful compilation with `go build ./...`.

---
*PR created automatically by Jules for task [6944157751109421905](https://jules.google.com/task/6944157751109421905) started by @mustafaturan*