### PR TITLE
🛡️ Sentinel: [HIGH] Enforce JWT audience validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** The Slack OAuth flow used a predictable base62 workspace ID as the `state` parameter. This lacked cryptographic integrity and session binding, making it vulnerable to CSRF attacks where an attacker could force a user to link their Slack workspace to an arbitrary AgentRQ workspace.
 **Learning:** The `state` parameter in OAuth2 is intended to be a non-guessable, session-bound value to prevent CSRF. Using a resource ID directly is insufficient.
 **Prevention:** Always use cryptographically signed tokens or high-entropy random nonces for the OAuth `state` parameter. In this project, `TokenService.CreateOAuthStateToken` provides a secure, signed JWT that can carry payload (like workspace ID) while ensuring origin and integrity.
+
+## 2025-05-24 - Missing JWT Audience Validation
+**Vulnerability:** The application used JWTs for both human UI sessions and MCP (service-to-service) authentication, but the API handlers did not verify the `aud` (audience) claim. This allowed a validly signed but restricted-scope MCP token to be used to access sensitive human-only API endpoints and SSE streams.
+**Learning:** Valid signature and expiration are insufficient for JWT security. Different parts of an application (e.g., UI vs. API vs. Webhooks) should use distinct audience claims to prevent token misuse across security boundaries.
+**Prevention:** Always enforce strict audience validation at every authentication checkpoint. Use distinct constants (like `ActorHumanAudience`) and verify them using helper functions like `auth.HasAudience` before granting access.

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -838,9 +838,17 @@ func eventsHandler(ctrl crud.Controller, bus *eventbus.Bus, tokenSvc auth.TokenS
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
+
 		claims, err := tokenSvc.ValidateToken(cookie.Value)
 		if err != nil {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		// Situational security: only tokens intended for the human UI (ActorHumanAudience)
+		// are allowed to access SSE events.
+		if !auth.HasAudience(claims, auth.ActorHumanAudience) {
+			http.Error(w, "Unauthorized: invalid audience", http.StatusUnauthorized)
 			return
 		}
 		userID := claims.Subject

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -233,6 +233,12 @@ func (h *handler) authMiddleware() fiber.Handler {
 			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "unauthorized"})
 		}
 
+		// Situational security: only tokens intended for the human UI (ActorHumanAudience)
+		// are allowed to access protected API endpoints.
+		if !auth.HasAudience(claims, auth.ActorHumanAudience) {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "unauthorized: invalid audience"})
+		}
+
 		c.Locals("user_id", claims.Subject)
 		c.Locals("user_email", claims.Email)
 		c.Locals("user_name", claims.Name)

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -407,7 +407,11 @@ func (h *handler) oauthAuthorizeHandler() http.Handler {
 		var userID string
 		if cookie, err := r.Cookie("at"); err == nil && cookie.Value != "" {
 			if claims, err := h.tokenSvc.ValidateToken(cookie.Value); err == nil && claims != nil {
-				userID = claims.Subject
+				// Only tokens intended for the human UI (ActorHumanAudience) are allowed
+				// to identify the session for OAuth authorization.
+				if auth.HasAudience(claims, auth.ActorHumanAudience) {
+					userID = claims.Subject
+				}
 			}
 		}
 

--- a/backend/internal/handler/mcp/mcp_test.go
+++ b/backend/internal/handler/mcp/mcp_test.go
@@ -25,7 +25,15 @@ type mockTokenSvc struct {
 }
 
 func (m *mockTokenSvc) ValidateToken(tokenStr string) (*auth.Claims, error) {
-	if tokenStr == "valid-auth-cookie" || tokenStr == m.validCode || tokenStr == "valid-refresh-token" {
+	if tokenStr == "valid-auth-cookie" {
+		return &auth.Claims{
+			RegisteredClaims: jwt.RegisteredClaims{
+				Subject:  monoflake.IDFromBase62("user123").String(),
+				Audience: jwt.ClaimStrings{auth.ActorHumanAudience},
+			},
+		}, nil
+	}
+	if tokenStr == m.validCode || tokenStr == "valid-refresh-token" {
 		return &auth.Claims{
 			RegisteredClaims: jwt.RegisteredClaims{
 				Subject:  monoflake.IDFromBase62("user123").String(),


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing JWT Audience Validation
🎯 Impact: Validly signed but restricted-scope MCP tokens could be used to impersonate humans and access sensitive UI APIs and SSE streams.
🔧 Fix: Added explicit audience checks using `auth.HasAudience(claims, auth.ActorHumanAudience)` in the auth middleware, SSE handler, and OAuth authorization flow.
✅ Verification: Verified with a reproduction test (confirming 401 Unauthorized for MCP tokens in UI routes) and updated existing test suites.

---
*PR created automatically by Jules for task [5554759850189294920](https://jules.google.com/task/5554759850189294920) started by @mustafaturan*