### PR TITLE
🛡️ Sentinel: Fix IDOR/BOLA in message and attachment retrieval

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** The Slack OAuth flow used a predictable base62 workspace ID as the `state` parameter. This lacked cryptographic integrity and session binding, making it vulnerable to CSRF attacks where an attacker could force a user to link their Slack workspace to an arbitrary AgentRQ workspace.
 **Learning:** The `state` parameter in OAuth2 is intended to be a non-guessable, session-bound value to prevent CSRF. Using a resource ID directly is insufficient.
 **Prevention:** Always use cryptographically signed tokens or high-entropy random nonces for the OAuth `state` parameter. In this project, `TokenService.CreateOAuthStateToken` provides a secure, signed JWT that can carry payload (like workspace ID) while ensuring origin and integrity.
+
+## 2024-05-24 - IDOR in Message and Attachment Retrieval
+**Vulnerability:** The `ListMessages`, `UpdateMessageMetadata`, and `GetWorkspaceAttachmentIDs` repository methods were vulnerable to IDOR/BOLA as they only used resource IDs for queries, potentially allowing access to other users' data.
+**Learning:** Defense-in-depth requires that the persistence layer enforces ownership checks, regardless of higher-level controller logic. For cross-hierarchical checks (e.g., messages -> tasks -> workspaces) in SQLite, subqueries are more reliable and performant than complex joins in GORM.
+**Prevention:** Proactively include `userID` in all repository signatures for resource-scoped operations. Use the pattern `task_id IN (SELECT id FROM tasks WHERE user_id = ?)` to enforce ownership across the data hierarchy.

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -489,7 +489,7 @@ func New(cfg Config) (*App, error) {
 				}
 				return msgID, nil
 			},
-			func(ctx context.Context, taskID int64, messageID int64, metadata any) error {
+			func(ctx context.Context, taskID int64, messageID int64, userID int64, metadata any) error {
 				existingMetadata := make(map[string]any)
 				if m, err := repo.SystemGetMessage(ctx, messageID); err == nil && len(m.Metadata) > 0 {
 					_ = json.Unmarshal(m.Metadata, &existingMetadata)
@@ -504,9 +504,9 @@ func New(cfg Config) (*App, error) {
 				}
 
 				b, _ := json.Marshal(existingMetadata)
-				err := repo.UpdateMessageMetadata(ctx, taskID, messageID, b)
+				uid := monoflake.IDFromBase62(workspaceOwner).Int64()
+				err := repo.UpdateMessageMetadata(ctx, taskID, messageID, uid, b)
 				if err == nil {
-					uid := monoflake.IDFromBase62(workspaceOwner).Int64()
 					latest, _ := repo.GetTask(ctx, workspaceID, taskID, uid)
 					bus.Publish(workspaceID, workspaceOwner, eventbus.Event{
 						Type:    "task.updated",
@@ -675,8 +675,9 @@ func New(cfg Config) (*App, error) {
 				if taskID != 0 && eventType != "" {
 					t, err := repo.SystemGetTask(ctx, taskID)
 					if err == nil {
+						uid := monoflake.IDFromBase62(ownerID).Int64()
 						// Preload task messages
-						messages, err := repo.ListMessages(ctx, t.ID)
+						messages, err := repo.ListMessages(ctx, t.ID, uid)
 						if err == nil {
 							t.Messages = messages
 						}

--- a/backend/internal/controller/crud/task.go
+++ b/backend/internal/controller/crud/task.go
@@ -591,7 +591,7 @@ func (c *controller) UpdateMessageMetadata(ctx context.Context, req entity.Updat
 		return err
 	}
 
-	if err := c.repository.UpdateMessageMetadata(ctx, req.TaskID, req.MessageID, b); err != nil {
+	if err := c.repository.UpdateMessageMetadata(ctx, req.TaskID, req.MessageID, uid, b); err != nil {
 		return err
 	}
 	c.emitEvent(ctx, entity.CRUDEvent{

--- a/backend/internal/controller/crud/task_test.go
+++ b/backend/internal/controller/crud/task_test.go
@@ -784,7 +784,7 @@ func TestUpdateMessageMetadata_Success(t *testing.T) {
 	e := newTestController(t)
 
 	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(10), testUserID).Return(model.Task{}, nil)
-	e.repo.EXPECT().UpdateMessageMetadata(gomock.Any(), int64(10), int64(500), gomock.Any()).Return(nil)
+	e.repo.EXPECT().UpdateMessageMetadata(gomock.Any(), int64(10), int64(500), testUserID, gomock.Any()).Return(nil)
 
 	err := e.controller.UpdateMessageMetadata(context.Background(), entity.UpdateMessageMetadataRequest{
 		WorkspaceID: 1,

--- a/backend/internal/controller/crud/workspace.go
+++ b/backend/internal/controller/crud/workspace.go
@@ -99,7 +99,7 @@ func (c *controller) ListWorkspaces(ctx context.Context, req entity.ListWorkspac
 func (c *controller) DeleteWorkspace(ctx context.Context, req entity.DeleteWorkspaceRequest) error {
 	// 1. Get all task and message attachment IDs directly from DB
 	uid := monoflake.IDFromBase62(req.UserID).Int64()
-	attachmentIDs, _ := c.repository.GetWorkspaceAttachmentIDs(ctx, req.ID)
+	attachmentIDs, _ := c.repository.GetWorkspaceAttachmentIDs(ctx, req.ID, uid)
 
 	// 2. Delete from DB (repository handles cascaded DB delete)
 	if err := c.repository.DeleteWorkspace(ctx, req.ID, uid); err != nil {

--- a/backend/internal/controller/crud/workspace_test.go
+++ b/backend/internal/controller/crud/workspace_test.go
@@ -38,7 +38,7 @@ func TestCreateWorkspace_WithOptions(t *testing.T) {
 func TestDeleteWorkspace_Complex(t *testing.T) {
 	e := newTestController(t)
 
-	e.repo.EXPECT().GetWorkspaceAttachmentIDs(gomock.Any(), int64(1)).Return([]string{"att-1", "att-2"}, nil)
+	e.repo.EXPECT().GetWorkspaceAttachmentIDs(gomock.Any(), int64(1), testUserID).Return([]string{"att-1", "att-2"}, nil)
 	e.repo.EXPECT().DeleteWorkspace(gomock.Any(), int64(1), testUserID).Return(nil)
 	e.storage.EXPECT().Delete("att-1").Return(nil)
 	e.storage.EXPECT().Delete("att-2").Return(nil)

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -46,7 +46,7 @@ type ListTasksFilter struct {
 type ListTasksFunc func(ctx context.Context, filter ListTasksFilter) ([]model.Task, error)
 type GetNextTaskFunc func(ctx context.Context) (model.Task, error)
 type ReplyFunc func(ctx context.Context, chatID string, text string, attachments []entity.Attachment, metadata any) (int64, error)
-type UpdateMessageMetadataFunc func(ctx context.Context, taskID int64, messageID int64, metadata any) error
+type UpdateMessageMetadataFunc func(ctx context.Context, taskID int64, messageID int64, userID int64, metadata any) error
 type UpdateWorkspaceAutoAllowedToolsFunc func(ctx context.Context, tools []string) error
 type PublishEventFunc func(ctx context.Context, eventName string, payload string, faq []entity.EventFAQ) error
 
@@ -1306,7 +1306,8 @@ func (ps *WorkspaceServer) SendPermissionVerdict(ctx context.Context, taskID int
 							ps.permissionResponsesMu.RUnlock()
 
 							if hasMsg {
-								_ = ps.updateMessageMetadata(ctx, taskID, msgID, map[string]any{"status": behavior})
+							uid := monoflake.IDFromBase62(ps.userID).Int64()
+							_ = ps.updateMessageMetadata(ctx, taskID, msgID, uid, map[string]any{"status": behavior})
 							}
 						}
 

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -255,7 +255,7 @@ func (c *controller) OnMessageCreated(ctx context.Context, msg entity.Message, t
 				msg.Metadata = metaMap
 				b, marshalErr := json.Marshal(metaMap)
 				if marshalErr == nil {
-					if updateErr := c.repo.UpdateMessageMetadata(ctx, task.ID, msg.ID, b); updateErr != nil {
+					if updateErr := c.repo.UpdateMessageMetadata(ctx, task.ID, msg.ID, task.UserID, b); updateErr != nil {
 						zlog.Error().Err(updateErr).Int64("messageID", msg.ID).Msg("[slack] failed to update message metadata with slack details")
 					}
 				}
@@ -757,7 +757,7 @@ func (c *controller) HandleMCPPermission(ctx context.Context, action SlackBlockA
 
 	// Try to find the permission request message and save the slack decision flag in its metadata first,
 	// so that OnMessageUpdated can skip overwriting the slack-initiated UI update.
-	messages, listErr := c.repo.ListMessages(ctx, taskID)
+	messages, listErr := c.repo.ListMessages(ctx, taskID, ws.UserID)
 	if listErr == nil {
 		for _, m := range messages {
 			var metadata map[string]any
@@ -775,7 +775,7 @@ func (c *controller) HandleMCPPermission(ctx context.Context, action SlackBlockA
 					metadata["slack_user_name"] = action.UserName
 					b, marshalErr := json.Marshal(metadata)
 					if marshalErr == nil {
-						_ = c.repo.UpdateMessageMetadata(ctx, taskID, m.ID, b)
+						_ = c.repo.UpdateMessageMetadata(ctx, taskID, m.ID, ws.UserID, b)
 					}
 					break
 				}

--- a/backend/internal/controller/slack/slack_test.go
+++ b/backend/internal/controller/slack/slack_test.go
@@ -1107,13 +1107,13 @@ func TestHandleMCPPermission_Success_Allow(t *testing.T) {
 		}, nil)
 
 	mockRepo.EXPECT().
-		ListMessages(gomock.Any(), taskID).
+		ListMessages(gomock.Any(), taskID, int64(100)).
 		Return([]model.Message{permMsg}, nil)
 
 	var capturedMeta []byte
 	mockRepo.EXPECT().
-		UpdateMessageMetadata(gomock.Any(), taskID, int64(7), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ int64, _ int64, b []byte) error {
+		UpdateMessageMetadata(gomock.Any(), taskID, int64(7), int64(100), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ int64, _ int64, _ int64, b []byte) error {
 			capturedMeta = b
 			return nil
 		})

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -33,9 +33,9 @@ type Repository interface {
 
 	// Message
 	CreateMessage(ctx context.Context, m model.Message) error
-	ListMessages(ctx context.Context, taskID int64) ([]model.Message, error)
-	UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte) error
-	GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64) ([]string, error)
+	ListMessages(ctx context.Context, taskID int64, userID int64) ([]model.Message, error)
+	UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, userID int64, metadata []byte) error
+	GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64, userID int64) ([]string, error)
 
 	SystemGetWorkspace(ctx context.Context, id int64) (model.Workspace, error)
 	SystemGetTask(ctx context.Context, id int64) (model.Task, error)
@@ -349,22 +349,22 @@ func (r *repository) CreateMessage(ctx context.Context, m model.Message) error {
 	return r.conn(ctx).Create(&m).Error
 }
 
-func (r *repository) ListMessages(ctx context.Context, taskID int64) ([]model.Message, error) {
+func (r *repository) ListMessages(ctx context.Context, taskID int64, userID int64) ([]model.Message, error) {
 	var msgs []model.Message
-	err := r.conn(ctx).Where("task_id = ?", taskID).Order("created_at asc").Find(&msgs).Error
+	err := r.conn(ctx).Where("task_id = ? AND user_id = ?", taskID, userID).Order("created_at asc").Find(&msgs).Error
 	return msgs, err
 }
 
-func (r *repository) UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte) error {
-	return r.conn(ctx).Model(&model.Message{}).Where("id = ? AND task_id = ?", messageID, taskID).Update("metadata", metadata).Error
+func (r *repository) UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, userID int64, metadata []byte) error {
+	return r.conn(ctx).Model(&model.Message{}).Where("id = ? AND task_id = ? AND user_id = ?", messageID, taskID, userID).Update("metadata", metadata).Error
 }
 
-func (r *repository) GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64) ([]string, error) {
+func (r *repository) GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64, userID int64) ([]string, error) {
 	var attachmentIDs []string
 
 	// 1. Get attachments from tasks
 	var taskAttachments []string
-	err := r.conn(ctx).Model(&model.Task{}).Where("workspace_id = ?", workspaceID).Pluck("attachments", &taskAttachments).Error
+	err := r.conn(ctx).Model(&model.Task{}).Where("workspace_id = ? AND user_id = ?", workspaceID, userID).Pluck("attachments", &taskAttachments).Error
 	if err == nil {
 		for _, ta := range taskAttachments {
 			if len(ta) > 0 {
@@ -382,10 +382,11 @@ func (r *repository) GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID 
 
 	// 2. Get attachments from messages
 	var msgAttachments []string
+	// For messages, we use a subquery for the user ownership check to ensure compatibility
+	// between SQLite and PostgreSQL, and to avoid issues with complex joins in GORM.
 	err = r.conn(ctx).Model(&model.Message{}).
-		Joins("JOIN tasks ON tasks.id = messages.task_id").
-		Where("tasks.workspace_id = ?", workspaceID).
-		Pluck("messages.attachments", &msgAttachments).Error
+		Where("user_id = ? AND task_id IN (SELECT id FROM tasks WHERE workspace_id = ? AND user_id = ?)", userID, workspaceID, userID).
+		Pluck("attachments", &msgAttachments).Error
 	if err == nil {
 		for _, ma := range msgAttachments {
 			if len(ma) > 0 {

--- a/backend/internal/repository/base/repository_test.go
+++ b/backend/internal/repository/base/repository_test.go
@@ -140,15 +140,17 @@ func TestRepository_UpdateMessageMetadata(t *testing.T) {
 	ctx := context.Background()
 	taskID := int64(100)
 	messageID := int64(500)
+	userID := int64(1)
 
 	db.Create(&model.Message{
 		ID:     messageID,
 		TaskID: taskID,
+		UserID: userID,
 		Text:   "Initial text",
 	})
 
-	// Case 1: Success update with correct taskID
-	err = repo.UpdateMessageMetadata(ctx, taskID, messageID, []byte(`{"updated":true}`))
+	// Case 1: Success update with correct taskID and userID
+	err = repo.UpdateMessageMetadata(ctx, taskID, messageID, userID, []byte(`{"updated":true}`))
 	if err != nil {
 		t.Errorf("expected nil error, got %v", err)
 	}
@@ -160,7 +162,7 @@ func TestRepository_UpdateMessageMetadata(t *testing.T) {
 	}
 
 	// Case 2: Update with WRONG taskID (IDOR)
-	err = repo.UpdateMessageMetadata(ctx, 999, messageID, []byte(`{"hacked":true}`))
+	err = repo.UpdateMessageMetadata(ctx, 999, messageID, userID, []byte(`{"hacked":true}`))
 	if err != nil {
 		t.Errorf("expected nil error (GORM Update doesn't return error on no rows), got %v", err)
 	}
@@ -168,6 +170,17 @@ func TestRepository_UpdateMessageMetadata(t *testing.T) {
 	db.First(&m, messageID)
 	if string(m.Metadata) == `{"hacked":true}` {
 		t.Error("vulnerability detected: metadata was updated with wrong taskID")
+	}
+
+	// Case 3: Update with WRONG userID (BOLA/IDOR)
+	err = repo.UpdateMessageMetadata(ctx, taskID, messageID, 999, []byte(`{"bola":true}`))
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+
+	db.First(&m, messageID)
+	if string(m.Metadata) == `{"bola":true}` {
+		t.Error("vulnerability detected: metadata was updated with wrong userID")
 	}
 }
 
@@ -222,6 +235,107 @@ func TestRepository_ListTasks_PreloadMessages(t *testing.T) {
 		if len(task.Messages) != 1 {
 			t.Errorf("expected 1 preloaded message for task %d, got %d", task.ID, len(task.Messages))
 		}
+	}
+}
+
+func TestRepository_ListMessages_BOLA(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+
+	_ = db.AutoMigrate(&model.Message{})
+	repo := New(&mockDB{db: db})
+
+	ctx := context.Background()
+	taskID := int64(100)
+	userID := int64(1)
+
+	db.Create(&model.Message{ID: 1, TaskID: taskID, UserID: userID, Text: "Msg 1"})
+	db.Create(&model.Message{ID: 2, TaskID: taskID, UserID: 999, Text: "Msg 2 (attacker)"})
+
+	// Case 1: Fetch messages for task with owner userID
+	msgs, err := repo.ListMessages(ctx, taskID, userID)
+	if err != nil {
+		t.Fatalf("ListMessages failed: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Errorf("expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0].ID != 1 {
+		t.Errorf("expected message 1, got %d", msgs[0].ID)
+	}
+
+	// Case 2: Fetch messages with wrong userID (BOLA)
+	msgs, _ = repo.ListMessages(ctx, taskID, 999)
+	if len(msgs) != 1 || msgs[0].ID != 2 {
+		t.Errorf("expected only attacker's message, got %d messages", len(msgs))
+	}
+}
+
+func TestRepository_GetWorkspaceAttachmentIDs_BOLA(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+
+	_ = db.AutoMigrate(&model.Task{}, &model.Message{})
+	repo := New(&mockDB{db: db})
+
+	ctx := context.Background()
+	workspaceID := int64(100)
+	userID := int64(1)
+
+	// Task attachment
+	db.Create(&model.Task{
+		ID:          1,
+		WorkspaceID: workspaceID,
+		UserID:      userID,
+		Attachments: []byte(`[{"id":"att1"}]`),
+	})
+	// Message attachment
+	db.Create(&model.Message{
+		ID:          10,
+		TaskID:      1,
+		UserID:      userID,
+		Attachments: []byte(`[{"id":"att2"}]`),
+	})
+
+	// Attacker's data
+	db.Create(&model.Task{
+		ID:          2,
+		WorkspaceID: workspaceID,
+		UserID:      999,
+		Attachments: []byte(`[{"id":"att-hacked"}]`),
+	})
+
+	// Case 1: Fetch attachments for workspace with owner userID
+	ids, err := repo.GetWorkspaceAttachmentIDs(ctx, workspaceID, userID)
+	if err != nil {
+		t.Fatalf("GetWorkspaceAttachmentIDs failed: %v", err)
+	}
+
+	foundAtt1 := false
+	foundAtt2 := false
+	foundAttHacked := false
+
+	for _, id := range ids {
+		if id == "att1" {
+			foundAtt1 = true
+		}
+		if id == "att2" {
+			foundAtt2 = true
+		}
+		if id == "att-hacked" {
+			foundAttHacked = true
+		}
+	}
+
+	if !foundAtt1 || !foundAtt2 {
+		t.Errorf("expected att1 and att2 to be found, got %v", ids)
+	}
+	if foundAttHacked {
+		t.Error("vulnerability detected: found attacker's attachment ID")
 	}
 }
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Broken Object Level Authorization (BOLA) / Insecure Direct Object Reference (IDOR) in message listing, metadata updates, and workspace attachment retrieval.
🎯 **Impact:** An authenticated attacker could potentially access message history, update internal message metadata, or retrieve sensitive attachment IDs belonging to other users' workspaces by manipulating resource IDs in API requests.
🔧 **Fix:** Hardened the `Repository` interface and implementation in `backend/internal/repository/base/repository.go` by adding a mandatory `userID` parameter and enforcing owner-based filtering at the database level. Updated all call sites across the backend to ensure defense-in-depth.
✅ **Verification:** Added dedicated BOLA verification tests in `backend/internal/repository/base/repository_test.go`. Verified that all backend unit tests pass (`go test ./internal/...`). Verified successful compilation of the entire backend.

---
*PR created automatically by Jules for task [491394427946467678](https://jules.google.com/task/491394427946467678) started by @mustafaturan*