### PR TITLE
fix(scheduler): catch up skipped minutes when ticks are delayed

### DIFF
--- a/backend/internal/service/scheduler/scheduler.go
+++ b/backend/internal/service/scheduler/scheduler.go
@@ -23,10 +23,11 @@ type Service interface {
 }
 
 type scheduler struct {
-	repo   base.Repository
-	idgen  idgen.Service
-	bus    *eventbus.Bus
-	pubsub pubsub.Service
+	repo      base.Repository
+	idgen     idgen.Service
+	bus       *eventbus.Bus
+	pubsub    pubsub.Service
+	lastTick  time.Time
 }
 
 func New(repo base.Repository, idgen idgen.Service, bus *eventbus.Bus, ps pubsub.Service) Service {
@@ -50,6 +51,27 @@ func (s *scheduler) Start(ctx context.Context) {
 }
 
 func (s *scheduler) tick(ctx context.Context) {
+	s.tickAt(ctx, time.Now().UTC())
+}
+
+func (s *scheduler) tickAt(ctx context.Context, ts time.Time) {
+	current := ts.Truncate(time.Minute)
+
+	// If processing was delayed and we missed one or more whole minutes,
+	// catch up by evaluating every minute since the last successful tick.
+	start := current
+	if !s.lastTick.IsZero() {
+		start = s.lastTick.Add(time.Minute).Truncate(time.Minute)
+	}
+
+	for probe := start; !probe.After(current); probe = probe.Add(time.Minute) {
+		s.tickMinute(ctx, probe)
+	}
+
+	s.lastTick = current
+}
+
+func (s *scheduler) tickMinute(ctx context.Context, now time.Time) {
 	crons, err := s.repo.SystemListTasksByStatus(ctx, "cron")
 	if err != nil {
 		zlog.Error().Err(err).Msg("scheduler: failed to list crons")
@@ -57,7 +79,6 @@ func (s *scheduler) tick(ctx context.Context) {
 	}
 
 	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
-	now := time.Now().UTC().Truncate(time.Minute)
 
 	for _, c := range crons {
 		if c.CronSchedule == "" {

--- a/backend/internal/service/scheduler/scheduler_test.go
+++ b/backend/internal/service/scheduler/scheduler_test.go
@@ -151,4 +151,32 @@ func TestScheduler(t *testing.T) {
 		mockRepo.EXPECT().SystemListTasksByStatus(gomock.Any(), "cron").Return(nil, context.DeadlineExceeded)
 		s.(*scheduler).tick(context.Background())
 	})
+
+	t.Run("TickAtCatchesUpSkippedMinutes", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockRepo := mock_repo.NewMockRepository(ctrl)
+		mockIdgen := mock_idgen.NewMockService(ctrl)
+		mockPubSub := mock_pubsub.NewMockService(ctrl)
+		s := New(mockRepo, mockIdgen, bus, mockPubSub).(*scheduler)
+
+		task := model.Task{
+			ID:           1,
+			CronSchedule: "* * * * *",
+			WorkspaceID:  10,
+			UserID:       1,
+		}
+
+		// Two minutes are processed: the skipped minute and the current minute.
+		mockRepo.EXPECT().SystemListTasksByStatus(gomock.Any(), "cron").Return([]model.Task{task}, nil).Times(2)
+		mockRepo.EXPECT().SystemCheckTaskExists(gomock.Any(), int64(10), int64(1), "notstarted").Return(false, nil).Times(2)
+		mockRepo.EXPECT().SystemCheckTaskExists(gomock.Any(), int64(10), int64(1), "ongoing").Return(false, nil).Times(2)
+		mockIdgen.EXPECT().NextID().Return(int64(2)).Times(2)
+		mockRepo.EXPECT().CreateTask(gomock.Any(), gomock.Any()).Return(model.Task{ID: 2}, nil).Times(2)
+		mockPubSub.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(&pubsub.PublishResponse{}, nil).AnyTimes()
+
+		now := time.Date(2026, 8, 4, 12, 5, 0, 0, time.UTC)
+		s.lastTick = now.Add(-2 * time.Minute)
+		s.tickAt(context.Background(), now)
+	})
 }


### PR DESCRIPTION
Part of #232

## Problem

The scheduler truncated the current timestamp to the minute and only evaluated that single minute. If a tick was delayed or dropped (for example because previous processing exceeded the 1-minute interval), the cron schedule for any skipped minute was silently missed.

## Fix

Track the last processed minute (`lastTick`) and, on each tick, evaluate every minute from `lastTick + 1` through the current minute. This makes the scheduler robust to processing lag and missed ticker firings.

## Test

Added `TickAtCatchesUpSkippedMinutes`, which sets `lastTick` two minutes in the past and verifies that the cron schedule fires for both the skipped minute and the current minute.

## Verification

```bash
cd backend && go test ./internal/service/scheduler/... -v
```

All scheduler tests pass.
