### PR TITLE
🛡️ Sentinel: Enforce JWT audience scoping for human sessions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** The Slack OAuth flow used a predictable base62 workspace ID as the `state` parameter. This lacked cryptographic integrity and session binding, making it vulnerable to CSRF attacks where an attacker could force a user to link their Slack workspace to an arbitrary AgentRQ workspace.
 **Learning:** The `state` parameter in OAuth2 is intended to be a non-guessable, session-bound value to prevent CSRF. Using a resource ID directly is insufficient.
 **Prevention:** Always use cryptographically signed tokens or high-entropy random nonces for the OAuth `state` parameter. In this project, `TokenService.CreateOAuthStateToken` provides a secure, signed JWT that can carry payload (like workspace ID) while ensuring origin and integrity.
+
+## 2026-07-13 - JWT Audience Scoping for Human Sessions
+**Vulnerability:** Human session endpoints (API, SSE) only validated JWT signature and expiry, allowing any valid JWT (like long-lived MCP agent tokens) to impersonate a human user if provided in the authentication cookie or header.
+**Learning:** Successful cryptographic validation of a JWT doesn't imply it is authorized for the current context. Scoping via the `aud` (audience) claim is essential to distinguish between different token actors (e.g., human vs. agent) and prevent token substitution attacks.
+**Prevention:** Always enforce the required audience claim (e.g., `auth.ActorHumanAudience`) at all human-actor authentication entry points.

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -913,7 +913,7 @@ func eventsHandler(ctrl crud.Controller, bus *eventbus.Bus, tokenSvc auth.TokenS
 			return
 		}
 		claims, err := tokenSvc.ValidateToken(cookie.Value)
-		if err != nil {
+		if err != nil || !auth.HasAudience(claims, auth.ActorHumanAudience) {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -232,7 +232,7 @@ func (h *handler) authMiddleware() fiber.Handler {
 		}
 
 		claims, err := h.tokenSvc.ValidateToken(tokenStr)
-		if err != nil {
+		if err != nil || !auth.HasAudience(claims, auth.ActorHumanAudience) {
 			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "unauthorized"})
 		}
 

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/agentrq/agentrq/backend/internal/repository/base"
 	"github.com/agentrq/agentrq/backend/internal/service/auth"
 	"github.com/gofiber/fiber/v2"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/mustafaturan/monoflake"
 )
 
@@ -32,6 +33,7 @@ type mockTokenSvc struct {
 	auth.TokenService
 	createTokenFunc    func(userID, email, name, picture string) (string, error)
 	createMCPTokenFunc func(userID, workspaceID, tokenType string) (string, error)
+	ValidateTokenFunc  func(tokenStr string) (*auth.Claims, error)
 }
 
 func (m *mockTokenSvc) CreateToken(userID, email, name, picture string) (string, error) {
@@ -40,6 +42,13 @@ func (m *mockTokenSvc) CreateToken(userID, email, name, picture string) (string,
 
 func (m *mockTokenSvc) CreateMCPToken(userID, workspaceID, tokenType string) (string, error) {
 	return m.createMCPTokenFunc(userID, workspaceID, tokenType)
+}
+
+func (m *mockTokenSvc) ValidateToken(tokenStr string) (*auth.Claims, error) {
+	if m.ValidateTokenFunc != nil {
+		return m.ValidateTokenFunc(tokenStr)
+	}
+	return nil, nil
 }
 
 func (m *mockTokenSvc) CreateOAuthStateToken(redirectURL, provider string) (string, error) {
@@ -373,4 +382,65 @@ func TestSendPermissionVerdict_RequiresWorkspaceAccess(t *testing.T) {
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected status 403, got %d", resp.StatusCode)
 	}
+}
+
+func TestAuthMiddleware_AudienceEnforcement(t *testing.T) {
+	app := fiber.New()
+	mockSvc := &mockTokenSvc{}
+	h := &handler{tokenSvc: mockSvc}
+
+	app.Use(h.authMiddleware())
+	app.Get("/test", func(c *fiber.Ctx) error {
+		return c.SendStatus(http.StatusOK)
+	})
+
+	t.Run("Token with correct human audience is allowed", func(t *testing.T) {
+		mockSvc.ValidateTokenFunc = func(tokenStr string) (*auth.Claims, error) {
+			return &auth.Claims{
+				RegisteredClaims: jwt.RegisteredClaims{
+					Subject:  "user123",
+					Audience: jwt.ClaimStrings{auth.ActorHumanAudience},
+				},
+			}, nil
+		}
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.AddCookie(&http.Cookie{Name: "at", Value: "valid-human-token"})
+		resp, _ := app.Test(req)
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("Token with incorrect audience is rejected", func(t *testing.T) {
+		mockSvc.ValidateTokenFunc = func(tokenStr string) (*auth.Claims, error) {
+			return &auth.Claims{
+				RegisteredClaims: jwt.RegisteredClaims{
+					Subject:  "user123",
+					Audience: jwt.ClaimStrings{"some-other-audience"},
+				},
+			}, nil
+		}
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.AddCookie(&http.Cookie{Name: "at", Value: "mcp-token-used-as-human"})
+		resp, _ := app.Test(req)
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("Token with no audience is rejected", func(t *testing.T) {
+		mockSvc.ValidateTokenFunc = func(tokenStr string) (*auth.Claims, error) {
+			return &auth.Claims{
+				RegisteredClaims: jwt.RegisteredClaims{
+					Subject: "user123",
+				},
+			}, nil
+		}
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.AddCookie(&http.Cookie{Name: "at", Value: "no-audience-token"})
+		resp, _ := app.Test(req)
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", resp.StatusCode)
+		}
+	})
 }

--- a/backend/internal/handler/api/middleware/ratelimit/ratelimit.go
+++ b/backend/internal/handler/api/middleware/ratelimit/ratelimit.go
@@ -71,7 +71,7 @@ func New(enabled bool, maxPerIP int, maxPerUser int, window time.Duration, token
 
 			// 1. Try resolving authenticated User ID from JWT cookie
 			if cookie, err := r.Cookie("at"); err == nil && cookie.Value != "" {
-				if claims, err := tokenSvc.ValidateToken(cookie.Value); err == nil && claims.Subject != "" {
+				if claims, err := tokenSvc.ValidateToken(cookie.Value); err == nil && claims.Subject != "" && auth.HasAudience(claims, auth.ActorHumanAudience) {
 					userKey = "user:" + claims.Subject
 				}
 			}
@@ -81,7 +81,7 @@ func New(enabled bool, maxPerIP int, maxPerUser int, window time.Duration, token
 				if authHeader := r.Header.Get("Authorization"); authHeader != "" {
 					tokenStr := strings.TrimPrefix(authHeader, "Bearer ")
 					tokenStr = strings.TrimSpace(tokenStr)
-					if claims, err := tokenSvc.ValidateToken(tokenStr); err == nil && claims.Subject != "" {
+					if claims, err := tokenSvc.ValidateToken(tokenStr); err == nil && claims.Subject != "" && auth.HasAudience(claims, auth.ActorHumanAudience) {
 						userKey = "user:" + claims.Subject
 					}
 				}
@@ -90,7 +90,7 @@ func New(enabled bool, maxPerIP int, maxPerUser int, window time.Duration, token
 			// 3. Try resolving from query parameters
 			if userKey == "" {
 				if tokenStr := r.URL.Query().Get("token"); tokenStr != "" {
-					if claims, err := tokenSvc.ValidateToken(tokenStr); err == nil && claims.Subject != "" {
+					if claims, err := tokenSvc.ValidateToken(tokenStr); err == nil && claims.Subject != "" && auth.HasAudience(claims, auth.ActorHumanAudience) {
 						userKey = "user:" + claims.Subject
 					}
 				}

--- a/backend/internal/handler/mcp/mcp_test.go
+++ b/backend/internal/handler/mcp/mcp_test.go
@@ -26,10 +26,14 @@ type mockTokenSvc struct {
 
 func (m *mockTokenSvc) ValidateToken(tokenStr string) (*auth.Claims, error) {
 	if tokenStr == "valid-auth-cookie" || tokenStr == m.validCode || tokenStr == "valid-refresh-token" {
+		aud := jwt.ClaimStrings{"ws123", "authorization_code"}
+		if tokenStr == "valid-auth-cookie" {
+			aud = jwt.ClaimStrings{auth.ActorHumanAudience}
+		}
 		return &auth.Claims{
 			RegisteredClaims: jwt.RegisteredClaims{
 				Subject:  monoflake.IDFromBase62("user123").String(),
-				Audience: jwt.ClaimStrings{"ws123", "authorization_code"},
+				Audience: aud,
 			},
 		}, nil
 	}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: JWT token substitution/impersonation. Prior to this change, human session endpoints only validated the JWT signature and expiration, but not the intended audience.
🎯 Impact: This allowed any valid JWT issued by the system (such as long-lived, scoped MCP agent tokens) to be used to authenticate as a human user, potentially leading to privilege escalation and unauthorized resource access.
🔧 Fix: Enhanced the authentication middleware, SSE event handler, and rate-limiting logic to strictly verify the `actor:human` audience claim for all human-actor authentication entry points.
✅ Verification: Added `TestAuthMiddleware_AudienceEnforcement` to `api_test.go` and verified that tokens with incorrect or missing audiences are correctly rejected. Ensured all existing backend tests pass.

---
*PR created automatically by Jules for task [6414582484215247522](https://jules.google.com/task/6414582484215247522) started by @mustafaturan*