### PR TITLE
fix(frontend): align cron schedule UI with backend hourly-minimum guardrail

### DIFF
--- a/frontend/src/components/TaskFeed.vue
+++ b/frontend/src/components/TaskFeed.vue
@@ -418,8 +418,6 @@ const displayGroups = computed(() => {
     if (cronTasks.length === 0) return [{ title: 'Scheduled', tasks: [], hasMore: scheduledHasMore.value, category: 'scheduled' }];
     
     const categories = [
-      { label: 'Every 15 mins', values: ['*/15 * * * *'] },
-      { label: 'Every 30 mins', values: ['*/30 * * * *'] },
       { label: 'Hourly', values: ['0 * * * *'] },
       { label: 'Daily', values: ['0 0 * * *'] },
       { label: 'Weekly', values: ['0 0 * * 0'] },

--- a/frontend/src/composables/useCron.js
+++ b/frontend/src/composables/useCron.js
@@ -18,8 +18,6 @@ export function useCron() {
 
     const presets = {
       '0 * * * *': 'Hourly',
-      '*/15 * * * *': 'Every 15m',
-      '*/30 * * * *': 'Every 30m',
     };
     if (presets[cron]) return presets[cron];
 

--- a/frontend/src/views/EventDetailView.vue
+++ b/frontend/src/views/EventDetailView.vue
@@ -122,9 +122,7 @@ watch([triggerScheduleType, triggerOneTimeDate, triggerRepeatPreset, triggerRepe
   const minutes = d.getUTCMinutes()
   const hours = d.getUTCHours()
   const p = triggerRepeatPreset.value
-  if (p === '15min') triggerForm.value.cronSchedule = '*/15 * * * *'
-  else if (p === '30min') triggerForm.value.cronSchedule = '*/30 * * * *'
-  else if (p === 'hourly') triggerForm.value.cronSchedule = '0 * * * *'
+  if (p === 'hourly') triggerForm.value.cronSchedule = '0 * * * *'
   else if (p === '2hour') triggerForm.value.cronSchedule = '0 */2 * * *'
   else if (p === '12hour') {
     const h2 = new Date(d); h2.setHours(h2.getHours() + 12)

--- a/frontend/src/views/TaskFormView.vue
+++ b/frontend/src/views/TaskFormView.vue
@@ -168,8 +168,6 @@
                                <label class="text-[9px] font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-widest">Frequency</label>
                                <select v-model="repeatPreset" 
                                        class="bg-white dark:bg-zinc-950 border border-gray-200 dark:border-zinc-700 rounded-sm px-2 py-2 text-[10px] font-semibold text-gray-900 dark:text-zinc-50 outline-none w-full">
-                                 <option value="15min">Every 15 mins</option>
-                                 <option value="30min">Every 30 mins</option>
                                  <option value="hourly">Hourly</option>
                                  <option value="2hour">Bi-hourly</option>
                                  <option value="12hour">Twice a day</option>
@@ -180,7 +178,7 @@
                                </select>
                              </div>
 
-                             <div v-if="!['15min', '30min', 'hourly', '2hour'].includes(repeatPreset)" class="flex flex-col gap-1.5 w-[90px]">
+                             <div v-if="!['hourly', '2hour'].includes(repeatPreset)" class="flex flex-col gap-1.5 w-[90px]">
                                <label class="text-[9px] font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-widest">Time</label>
                                <input type="time" v-model="repeatTime"
                                       class="bg-white dark:bg-zinc-950 border border-gray-200 dark:border-zinc-700 rounded-sm px-2 py-1.5 text-[10px] font-semibold text-gray-900 dark:text-zinc-50 outline-none w-full" />
@@ -375,11 +373,7 @@ function parseCronToUI(cron) {
     oneTimeDate.value = `${year}-${mon}-${day}T${hh}:${mm}`;
   } else {
     scheduleType.value = 'repeated';
-    if (cron === '*/15 * * * *') {
-      repeatPreset.value = '15min';
-    } else if (cron === '*/30 * * * *') {
-      repeatPreset.value = '30min';
-    } else if (cron === '0 * * * *') {
+    if (cron === '0 * * * *') {
       repeatPreset.value = 'hourly';
     } else if (cron === '0 */2 * * *') {
       repeatPreset.value = '2hour';
@@ -444,11 +438,7 @@ watch([scheduleType, oneTimeDate, repeatPreset, repeatTime, selectedDays], () =>
   const minutes = d.getUTCMinutes();
   const hours = d.getUTCHours();
 
-  if (repeatPreset.value === '15min') {
-    newTask.value.cronSchedule = '*/15 * * * *';
-  } else if (repeatPreset.value === '30min') {
-    newTask.value.cronSchedule = '*/30 * * * *';
-  } else if (repeatPreset.value === 'hourly') {
+  if (repeatPreset.value === 'hourly') {
     newTask.value.cronSchedule = `0 * * * *`;
   } else if (repeatPreset.value === '2hour') {
     newTask.value.cronSchedule = `0 */2 * * *`;


### PR DESCRIPTION
## Summary
The frontend schedule UI offered "Every 15 mins" / "Every 30 mins", which generated `*/15 * * * *` and `*/30 * * * *`. Those expressions fail backend `ValidateCronGranularity` (used for MCP/agent and event-trigger paths), so users could pick a valid-looking option and then get a create/update error. Human REST still allows sub-hourly via `ValidateCronSyntax`, but the UI should not advertise schedules that the stricter paths reject.

This change removes those presets from the task form and event-trigger generators, and drops the matching labels in `useCron`, so the UI only produces hourly-or-coarser recurring schedules (plus one-time minute-precision), matching the backend guardrail.
