### PR TITLE
feat(ui): allow editing not started tasks and add edit action to task…

### DIFF
--- a/backend/internal/controller/crud/task.go
+++ b/backend/internal/controller/crud/task.go
@@ -723,8 +723,8 @@ func (c *controller) UpdateScheduledTask(ctx context.Context, req entity.UpdateS
 	if err != nil {
 		return nil, err
 	}
-	if m.Status != "cron" {
-		return nil, fmt.Errorf("only chronic tasks can be edited this way")
+	if m.Status != "cron" && m.Status != "notstarted" {
+		return nil, fmt.Errorf("only chronic or not started tasks can be edited")
 	}
 
 	if req.CronSchedule == "" {
@@ -734,6 +734,7 @@ func (c *controller) UpdateScheduledTask(ctx context.Context, req entity.UpdateS
 		if err := validateCronForContext(ctx, req.CronSchedule); err != nil {
 			return nil, err
 		}
+		m.Status = "cron"
 		m.CronSchedule = req.CronSchedule
 	}
 

--- a/backend/internal/controller/crud/task_test.go
+++ b/backend/internal/controller/crud/task_test.go
@@ -702,6 +702,32 @@ func TestUpdateScheduledTask_Success(t *testing.T) {
 	}
 }
 
+func TestUpdateScheduledTask_NotStartedToCron(t *testing.T) {
+	e := newTestController(t)
+
+	task := model.Task{ID: 10, WorkspaceID: 1, Status: "notstarted"}
+	updated := model.Task{ID: 10, WorkspaceID: 1, Status: "cron", Title: "scheduled title", CronSchedule: "0 9 * * 1"}
+
+	e.repo.EXPECT().GetWorkspace(gomock.Any(), int64(1), testUserID).Return(activeWorkspace(), nil)
+	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(10), testUserID).Return(task, nil)
+	e.repo.EXPECT().UpdateTask(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, m model.Task) (model.Task, error) {
+		if m.Status != "cron" {
+			t.Errorf("expected status 'cron', got %s", m.Status)
+		}
+		return updated, nil
+	})
+
+	resp, err := e.controller.UpdateScheduledTask(context.Background(), entity.UpdateScheduledTaskRequest{
+		WorkspaceID: 1, TaskID: 10, Title: "scheduled title", CronSchedule: "0 9 * * 1", UserID: testUserIDStr,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Task.Status != "cron" {
+		t.Errorf("expected status 'cron', got %s", resp.Task.Status)
+	}
+}
+
 func TestUpdateScheduledTask_NonCronTask_Rejected(t *testing.T) {
 	e := newTestController(t)
 

--- a/frontend/src/components/TaskFeed.vue
+++ b/frontend/src/components/TaskFeed.vue
@@ -43,8 +43,8 @@
                   <span class="text-[10px] font-medium text-gray-500 dark:text-zinc-400 bg-gray-50 dark:bg-zinc-800/50 px-1.5 py-0.5 rounded uppercase tracking-tight group-hover:bg-gray-100 dark:group-hover:bg-zinc-700 group-hover:text-black dark:group-hover:text-white transition-colors">{{ t.assignee === 'agent' ? 'Agent' : 'Human' }}</span>
                 </div>
                 <div class="flex items-center gap-2">
-                   <!-- Action Menu (Hover) -->
-                   <div class="opacity-0 group-hover:opacity-100 flex items-center gap-1 mr-2 transition-opacity duration-150">
+                   <!-- Action Menu (Visible on mobile, hover on desktop) -->
+                   <div class="opacity-100 md:opacity-0 md:group-hover:opacity-100 flex items-center gap-1 mr-2 transition-opacity duration-150">
                       <!-- Task Reordering -->
                       <template v-if="!isArchived && t.status === 'notstarted' && grp.title === 'Not Started'">
                         <button @click.stop="reorderTask(t, -1)" class="text-gray-500 hover:text-gray-900 dark:hover:text-zinc-50 hover:bg-gray-100 dark:hover:bg-zinc-700 p-1 rounded-sm transition-all" title="Move Up">
@@ -55,7 +55,7 @@
                         </button>
                       </template>
 
-                      <button v-if="!isArchived && t.status === 'cron'" @click.stop="triggerEdit(t)" class="text-gray-500 hover:text-gray-900 dark:hover:text-zinc-50 hover:bg-gray-100 dark:hover:bg-zinc-700 p-1 rounded-sm transition-all">
+                      <button v-if="!isArchived && (t.status === 'cron' || t.status === 'notstarted')" @click.stop="triggerEdit(t)" class="text-gray-500 hover:text-gray-900 dark:hover:text-zinc-50 hover:bg-gray-100 dark:hover:bg-zinc-700 p-1 rounded-sm transition-all" title="Edit Task">
                         <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg>
                       </button>
                       <button v-if="!isArchived" @click.stop="triggerDelete(t)" class="text-gray-500 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-500/10 p-1 rounded-sm transition-all">

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -41,14 +41,7 @@
               </button>
             </div>
 
-            <!-- Edit Button (For Scheduled Tasks) -->
-            <button v-if="task.cron" @click="router.push(`/workspaces/${workspaceId}/tasks/${taskId}/edit`)"
-                    @mouseenter="tooltipStore.show($event, 'Edit Scheduled Task', 'bottom')"
-                    @mouseleave="tooltipStore.hide()"
-                    class="h-7 px-2 text-gray-500 dark:text-zinc-400 hover:text-black dark:hover:text-white hover:bg-gray-100 dark:hover:bg-zinc-800 bg-white dark:bg-zinc-900 border border-gray-100 dark:border-zinc-800 rounded-lg transition-all shadow-sm flex items-center justify-center gap-1.5" title="Edit Task">
-              <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg>
-              <span class="hidden sm:inline text-[8px] font-black uppercase tracking-tighter">Edit</span>
-            </button>
+
 
             <!-- Status Selector -->
             <div class="relative">

--- a/frontend/src/views/TaskFormView.vue
+++ b/frontend/src/views/TaskFormView.vue
@@ -24,7 +24,7 @@
       <div class="w-full max-w-3xl space-y-4">
         
         <h1 class="text-xl md:text-3xl font-black text-gray-800 dark:text-zinc-200 tracking-tight text-center mb-8">
-          {{ isEditMode ? 'Edit Scheduled Task' : 'What do you want to achieve?' }}
+          {{ isEditMode ? 'Edit Task' : 'What do you want to achieve?' }}
         </h1>
 
         <!-- Drag & Drop Overlay inside the main container -->
@@ -531,7 +531,7 @@ async function submitEditProtocol() {
       newTask.value.assignee, newTask.value.cronSchedule,
       newTask.value.allowAllCommands
     );
-    notifySuccess('Scheduled Task Updated');
+    notifySuccess('Task Updated');
     goBack(newTask.value.cronSchedule !== '');
   } catch(err) {
     notifyError("Update Error: " + err.message);


### PR DESCRIPTION
… listing

Allow editing 'notstarted' tasks in addition to scheduled tasks. Display edit icon action button in task listing (visible on mobile and on hover for desktop).