### PR TITLE
🛡️ Sentinel: Fix BOLA in repository layer

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** The Slack OAuth flow used a predictable base62 workspace ID as the `state` parameter. This lacked cryptographic integrity and session binding, making it vulnerable to CSRF attacks where an attacker could force a user to link their Slack workspace to an arbitrary AgentRQ workspace.
 **Learning:** The `state` parameter in OAuth2 is intended to be a non-guessable, session-bound value to prevent CSRF. Using a resource ID directly is insufficient.
 **Prevention:** Always use cryptographically signed tokens or high-entropy random nonces for the OAuth `state` parameter. In this project, `TokenService.CreateOAuthStateToken` provides a secure, signed JWT that can carry payload (like workspace ID) while ensuring origin and integrity.
+
+## 2026-07-14 - BOLA Protection in Repository Layer
+**Vulnerability:** Core repository methods `ListMessages`, `UpdateMessageMetadata`, and `GetWorkspaceAttachmentIDs` lacked `userID` ownership checks, allowing potential IDOR/BOLA attacks where an authenticated user could access or modify messages and attachments of other users' tasks/workspaces.
+**Learning:** Adding a `userID` filter directly on a `messages` table can be too restrictive and cause functional regressions if the user is the task owner but not the message author. Resource ownership (Task/Workspace) must be verified before allowing access to sub-resources (Messages/Attachments).
+**Prevention:** Use subqueries or joins to verify ownership of the parent resource (e.g., `task_id IN (SELECT id FROM tasks WHERE user_id = ?)`) when performing operations on child resources, ensuring that the owner can access all relevant data while preventing unauthorized access from others.

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -504,9 +504,9 @@ func New(cfg Config) (*App, error) {
 				}
 
 				b, _ := json.Marshal(existingMetadata)
-				err := repo.UpdateMessageMetadata(ctx, taskID, messageID, b)
+				uid := monoflake.IDFromBase62(workspaceOwner).Int64()
+				err := repo.UpdateMessageMetadata(ctx, taskID, messageID, uid, b)
 				if err == nil {
-					uid := monoflake.IDFromBase62(workspaceOwner).Int64()
 					latest, _ := repo.GetTask(ctx, workspaceID, taskID, uid)
 					bus.Publish(workspaceID, workspaceOwner, eventbus.Event{
 						Type:    "task.updated",
@@ -676,7 +676,7 @@ func New(cfg Config) (*App, error) {
 					t, err := repo.SystemGetTask(ctx, taskID)
 					if err == nil {
 						// Preload task messages
-						messages, err := repo.ListMessages(ctx, t.ID)
+						messages, err := repo.ListMessages(ctx, t.ID, ev.UserID)
 						if err == nil {
 							t.Messages = messages
 						}

--- a/backend/internal/controller/crud/task.go
+++ b/backend/internal/controller/crud/task.go
@@ -591,7 +591,7 @@ func (c *controller) UpdateMessageMetadata(ctx context.Context, req entity.Updat
 		return err
 	}
 
-	if err := c.repository.UpdateMessageMetadata(ctx, req.TaskID, req.MessageID, b); err != nil {
+	if err := c.repository.UpdateMessageMetadata(ctx, req.TaskID, req.MessageID, uid, b); err != nil {
 		return err
 	}
 	c.emitEvent(ctx, entity.CRUDEvent{

--- a/backend/internal/controller/crud/task_test.go
+++ b/backend/internal/controller/crud/task_test.go
@@ -784,7 +784,7 @@ func TestUpdateMessageMetadata_Success(t *testing.T) {
 	e := newTestController(t)
 
 	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(10), testUserID).Return(model.Task{}, nil)
-	e.repo.EXPECT().UpdateMessageMetadata(gomock.Any(), int64(10), int64(500), gomock.Any()).Return(nil)
+	e.repo.EXPECT().UpdateMessageMetadata(gomock.Any(), int64(10), int64(500), testUserID, gomock.Any()).Return(nil)
 
 	err := e.controller.UpdateMessageMetadata(context.Background(), entity.UpdateMessageMetadataRequest{
 		WorkspaceID: 1,

--- a/backend/internal/controller/crud/workspace.go
+++ b/backend/internal/controller/crud/workspace.go
@@ -99,7 +99,7 @@ func (c *controller) ListWorkspaces(ctx context.Context, req entity.ListWorkspac
 func (c *controller) DeleteWorkspace(ctx context.Context, req entity.DeleteWorkspaceRequest) error {
 	// 1. Get all task and message attachment IDs directly from DB
 	uid := monoflake.IDFromBase62(req.UserID).Int64()
-	attachmentIDs, _ := c.repository.GetWorkspaceAttachmentIDs(ctx, req.ID)
+	attachmentIDs, _ := c.repository.GetWorkspaceAttachmentIDs(ctx, req.ID, uid)
 
 	// 2. Delete from DB (repository handles cascaded DB delete)
 	if err := c.repository.DeleteWorkspace(ctx, req.ID, uid); err != nil {

--- a/backend/internal/controller/crud/workspace_test.go
+++ b/backend/internal/controller/crud/workspace_test.go
@@ -38,7 +38,7 @@ func TestCreateWorkspace_WithOptions(t *testing.T) {
 func TestDeleteWorkspace_Complex(t *testing.T) {
 	e := newTestController(t)
 
-	e.repo.EXPECT().GetWorkspaceAttachmentIDs(gomock.Any(), int64(1)).Return([]string{"att-1", "att-2"}, nil)
+	e.repo.EXPECT().GetWorkspaceAttachmentIDs(gomock.Any(), int64(1), testUserID).Return([]string{"att-1", "att-2"}, nil)
 	e.repo.EXPECT().DeleteWorkspace(gomock.Any(), int64(1), testUserID).Return(nil)
 	e.storage.EXPECT().Delete("att-1").Return(nil)
 	e.storage.EXPECT().Delete("att-2").Return(nil)

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -255,7 +255,9 @@ func (c *controller) OnMessageCreated(ctx context.Context, msg entity.Message, t
 				msg.Metadata = metaMap
 				b, marshalErr := json.Marshal(metaMap)
 				if marshalErr == nil {
-					if updateErr := c.repo.UpdateMessageMetadata(ctx, task.ID, msg.ID, b); updateErr != nil {
+					ownerID := monoflake.ID(task.UserID).String()
+					uid := monoflake.IDFromBase62(ownerID).Int64()
+					if updateErr := c.repo.UpdateMessageMetadata(ctx, task.ID, msg.ID, uid, b); updateErr != nil {
 						zlog.Error().Err(updateErr).Int64("messageID", msg.ID).Msg("[slack] failed to update message metadata with slack details")
 					}
 				}
@@ -757,7 +759,8 @@ func (c *controller) HandleMCPPermission(ctx context.Context, action SlackBlockA
 
 	// Try to find the permission request message and save the slack decision flag in its metadata first,
 	// so that OnMessageUpdated can skip overwriting the slack-initiated UI update.
-	messages, listErr := c.repo.ListMessages(ctx, taskID)
+	uid := monoflake.IDFromBase62(ownerID).Int64()
+	messages, listErr := c.repo.ListMessages(ctx, taskID, uid)
 	if listErr == nil {
 		for _, m := range messages {
 			var metadata map[string]any
@@ -775,7 +778,7 @@ func (c *controller) HandleMCPPermission(ctx context.Context, action SlackBlockA
 					metadata["slack_user_name"] = action.UserName
 					b, marshalErr := json.Marshal(metadata)
 					if marshalErr == nil {
-						_ = c.repo.UpdateMessageMetadata(ctx, taskID, m.ID, b)
+						_ = c.repo.UpdateMessageMetadata(ctx, taskID, m.ID, uid, b)
 					}
 					break
 				}

--- a/backend/internal/controller/slack/slack_test.go
+++ b/backend/internal/controller/slack/slack_test.go
@@ -1107,13 +1107,13 @@ func TestHandleMCPPermission_Success_Allow(t *testing.T) {
 		}, nil)
 
 	mockRepo.EXPECT().
-		ListMessages(gomock.Any(), taskID).
+		ListMessages(gomock.Any(), taskID, int64(100)).
 		Return([]model.Message{permMsg}, nil)
 
 	var capturedMeta []byte
 	mockRepo.EXPECT().
-		UpdateMessageMetadata(gomock.Any(), taskID, int64(7), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ int64, _ int64, b []byte) error {
+		UpdateMessageMetadata(gomock.Any(), taskID, int64(7), int64(100), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ int64, _ int64, _ int64, b []byte) error {
 			capturedMeta = b
 			return nil
 		})

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -33,9 +33,9 @@ type Repository interface {
 
 	// Message
 	CreateMessage(ctx context.Context, m model.Message) error
-	ListMessages(ctx context.Context, taskID int64) ([]model.Message, error)
-	UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte) error
-	GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64) ([]string, error)
+	ListMessages(ctx context.Context, taskID int64, userID int64) ([]model.Message, error)
+	UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, userID int64, metadata []byte) error
+	GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64, userID int64) ([]string, error)
 
 	SystemGetWorkspace(ctx context.Context, id int64) (model.Workspace, error)
 	SystemGetTask(ctx context.Context, id int64) (model.Task, error)
@@ -278,6 +278,7 @@ func (r *repository) ListTasks(ctx context.Context, req entity.ListTasksRequest,
 			var batchMessages []model.Message
 			err := r.conn(ctx).
 				Where("task_id IN ?", batch).
+				Where("task_id IN (SELECT id FROM tasks WHERE user_id = ?)", userID).
 				Where("id = (SELECT MAX(id) FROM messages m2 WHERE m2.task_id = messages.task_id) OR (" + metadataExpr + ")").
 				Order("created_at asc").
 				Find(&batchMessages).Error
@@ -349,22 +350,29 @@ func (r *repository) CreateMessage(ctx context.Context, m model.Message) error {
 	return r.conn(ctx).Create(&m).Error
 }
 
-func (r *repository) ListMessages(ctx context.Context, taskID int64) ([]model.Message, error) {
+func (r *repository) ListMessages(ctx context.Context, taskID int64, userID int64) ([]model.Message, error) {
 	var msgs []model.Message
-	err := r.conn(ctx).Where("task_id = ?", taskID).Order("created_at asc").Find(&msgs).Error
+	// Verify task ownership to allow listing all messages in that task (human, agent, system, etc)
+	err := r.conn(ctx).
+		Where("task_id = ? AND task_id IN (SELECT id FROM tasks WHERE user_id = ?)", taskID, userID).
+		Order("created_at asc").
+		Find(&msgs).Error
 	return msgs, err
 }
 
-func (r *repository) UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte) error {
-	return r.conn(ctx).Model(&model.Message{}).Where("id = ? AND task_id = ?", messageID, taskID).Update("metadata", metadata).Error
+func (r *repository) UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, userID int64, metadata []byte) error {
+	// Verify task ownership before updating metadata for any message within it
+	return r.conn(ctx).Model(&model.Message{}).
+		Where("id = ? AND task_id = ? AND task_id IN (SELECT id FROM tasks WHERE user_id = ?)", messageID, taskID, userID).
+		Update("metadata", metadata).Error
 }
 
-func (r *repository) GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64) ([]string, error) {
+func (r *repository) GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64, userID int64) ([]string, error) {
 	var attachmentIDs []string
 
 	// 1. Get attachments from tasks
 	var taskAttachments []string
-	err := r.conn(ctx).Model(&model.Task{}).Where("workspace_id = ?", workspaceID).Pluck("attachments", &taskAttachments).Error
+	err := r.conn(ctx).Model(&model.Task{}).Where("workspace_id = ? AND user_id = ?", workspaceID, userID).Pluck("attachments", &taskAttachments).Error
 	if err == nil {
 		for _, ta := range taskAttachments {
 			if len(ta) > 0 {
@@ -384,7 +392,7 @@ func (r *repository) GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID 
 	var msgAttachments []string
 	err = r.conn(ctx).Model(&model.Message{}).
 		Joins("JOIN tasks ON tasks.id = messages.task_id").
-		Where("tasks.workspace_id = ?", workspaceID).
+		Where("tasks.workspace_id = ? AND tasks.user_id = ?", workspaceID, userID).
 		Pluck("messages.attachments", &msgAttachments).Error
 	if err == nil {
 		for _, ma := range msgAttachments {

--- a/backend/internal/repository/base/repository_test.go
+++ b/backend/internal/repository/base/repository_test.go
@@ -134,21 +134,24 @@ func TestRepository_UpdateMessageMetadata(t *testing.T) {
 		t.Fatalf("failed to connect database: %v", err)
 	}
 
-	_ = db.AutoMigrate(&model.Message{})
+	_ = db.AutoMigrate(&model.Task{}, &model.Message{})
 	repo := New(&mockDB{db: db})
 
 	ctx := context.Background()
 	taskID := int64(100)
 	messageID := int64(500)
+	userID := int64(1)
 
+	db.Create(&model.Task{ID: taskID, UserID: userID})
 	db.Create(&model.Message{
 		ID:     messageID,
 		TaskID: taskID,
+		UserID: 99, // author doesn't have to be the owner
 		Text:   "Initial text",
 	})
 
-	// Case 1: Success update with correct taskID
-	err = repo.UpdateMessageMetadata(ctx, taskID, messageID, []byte(`{"updated":true}`))
+	// Case 1: Success update with correct taskID and userID
+	err = repo.UpdateMessageMetadata(ctx, taskID, messageID, userID, []byte(`{"updated":true}`))
 	if err != nil {
 		t.Errorf("expected nil error, got %v", err)
 	}
@@ -160,7 +163,7 @@ func TestRepository_UpdateMessageMetadata(t *testing.T) {
 	}
 
 	// Case 2: Update with WRONG taskID (IDOR)
-	err = repo.UpdateMessageMetadata(ctx, 999, messageID, []byte(`{"hacked":true}`))
+	err = repo.UpdateMessageMetadata(ctx, 999, messageID, userID, []byte(`{"hacked":true}`))
 	if err != nil {
 		t.Errorf("expected nil error (GORM Update doesn't return error on no rows), got %v", err)
 	}
@@ -168,6 +171,115 @@ func TestRepository_UpdateMessageMetadata(t *testing.T) {
 	db.First(&m, messageID)
 	if string(m.Metadata) == `{"hacked":true}` {
 		t.Error("vulnerability detected: metadata was updated with wrong taskID")
+	}
+
+	// Case 3: Update with WRONG userID (BOLA)
+	err = repo.UpdateMessageMetadata(ctx, taskID, messageID, 999, []byte(`{"bola":true}`))
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+
+	db.First(&m, messageID)
+	if string(m.Metadata) == `{"bola":true}` {
+		t.Error("vulnerability detected: metadata was updated with wrong userID")
+	}
+}
+
+func TestRepository_ListMessages_Ownership(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+
+	_ = db.AutoMigrate(&model.Task{}, &model.Message{})
+	repo := New(&mockDB{db: db})
+
+	ctx := context.Background()
+	taskID := int64(100)
+	userID := int64(1)
+	otherUserID := int64(2)
+
+	db.Create(&model.Task{ID: taskID, UserID: userID})
+	db.Create(&model.Message{ID: 1, TaskID: taskID, UserID: userID, Text: "Msg 1"})
+	db.Create(&model.Message{ID: 2, TaskID: taskID, UserID: 0, Sender: "agent", Text: "Agent reply"})
+
+	// Case 1: Owner lists all messages in the task
+	msgs, err := repo.ListMessages(ctx, taskID, userID)
+	if err != nil {
+		t.Fatalf("ListMessages failed: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Errorf("expected 2 messages for task owner, got %d", len(msgs))
+	}
+
+	// Case 2: Other user lists messages (doesn't own the task)
+	msgs, err = repo.ListMessages(ctx, taskID, otherUserID)
+	if err != nil {
+		t.Fatalf("ListMessages failed: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("expected 0 messages for non-owner, got %d", len(msgs))
+	}
+}
+
+func TestRepository_GetWorkspaceAttachmentIDs_Ownership(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+
+	_ = db.AutoMigrate(&model.Task{}, &model.Message{})
+	repo := New(&mockDB{db: db})
+
+	ctx := context.Background()
+	workspaceID := int64(1)
+	userID := int64(10)
+	otherUserID := int64(20)
+
+	// Task with attachment for userID 10
+	db.Create(&model.Task{
+		ID:          1,
+		WorkspaceID: workspaceID,
+		UserID:      userID,
+		Attachments: []byte(`[{"id":"att-1","filename":"f1.txt"}]`),
+	})
+
+	// Message with attachment for userID 10
+	db.Create(&model.Message{
+		ID:     101,
+		TaskID: 1,
+		UserID: userID,
+		Attachments: []byte(`[{"id":"att-2","filename":"f2.txt"}]`),
+	})
+
+	// Task with attachment for otherUserID
+	db.Create(&model.Task{
+		ID:          2,
+		WorkspaceID: workspaceID,
+		UserID:      otherUserID,
+		Attachments: []byte(`[{"id":"att-3","filename":"f3.txt"}]`),
+	})
+
+	// Case 1: Owner gets attachment IDs
+	ids, err := repo.GetWorkspaceAttachmentIDs(ctx, workspaceID, userID)
+	if err != nil {
+		t.Fatalf("GetWorkspaceAttachmentIDs failed: %v", err)
+	}
+	// att-1 from task 1, att-2 from message 101 (joined via task 1 which belongs to userID 10)
+	// Wait, the join in GetWorkspaceAttachmentIDs joins tasks ON tasks.id = messages.task_id
+	// and checks tasks.workspace_id = ? AND tasks.user_id = ?.
+	// Since task 1 belongs to userID 10, message 101's attachment will be included for userID 10.
+	if len(ids) != 2 {
+		t.Errorf("expected 2 attachment IDs for owner, got %d: %v", len(ids), ids)
+	}
+
+	// Case 2: Other user gets attachment IDs
+	ids, err = repo.GetWorkspaceAttachmentIDs(ctx, workspaceID, otherUserID)
+	if err != nil {
+		t.Fatalf("GetWorkspaceAttachmentIDs failed: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "att-3" {
+		t.Errorf("expected 1 attachment ID (att-3) for other user, got %d: %v", len(ids), ids)
 	}
 }
 
@@ -208,6 +320,13 @@ func TestRepository_ListTasks_PreloadMessages(t *testing.T) {
 		PreloadMessages: true,
 		Limit:           10,
 	}
+
+	// Update existing test expectations: ListTasks preloads messages using r.conn(ctx).
+	// The preloading logic in ListTasks also needs to be userID scoped.
+	// My previous change to ListTasks implementation:
+	// I didn't change ListTasks implementation yet? Let me check.
+	// Oh, I see ListTasks already took userID and used it for tasks: q := r.conn(ctx).Where("user_id = ?", userID)
+	// But it didn't use it for the message preloading subquery.
 
 	tasks, err := repo.ListTasks(ctx, req, userID)
 	if err != nil {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Broken Object Level Authorization (BOLA) / IDOR
🎯 **Impact:** An authenticated user could potentially list messages, update metadata, or retrieve attachment IDs from other users' tasks or workspaces by guessing or obtaining their IDs.
🔧 **Fix:** Updated the `Repository` interface and implementation to require a `userID` for scoped methods. Implemented ownership verification using subqueries (e.g., `task_id IN (SELECT id FROM tasks WHERE user_id = ?)`) to ensure access is granted based on parent resource ownership rather than individual record authorship.
✅ **Verification:**
- Added unit tests in `repository_test.go` specifically targeting BOLA scenarios.
- Verified that task owners can still see messages authored by others (agents).
- Confirmed all backend tests pass and the system compiles correctly.

---
*PR created automatically by Jules for task [12747834349481303655](https://jules.google.com/task/12747834349481303655) started by @mustafaturan*