### PR TITLE
🛡️ Sentinel: [HIGH] Enforce ActorHumanAudience validation in JWT authentication

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -917,6 +917,13 @@ func eventsHandler(ctrl crud.Controller, bus *eventbus.Bus, tokenSvc auth.TokenS
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
+
+		// Enforce human actor audience to prevent token misuse
+		if !auth.HasAudience(claims, auth.ActorHumanAudience) {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
 		userID := claims.Subject
 
 		workspaceIDParam := r.PathValue("id")

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -236,6 +236,11 @@ func (h *handler) authMiddleware() fiber.Handler {
 			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "unauthorized"})
 		}
 
+		// Enforce human actor audience to prevent token misuse
+		if !auth.HasAudience(claims, auth.ActorHumanAudience) {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "unauthorized"})
+		}
+
 		c.Locals("user_id", claims.Subject)
 		c.Locals("user_email", claims.Email)
 		c.Locals("user_name", claims.Name)

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/agentrq/agentrq/backend/internal/controller/crud"
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	"github.com/agentrq/agentrq/backend/internal/repository/base"
@@ -48,6 +49,26 @@ func (m *mockTokenSvc) CreateOAuthStateToken(redirectURL, provider string) (stri
 
 func (m *mockTokenSvc) ValidateOAuthStateToken(tokenStr, provider string) (string, error) {
 	return tokenStr, nil // treat the raw value as the redirect URL in simple tests
+}
+
+func (m *mockTokenSvc) ValidateToken(tokenStr string) (*auth.Claims, error) {
+	if tokenStr == "valid-human-token" {
+		return &auth.Claims{
+			RegisteredClaims: jwt.RegisteredClaims{
+				Subject:  "user1",
+				Audience: jwt.ClaimStrings{auth.ActorHumanAudience},
+			},
+		}, nil
+	}
+	if tokenStr == "valid-mcp-token" {
+		return &auth.Claims{
+			RegisteredClaims: jwt.RegisteredClaims{
+				Subject:  "user1",
+				Audience: jwt.ClaimStrings{"workspace1"},
+			},
+		}, nil
+	}
+	return nil, base.ErrNotFound
 }
 
 type mockCrudController struct {
@@ -328,6 +349,46 @@ type mockCrudWorkspaceAccess struct {
 
 func (m *mockCrudWorkspaceAccess) CheckWorkspaceAccess(ctx context.Context, id int64, userID string) (bool, error) {
 	return m.checkWorkspaceAccessFunc(ctx, id, userID)
+}
+
+func TestAuthMiddleware_AudienceValidation(t *testing.T) {
+	app := fiber.New()
+	tokenSvc := &mockTokenSvc{}
+
+	h := &handler{
+		tokenSvc: tokenSvc,
+	}
+
+	app.Use(h.authMiddleware())
+	app.Get("/test", func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	t.Run("Token with human audience is accepted", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.AddCookie(&http.Cookie{Name: "at", Value: "valid-human-token"})
+		resp, _ := app.Test(req)
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Expected status 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("Token without human audience (MCP token) is rejected", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.AddCookie(&http.Cookie{Name: "at", Value: "valid-mcp-token"})
+		resp, _ := app.Test(req)
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("Expected status 401, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("Missing token is rejected", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", nil)
+		resp, _ := app.Test(req)
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("Expected status 401, got %d", resp.StatusCode)
+		}
+	})
 }
 
 func TestSendPermissionVerdict_RequiresWorkspaceAccess(t *testing.T) {

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -407,7 +407,10 @@ func (h *handler) oauthAuthorizeHandler() http.Handler {
 		var userID string
 		if cookie, err := r.Cookie("at"); err == nil && cookie.Value != "" {
 			if claims, err := h.tokenSvc.ValidateToken(cookie.Value); err == nil && claims != nil {
-				userID = claims.Subject
+				// Enforce human actor audience to prevent token misuse
+				if auth.HasAudience(claims, auth.ActorHumanAudience) {
+					userID = claims.Subject
+				}
 			}
 		}
 

--- a/backend/internal/handler/mcp/mcp_test.go
+++ b/backend/internal/handler/mcp/mcp_test.go
@@ -26,10 +26,14 @@ type mockTokenSvc struct {
 
 func (m *mockTokenSvc) ValidateToken(tokenStr string) (*auth.Claims, error) {
 	if tokenStr == "valid-auth-cookie" || tokenStr == m.validCode || tokenStr == "valid-refresh-token" {
+		aud := jwt.ClaimStrings{"ws123", "authorization_code"}
+		if tokenStr == "valid-auth-cookie" {
+			aud = append(aud, auth.ActorHumanAudience)
+		}
 		return &auth.Claims{
 			RegisteredClaims: jwt.RegisteredClaims{
 				Subject:  monoflake.IDFromBase62("user123").String(),
-				Audience: jwt.ClaimStrings{"ws123", "authorization_code"},
+				Audience: aud,
 			},
 		}, nil
 	}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Context-less JWT Validation
🎯 Impact: If a service-level MCP token (valid for 365 days) is leaked, it could be used to impersonate a human user and perform administrative actions on the UI-facing API, bypassing the intended security boundaries of machine-to-machine tokens.
🔧 Fix: Enforced explicit validation of the 'actor:human' audience (ActorHumanAudience) in all authentication points that identify a user session for the human UI and event streams.
✅ Verification: Added unit tests in 'internal/handler/api/api_test.go' that specifically verify that tokens without the 'actor:human' audience are rejected with a 401 Unauthorized error. Verified that all existing tests in the suite pass correctly.

---
*PR created automatically by Jules for task [599869026454350960](https://jules.google.com/task/599869026454350960) started by @mustafaturan*