### PR TITLE
chore: bump patch version to v0.3.12

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.3.11"
+	_appVersion   = "v0.3.12"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.3.11" {
-			t.Errorf("Expected version v0.3.11, got %s", s.Version())
+		if s.Version() != "v0.3.12" {
+			t.Errorf("Expected version v0.3.12, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.3.11",
+      "version": "0.3.12",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.3.11",
+  "version": "0.3.12",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
Changes since v0.3.11:

fix:
- push: prune expired Web Push subscriptions on 404/410 (#252)
- slack: fix CSRF vulnerability in Slack OAuth flow by using JWT-signed state parameter (#208)

docs:
- events: clarify event publishing is agent-driven, not automatic on completion (#253)

chore:
- gitignore: ignore local SQLite runtime/WAL sidecar files under backend/cmd/server/_storage (#258)