### PR TITLE
fix(backend): return 404 for missing static assets instead of index.html

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -786,8 +786,16 @@ func New(cfg Config) (*App, error) {
 
 	// SPA Fallback
 	fiberApp.Get("/*", func(c *fiber.Ctx) error {
-		if strings.HasPrefix(c.Path(), "/api/") || strings.HasPrefix(c.Path(), "/mcp") || strings.HasPrefix(c.Path(), "/.well-known/") {
+		path := c.Path()
+		if strings.HasPrefix(path, "/api/") || strings.HasPrefix(path, "/mcp") || strings.HasPrefix(path, "/.well-known/") {
 			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "Not Found"})
+		}
+		// If it's a request for a static asset file (has an extension like .js, .css, .wasm, etc.), return 404 instead of falling back to index.html
+		if idx := strings.LastIndex(path, "."); idx != -1 && idx > strings.LastIndex(path, "/") {
+			ext := path[idx:]
+			if ext != ".html" {
+				return c.Status(fiber.StatusNotFound).SendString("Not Found")
+			}
 		}
 		c.Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
 		c.Set("Pragma", "no-cache")


### PR DESCRIPTION
### Description

#### 1. The Problem
When running the application, the PWA console/browser logs the following error:
```
Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html". Strict MIME type checking is enforced for module scripts per HTML spec.
```
This happens when the browser attempts to fetch static assets (such as the Service Worker script `/sw.js` or dynamically imported Web Worker chunks) that are either missing from the server's static directory (common in development environments before a full production build) or are outdated.

#### 2. The Cause
The Go backend's SPA fallback middleware intercepted **any** path that did not begin with `/api/`, `/mcp`, or `/.well-known/` and served `./public/index.html` (with a `200 OK` status and `text/html` Content-Type). 

Because of this wildcard fallback, requesting missing files with extensions like `.js`, `.css`, or `.wasm` resulted in the server returning the index HTML file. The browser then tried to parse this HTML text as a JavaScript/Wasm module, leading to the strict MIME type check failure.

#### 3. The Solution
Modified the SPA fallback handler in [backend/internal/app/app.go](file:///private/var/dev/mt/Code/go/src/github.com/agentrq/agentrq/backend/internal/app/app.go#L787-L803):
- Inspects the request path to see if it targets a static asset file (i.e. contains a dot in the final path segment, denoting a file extension).
- If a file extension is detected (and it is not `.html`), the server immediately returns a clean `404 Not Found` response instead of falling back to `index.html`.
- This informs the browser correctly that the script is missing, avoiding the incorrect `text/html` MIME type parse error.

#### 4. Verification
- Verified compilation and test suite passing (`make test`).