### PR TITLE
refactor: remove TokenEncrypted and TokenNonce from Workspace

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -266,7 +266,6 @@ func New(cfg Config) (*App, error) {
 		Storage:    storageSvc,
 		Image:      imgSvc,
 		PubSub:     pubsubSvc,
-		TokenKey:   cfg.Auth.WorkspaceTokenKey,
 		Limiter:    rateLimiter,
 	})
 
@@ -752,7 +751,6 @@ func New(cfg Config) (*App, error) {
 		MCPManager: mcpManager,
 		Crud:       crudCtrl,
 		TokenSvc:   tokenSvc,
-		TokenKey:   cfg.Auth.WorkspaceTokenKey,
 		BaseURL:    cfg.App.BaseURL,
 		Mux:        mux,
 	}); err != nil {
@@ -773,7 +771,6 @@ func New(cfg Config) (*App, error) {
 		Domain:           cfg.App.Domain,
 		CookieSecure:     cookieSecure,
 		BasePath:         cfg.App.BasePath,
-		TokenKey:         cfg.Auth.WorkspaceTokenKey,
 		RootLoginEnabled: cfg.Auth.RootLoginEnabled,
 		RootToken:        cfg.Auth.RootAccessToken,
 		GithubClientID:   cfg.Auth.GitHub.ClientID,

--- a/backend/internal/controller/crud/common_test.go
+++ b/backend/internal/controller/crud/common_test.go
@@ -41,7 +41,6 @@ func newTestController(t *testing.T) *testEnv {
 		Storage:    stor,
 		Image:      img,
 		PubSub:     psSvc,
-		TokenKey:   "test-key",
 	})
 
 	return &testEnv{

--- a/backend/internal/controller/crud/crud.go
+++ b/backend/internal/controller/crud/crud.go
@@ -19,7 +19,6 @@ type (
 		Storage    storage.Service
 		Image      image.Service
 		PubSub     pubsub.Service
-		TokenKey   string
 		Limiter    ratelimit.Limiter
 	}
 
@@ -37,7 +36,6 @@ type (
 		storage    storage.Service
 		image      image.Service
 		pubsub     pubsub.Service
-		tokenKey   string
 		limiter    ratelimit.Limiter
 	}
 )
@@ -49,7 +47,6 @@ func New(p Params) Controller {
 		storage:    p.Storage,
 		image:      p.Image,
 		pubsub:     p.PubSub,
-		tokenKey:   p.TokenKey,
 		limiter:    p.Limiter,
 	}
 }

--- a/backend/internal/controller/crud/workspace.go
+++ b/backend/internal/controller/crud/workspace.go
@@ -8,7 +8,6 @@ import (
 
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	"github.com/agentrq/agentrq/backend/internal/data/model"
-	"github.com/agentrq/agentrq/backend/internal/service/security"
 	"github.com/mustafaturan/monoflake"
 	"gorm.io/datatypes"
 )
@@ -29,16 +28,6 @@ func (c *controller) CreateWorkspace(ctx context.Context, req entity.CreateWorks
 		Description:          req.Workspace.Description,
 		AllowAllCommands:     req.Workspace.AllowAllCommands,
 		SelfLearningLoopNote: req.Workspace.SelfLearningLoopNote,
-	}
-
-	// Generate and encrypt token for new workspace
-	token, _ := security.GenerateSecret(16)
-	if token != "" && c.tokenKey != "" {
-		enc, nonce, err := security.Encrypt(token, c.tokenKey)
-		if err == nil {
-			m.TokenEncrypted = enc
-			m.TokenNonce = nonce
-		}
 	}
 
 	if req.Workspace.NotificationSettings != nil {
@@ -302,8 +291,6 @@ func fromModelWorkspaceToEntity(m model.Workspace) entity.Workspace {
 		Description:      m.Description,
 		Icon:             m.Icon,
 		ArchivedAt:       m.ArchivedAt,
-		TokenEncrypted:   m.TokenEncrypted,
-		TokenNonce:       m.TokenNonce,
 		AutoAllowedTools:     make([]string, 0),
 		AllowAllCommands:     m.AllowAllCommands,
 		SelfLearningLoopNote: m.SelfLearningLoopNote,

--- a/backend/internal/controller/notification/notification.go
+++ b/backend/internal/controller/notification/notification.go
@@ -198,8 +198,6 @@ func (c *controller) fromModelWorkspaceToEntity(m model.Workspace) entity.Worksp
 		Description:      m.Description,
 		Icon:             m.Icon,
 		ArchivedAt:       m.ArchivedAt,
-		TokenEncrypted:   m.TokenEncrypted,
-		TokenNonce:       m.TokenNonce,
 		AutoAllowedTools: make([]string, 0),
 	}
 	if len(m.AutoAllowedTools) > 0 {

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -995,8 +995,6 @@ func (c *controller) fromModelWorkspaceToEntity(m model.Workspace) entity.Worksp
 		Description:    m.Description,
 		Icon:           m.Icon,
 		ArchivedAt:     m.ArchivedAt,
-		TokenEncrypted: m.TokenEncrypted,
-		TokenNonce:     m.TokenNonce,
 	}
 }
 

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -30,8 +30,6 @@ type (
 		Icon                 string
 		NotificationSettings *NotificationSettings
 		AgentConnected       bool
-		TokenEncrypted       string
-		TokenNonce           string
 		AutoAllowedTools     []string
 		AllowAllCommands     bool
 		SelfLearningLoopNote string

--- a/backend/internal/data/model/model.go
+++ b/backend/internal/data/model/model.go
@@ -18,8 +18,6 @@ type (
 		ArchivedAt           *time.Time
 		Icon                 string         `gorm:"type:text"`
 		NotificationSettings datatypes.JSON `gorm:"type:text"`
-		TokenEncrypted       string         `gorm:"type:text"`
-		TokenNonce           string         `gorm:"type:varchar(64)"`
 		AutoAllowedTools     datatypes.JSON `gorm:"type:text"`
 		AllowAllCommands     bool           `gorm:"default:false"`
 		SelfLearningLoopNote string         `gorm:"type:text"`

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -38,7 +38,6 @@ type (
 		Domain           string
 		CookieSecure     bool
 		BasePath         string
-		TokenKey         string
 		RootLoginEnabled bool
 		RootToken        string
 		Router           fiber.Router
@@ -61,7 +60,6 @@ type (
 		domain           string
 		cookieSecure     bool
 		basePath         string
-		tokenKey         string
 		rootLoginEnabled bool
 		rootToken        string
 		router           fiber.Router
@@ -94,7 +92,6 @@ func New(p Params) (Handler, error) {
 		domain:           p.Domain,
 		cookieSecure:     p.CookieSecure,
 		basePath:         p.BasePath,
-		tokenKey:         p.TokenKey,
 		rootLoginEnabled: p.RootLoginEnabled,
 		rootToken:        p.RootToken,
 		router:           p.Router,
@@ -139,7 +136,7 @@ func newContext(c *fiber.Ctx) (context.Context, context.CancelFunc) {
 	return withLocals(ctx), cancel
 }
 
-func (h *handler) mcpURL(workspaceID int64, token string) string {
+func (h *handler) mcpURL(workspaceID int64) string {
 	id := monoflake.ID(workspaceID).String()
 	url := fmt.Sprintf("%s/mcp/%s", h.mcpBaseURL, id)
 
@@ -154,9 +151,6 @@ func (h *handler) mcpURL(workspaceID int64, token string) string {
 		url = fmt.Sprintf("%s://%s.mcp.%s", proto, id36, h.domain)
 	}
 
-	if token != "" {
-		url += "?token=" + token
-	}
 	return url
 }
 
@@ -554,15 +548,8 @@ func (h *handler) createWorkspace() fiber.Handler {
 		rs.Workspace.AgentConnected = h.mcpManager.IsAgentConnected(rs.Workspace.ID)
 		h.enrichWorkspaceSlack(ctx, &rs.Workspace)
 
-		// Decrypt situational secret for mission owner visibility
-		token := ""
-		if rs.Workspace.TokenEncrypted != "" {
-			dec, _ := security.Decrypt(rs.Workspace.TokenEncrypted, h.tokenKey, rs.Workspace.TokenNonce)
-			token = dec
-		}
-
 		c.Status(http.StatusCreated)
-		return c.Send(mapper.FromCreateWorkspaceResponseEntityToHTTPResponse(rs, h.mcpURL(rs.Workspace.ID, token)))
+		return c.Send(mapper.FromCreateWorkspaceResponseEntityToHTTPResponse(rs, h.mcpURL(rs.Workspace.ID)))
 	}
 }
 
@@ -588,15 +575,8 @@ func (h *handler) getWorkspace() fiber.Handler {
 		rs.Workspace.AgentConnected = h.mcpManager.IsAgentConnected(rs.Workspace.ID)
 		h.enrichWorkspaceSlack(ctx, &rs.Workspace)
 
-		// Decrypt situational secret for mission owner visibility
-		token := ""
-		if rs.Workspace.TokenEncrypted != "" {
-			dec, _ := security.Decrypt(rs.Workspace.TokenEncrypted, h.tokenKey, rs.Workspace.TokenNonce)
-			token = dec
-		}
-
 		c.Status(http.StatusOK)
-		return c.Send(mapper.FromGetWorkspaceResponseEntityToHTTPResponse(rs, h.mcpURL(rs.Workspace.ID, token)))
+		return c.Send(mapper.FromGetWorkspaceResponseEntityToHTTPResponse(rs, h.mcpURL(rs.Workspace.ID)))
 	}
 }
 
@@ -622,17 +602,8 @@ func (h *handler) listWorkspaces() fiber.Handler {
 			h.enrichWorkspaceSlack(ctx, &rs.Workspaces[i])
 		}
 
-		mcpURLWithToken := func(workspaceID int64) string {
-			// For list, we generally don't include plain token unless strictly situational required.
-			// However, since missionowner is viewing THEIR workspaces, we can include it.
-			// Optimized: We would need the full workspace model here.
-			// For now, list will show generic URL to save decryption cost,
-			// detail will show full URL.
-			return h.mcpURL(workspaceID, "")
-		}
-
 		c.Status(http.StatusOK)
-		return c.Send(mapper.FromListWorkspacesResponseEntityToHTTPResponse(rs, mcpURLWithToken))
+		return c.Send(mapper.FromListWorkspacesResponseEntityToHTTPResponse(rs, h.mcpURL))
 	}
 }
 
@@ -736,15 +707,8 @@ func (h *handler) updateWorkspace() fiber.Handler {
 		rs.Workspace.AgentConnected = h.mcpManager.IsAgentConnected(rq.Workspace.ID)
 		h.enrichWorkspaceSlack(ctx, &rs.Workspace)
 
-		// Decrypt situational secret for mission owner visibility
-		token := ""
-		if rs.Workspace.TokenEncrypted != "" {
-			dec, _ := security.Decrypt(rs.Workspace.TokenEncrypted, h.tokenKey, rs.Workspace.TokenNonce)
-			token = dec
-		}
-
 		c.Status(http.StatusOK)
-		return c.Send(mapper.FromUpdateWorkspaceResponseEntityToHTTPResponse(&rs.Workspace, h.mcpURL(rq.Workspace.ID, token)))
+		return c.Send(mapper.FromUpdateWorkspaceResponseEntityToHTTPResponse(&rs.Workspace, h.mcpURL(rq.Workspace.ID)))
 	}
 }
 

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -20,7 +20,6 @@ import (
 
 	mcpctrl "github.com/agentrq/agentrq/backend/internal/controller/mcp"
 	"github.com/agentrq/agentrq/backend/internal/service/auth"
-	"github.com/agentrq/agentrq/backend/internal/service/security"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/mustafaturan/monoflake"
@@ -30,7 +29,6 @@ type Params struct {
 	MCPManager *mcpctrl.Manager
 	Crud       crud.Controller
 	TokenSvc   auth.TokenService
-	TokenKey   string
 	BaseURL    string
 	Mux        *http.ServeMux
 }
@@ -41,7 +39,6 @@ type handler struct {
 	mcpManager *mcpctrl.Manager
 	crud       crud.Controller
 	tokenSvc   auth.TokenService
-	tokenKey   string
 	baseURL    string
 }
 
@@ -65,7 +62,6 @@ func New(p Params) (Handler, error) {
 		mcpManager: p.MCPManager,
 		crud:       p.Crud,
 		tokenSvc:   p.TokenSvc,
-		tokenKey:   p.TokenKey,
 		baseURL:    p.BaseURL,
 	}
 
@@ -178,28 +174,11 @@ func (h *handler) streamableHandler() http.Handler {
 
 		// 1. Mandatory token check if workspace has it in DB
 		queryToken := getTokenVal(r)
-		workspace, err := h.crud.SystemGetWorkspace(r.Context(), workspaceID)
-		if err != nil {
-			sendJSONRPCError(w, "situational security: workspace not found", jsonrpc.CodeInvalidParams, http.StatusNotFound)
-			return
-		}
-
 		userID := ""
 		if queryToken == "" {
 			sendJSONRPCError(w, "situational security: mission token required", jsonrpc.CodeInvalidRequest, http.StatusUnauthorized)
 			return
 		}
-
-		// If it's a 16-character mission token, decrypt and check
-		if len(queryToken) == 16 {
-			dec, decErr := security.Decrypt(workspace.TokenEncrypted, h.tokenKey, workspace.TokenNonce)
-			if decErr != nil || !security.SecureCompare(dec, queryToken) {
-				sendJSONRPCError(w, "situational security: invalid mission token", jsonrpc.CodeInvalidRequest, http.StatusUnauthorized)
-				return
-			}
-			userID = monoflake.ID(workspace.UserID).String()
-		}
-		// If length is not 16, it might be a valid JWT OAuth token. It will be checked via identifyUser below.
 
 		// 2. Mandatory Mcp-Session-Id for non-initialize requests
 		sessionID := r.Header.Get("Mcp-Session-Id")
@@ -235,11 +214,7 @@ func (h *handler) streamableHandler() http.Handler {
 		// Create a new context with claims if we have them
 		ctx := r.Context()
 		var requestClaims *auth.Claims
-		if len(queryToken) == 16 {
-			requestClaims = &auth.Claims{
-				RegisteredClaims: jwt.RegisteredClaims{Subject: userID},
-			}
-		} else if claims, err := h.tokenSvc.ValidateToken(queryToken); err == nil {
+		if claims, err := h.tokenSvc.ValidateToken(queryToken); err == nil {
 			requestClaims = claims
 		}
 		if requestClaims == nil && userID != "" {
@@ -269,17 +244,6 @@ func (h *handler) streamableHandler() http.Handler {
 func (h *handler) identifyUser(ctx context.Context, workspaceID int64, tokenStr string) string {
 	if tokenStr == "" {
 		return ""
-	}
-
-	// 1. Try situational secret (16-chars)
-	if len(tokenStr) == 16 {
-		workspace, err := h.crud.SystemGetWorkspace(ctx, workspaceID)
-		if err == nil && workspace.TokenEncrypted != "" {
-			dec, decErr := security.Decrypt(workspace.TokenEncrypted, h.tokenKey, workspace.TokenNonce)
-			if decErr == nil && security.SecureCompare(dec, tokenStr) {
-				return monoflake.ID(workspace.UserID).String()
-			}
-		}
 	}
 
 	// 2. Try JWT situational authentication


### PR DESCRIPTION
Remove legacy static mission token fields (TokenEncrypted, TokenNonce) from Workspace model/entity and clean up unused token decryption code paths across controllers and handlers.