### PR TITLE
🛡️ Sentinel: Harden JWT and OAuth authentication

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,13 @@
 **Vulnerability:** The Slack OAuth flow used a predictable base62 workspace ID as the `state` parameter. This lacked cryptographic integrity and session binding, making it vulnerable to CSRF attacks where an attacker could force a user to link their Slack workspace to an arbitrary AgentRQ workspace.
 **Learning:** The `state` parameter in OAuth2 is intended to be a non-guessable, session-bound value to prevent CSRF. Using a resource ID directly is insufficient.
 **Prevention:** Always use cryptographically signed tokens or high-entropy random nonces for the OAuth `state` parameter. In this project, `TokenService.CreateOAuthStateToken` provides a secure, signed JWT that can carry payload (like workspace ID) while ensuring origin and integrity.
+
+## 2025-05-24 - Enforce Human Audience for UI APIs
+**Vulnerability:** The application used a shared JWT secret for both human UI sessions and service-level MCP tokens. Without explicit audience validation, a service-level MCP token (which might have long expiration) could be misused to access human-only UI REST APIs.
+**Learning:** In a multi-actor system (Humans, Agents/MCP), sharing a signing secret requires explicit 'aud' (audience) or 'sub' (subject) type validation in middleware to prevent token cross-contamination.
+**Prevention:** Always include an 'actor' or specific audience claim in JWTs and verify it in the corresponding middleware. We now use 'actor:human' for UI sessions.
+
+## 2025-05-25 - Strict OAuth State Enforcement
+**Vulnerability:** The OAuth callback handlers for Google and GitHub were too lenient; if the 'state' parameter was missing or failed JWT validation, they would fall back to redirecting the user to the home page ('/'). This could lead to login CSRF or session fixation if an attacker can force a login flow.
+**Learning:** OAuth 'state' validation MUST be a terminal failure. Falling back to a "safe" default mask a failure in the security handshake.
+**Prevention:** Return a 403 Forbidden or similar hard error when OAuth state validation fails. Never fall back to a default redirect on security validation failure.

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -843,6 +843,13 @@ func eventsHandler(ctrl crud.Controller, bus *eventbus.Bus, tokenSvc auth.TokenS
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
+
+		// Ensure the token is intended for human actor UI access.
+		if !auth.HasAudience(claims, auth.ActorHumanAudience) {
+			http.Error(w, "Unauthorized: human audience required", http.StatusUnauthorized)
+			return
+		}
+
 		userID := claims.Subject
 
 		workspaceIDParam := r.PathValue("id")

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -233,6 +233,12 @@ func (h *handler) authMiddleware() fiber.Handler {
 			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "unauthorized"})
 		}
 
+		// Ensure the token is intended for human actor UI access,
+		// preventing service-level MCP tokens from accessing these APIs.
+		if !auth.HasAudience(claims, auth.ActorHumanAudience) {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "unauthorized: human audience required"})
+		}
+
 		c.Locals("user_id", claims.Subject)
 		c.Locals("user_email", claims.Email)
 		c.Locals("user_name", claims.Name)
@@ -385,12 +391,15 @@ func (h *handler) googleCallback() fiber.Handler {
 		}
 		c.Cookie(cookie)
 
-		redirectURL := "/"
-		if stateToken := c.Query("state"); stateToken != "" {
-			if rurl, err := h.tokenSvc.ValidateOAuthStateToken(stateToken, "google"); err == nil {
-				redirectURL = h.sanitizeRedirectURL(rurl)
-			}
+		stateToken := c.Query("state")
+		if stateToken == "" {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "missing state parameter"})
 		}
+		rurl, err := h.tokenSvc.ValidateOAuthStateToken(stateToken, "google")
+		if err != nil {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "invalid state parameter"})
+		}
+		redirectURL := h.sanitizeRedirectURL(rurl)
 
 		return c.Redirect(redirectURL)
 	}
@@ -465,12 +474,15 @@ func (h *handler) githubCallback() fiber.Handler {
 		}
 		c.Cookie(cookie)
 
-		redirectURL := "/"
-		if stateToken := c.Query("state"); stateToken != "" {
-			if rurl, err := h.tokenSvc.ValidateOAuthStateToken(stateToken, "github"); err == nil {
-				redirectURL = h.sanitizeRedirectURL(rurl)
-			}
+		stateToken := c.Query("state")
+		if stateToken == "" {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "missing state parameter"})
 		}
+		rurl, err := h.tokenSvc.ValidateOAuthStateToken(stateToken, "github")
+		if err != nil {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "invalid state parameter"})
+		}
+		redirectURL := h.sanitizeRedirectURL(rurl)
 
 		return c.Redirect(redirectURL)
 	}

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -119,38 +119,29 @@ func TestGoogleCallback_StateJWT(t *testing.T) {
 		}
 	})
 
-	t.Run("Forged state falls back to /", func(t *testing.T) {
+	t.Run("Forged state returns 403", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state=forged-not-a-jwt", nil)
 		resp, _ := app.Test(req)
-		if resp.StatusCode != http.StatusFound {
-			t.Fatalf("expected 302, got %d", resp.StatusCode)
-		}
-		if loc := resp.Header.Get("Location"); loc != "/" {
-			t.Errorf("expected /, got %s", loc)
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("expected 403, got %d", resp.StatusCode)
 		}
 	})
 
-	t.Run("Wrong provider state falls back to /", func(t *testing.T) {
+	t.Run("Wrong provider state returns 403", func(t *testing.T) {
 		// State signed for github should be rejected by google callback
 		state, _ := realTokenSvc.CreateOAuthStateToken("/workspaces", "github")
 		req := httptest.NewRequest("GET", "/google/callback?code=valid-code&state="+state, nil)
 		resp, _ := app.Test(req)
-		if resp.StatusCode != http.StatusFound {
-			t.Fatalf("expected 302, got %d", resp.StatusCode)
-		}
-		if loc := resp.Header.Get("Location"); loc != "/" {
-			t.Errorf("expected /, got %s", loc)
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("expected 403, got %d", resp.StatusCode)
 		}
 	})
 
-	t.Run("Missing state falls back to /", func(t *testing.T) {
+	t.Run("Missing state returns 403", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/google/callback?code=valid-code", nil)
 		resp, _ := app.Test(req)
-		if resp.StatusCode != http.StatusFound {
-			t.Fatalf("expected 302, got %d", resp.StatusCode)
-		}
-		if loc := resp.Header.Get("Location"); loc != "/" {
-			t.Errorf("expected /, got %s", loc)
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("expected 403, got %d", resp.StatusCode)
 		}
 	})
 }
@@ -373,4 +364,35 @@ func TestSendPermissionVerdict_RequiresWorkspaceAccess(t *testing.T) {
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected status 403, got %d", resp.StatusCode)
 	}
+}
+
+func TestAuthMiddleware_AudienceRequired(t *testing.T) {
+	realTokenSvc := auth.NewTokenService(auth.TokenConfig{JWTSecret: "test-secret"})
+	app := fiber.New()
+	h := &handler{tokenSvc: realTokenSvc}
+
+	app.Use(h.authMiddleware())
+	app.Get("/test", func(c *fiber.Ctx) error {
+		return c.SendStatus(http.StatusOK)
+	})
+
+	t.Run("Human token is accepted", func(t *testing.T) {
+		token, _ := realTokenSvc.CreateToken("user1", "user1@example.com", "User One", "")
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.AddCookie(&http.Cookie{Name: "at", Value: token})
+		resp, _ := app.Test(req)
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("MCP token without human audience is rejected", func(t *testing.T) {
+		token, _ := realTokenSvc.CreateMCPToken("user1", "work1", "access")
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.AddCookie(&http.Cookie{Name: "at", Value: token})
+		resp, _ := app.Test(req)
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", resp.StatusCode)
+		}
+	})
 }


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability:
1. Missing audience validation in API middleware allowed service-level MCP tokens to access human UI APIs.
2. Lenient OAuth state validation allowed flow continuation even with missing/invalid state.

🎯 Impact:
1. Potential unauthorized access to UI APIs using long-lived MCP tokens.
2. Risk of login CSRF attacks due to lack of strict state enforcement.

🔧 Fix:
1. Enforced `ActorHumanAudience` in `authMiddleware` and `eventsHandler`.
2. Modified OAuth callbacks to return 403 Forbidden on state validation failure.
3. Updated and added tests to verify these security constraints.

✅ Verification:
Ran `cd backend && go test ./internal/handler/api/...` and verified all tests pass, including new security cases.

---
*PR created automatically by Jules for task [16964548995531481765](https://jules.google.com/task/16964548995531481765) started by @mustafaturan*