### PR TITLE
docs: add Windows Codex gateway launch workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,9 @@ Create a `.mcp.json` in your project root so `codex-gateway` can connect to the 
 
 ### Usage
 
-Run `codex-gateway` from your agentrq workspace root (the directory containing `.mcp.json`):
+Run `codex-gateway` from your AgentRQ workspace root (the directory containing `.mcp.json`).
+
+On macOS and Linux:
 
 ```bash
 # Default: runs `codex app-server`
@@ -232,6 +234,21 @@ codex-gateway
 # Custom codex command
 codex-gateway -- codex app-server
 ```
+
+On Windows PowerShell, the npm shim may not forward `--` correctly and the
+gateway's default codex lookup may fail. Until
+[`agentrq/codex-gateway#2`](https://github.com/agentrq/codex-gateway/issues/2)
+is resolved, invoke the `.cmd` shim and native Codex executable explicitly:
+
+```powershell
+$gateway = (Get-Command codex-gateway.cmd).Source
+$codex = Get-ChildItem (npm root -g) -Filter codex.exe -Recurse |
+  Select-Object -First 1 -ExpandProperty FullName
+& $gateway -- $codex app-server
+```
+
+If `$codex` is empty, confirm that `@openai/codex` is installed globally and
+that its platform package contains `codex.exe`.
 
 ## 👑 Supervisor (CoreMCP)
 

--- a/frontend/src/views/WorkspaceSettingsView.vue
+++ b/frontend/src/views/WorkspaceSettingsView.vue
@@ -148,13 +148,29 @@
                         </div>
                       </div>
                       <div class="space-y-2">
-                        <p class="text-[11px] text-gray-600 dark:text-zinc-400 font-medium">2. Start the bridge:</p>
+                        <p class="text-[11px] text-gray-600 dark:text-zinc-400 font-medium">2. Start the bridge on macOS or Linux:</p>
                         <div class="bg-white dark:bg-zinc-900 p-3 rounded-sm border border-gray-200 dark:border-zinc-700 flex items-center justify-between group shadow-sm overflow-hidden">
                           <div class="flex-1 min-w-0 overflow-x-auto no-scrollbar">
                             <code class="text-[10px] text-gray-900 dark:text-white font-bold whitespace-nowrap">codex-gateway -- codex app-server</code>
                           </div>
                           <button type="button" @click="copyToClipboard('codex-gateway -- codex app-server', 'codexStart')" class="text-[9px] font-bold uppercase tracking-widest pl-4 shrink-0 transition-colors" :class="copiedState.codexStart ? 'text-green-500' : 'text-gray-400 hover:text-black dark:hover:text-white'">
                             {{ copiedState.codexStart ? 'Copied!' : 'Copy' }}
+                          </button>
+                        </div>
+                      </div>
+                      <div class="space-y-2">
+                        <p class="text-[11px] text-gray-600 font-medium">3. Windows PowerShell workaround:</p>
+                        <p class="text-[10px] leading-relaxed text-amber-700">
+                          The npm shim may not forward the custom command correctly. Until
+                          <a href="https://github.com/agentrq/codex-gateway/issues/2" target="_blank" rel="noopener noreferrer" class="underline underline-offset-2 hover:text-amber-900">codex-gateway#2</a>
+                          is resolved, invoke the gateway shim and native Codex executable explicitly.
+                        </p>
+                        <div class="bg-white p-3 rounded-sm border border-gray-200 flex items-start justify-between group overflow-hidden">
+                          <div class="flex-1 min-w-0 overflow-x-auto no-scrollbar">
+                            <code class="text-[10px] leading-relaxed text-gray-900 font-bold whitespace-pre">{{ codexWindowsStartCommand }}</code>
+                          </div>
+                          <button type="button" @click="copyToClipboard(codexWindowsStartCommand, 'codexWindowsStart')" class="text-[9px] font-bold uppercase tracking-widest pl-4 shrink-0 transition-colors" :class="copiedState.codexWindowsStart ? 'text-green-500' : 'text-gray-400 hover:text-black'">
+                            {{ copiedState.codexWindowsStart ? 'Copied!' : 'Copy' }}
                           </button>
                         </div>
                       </div>
@@ -528,6 +544,10 @@ const iconError = ref('');
 const showArchiveConfirm = ref(false);
 const showDeleteConfirm = ref(false);
 const activeConnectionTab = ref('claude');
+const codexWindowsStartCommand = `$gateway = (Get-Command codex-gateway.cmd).Source
+$codex = Get-ChildItem (npm root -g) -Filter codex.exe -Recurse |
+  Select-Object -First 1 -ExpandProperty FullName
+& $gateway -- $codex app-server`;
 const token = ref('');
 const slackConfig = ref(null);
 


### PR DESCRIPTION
## Summary

- separate the Codex gateway launch guidance by platform
- retain the existing `codex-gateway -- codex app-server` flow for macOS and Linux
- add a copyable Windows PowerShell workaround to both the README and Workspace Settings UI
- link the upstream `agentrq/codex-gateway#2` runtime issue from both user-facing surfaces

## Root cause

On Windows, globally installed npm commands are commonly exposed through `.cmd` and PowerShell shims. The current Codex gateway expects a literal `--` delimiter and otherwise falls back to spawning a bare `codex` command. PowerShell/npm shim forwarding can lose that delimiter, while Node's process spawning does not necessarily resolve the Codex npm shim the same way an interactive PowerShell session does.

As a result, the existing command could fall back to `codex app-server` and fail with `spawn codex ENOENT` on an otherwise valid installation.

## What changed

### README

The Codex Gateway usage section now:

1. labels the existing command as the macOS/Linux path
2. explains the temporary Windows limitation
3. links the upstream gateway issue
4. provides a PowerShell command that resolves `codex-gateway.cmd`, locates the installed native `codex.exe`, and passes that executable explicitly
5. includes troubleshooting guidance when the native executable cannot be found

### Workspace Settings UI

The Codex Setup tab mirrors the README guidance and includes a copy button for the multiline PowerShell workaround. The upstream issue opens safely in a new tab using `rel="noopener noreferrer"`.

## User impact

Windows users are no longer directed only to a command known to be unreliable in PowerShell. They receive an actionable workaround in the same Setup UI where they configure the gateway, while macOS and Linux guidance remains unchanged.

## Validation

- `npm run build` — passed (Vite production build and PWA service-worker build)
- `git diff --check` — passed
- PowerShell parser validation for the displayed workaround — passed
- verified native `codex.exe` discovery against a global Codex installation
- two-axis review against repository/frontend standards and issue #207 requirements — passed after review corrections

Closes #207