### PR TITLE
feat(analytics): add task/message activity heatmaps to workspace stats

### DIFF
--- a/backend/internal/controller/crud/workspace.go
+++ b/backend/internal/controller/crud/workspace.go
@@ -238,17 +238,19 @@ func (c *controller) GetDetailedWorkspaceStats(ctx context.Context, req entity.G
 	case "30d":
 		startTime = now.AddDate(0, 0, -30).Unix()
 	case "week":
-		// Start of current week (Monday)
+		// Full current week, Monday through Sunday, regardless of today's weekday
 		daysSinceMonday := int(now.Weekday()) - 1
 		if daysSinceMonday < 0 {
 			daysSinceMonday = 6
 		}
 		start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()).AddDate(0, 0, -daysSinceMonday)
 		startTime = start.Unix()
+		endTime = start.AddDate(0, 0, 7).Unix() - 1
 	case "month":
-		// Start of current month
+		// Full current month, 1st through the last day, regardless of today's date
 		start := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
 		startTime = start.Unix()
+		endTime = start.AddDate(0, 1, 0).Unix() - 1
 	case "custom":
 		startTime = req.From
 		if req.To > 0 {

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -345,6 +345,7 @@ type (
 	GetDetailedWorkspaceStatsResponse struct {
 		Summary    WorkspaceStatsSummary    `json:"summary"`
 		Timeseries WorkspaceStatsTimeseries `json:"timeseries"`
+		Heatmap    WorkspaceStatsHeatmap    `json:"heatmap"`
 	}
 
 	WorkspaceStatsSummary struct {
@@ -359,6 +360,19 @@ type (
 	WorkspaceStatsTimeseries struct {
 		TasksCompleted []DailyStat `json:"tasksCompleted"`
 		Messages       []DailyStat `json:"messages"`
+	}
+
+	HeatmapStat struct {
+		Bucket string `json:"bucket"`
+		Count  int64  `json:"count"`
+	}
+
+	WorkspaceStatsHeatmap struct {
+		Granularity    string        `json:"granularity"` // "hour" or "day"
+		RangeStart     int64         `json:"rangeStart"`  // unix timestamp
+		RangeEnd       int64         `json:"rangeEnd"`     // unix timestamp
+		TasksCompleted []HeatmapStat `json:"tasksCompleted"`
+		Messages       []HeatmapStat `json:"messages"`
 	}
 
 	User struct {

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -459,12 +459,14 @@ func (r *repository) GetDetailedWorkspaceStats(ctx context.Context, workspaceID 
 
 	// Dialect specific date formatting
 	dialect := r.conn(ctx).Dialector.Name()
-	var dateExpr string
+	var dateExpr, hourExpr string
 	if dialect == "sqlite" {
 		dateExpr = "strftime('%Y-%m-%d', datetime(occurred_at, 'unixepoch', 'localtime'))"
+		hourExpr = "strftime('%Y-%m-%d %H:00', datetime(occurred_at, 'unixepoch', 'localtime'))"
 	} else {
 		// Assume Postgres
 		dateExpr = "TO_CHAR(TO_TIMESTAMP(occurred_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD')"
+		hourExpr = "TO_CHAR(TO_TIMESTAMP(occurred_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:00')"
 	}
 
 	// 1. Get Summary Stats
@@ -517,6 +519,37 @@ func (r *repository) GetDetailedWorkspaceStats(ctx context.Context, workspaceID 
 		Group("date").
 		Order("date ASC").
 		Scan(&res.Timeseries.Messages).Error
+	if err != nil {
+		return res, err
+	}
+
+	// 4. Heatmap: hourly buckets for windows of a week or less, daily buckets otherwise
+	const heatmapHourlyThresholdSeconds = 7 * 24 * 3600
+	bucketExpr := dateExpr
+	res.Heatmap.Granularity = "day"
+	if endTime > startTime && endTime-startTime <= heatmapHourlyThresholdSeconds {
+		bucketExpr = hourExpr
+		res.Heatmap.Granularity = "hour"
+	}
+	res.Heatmap.RangeStart = startTime
+	res.Heatmap.RangeEnd = endTime
+
+	err = r.conn(ctx).Model(&model.Telemetry{}).
+		Select(bucketExpr+" as bucket, count(*) as count").
+		Where("workspace_id = ? AND occurred_at >= ? AND occurred_at <= ? AND action = ?", workspaceID, startTime, endTime, model.ActionIDTaskComplete).
+		Group("bucket").
+		Order("bucket ASC").
+		Scan(&res.Heatmap.TasksCompleted).Error
+	if err != nil {
+		return res, err
+	}
+
+	err = r.conn(ctx).Model(&model.Telemetry{}).
+		Select(bucketExpr+" as bucket, count(*) as count").
+		Where("workspace_id = ? AND occurred_at >= ? AND occurred_at <= ? AND action = ?", workspaceID, startTime, endTime, model.ActionIDMessageCreate).
+		Group("bucket").
+		Order("bucket ASC").
+		Scan(&res.Heatmap.Messages).Error
 
 	return res, err
 }

--- a/backend/internal/repository/base/repository_test.go
+++ b/backend/internal/repository/base/repository_test.go
@@ -286,6 +286,72 @@ func TestRepository_GetWorkspaceTaskCountsByCategory(t *testing.T) {
 	}
 }
 
+func TestRepository_GetDetailedWorkspaceStats_Heatmap(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+
+	_ = db.AutoMigrate(&model.Telemetry{})
+	repo := New(&mockDB{db: db})
+
+	ctx := context.Background()
+	workspaceID := int64(100)
+	now := time.Now()
+
+	// Two task-complete events an hour apart, two message events an hour apart.
+	db.Create(&model.Telemetry{WorkspaceID: workspaceID, OccurredAt: now.Add(-2 * time.Hour).Unix(), Action: model.ActionIDTaskComplete})
+	db.Create(&model.Telemetry{WorkspaceID: workspaceID, OccurredAt: now.Add(-1 * time.Hour).Unix(), Action: model.ActionIDTaskComplete})
+	db.Create(&model.Telemetry{WorkspaceID: workspaceID, OccurredAt: now.Add(-1 * time.Hour).Unix(), Action: model.ActionIDMessageCreate})
+
+	// Window <= 7 days: heatmap buckets by hour.
+	shortStart := now.Add(-3 * time.Hour).Unix()
+	shortEnd := now.Unix()
+	res, err := repo.GetDetailedWorkspaceStats(ctx, workspaceID, shortStart, shortEnd)
+	if err != nil {
+		t.Fatalf("GetDetailedWorkspaceStats failed: %v", err)
+	}
+	if res.Heatmap.Granularity != "hour" {
+		t.Errorf("expected hour granularity for a <=7d window, got %q", res.Heatmap.Granularity)
+	}
+	if res.Heatmap.RangeStart != shortStart || res.Heatmap.RangeEnd != shortEnd {
+		t.Errorf("expected heatmap range [%d,%d], got [%d,%d]", shortStart, shortEnd, res.Heatmap.RangeStart, res.Heatmap.RangeEnd)
+	}
+	var totalTasks, totalMessages int64
+	for _, s := range res.Heatmap.TasksCompleted {
+		totalTasks += s.Count
+	}
+	for _, s := range res.Heatmap.Messages {
+		totalMessages += s.Count
+	}
+	if totalTasks != 2 {
+		t.Errorf("expected 2 completed-task heatmap entries, got %d", totalTasks)
+	}
+	if totalMessages != 1 {
+		t.Errorf("expected 1 message heatmap entry, got %d", totalMessages)
+	}
+
+	// Older event, 10 days back, to exercise the day-granularity path.
+	db.Create(&model.Telemetry{WorkspaceID: workspaceID, OccurredAt: now.AddDate(0, 0, -10).Unix(), Action: model.ActionIDTaskComplete})
+
+	longStart := now.AddDate(0, 0, -30).Unix()
+	longEnd := now.Unix()
+	res, err = repo.GetDetailedWorkspaceStats(ctx, workspaceID, longStart, longEnd)
+	if err != nil {
+		t.Fatalf("GetDetailedWorkspaceStats failed: %v", err)
+	}
+	if res.Heatmap.Granularity != "day" {
+		t.Errorf("expected day granularity for a >7d window, got %q", res.Heatmap.Granularity)
+	}
+	totalTasks = 0
+	for _, s := range res.Heatmap.TasksCompleted {
+		totalTasks += s.Count
+	}
+	if totalTasks != 3 {
+		t.Errorf("expected 3 completed-task heatmap entries over 30d, got %d", totalTasks)
+	}
+}
+
 func TestRepository_Event_CRUD(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	if err != nil {

--- a/frontend/src/components/HeatmapChart.vue
+++ b/frontend/src/components/HeatmapChart.vue
@@ -1,0 +1,223 @@
+<template>
+  <div class="w-full h-full flex flex-col gap-1.5">
+    <div v-if="columns.length === 0" class="flex-1 flex items-center justify-center">
+      <span class="text-[10px] font-black text-gray-300 dark:text-zinc-500 uppercase tracking-widest italic">No data points</span>
+    </div>
+
+    <div v-else class="flex-1 flex flex-col gap-1.5 min-h-0">
+      <!-- Column labels (months, or days) -->
+      <div class="flex gap-[3px] pl-6">
+        <div
+          v-for="(col, i) in columns"
+          :key="'lbl-' + i"
+          class="relative flex-1 min-w-0 text-[9px] font-black text-gray-400 dark:text-zinc-500 uppercase tracking-widest leading-none"
+        >
+          <span
+            v-if="col.label"
+            class="absolute top-0 whitespace-nowrap"
+            :class="i >= columns.length - 2 ? 'right-0' : 'left-0'"
+          >{{ col.label }}</span>
+        </div>
+      </div>
+
+      <!-- Grid body -->
+      <div class="flex flex-1 gap-[3px] min-h-0">
+        <!-- Row labels -->
+        <div class="flex flex-col justify-between gap-[3px] w-6 flex-shrink-0">
+          <span
+            v-for="(lbl, i) in rowLabels"
+            :key="'row-' + i"
+            class="flex-1 text-[9px] font-black text-gray-400 dark:text-zinc-500 uppercase tracking-widest leading-none flex items-center"
+          >{{ lbl }}</span>
+        </div>
+
+        <!-- Columns of cells -->
+        <div class="flex-1 flex gap-[3px]">
+          <div v-for="(col, ci) in columns" :key="'col-' + ci" class="flex-1 min-w-0 flex flex-col gap-[3px]">
+            <div
+              v-for="(cell, ri) in col.cells"
+              :key="'cell-' + ri"
+              class="rounded-sm transition-colors"
+              :class="[levelClass(cell), cell.dimmed ? 'opacity-30' : 'cursor-pointer flex-1']"
+              :style="{ flex: cell.dimmed ? '1 1 0%' : undefined }"
+              @mouseenter="!cell.dimmed && onCellEnter($event, cell)"
+              @mouseleave="hovered = null"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <Teleport to="body">
+      <div
+        v-if="hovered"
+        class="fixed z-50 bg-black dark:bg-white text-white dark:text-black px-2 py-1 text-[10px] font-black uppercase tracking-widest pointer-events-none rounded shadow-lg whitespace-nowrap"
+        :style="{ left: hovered.x + 'px', top: hovered.y + 'px', transform: `translate(-50%, ${hovered.showBelow ? '0' : '-100%'})` }"
+      >{{ hovered.label }}: {{ hovered.count }}</div>
+    </Teleport>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue';
+
+const props = defineProps({
+  data: { type: Array, default: () => [] }, // [{ bucket, count }]
+  granularity: { type: String, default: 'day' }, // 'hour' | 'day'
+  rangeStart: { type: Number, default: 0 }, // unix seconds
+  rangeEnd: { type: Number, default: 0 }, // unix seconds
+  metricLabel: { type: String, default: 'Count' },
+  weekdayColumnLabels: { type: Boolean, default: false } // show "Mon"/"Tue" column headers instead of dates
+});
+
+const hovered = ref(null);
+
+function onCellEnter(e, cell) {
+  const rect = e.currentTarget.getBoundingClientRect();
+  const showBelow = rect.top < 80;
+  hovered.value = {
+    label: cell.label,
+    count: cell.count,
+    x: rect.left + rect.width / 2,
+    y: showBelow ? rect.bottom + 6 : rect.top - 6,
+    showBelow
+  };
+}
+
+const LEVEL_CLASSES = [
+  'bg-gray-100 dark:bg-zinc-800/60',
+  'bg-gray-300 dark:bg-zinc-600',
+  'bg-gray-500 dark:bg-zinc-500',
+  'bg-gray-700 dark:bg-zinc-300',
+  'bg-black dark:bg-zinc-50'
+];
+
+const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+function pad2(n) {
+  return String(n).padStart(2, '0');
+}
+
+function toISODate(d) {
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+}
+
+function startOfDay(d) {
+  const r = new Date(d);
+  r.setHours(0, 0, 0, 0);
+  return r;
+}
+
+const maxCount = computed(() => {
+  if (!props.data || props.data.length === 0) return 0;
+  return Math.max(...props.data.map(d => d.count), 0);
+});
+
+function levelForCount(count) {
+  const max = maxCount.value;
+  if (!count || max <= 0) return 0;
+  const ratio = count / max;
+  if (ratio > 0.75) return 4;
+  if (ratio > 0.5) return 3;
+  if (ratio > 0.25) return 2;
+  return 1;
+}
+
+function levelClass(cell) {
+  return LEVEL_CLASSES[levelForCount(cell.count)];
+}
+
+const rowLabels = computed(() => {
+  if (props.granularity === 'hour') {
+    // 24 rows (hours), label every 6 hours
+    return Array.from({ length: 24 }, (_, h) => {
+      if (h === 0) return '12a';
+      if (h === 6) return '6a';
+      if (h === 12) return '12p';
+      if (h === 18) return '6p';
+      return '';
+    });
+  }
+  // 7 rows (Sun..Sat), label Mon/Wed/Fri like a GitHub-style contribution graph
+  return DAY_NAMES.map((name, i) => ([1, 3, 5].includes(i) ? name : ''));
+});
+
+const dataMap = computed(() => {
+  const m = new Map();
+  for (const d of props.data || []) {
+    m.set(d.bucket, d.count);
+  }
+  return m;
+});
+
+// Hour x Day grid: columns = days in the window, rows = hours 0-23
+const hourColumns = computed(() => {
+  if (!props.rangeStart || !props.rangeEnd) return [];
+  const start = startOfDay(new Date(props.rangeStart * 1000));
+  const end = new Date(props.rangeEnd * 1000);
+
+  const days = [];
+  let cur = new Date(start);
+  while (cur <= end) {
+    days.push(toISODate(cur));
+    cur.setDate(cur.getDate() + 1);
+  }
+
+  return days.map(dateStr => {
+    const d = new Date(`${dateStr}T00:00:00`);
+    const cells = [];
+    for (let h = 0; h < 24; h++) {
+      const bucket = `${dateStr} ${pad2(h)}:00`;
+      const bucketTs = Math.floor(new Date(`${dateStr}T${pad2(h)}:00:00`).getTime() / 1000);
+      const dimmed = bucketTs < props.rangeStart || bucketTs > props.rangeEnd;
+      cells.push({
+        count: dataMap.value.get(bucket) || 0,
+        label: `${MONTH_NAMES[d.getMonth()]} ${d.getDate()} ${pad2(h)}:00`,
+        dimmed
+      });
+    }
+    return {
+      label: props.weekdayColumnLabels ? DAY_NAMES[d.getDay()] : `${MONTH_NAMES[d.getMonth()]} ${d.getDate()}`,
+      cells
+    };
+  });
+});
+
+// Day x Week grid: columns = weeks, rows = day-of-week (Sun..Sat)
+const dayColumns = computed(() => {
+  if (!props.rangeStart || !props.rangeEnd) return [];
+  const rangeStartDate = startOfDay(new Date(props.rangeStart * 1000));
+  const rangeEndDate = startOfDay(new Date(props.rangeEnd * 1000));
+
+  const gridStart = new Date(rangeStartDate);
+  gridStart.setDate(gridStart.getDate() - gridStart.getDay());
+
+  const weeks = [];
+  let cur = new Date(gridStart);
+  while (cur <= rangeEndDate) {
+    const week = { label: '', cells: [] };
+    for (let d = 0; d < 7; d++) {
+      const dateStr = toISODate(cur);
+      const dimmed = cur < rangeStartDate || cur > rangeEndDate;
+      // Label the first column of each month (even if the month name repeats
+      // for ranges spanning more than a year), skipping a month that only has
+      // its very first day inside the window — a boundary sliver with no
+      // real data, e.g. a trailing "Jan" when the range ends exactly on Jan 1st.
+      if (cur.getDate() === 1 && cur >= rangeStartDate && cur < rangeEndDate) {
+        week.label = MONTH_NAMES[cur.getMonth()];
+      }
+      week.cells.push({
+        count: dataMap.value.get(dateStr) || 0,
+        label: `${MONTH_NAMES[cur.getMonth()]} ${cur.getDate()}`,
+        dimmed
+      });
+      cur.setDate(cur.getDate() + 1);
+    }
+    weeks.push(week);
+  }
+  return weeks;
+});
+
+const columns = computed(() => (props.granularity === 'hour' ? hourColumns.value : dayColumns.value));
+</script>

--- a/frontend/src/components/WorkspaceStats.vue
+++ b/frontend/src/components/WorkspaceStats.vue
@@ -64,6 +64,53 @@
       </div>
     </div>
 
+    <!-- Heatmaps Section -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <!-- Task Heatmap -->
+      <div class="bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-sm p-6 shadow-sm">
+        <div class="flex items-center justify-between mb-6">
+          <h3 class="text-[11px] font-black uppercase tracking-widest text-gray-900 dark:text-zinc-50">Task Activity Heatmap</h3>
+          <div class="text-gray-400 dark:text-zinc-500 text-[9px] font-black uppercase tracking-widest">{{ heatmapGranularity === 'hour' ? 'By Hour' : 'By Day' }}</div>
+        </div>
+        <div class="h-56 w-full relative">
+          <div v-if="loading" class="absolute inset-0 flex items-center justify-center z-10">
+            <div class="text-[10px] font-black text-gray-300 dark:text-zinc-400 animate-pulse">Computing...</div>
+          </div>
+          <HeatmapChart
+            v-if="stats && stats.heatmap"
+            :data="stats.heatmap.tasksCompleted || []"
+            :granularity="heatmapGranularity"
+            :range-start="stats.heatmap.rangeStart"
+            :range-end="stats.heatmap.rangeEnd"
+            :weekday-column-labels="activeRange === 'week'"
+            metric-label="Tasks"
+          />
+        </div>
+      </div>
+
+      <!-- Message Heatmap -->
+      <div class="bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-sm p-6 shadow-sm">
+        <div class="flex items-center justify-between mb-6">
+          <h3 class="text-[11px] font-black uppercase tracking-widest text-gray-900 dark:text-zinc-50">Message Activity Heatmap</h3>
+          <div class="text-gray-400 dark:text-zinc-500 text-[9px] font-black uppercase tracking-widest">{{ heatmapGranularity === 'hour' ? 'By Hour' : 'By Day' }}</div>
+        </div>
+        <div class="h-56 w-full relative">
+          <div v-if="loading" class="absolute inset-0 flex items-center justify-center z-10">
+            <div class="text-[10px] font-black text-gray-300 dark:text-zinc-400 animate-pulse">Computing...</div>
+          </div>
+          <HeatmapChart
+            v-if="stats && stats.heatmap"
+            :data="stats.heatmap.messages || []"
+            :granularity="heatmapGranularity"
+            :range-start="stats.heatmap.rangeStart"
+            :range-end="stats.heatmap.rangeEnd"
+            :weekday-column-labels="activeRange === 'week'"
+            metric-label="Messages"
+          />
+        </div>
+      </div>
+    </div>
+
     <!-- Charts Section -->
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <!-- Task Chart -->
@@ -76,10 +123,10 @@
           <div v-if="loading" class="absolute inset-0 flex items-center justify-center z-10">
             <div class="text-[10px] font-black text-gray-300 dark:text-zinc-400 animate-pulse">Computing...</div>
           </div>
-          <ChartSVG 
+          <ChartSVG
             v-if="stats && stats.timeseries"
-            :data="stats.timeseries.tasksCompleted || []" 
-            :color="isDark ? '#d4d4d8' : '#27272a'" 
+            :data="stats.timeseries.tasksCompleted || []"
+            :color="isDark ? '#d4d4d8' : '#27272a'"
             :fixed-length="chartFixedLength"
             :last-date="chartEndDate"
           />
@@ -96,10 +143,10 @@
           <div v-if="loading" class="absolute inset-0 flex items-center justify-center z-10">
             <div class="text-[10px] font-black text-gray-300 dark:text-zinc-400 animate-pulse">Computing...</div>
           </div>
-          <ChartSVG 
+          <ChartSVG
             v-if="stats && stats.timeseries"
-            :data="stats.timeseries.messages || []" 
-            :color="isDark ? '#d4d4d8' : '#27272a'" 
+            :data="stats.timeseries.messages || []"
+            :color="isDark ? '#d4d4d8' : '#27272a'"
             :fixed-length="chartFixedLength"
             :last-date="chartEndDate"
           />
@@ -113,6 +160,7 @@
 import { ref, onMounted, computed, watch } from 'vue';
 import { fetchWorkspaceStats } from '../api';
 import ChartSVG from './ChartSVG.vue';
+import HeatmapChart from './HeatmapChart.vue';
 import { useThemeStore } from '../stores/themeStore';
 
 const props = defineProps({
@@ -170,6 +218,8 @@ const chartEndDate = computed(() => {
   const d = String(now.getDate()).padStart(2, '0');
   return `${y}-${m}-${d}`;
 });
+
+const heatmapGranularity = computed(() => stats.value?.heatmap?.granularity || 'day');
 
 const chartFixedLength = computed(() => {
   if (activeRange.value === '7d' || activeRange.value === 'week') return 7;


### PR DESCRIPTION
Adds GitHub-style contribution heatmaps for tasks completed and messages sent on the workspace analytics page, positioned above the existing trend charts. The grid granularity adapts to the selected time window: hour x day for windows of 7 days or less (with weekday names for the "week" preset), day x month for longer windows.

Backend: GetDetailedWorkspaceStats now returns a `heatmap` block bucketing Telemetry rows by hour or day depending on window width, plus the resolved rangeStart/rangeEnd. The "week" and "month" presets now always span the full calendar window (Mon-Sun, 1st-last day) instead of stopping at "now".

Frontend: new HeatmapChart.vue renders the grid with CSS (no chart library), following the existing flat/monochrome design system, with teleported hover tooltips (immune to container clipping) and month column labels that handle multi-year ranges cleanly (no duplicate trailing boundary-day labels, no scroll required to fit).

AgentRQ Task: 0h6ET4sZoPZ