### PR TITLE
🛡️ Sentinel: Fix rate-limiting audience scoping

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** The Slack OAuth flow used a predictable base62 workspace ID as the `state` parameter. This lacked cryptographic integrity and session binding, making it vulnerable to CSRF attacks where an attacker could force a user to link their Slack workspace to an arbitrary AgentRQ workspace.
 **Learning:** The `state` parameter in OAuth2 is intended to be a non-guessable, session-bound value to prevent CSRF. Using a resource ID directly is insufficient.
 **Prevention:** Always use cryptographically signed tokens or high-entropy random nonces for the OAuth `state` parameter. In this project, `TokenService.CreateOAuthStateToken` provides a secure, signed JWT that can carry payload (like workspace ID) while ensuring origin and integrity.
+
+## 2026-07-16 - Improper Audience Scoping in Rate Limit Middleware
+**Vulnerability:** The rate limiting middleware mapped any valid token with a non-empty `Subject` to a user-scoped rate limit `user:<userID>`. Because it did not verify the token's audience, service-to-service or MCP tokens (which are long-lived and have different use cases) could share or exhaust a human user's rate limiting quota.
+**Learning:** Multi-audience JWT setups must enforce strict audience verification at every validation point (such as rate limiters and auth middleware) to ensure that token scopes do not bleed into incorrect security/operational contexts.
+**Prevention:** Always verify that the validated JWT contains the expected audience (such as `actor:human` for human user sessions) before extracting the subject or treating the token as a human user session.

--- a/backend/internal/handler/api/middleware/ratelimit/ratelimit.go
+++ b/backend/internal/handler/api/middleware/ratelimit/ratelimit.go
@@ -66,12 +66,15 @@ func New(enabled bool, maxPerIP int, maxPerUser int, window time.Duration, token
 			}
 			ipKey := "ip:" + ip
 
-			// Extract User ID if authenticated
+			// Extract User ID if authenticated.
+			// Security enhancement: Only scope rate-limiting by userKey if the token carries
+			// the "actor:human" audience. This prevents service-to-service or MCP tokens (which
+			// lack human scope) from sharing or exhausting the human user's rate limit quota.
 			userKey := ""
 
 			// 1. Try resolving authenticated User ID from JWT cookie
 			if cookie, err := r.Cookie("at"); err == nil && cookie.Value != "" {
-				if claims, err := tokenSvc.ValidateToken(cookie.Value); err == nil && claims.Subject != "" {
+				if claims, err := tokenSvc.ValidateToken(cookie.Value); err == nil && claims.Subject != "" && auth.HasAudience(claims, auth.ActorHumanAudience) {
 					userKey = "user:" + claims.Subject
 				}
 			}
@@ -81,7 +84,7 @@ func New(enabled bool, maxPerIP int, maxPerUser int, window time.Duration, token
 				if authHeader := r.Header.Get("Authorization"); authHeader != "" {
 					tokenStr := strings.TrimPrefix(authHeader, "Bearer ")
 					tokenStr = strings.TrimSpace(tokenStr)
-					if claims, err := tokenSvc.ValidateToken(tokenStr); err == nil && claims.Subject != "" {
+					if claims, err := tokenSvc.ValidateToken(tokenStr); err == nil && claims.Subject != "" && auth.HasAudience(claims, auth.ActorHumanAudience) {
 						userKey = "user:" + claims.Subject
 					}
 				}
@@ -90,7 +93,7 @@ func New(enabled bool, maxPerIP int, maxPerUser int, window time.Duration, token
 			// 3. Try resolving from query parameters
 			if userKey == "" {
 				if tokenStr := r.URL.Query().Get("token"); tokenStr != "" {
-					if claims, err := tokenSvc.ValidateToken(tokenStr); err == nil && claims.Subject != "" {
+					if claims, err := tokenSvc.ValidateToken(tokenStr); err == nil && claims.Subject != "" && auth.HasAudience(claims, auth.ActorHumanAudience) {
 						userKey = "user:" + claims.Subject
 					}
 				}

--- a/backend/internal/handler/api/middleware/ratelimit/ratelimit_test.go
+++ b/backend/internal/handler/api/middleware/ratelimit/ratelimit_test.go
@@ -1,0 +1,145 @@
+package ratelimit
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/agentrq/agentrq/backend/internal/service/auth"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type mockTokenSvc struct {
+	auth.TokenService
+	validateTokenFunc func(tokenStr string) (*auth.Claims, error)
+}
+
+func (m *mockTokenSvc) ValidateToken(tokenStr string) (*auth.Claims, error) {
+	return m.validateTokenFunc(tokenStr)
+}
+
+func TestRatelimitMiddleware(t *testing.T) {
+	// 1. Set up a simple mock token service
+	tokenSvc := &mockTokenSvc{}
+
+	// Create a dummy next handler
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	t.Run("Disabled rate limiter", func(t *testing.T) {
+		limiter := New(false, 1, 1, 1*time.Second, tokenSvc)
+		handler := limiter(nextHandler)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rec.Code)
+		}
+	})
+
+	t.Run("IP-based rate limit blocks over limit", func(t *testing.T) {
+		// Enabled, Max IP = 1, Max User = 5, Window = 1s
+		limiter := New(true, 1, 5, 1*time.Second, tokenSvc)
+		handler := limiter(nextHandler)
+
+		// 1st request from same IP
+		req1 := httptest.NewRequest("GET", "/", nil)
+		req1.RemoteAddr = "1.2.3.4:1234"
+		rec1 := httptest.NewRecorder()
+		handler.ServeHTTP(rec1, req1)
+		if rec1.Code != http.StatusOK {
+			t.Errorf("expected 1st request 200, got %d", rec1.Code)
+		}
+
+		// 2nd request from same IP (blocked)
+		req2 := httptest.NewRequest("GET", "/", nil)
+		req2.RemoteAddr = "1.2.3.4:1234"
+		rec2 := httptest.NewRecorder()
+		handler.ServeHTTP(rec2, req2)
+		if rec2.Code != http.StatusTooManyRequests {
+			t.Errorf("expected 2nd request 429, got %d", rec2.Code)
+		}
+	})
+
+	t.Run("User-based rate limiting scopes correctly with actor:human audience", func(t *testing.T) {
+		// Enabled, Max IP = 10, Max User = 1, Window = 1s
+		limiter := New(true, 10, 1, 1*time.Second, tokenSvc)
+		handler := limiter(nextHandler)
+
+		// Set mock token validation to return a valid human token
+		tokenSvc.validateTokenFunc = func(tokenStr string) (*auth.Claims, error) {
+			if tokenStr == "human-token" {
+				return &auth.Claims{
+					RegisteredClaims: jwt.RegisteredClaims{
+						Subject:  "user-123",
+						Audience: jwt.ClaimStrings{auth.ActorHumanAudience},
+					},
+				}, nil
+			}
+			return nil, errors.New("invalid token")
+		}
+
+		// 1st request for User 123
+		req1 := httptest.NewRequest("GET", "/?token=human-token", nil)
+		req1.RemoteAddr = "1.1.1.1:1234"
+		rec1 := httptest.NewRecorder()
+		handler.ServeHTTP(rec1, req1)
+		if rec1.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rec1.Code)
+		}
+
+		// 2nd request for User 123 (from a different IP) - should be blocked by User Limit (Max User = 1)
+		req2 := httptest.NewRequest("GET", "/?token=human-token", nil)
+		req2.RemoteAddr = "2.2.2.2:1234"
+		rec2 := httptest.NewRecorder()
+		handler.ServeHTTP(rec2, req2)
+		if rec2.Code != http.StatusTooManyRequests {
+			t.Errorf("expected 429 for second user request, got %d", rec2.Code)
+		}
+	})
+
+	t.Run("User-based rate limiting is bypassed for non-human tokens", func(t *testing.T) {
+		// Enabled, Max IP = 10, Max User = 1, Window = 1s
+		limiter := New(true, 10, 1, 1*time.Second, tokenSvc)
+		handler := limiter(nextHandler)
+
+		// Set mock token validation to return an MCP/Agent token (has subject but no "actor:human" audience)
+		tokenSvc.validateTokenFunc = func(tokenStr string) (*auth.Claims, error) {
+			if tokenStr == "mcp-token" {
+				return &auth.Claims{
+					RegisteredClaims: jwt.RegisteredClaims{
+						Subject:  "user-123",
+						Audience: jwt.ClaimStrings{"workspace-abc", "some-mcp-scope"},
+					},
+				}, nil
+			}
+			return nil, errors.New("invalid token")
+		}
+
+		// 1st request for MCP token from IP 1.1.1.1
+		req1 := httptest.NewRequest("GET", "/?token=mcp-token", nil)
+		req1.RemoteAddr = "1.1.1.1:1234"
+		rec1 := httptest.NewRecorder()
+		handler.ServeHTTP(rec1, req1)
+		if rec1.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rec1.Code)
+		}
+
+		// 2nd request for same MCP token but from IP 2.2.2.2.
+		// If scoping works, it should NOT map to user:user-123 (which would block it since Max User = 1).
+		// Instead, it is treated as a separate IP-based request and should succeed (since Max IP = 10).
+		req2 := httptest.NewRequest("GET", "/?token=mcp-token", nil)
+		req2.RemoteAddr = "2.2.2.2:1234"
+		rec2 := httptest.NewRecorder()
+		handler.ServeHTTP(rec2, req2)
+		if rec2.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d (might have incorrectly matched user limit)", rec2.Code)
+		}
+	})
+}


### PR DESCRIPTION
This security fix prevents long-lived non-human (MCP) tokens from exhausting human rate-limit quotas by strictly validating that the rate limit user key is only assigned if the validated JWT token carries the "actor:human" audience.

---
*PR created automatically by Jules for task [17999188693137696849](https://jules.google.com/task/17999188693137696849) started by @mustafaturan*