### PR TITLE
🛡️ Sentinel: Enforce 'actor:human' audience for session tokens

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -913,7 +913,7 @@ func eventsHandler(ctrl crud.Controller, bus *eventbus.Bus, tokenSvc auth.TokenS
 			return
 		}
 		claims, err := tokenSvc.ValidateToken(cookie.Value)
-		if err != nil {
+		if err != nil || !auth.HasAudience(claims, auth.ActorHumanAudience) {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -232,7 +232,7 @@ func (h *handler) authMiddleware() fiber.Handler {
 		}
 
 		claims, err := h.tokenSvc.ValidateToken(tokenStr)
-		if err != nil {
+		if err != nil || !auth.HasAudience(claims, auth.ActorHumanAudience) {
 			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "unauthorized"})
 		}
 

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/golang-jwt/jwt/v5"
+
 	"github.com/agentrq/agentrq/backend/internal/controller/crud"
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	"github.com/agentrq/agentrq/backend/internal/repository/base"
@@ -32,6 +34,7 @@ type mockTokenSvc struct {
 	auth.TokenService
 	createTokenFunc    func(userID, email, name, picture string) (string, error)
 	createMCPTokenFunc func(userID, workspaceID, tokenType string) (string, error)
+	validateTokenFunc  func(tokenStr string) (*auth.Claims, error)
 }
 
 func (m *mockTokenSvc) CreateToken(userID, email, name, picture string) (string, error) {
@@ -40,6 +43,13 @@ func (m *mockTokenSvc) CreateToken(userID, email, name, picture string) (string,
 
 func (m *mockTokenSvc) CreateMCPToken(userID, workspaceID, tokenType string) (string, error) {
 	return m.createMCPTokenFunc(userID, workspaceID, tokenType)
+}
+
+func (m *mockTokenSvc) ValidateToken(tokenStr string) (*auth.Claims, error) {
+	if m.validateTokenFunc != nil {
+		return m.validateTokenFunc(tokenStr)
+	}
+	return nil, nil
 }
 
 func (m *mockTokenSvc) CreateOAuthStateToken(redirectURL, provider string) (string, error) {
@@ -372,5 +382,78 @@ func TestSendPermissionVerdict_RequiresWorkspaceAccess(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected status 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestAuthMiddleware_AudienceEnforcement(t *testing.T) {
+	app := fiber.New()
+	tokenSvc := &mockTokenSvc{}
+
+	h := &handler{
+		tokenSvc: tokenSvc,
+	}
+
+	app.Use(h.authMiddleware())
+	app.Get("/test", func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	tests := []struct {
+		name           string
+		token          string
+		claims         *auth.Claims
+		expectedStatus int
+	}{
+		{
+			name:  "Valid human token",
+			token: "valid-human",
+			claims: &auth.Claims{
+				RegisteredClaims: jwt.RegisteredClaims{
+					Subject:  "user1",
+					Audience: jwt.ClaimStrings{auth.ActorHumanAudience},
+				},
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:  "Invalid audience (agent token)",
+			token: "agent-token",
+			claims: &auth.Claims{
+				RegisteredClaims: jwt.RegisteredClaims{
+					Subject:  "user1",
+					Audience: jwt.ClaimStrings{"ws123", "access"},
+				},
+			},
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name:  "Missing audience",
+			token: "no-aud",
+			claims: &auth.Claims{
+				RegisteredClaims: jwt.RegisteredClaims{
+					Subject: "user1",
+				},
+			},
+			expectedStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokenSvc.validateTokenFunc = func(tokenStr string) (*auth.Claims, error) {
+				if tokenStr == tt.token {
+					return tt.claims, nil
+				}
+				return nil, jwt.ErrSignatureInvalid
+			}
+
+			req := httptest.NewRequest("GET", "/test", nil)
+			req.AddCookie(&http.Cookie{Name: "at", Value: tt.token})
+			resp, _ := app.Test(req)
+
+			if resp.StatusCode != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, resp.StatusCode)
+			}
+		})
 	}
 }

--- a/backend/internal/handler/coremcp/coremcp.go
+++ b/backend/internal/handler/coremcp/coremcp.go
@@ -265,7 +265,7 @@ func (h *handler) oauthAuthorizeHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var userID string
 		if cookie, err := r.Cookie("at"); err == nil && cookie.Value != "" {
-			if claims, err := h.tokenSvc.ValidateToken(cookie.Value); err == nil && claims != nil {
+			if claims, err := h.tokenSvc.ValidateToken(cookie.Value); err == nil && auth.HasAudience(claims, auth.ActorHumanAudience) {
 				userID = claims.Subject
 			}
 		}

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -406,7 +406,7 @@ func (h *handler) oauthAuthorizeHandler() http.Handler {
 		// 1. Is user logged in?
 		var userID string
 		if cookie, err := r.Cookie("at"); err == nil && cookie.Value != "" {
-			if claims, err := h.tokenSvc.ValidateToken(cookie.Value); err == nil && claims != nil {
+			if claims, err := h.tokenSvc.ValidateToken(cookie.Value); err == nil && auth.HasAudience(claims, auth.ActorHumanAudience) {
 				userID = claims.Subject
 			}
 		}

--- a/backend/internal/handler/mcp/mcp_test.go
+++ b/backend/internal/handler/mcp/mcp_test.go
@@ -26,10 +26,14 @@ type mockTokenSvc struct {
 
 func (m *mockTokenSvc) ValidateToken(tokenStr string) (*auth.Claims, error) {
 	if tokenStr == "valid-auth-cookie" || tokenStr == m.validCode || tokenStr == "valid-refresh-token" {
+		audience := jwt.ClaimStrings{"ws123", "authorization_code"}
+		if tokenStr == "valid-auth-cookie" {
+			audience = append(audience, auth.ActorHumanAudience)
+		}
 		return &auth.Claims{
 			RegisteredClaims: jwt.RegisteredClaims{
 				Subject:  monoflake.IDFromBase62("user123").String(),
-				Audience: jwt.ClaimStrings{"ws123", "authorization_code"},
+				Audience: audience,
 			},
 		}, nil
 	}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: JWT Audience Confusion
🎯 Impact: Without strict audience enforcement, a long-lived token issued for an agent or a specific workspace could potentially be used as a session cookie ('at') to access human-oriented API endpoints or initiate OAuth flows on behalf of the user, leading to session hijacking or privilege escalation if agent tokens are leaked or compromised.
🔧 Fix: Added explicit checks for `auth.ActorHumanAudience` using `auth.HasAudience` in all handlers that resolve a user session from the 'at' cookie.
✅ Verification: Added `TestAuthMiddleware_AudienceEnforcement` in `api_test.go` covering valid human tokens, agent tokens (wrong audience), and tokens with missing audiences. All existing and new tests pass.

---
*PR created automatically by Jules for task [949121954050656417](https://jules.google.com/task/949121954050656417) started by @mustafaturan*