### PR TITLE
Ignore local runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,51 @@
-node_modules
-frontend/dist
-*.db
+# Environment and local secrets
 .env
-.DS_Store
-*_binary
-*.pid
-*.log
-*.tmp
-main
+.env.*
+!.env.example
 .mcp.json
-backend/internal/service/mocks
+
+# OS and editor files
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Logs and runtime state
+*.log
+*.pid
+*.tmp
+*.temp
+
+# Node / frontend
+node_modules/
+**/node_modules/
+frontend/dist/
+frontend/.vite/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Go build and test artifacts
+*_binary
+main
 coverage.out
+*.test
+
+# Generated test mocks
+backend/internal/service/mocks/
+
+# SQLite databases and WAL files
+*.db
+*.db-journal
+*.db-shm
+*.db-wal
 agentrq.db
-acp-gateway
-acp-gateway/coverage
-acp-gateway/dist
+
+# Project-local generated outputs
+acp-gateway/
 gemini-extension/
 claude-extension/
 .antigravitycli/


### PR DESCRIPTION
Group ignore rules by artifact type and cover SQLite WAL files produced by local development runs.

Constraint: Local AgentRQ startup creates SQLite sidecar files under backend/cmd/server/_storage

Rejected: Ignore the entire _storage directory | existing project assets live there and should remain visible

Confidence: high

Scope-risk: narrow

Directive: Keep package manager lockfiles visible unless the project standard changes

Tested: git check-ignore for SQLite WAL files, frontend dist, and node_modules

Not-tested: Cross-platform IDE-specific generated files beyond common defaults