### PR TITLE
chore: bump version to v0.3.18

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.3.17"
+	_appVersion   = "v0.3.18"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.3.17" {
-			t.Errorf("Expected version v0.3.17, got %s", s.Version())
+		if s.Version() != "v0.3.18" {
+			t.Errorf("Expected version v0.3.18, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.3.17",
+      "version": "0.3.18",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.3.17",
+  "version": "0.3.18",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
Bump backend and frontend versions to v0.3.18.

### **Summary of Changes in v0.3.18**

- **Markdown Rendering & Raw Toggle for Task Details**:
  - Task details in both standard task view (`TaskDetailView.vue`) and scheduled task view (`ScheduledTaskInstancesView.vue`) now render formatted Markdown when expanded.
  - Added an **MD** toggle button to switch between rendered Markdown and raw plain text format, matching the message toggle behavior.

- **Copy Task Details Text**:
  - Added a copy action button (`copyTaskBodyText`) in the expanded header bar of task details to quickly copy raw description text with clipboard state feedback.

- **UI Polish**:
  - Removed redundant `"Details"` text header label when expanded for a cleaner header action bar.