### PR TITLE
fix(backend): preserve eventId when spawning task from cron template

### DIFF
--- a/backend/internal/service/scheduler/scheduler.go
+++ b/backend/internal/service/scheduler/scheduler.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -96,6 +97,22 @@ func (s *scheduler) spawn(ctx context.Context, parent model.Task) {
 		return
 	}
 
+	body := parent.Body
+	// Keep the event link on spawned runs. The publish instruction must live in
+	// the body because scheduled children reach the agent via getTask/poller
+	// notifications, which have no event-aware path of their own.
+	if parent.EventID != 0 {
+		if ev, err := s.repo.GetEvent(ctx, parent.EventID, parent.UserID); err == nil {
+			instruction := fmt.Sprintf("\n\n[On completion: call publishEvent(%q, \"<your output payload>\")]", ev.Name)
+			if ev.PayloadGuidelines != "" {
+				instruction += fmt.Sprintf("\nPayload guidelines: %s", ev.PayloadGuidelines)
+			}
+			body += instruction
+		} else {
+			zlog.Warn().Err(err).Int64("cron_id", parent.ID).Int64("event_id", parent.EventID).Msg("scheduler: linked event not found")
+		}
+	}
+
 	now := time.Now()
 	child := model.Task{
 		ID:               s.idgen.NextID(),
@@ -107,10 +124,11 @@ func (s *scheduler) spawn(ctx context.Context, parent model.Task) {
 		Assignee:         parent.Assignee,
 		Status:           "notstarted",
 		Title:            parent.Title,
-		Body:             parent.Body,
+		Body:             body,
 		Attachments:      parent.Attachments,
 		ParentID:         parent.ID,
 		AllowAllCommands: parent.AllowAllCommands,
+		EventID:          parent.EventID,
 	}
 
 	created, err := s.repo.CreateTask(ctx, child)

--- a/backend/internal/service/scheduler/scheduler_test.go
+++ b/backend/internal/service/scheduler/scheduler_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -123,6 +124,36 @@ func TestScheduler(t *testing.T) {
 		mockRepo.EXPECT().CreateTask(gomock.Any(), gomock.Any()).Return(model.Task{ID: 2}, nil)
 		mockPubSub.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(&pubsub.PublishResponse{}, nil).AnyTimes()
 		mockRepo.EXPECT().DeleteTask(gomock.Any(), int64(10), int64(1), int64(1)).Return(nil)
+
+		s.(*scheduler).spawn(context.Background(), task)
+	})
+
+	// A cron template linked to an event must pass its EventID on to spawned
+	// children and carry the publishEvent instruction in the body — otherwise
+	// the event chain silently never fires on scheduled runs.
+	t.Run("SpawnCopiesEventLink", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockRepo := mock_repo.NewMockRepository(ctrl)
+		mockIdgen := mock_idgen.NewMockService(ctrl)
+		mockPubSub := mock_pubsub.NewMockService(ctrl)
+		s := New(mockRepo, mockIdgen, bus, mockPubSub)
+
+		task := model.Task{ID: 1, WorkspaceID: 10, UserID: 1, CronSchedule: "0 9 * * *", Body: "do the thing", EventID: 77}
+		mockRepo.EXPECT().SystemCheckTaskExists(gomock.Any(), int64(10), int64(1), "notstarted").Return(false, nil)
+		mockRepo.EXPECT().SystemCheckTaskExists(gomock.Any(), int64(10), int64(1), "ongoing").Return(false, nil)
+		mockRepo.EXPECT().GetEvent(gomock.Any(), int64(77), int64(1)).Return(model.Event{ID: 77, UserID: 1, Name: "run_done"}, nil)
+		mockIdgen.EXPECT().NextID().Return(int64(2))
+		mockRepo.EXPECT().CreateTask(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, child model.Task) (model.Task, error) {
+			if child.EventID != 77 {
+				t.Errorf("expected child EventID 77, got %d", child.EventID)
+			}
+			if !strings.Contains(child.Body, `publishEvent("run_done"`) {
+				t.Errorf("expected publishEvent instruction in child body, got %q", child.Body)
+			}
+			return model.Task{ID: 2}, nil
+		})
+		mockPubSub.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(&pubsub.PublishResponse{}, nil).AnyTimes()
 
 		s.(*scheduler).spawn(context.Background(), task)
 	})


### PR DESCRIPTION
## Summary
- The scheduler dropped `EventID` when cloning a cron template into a spawned task, so triggered runs lost their event link and never received the publishEvent completion instruction.
- Spawned tasks now inherit the parent's `EventID`, and the `[On completion: call publishEvent(...)]` instruction is appended to the child body, matching the REST/MCP task-creation paths.

## Testing
- `TestScheduler/SpawnCopiesEventLink` in `backend/internal/service/scheduler/scheduler_test.go` covers the new behavior.

In collaboration with Claude Code