### PR TITLE
fix(events): cascade trigger cleanup when deleting an event

### DIFF
--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -793,14 +793,26 @@ func (r *repository) UpdateEvent(ctx context.Context, id int64, userID int64, pa
 }
 
 func (r *repository) DeleteEvent(ctx context.Context, id int64, userID int64) error {
-	res := r.conn(ctx).Where("id = ? AND user_id = ?", id, userID).Delete(&model.Event{})
-	if res.Error != nil {
-		return res.Error
-	}
-	if res.RowsAffected == 0 {
-		return ErrNotFound
-	}
-	return nil
+	return r.conn(ctx).Transaction(func(tx *gorm.DB) error {
+		res := tx.Where("id = ? AND user_id = ?", id, userID).Delete(&model.Event{})
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return ErrNotFound
+		}
+
+		if err := tx.Where("event_id = ? AND user_id = ?", id, userID).Delete(&model.EventTrigger{}).Error; err != nil {
+			return err
+		}
+
+		if err := tx.Model(&model.EventTrigger{}).
+			Where("emit_event_id = ? AND user_id = ?", id, userID).
+			Update("emit_event_id", 0).Error; err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 // ── EventTriggers ──────────────────────────────────────────────────────────────

--- a/backend/internal/repository/base/repository_test.go
+++ b/backend/internal/repository/base/repository_test.go
@@ -291,7 +291,7 @@ func TestRepository_Event_CRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to connect database: %v", err)
 	}
-	_ = db.AutoMigrate(&model.Event{})
+	_ = db.AutoMigrate(&model.Event{}, &model.EventTrigger{})
 	repo := New(&mockDB{db: db})
 
 	ctx := context.Background()
@@ -368,6 +368,43 @@ func TestRepository_Event_CRUD(t *testing.T) {
 	_, err = repo.GetEvent(ctx, 100, userID)
 	if err != ErrNotFound {
 		t.Errorf("expected ErrNotFound after delete, got %v", err)
+	}
+}
+
+func TestRepository_DeleteEvent_CascadesTriggers(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+	_ = db.AutoMigrate(&model.Event{}, &model.EventTrigger{})
+	repo := New(&mockDB{db: db})
+
+	ctx := context.Background()
+	userID := int64(1)
+
+	db.Create(&model.Event{ID: 100, UserID: userID, Name: "deploy_done"})
+	db.Create(&model.Event{ID: 200, UserID: userID, Name: "tests_done"})
+	// Trigger owned by the event being deleted.
+	db.Create(&model.EventTrigger{ID: 1, EventID: 100, UserID: userID, WorkspaceID: 10, Title: "t1"})
+	// Trigger of another event that chains to the event being deleted.
+	db.Create(&model.EventTrigger{ID: 2, EventID: 200, UserID: userID, WorkspaceID: 10, Title: "t2", EmitEventID: 100})
+
+	if err := repo.DeleteEvent(ctx, 100, userID); err != nil {
+		t.Fatalf("DeleteEvent: %v", err)
+	}
+
+	var count int64
+	db.Model(&model.EventTrigger{}).Where("event_id = ?", 100).Count(&count)
+	if count != 0 {
+		t.Errorf("expected the deleted event's triggers to be removed, found %d", count)
+	}
+
+	var chained model.EventTrigger
+	if err := db.First(&chained, 2).Error; err != nil {
+		t.Fatalf("trigger of the surviving event should not be deleted: %v", err)
+	}
+	if chained.EmitEventID != 0 {
+		t.Errorf("expected dangling emitEventId to be cleared, got %d", chained.EmitEventID)
 	}
 }
 


### PR DESCRIPTION
## Bug

`DeleteEvent` removed only the `events` row. Its `event_triggers` rows survived — live in the DB but invisible in the UI, since trigger listing is per-event. Recreating an event with the same name gets a new ID, so the orphaned triggers never fire again yet can never be seen or deleted. Triggers of *other* events chained to the deleted one (`emit_event_id`) kept a dangling reference.

## Fix

`DeleteEvent` now runs in a transaction that:
1. deletes the event (unchanged `ErrNotFound` semantics),
2. deletes its `event_triggers` rows,
3. zeroes `emit_event_id` on the user's triggers that chained to the deleted event.

## Tests

- New `TestRepository_DeleteEvent_CascadesTriggers`: trigger rows of the deleted event are gone, a chained trigger of a surviving event is kept but its `emit_event_id` is cleared.
- `TestRepository_Event_CRUD` now migrates `event_triggers`, which the cascade touches.

Full `go test ./internal/...` passes (mocks regenerated via `make mocks`).

Note for maintainers: touches `repository.go`/`repository_test.go` only in `DeleteEvent` — no logical overlap with #234 (`ClaimNextTask`) or the Sentinel BOLA PRs (other repository methods); worst case is trivial rebase noise.

In collaboration with Claude Code