### PR TITLE
🛡️ Sentinel: Enforce token audience and harden repository BOLA protection

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -504,9 +504,9 @@ func New(cfg Config) (*App, error) {
 				}
 
 				b, _ := json.Marshal(existingMetadata)
-				err := repo.UpdateMessageMetadata(ctx, taskID, messageID, b)
+				uid := monoflake.IDFromBase62(workspaceOwner).Int64()
+				err := repo.UpdateMessageMetadata(ctx, taskID, messageID, b, uid)
 				if err == nil {
-					uid := monoflake.IDFromBase62(workspaceOwner).Int64()
 					latest, _ := repo.GetTask(ctx, workspaceID, taskID, uid)
 					bus.Publish(workspaceID, workspaceOwner, eventbus.Event{
 						Type:    "task.updated",
@@ -676,7 +676,8 @@ func New(cfg Config) (*App, error) {
 					t, err := repo.SystemGetTask(ctx, taskID)
 					if err == nil {
 						// Preload task messages
-						messages, err := repo.ListMessages(ctx, t.ID)
+						uid := monoflake.IDFromBase62(ownerID).Int64()
+						messages, err := repo.ListMessages(ctx, t.ID, uid)
 						if err == nil {
 							t.Messages = messages
 						}
@@ -913,7 +914,7 @@ func eventsHandler(ctrl crud.Controller, bus *eventbus.Bus, tokenSvc auth.TokenS
 			return
 		}
 		claims, err := tokenSvc.ValidateToken(cookie.Value)
-		if err != nil {
+		if err != nil || !auth.HasAudience(claims, auth.ActorHumanAudience) {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}

--- a/backend/internal/controller/crud/task.go
+++ b/backend/internal/controller/crud/task.go
@@ -591,7 +591,7 @@ func (c *controller) UpdateMessageMetadata(ctx context.Context, req entity.Updat
 		return err
 	}
 
-	if err := c.repository.UpdateMessageMetadata(ctx, req.TaskID, req.MessageID, b); err != nil {
+	if err := c.repository.UpdateMessageMetadata(ctx, req.TaskID, req.MessageID, b, uid); err != nil {
 		return err
 	}
 	c.emitEvent(ctx, entity.CRUDEvent{

--- a/backend/internal/controller/crud/task_test.go
+++ b/backend/internal/controller/crud/task_test.go
@@ -784,7 +784,7 @@ func TestUpdateMessageMetadata_Success(t *testing.T) {
 	e := newTestController(t)
 
 	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(10), testUserID).Return(model.Task{}, nil)
-	e.repo.EXPECT().UpdateMessageMetadata(gomock.Any(), int64(10), int64(500), gomock.Any()).Return(nil)
+	e.repo.EXPECT().UpdateMessageMetadata(gomock.Any(), int64(10), int64(500), gomock.Any(), gomock.Any()).Return(nil)
 
 	err := e.controller.UpdateMessageMetadata(context.Background(), entity.UpdateMessageMetadataRequest{
 		WorkspaceID: 1,

--- a/backend/internal/controller/crud/workspace.go
+++ b/backend/internal/controller/crud/workspace.go
@@ -99,7 +99,7 @@ func (c *controller) ListWorkspaces(ctx context.Context, req entity.ListWorkspac
 func (c *controller) DeleteWorkspace(ctx context.Context, req entity.DeleteWorkspaceRequest) error {
 	// 1. Get all task and message attachment IDs directly from DB
 	uid := monoflake.IDFromBase62(req.UserID).Int64()
-	attachmentIDs, _ := c.repository.GetWorkspaceAttachmentIDs(ctx, req.ID)
+	attachmentIDs, _ := c.repository.GetWorkspaceAttachmentIDs(ctx, req.ID, uid)
 
 	// 2. Delete from DB (repository handles cascaded DB delete)
 	if err := c.repository.DeleteWorkspace(ctx, req.ID, uid); err != nil {

--- a/backend/internal/controller/crud/workspace_test.go
+++ b/backend/internal/controller/crud/workspace_test.go
@@ -38,7 +38,7 @@ func TestCreateWorkspace_WithOptions(t *testing.T) {
 func TestDeleteWorkspace_Complex(t *testing.T) {
 	e := newTestController(t)
 
-	e.repo.EXPECT().GetWorkspaceAttachmentIDs(gomock.Any(), int64(1)).Return([]string{"att-1", "att-2"}, nil)
+	e.repo.EXPECT().GetWorkspaceAttachmentIDs(gomock.Any(), int64(1), gomock.Any()).Return([]string{"att-1", "att-2"}, nil)
 	e.repo.EXPECT().DeleteWorkspace(gomock.Any(), int64(1), testUserID).Return(nil)
 	e.storage.EXPECT().Delete("att-1").Return(nil)
 	e.storage.EXPECT().Delete("att-2").Return(nil)

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -255,7 +255,7 @@ func (c *controller) OnMessageCreated(ctx context.Context, msg entity.Message, t
 				msg.Metadata = metaMap
 				b, marshalErr := json.Marshal(metaMap)
 				if marshalErr == nil {
-					if updateErr := c.repo.UpdateMessageMetadata(ctx, task.ID, msg.ID, b); updateErr != nil {
+					if updateErr := c.repo.UpdateMessageMetadata(ctx, task.ID, msg.ID, b, task.UserID); updateErr != nil {
 						zlog.Error().Err(updateErr).Int64("messageID", msg.ID).Msg("[slack] failed to update message metadata with slack details")
 					}
 				}
@@ -757,7 +757,7 @@ func (c *controller) HandleMCPPermission(ctx context.Context, action SlackBlockA
 
 	// Try to find the permission request message and save the slack decision flag in its metadata first,
 	// so that OnMessageUpdated can skip overwriting the slack-initiated UI update.
-	messages, listErr := c.repo.ListMessages(ctx, taskID)
+	messages, listErr := c.repo.ListMessages(ctx, taskID, monoflake.IDFromBase62(ownerID).Int64())
 	if listErr == nil {
 		for _, m := range messages {
 			var metadata map[string]any
@@ -775,7 +775,7 @@ func (c *controller) HandleMCPPermission(ctx context.Context, action SlackBlockA
 					metadata["slack_user_name"] = action.UserName
 					b, marshalErr := json.Marshal(metadata)
 					if marshalErr == nil {
-						_ = c.repo.UpdateMessageMetadata(ctx, taskID, m.ID, b)
+						_ = c.repo.UpdateMessageMetadata(ctx, taskID, m.ID, b, monoflake.IDFromBase62(ownerID).Int64())
 					}
 					break
 				}

--- a/backend/internal/controller/slack/slack_test.go
+++ b/backend/internal/controller/slack/slack_test.go
@@ -1107,13 +1107,13 @@ func TestHandleMCPPermission_Success_Allow(t *testing.T) {
 		}, nil)
 
 	mockRepo.EXPECT().
-		ListMessages(gomock.Any(), taskID).
+		ListMessages(gomock.Any(), taskID, gomock.Any()).
 		Return([]model.Message{permMsg}, nil)
 
 	var capturedMeta []byte
 	mockRepo.EXPECT().
-		UpdateMessageMetadata(gomock.Any(), taskID, int64(7), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ int64, _ int64, b []byte) error {
+		UpdateMessageMetadata(gomock.Any(), taskID, int64(7), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ int64, _ int64, b []byte, _ int64) error {
 			capturedMeta = b
 			return nil
 		})

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -232,7 +232,7 @@ func (h *handler) authMiddleware() fiber.Handler {
 		}
 
 		claims, err := h.tokenSvc.ValidateToken(tokenStr)
-		if err != nil {
+		if err != nil || !auth.HasAudience(claims, auth.ActorHumanAudience) {
 			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "unauthorized"})
 		}
 

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -374,3 +374,36 @@ func TestSendPermissionVerdict_RequiresWorkspaceAccess(t *testing.T) {
 		t.Fatalf("expected status 403, got %d", resp.StatusCode)
 	}
 }
+
+func TestAuthMiddleware_AudienceEnforcement(t *testing.T) {
+	// Use a real token service so JWT signing and claims work as expected.
+	realTokenSvc := auth.NewTokenService(auth.TokenConfig{JWTSecret: "test-secret"})
+
+	app := fiber.New()
+	h := &handler{tokenSvc: realTokenSvc}
+	app.Use(h.authMiddleware())
+	app.Get("/protected", func(c *fiber.Ctx) error {
+		return c.SendStatus(http.StatusOK)
+	})
+
+	t.Run("Valid human token is accepted", func(t *testing.T) {
+		token, _ := realTokenSvc.CreateToken("user1", "test@example.com", "Test", "")
+		req := httptest.NewRequest("GET", "/protected", nil)
+		req.AddCookie(&http.Cookie{Name: "at", Value: token})
+		resp, _ := app.Test(req)
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("Token with wrong audience is rejected", func(t *testing.T) {
+		// Create an MCP token which lacks the "actor:human" audience.
+		token, _ := realTokenSvc.CreateMCPToken("user1", "work1", "access")
+		req := httptest.NewRequest("GET", "/protected", nil)
+		req.AddCookie(&http.Cookie{Name: "at", Value: token})
+		resp, _ := app.Test(req)
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", resp.StatusCode)
+		}
+	})
+}

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -406,7 +406,7 @@ func (h *handler) oauthAuthorizeHandler() http.Handler {
 		// 1. Is user logged in?
 		var userID string
 		if cookie, err := r.Cookie("at"); err == nil && cookie.Value != "" {
-			if claims, err := h.tokenSvc.ValidateToken(cookie.Value); err == nil && claims != nil {
+			if claims, err := h.tokenSvc.ValidateToken(cookie.Value); err == nil && auth.HasAudience(claims, auth.ActorHumanAudience) {
 				userID = claims.Subject
 			}
 		}

--- a/backend/internal/handler/mcp/mcp_test.go
+++ b/backend/internal/handler/mcp/mcp_test.go
@@ -26,12 +26,17 @@ type mockTokenSvc struct {
 
 func (m *mockTokenSvc) ValidateToken(tokenStr string) (*auth.Claims, error) {
 	if tokenStr == "valid-auth-cookie" || tokenStr == m.validCode || tokenStr == "valid-refresh-token" {
-		return &auth.Claims{
+		claims := &auth.Claims{
 			RegisteredClaims: jwt.RegisteredClaims{
-				Subject:  monoflake.IDFromBase62("user123").String(),
-				Audience: jwt.ClaimStrings{"ws123", "authorization_code"},
+				Subject: monoflake.IDFromBase62("user123").String(),
 			},
-		}, nil
+		}
+		if tokenStr == "valid-auth-cookie" {
+			claims.Audience = jwt.ClaimStrings{auth.ActorHumanAudience}
+		} else {
+			claims.Audience = jwt.ClaimStrings{"ws123", "authorization_code"}
+		}
+		return claims, nil
 	}
 	return nil, jwt.ErrSignatureInvalid
 }

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -33,9 +33,9 @@ type Repository interface {
 
 	// Message
 	CreateMessage(ctx context.Context, m model.Message) error
-	ListMessages(ctx context.Context, taskID int64) ([]model.Message, error)
-	UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte) error
-	GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64) ([]string, error)
+	ListMessages(ctx context.Context, taskID int64, userID int64) ([]model.Message, error)
+	UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte, userID int64) error
+	GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64, userID int64) ([]string, error)
 
 	SystemGetWorkspace(ctx context.Context, id int64) (model.Workspace, error)
 	SystemGetTask(ctx context.Context, id int64) (model.Task, error)
@@ -349,22 +349,22 @@ func (r *repository) CreateMessage(ctx context.Context, m model.Message) error {
 	return r.conn(ctx).Create(&m).Error
 }
 
-func (r *repository) ListMessages(ctx context.Context, taskID int64) ([]model.Message, error) {
+func (r *repository) ListMessages(ctx context.Context, taskID int64, userID int64) ([]model.Message, error) {
 	var msgs []model.Message
-	err := r.conn(ctx).Where("task_id = ?", taskID).Order("created_at asc").Find(&msgs).Error
+	err := r.conn(ctx).Where("task_id = ? AND user_id = ?", taskID, userID).Order("created_at asc").Find(&msgs).Error
 	return msgs, err
 }
 
-func (r *repository) UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte) error {
-	return r.conn(ctx).Model(&model.Message{}).Where("id = ? AND task_id = ?", messageID, taskID).Update("metadata", metadata).Error
+func (r *repository) UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte, userID int64) error {
+	return r.conn(ctx).Model(&model.Message{}).Where("id = ? AND task_id = ? AND user_id = ?", messageID, taskID, userID).Update("metadata", metadata).Error
 }
 
-func (r *repository) GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64) ([]string, error) {
+func (r *repository) GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64, userID int64) ([]string, error) {
 	var attachmentIDs []string
 
 	// 1. Get attachments from tasks
 	var taskAttachments []string
-	err := r.conn(ctx).Model(&model.Task{}).Where("workspace_id = ?", workspaceID).Pluck("attachments", &taskAttachments).Error
+	err := r.conn(ctx).Model(&model.Task{}).Where("workspace_id = ? AND user_id = ?", workspaceID, userID).Pluck("attachments", &taskAttachments).Error
 	if err == nil {
 		for _, ta := range taskAttachments {
 			if len(ta) > 0 {
@@ -384,7 +384,7 @@ func (r *repository) GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID 
 	var msgAttachments []string
 	err = r.conn(ctx).Model(&model.Message{}).
 		Joins("JOIN tasks ON tasks.id = messages.task_id").
-		Where("tasks.workspace_id = ?", workspaceID).
+		Where("tasks.workspace_id = ? AND tasks.user_id = ?", workspaceID, userID).
 		Pluck("messages.attachments", &msgAttachments).Error
 	if err == nil {
 		for _, ma := range msgAttachments {

--- a/backend/internal/repository/base/repository_test.go
+++ b/backend/internal/repository/base/repository_test.go
@@ -141,14 +141,16 @@ func TestRepository_UpdateMessageMetadata(t *testing.T) {
 	taskID := int64(100)
 	messageID := int64(500)
 
+	userID := int64(1)
 	db.Create(&model.Message{
 		ID:     messageID,
 		TaskID: taskID,
+		UserID: userID,
 		Text:   "Initial text",
 	})
 
-	// Case 1: Success update with correct taskID
-	err = repo.UpdateMessageMetadata(ctx, taskID, messageID, []byte(`{"updated":true}`))
+	// Case 1: Success update with correct taskID and userID
+	err = repo.UpdateMessageMetadata(ctx, taskID, messageID, []byte(`{"updated":true}`), userID)
 	if err != nil {
 		t.Errorf("expected nil error, got %v", err)
 	}
@@ -160,9 +162,26 @@ func TestRepository_UpdateMessageMetadata(t *testing.T) {
 	}
 
 	// Case 2: Update with WRONG taskID (IDOR)
-	err = repo.UpdateMessageMetadata(ctx, 999, messageID, []byte(`{"hacked":true}`))
+	err = repo.UpdateMessageMetadata(ctx, 999, messageID, []byte(`{"hacked":true}`), userID)
 	if err != nil {
 		t.Errorf("expected nil error (GORM Update doesn't return error on no rows), got %v", err)
+	}
+
+	db.First(&m, messageID)
+	if string(m.Metadata) == `{"hacked":true}` {
+		t.Error("vulnerability detected: metadata was updated with wrong taskID")
+	}
+
+	// Case 3: Update with WRONG userID (IDOR/BOLA)
+	otherUserID := int64(2)
+	err = repo.UpdateMessageMetadata(ctx, taskID, messageID, []byte(`{"bola":true}`), otherUserID)
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+
+	db.First(&m, messageID)
+	if string(m.Metadata) == `{"bola":true}` {
+		t.Error("vulnerability detected: metadata was updated with wrong userID")
 	}
 
 	db.First(&m, messageID)


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: 
1. Missing Audience Validation: Session tokens for the human UI did not have their audience verified, potentially allowing service-level MCP tokens to be reused for UI sessions.
2. Incomplete BOLA/IDOR Protection: Several repository methods for listing messages, updating metadata, and retrieving attachments relied on controller-level checks and did not enforce user ownership at the database query level.

🎯 Impact: 
1. Context-specific token reuse could lead to unauthorized access if a machine token is compromised.
2. Missing DB-level ownership checks increases the risk of Broken Object Level Authorization (BOLA), where a bug in a controller or a new API endpoint could inadvertently leak data or allow modification of other users' resources.

🔧 Fix: 
1. Updated `authMiddleware`, `eventsHandler`, and `oauthAuthorizeHandler` to explicitly verify the `actor:human` audience using `auth.HasAudience`.
2. Hardened `ListMessages`, `UpdateMessageMetadata`, and `GetWorkspaceAttachmentIDs` in the repository layer to require a `userID` and include it in SQL filters.
3. Updated all callers and tests to align with the new repository interface.

✅ Verification: 
1. Added `TestAuthMiddleware_AudienceEnforcement` in `api_test.go` to verify rejected tokens.
2. Updated `TestRepository_UpdateMessageMetadata` in `repository_test.go` to verify ownership enforcement.
3. Verified all backend tests pass (`cd backend && go test ./...`).
4. Confirmed successful compilation.

---
*PR created automatically by Jules for task [9234150263273424554](https://jules.google.com/task/9234150263273424554) started by @mustafaturan*