### PR TITLE
feat(tasks): record tool calls (auto-allowed and manual) and show the…

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -186,6 +186,7 @@ func New(cfg Config) (*App, error) {
 		&model.PushSubscription{},
 		&model.Event{},
 		&model.EventTrigger{},
+		&model.ToolCall{},
 	); err != nil {
 		return nil, fmt.Errorf("migrate db: %w", err)
 	}
@@ -550,6 +551,33 @@ func New(cfg Config) (*App, error) {
 						FAQ:     faq,
 					},
 				})
+				return nil
+			},
+			func(ctx context.Context, tc model.ToolCall) (model.ToolCall, error) {
+				created, err := repo.CreateToolCall(ctx, tc)
+				if err == nil {
+					uid := monoflake.IDFromBase62(workspaceOwner).Int64()
+					if latest, gErr := repo.GetTask(ctx, workspaceID, created.TaskID, uid); gErr == nil {
+						bus.Publish(workspaceID, workspaceOwner, eventbus.Event{
+							Type:    "task.updated",
+							Payload: mapper.FromModelTaskToView(latest),
+						})
+					}
+				}
+				return created, err
+			},
+			func(ctx context.Context, id int64, status string) error {
+				updated, err := repo.UpdateToolCallStatus(ctx, id, status)
+				if err != nil {
+					return err
+				}
+				uid := monoflake.IDFromBase62(workspaceOwner).Int64()
+				if latest, gErr := repo.GetTask(ctx, workspaceID, updated.TaskID, uid); gErr == nil {
+					bus.Publish(workspaceID, workspaceOwner, eventbus.Event{
+						Type:    "task.updated",
+						Payload: mapper.FromModelTaskToView(latest),
+					})
+				}
 				return nil
 			},
 			bus,

--- a/backend/internal/controller/crud/task.go
+++ b/backend/internal/controller/crud/task.go
@@ -633,6 +633,20 @@ func (c *controller) fromModelTaskToEntity(m model.Task) entity.Task {
 		}
 	}
 
+	toolCalls := make([]entity.ToolCall, len(m.ToolCalls))
+	for i, tc := range m.ToolCalls {
+		toolCalls[i] = entity.ToolCall{
+			ID:           tc.ID,
+			CreatedAt:    tc.CreatedAt,
+			TaskID:       tc.TaskID,
+			WorkspaceID:  tc.WorkspaceID,
+			ToolName:     tc.ToolName,
+			Description:  tc.Description,
+			InputPreview: tc.InputPreview,
+			Status:       tc.Status,
+		}
+	}
+
 	return entity.Task{
 		ID:               m.ID,
 		CreatedAt:        m.CreatedAt,
@@ -648,6 +662,7 @@ func (c *controller) fromModelTaskToEntity(m model.Task) entity.Task {
 		ReplyText:        m.ReplyText,
 		Attachments:      atts,
 		Messages:         msgs,
+		ToolCalls:        toolCalls,
 		CronSchedule:     m.CronSchedule,
 		ParentID:         m.ParentID,
 		SortOrder:        m.SortOrder,

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -50,6 +50,15 @@ type UpdateMessageMetadataFunc func(ctx context.Context, taskID int64, messageID
 type UpdateWorkspaceAutoAllowedToolsFunc func(ctx context.Context, tools []string) error
 type PublishEventFunc func(ctx context.Context, eventName string, payload string, faq []entity.EventFAQ) error
 
+// RecordToolCallFunc persists a tool-call permission decision (auto-allowed or
+// pending a manual verdict) so it can be shown as a "tool calls" list, separate
+// from the message thread.
+type RecordToolCallFunc func(ctx context.Context, tc model.ToolCall) (model.ToolCall, error)
+
+// UpdateToolCallStatusFunc updates a previously-recorded tool call once a manual
+// permission request is resolved ("allowed" or "denied").
+type UpdateToolCallStatusFunc func(ctx context.Context, id int64, status string) error
+
 type PermissionRequestParams struct {
 	RequestID    string `json:"request_id"`
 	TaskID       string `json:"task_id,omitempty"`
@@ -73,6 +82,8 @@ type WorkspaceServer struct {
 	updateMessageMetadata UpdateMessageMetadataFunc
 	updateAutoAllowed     UpdateWorkspaceAutoAllowedToolsFunc
 	publishEvent          PublishEventFunc
+	recordToolCall        RecordToolCallFunc
+	updateToolCallStatus  UpdateToolCallStatusFunc
 	bus                   *eventbus.Bus
 	idgen                 idgen.Service
 	storage               storage.Service
@@ -93,6 +104,8 @@ type WorkspaceServer struct {
 	requestTaskIDs        map[string]int64 // requestID -> taskID (resolved at request time)
 	permissionResponsesMu sync.RWMutex
 	permissionResponses   map[string]int64 // requestID -> messageID
+	toolCallIDsMu         sync.RWMutex
+	toolCallIDs           map[string]int64 // requestID -> ToolCall row ID (manual requests only, until resolved)
 	metadataMu            sync.RWMutex
 	icon                  string
 	name                  string
@@ -180,6 +193,8 @@ func NewWorkspaceServer(
 	updateMessageMetadata UpdateMessageMetadataFunc,
 	updateAutoAllowed UpdateWorkspaceAutoAllowedToolsFunc,
 	publishEvent PublishEventFunc,
+	recordToolCall RecordToolCallFunc,
+	updateToolCallStatus UpdateToolCallStatusFunc,
 	bus *eventbus.Bus,
 	ids idgen.Service,
 	store storage.Service,
@@ -205,6 +220,8 @@ func NewWorkspaceServer(
 		updateMessageMetadata: updateMessageMetadata,
 		updateAutoAllowed:     updateAutoAllowed,
 		publishEvent:          publishEvent,
+		recordToolCall:        recordToolCall,
+		updateToolCallStatus:  updateToolCallStatus,
 		bus:                   bus,
 		idgen:                 ids,
 		storage:               store,
@@ -216,6 +233,7 @@ func NewWorkspaceServer(
 		sessionTasks:          make(map[string]int64),
 		requestTaskIDs:        make(map[string]int64),
 		permissionResponses:   make(map[string]int64),
+		toolCallIDs:           make(map[string]int64),
 		icon:                  icon,
 		name:                  name,
 		description:           description,
@@ -1080,6 +1098,9 @@ func (ps *WorkspaceServer) notificationMiddleware(next mcp.MethodHandler) mcp.Me
 			isAutoAllowed := ps.checkAutoAllow(p.ToolName, p.InputPreview)
 			ps.autoAllowedToolsMu.RUnlock()
 
+			// Resolve taskID: first from the payload, then from the session, then from the DB.
+			taskID, ok := ps.resolveTaskID(ctx, sessID, p.TaskID)
+
 			if isAutoAllowed {
 				zlog.Info().Str("request_id", p.RequestID).Str("tool", p.ToolName).Msg("auto-allowing permission request")
 				go func() {
@@ -1087,43 +1108,10 @@ func (ps *WorkspaceServer) notificationMiddleware(next mcp.MethodHandler) mcp.Me
 					_ = ps.SendPermissionVerdict(context.Background(), 0, p.RequestID, "allow")
 				}()
 				ps.emitTelemetry(context.Background(), ActionMCPNotification, "permission_auto_allow")
+				if ok {
+					ps.persistToolCall(ctx, taskID, p, "auto_allowed")
+				}
 				return nil, nil
-			}
-
-			// Resolve taskID: first from the payload, then from the session, then from the DB.
-			var taskID int64
-			ok := false
-
-			// 1. From the incoming payload
-			if p.TaskID != "" {
-				if id := monoflake.IDFromBase62(p.TaskID); id != 0 {
-					if _, err := ps.getTask(ctx, id.Int64()); err == nil {
-						taskID = id.Int64()
-						ok = true
-					}
-				}
-			}
-
-			// 2. From the session mapping
-			if !ok {
-				ps.sessionTasksMu.RLock()
-				taskID, ok = ps.sessionTasks[sessID]
-				ps.sessionTasksMu.RUnlock()
-			}
-
-			// 3. Fallback: query the DB for the workspace's current ongoing or blocked task.
-			if !ok {
-				if tasks, err := ps.listTasks(ctx, ListTasksFilter{Status: []string{"ongoing", "blocked"}, Limit: 1}); err == nil {
-					for _, t := range tasks {
-						taskID = t.ID
-						ok = true
-						ps.sessionTasksMu.Lock()
-						ps.sessionTasks[sessID] = taskID
-						ps.sessionTasksMu.Unlock()
-						zlog.Debug().Str("session_id", sessID).Int64("task_id", taskID).Msg("Session not found; resolved task from DB")
-						break
-					}
-				}
 			}
 
 			if ok {
@@ -1135,6 +1123,7 @@ func (ps *WorkspaceServer) notificationMiddleware(next mcp.MethodHandler) mcp.Me
 						_ = ps.SendPermissionVerdict(context.Background(), taskID, p.RequestID, "allow")
 					}()
 					ps.emitTelemetry(context.Background(), ActionMCPNotification, "permission_auto_allow")
+					ps.persistToolCall(ctx, taskID, p, "auto_allowed")
 					return nil, nil
 				}
 
@@ -1153,6 +1142,12 @@ func (ps *WorkspaceServer) notificationMiddleware(next mcp.MethodHandler) mcp.Me
 				ps.requestTaskIDs[p.RequestID] = taskID
 				ps.requestTaskIDsMu.Unlock()
 
+				if tcID := ps.persistToolCall(ctx, taskID, p, "pending"); tcID != 0 {
+					ps.toolCallIDsMu.Lock()
+					ps.toolCallIDs[p.RequestID] = tcID
+					ps.toolCallIDsMu.Unlock()
+				}
+
 				msgID, _ := ps.reply(ctx, monoflake.ID(taskID).String(), fmt.Sprintf("Permission requested for %s: %s", p.ToolName, p.Description), nil, metadata)
 				if msgID != 0 {
 					ps.permissionResponsesMu.Lock()
@@ -1166,6 +1161,77 @@ func (ps *WorkspaceServer) notificationMiddleware(next mcp.MethodHandler) mcp.Me
 		}
 		return next(ctx, method, req)
 	}
+}
+
+// resolveTaskID finds which task a permission request/tool call belongs to:
+// first the payload's own taskID, then the session->task mapping, then (falling
+// back) the workspace's current ongoing/blocked task. Populates the session
+// mapping on the DB fallback so subsequent requests on the same session resolve
+// without another query.
+func (ps *WorkspaceServer) resolveTaskID(ctx context.Context, sessID, payloadTaskID string) (int64, bool) {
+	if payloadTaskID != "" {
+		if id := monoflake.IDFromBase62(payloadTaskID); id != 0 {
+			if _, err := ps.getTask(ctx, id.Int64()); err == nil {
+				return id.Int64(), true
+			}
+		}
+	}
+
+	ps.sessionTasksMu.RLock()
+	taskID, ok := ps.sessionTasks[sessID]
+	ps.sessionTasksMu.RUnlock()
+	if ok {
+		return taskID, true
+	}
+
+	if tasks, err := ps.listTasks(ctx, ListTasksFilter{Status: []string{"ongoing", "blocked"}, Limit: 1}); err == nil {
+		for _, t := range tasks {
+			ps.sessionTasksMu.Lock()
+			ps.sessionTasks[sessID] = t.ID
+			ps.sessionTasksMu.Unlock()
+			zlog.Debug().Str("session_id", sessID).Int64("task_id", t.ID).Msg("Session not found; resolved task from DB")
+			return t.ID, true
+		}
+	}
+
+	return 0, false
+}
+
+// toolCallInputPreviewMaxLen caps how much of a tool call's input preview gets
+// persisted — tool inputs (e.g. a large file write) can be arbitrarily long,
+// and the "tool calls" list only needs enough to identify what happened.
+const toolCallInputPreviewMaxLen = 2000
+
+func truncateForStorage(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
+}
+
+// persistToolCall records a tool-call permission decision so it shows up in the
+// task's "tool calls" list, separate from the message thread. Best-effort: this
+// is a secondary audit trail, not the allow/deny decision itself, so failures
+// are logged and swallowed. Returns the new row's ID (0 if not recorded).
+func (ps *WorkspaceServer) persistToolCall(ctx context.Context, taskID int64, p PermissionRequestParams, status string) int64 {
+	if ps.recordToolCall == nil {
+		return 0
+	}
+	tc, err := ps.recordToolCall(ctx, model.ToolCall{
+		ID:           ps.idgen.NextID(),
+		CreatedAt:    time.Now(),
+		TaskID:       taskID,
+		WorkspaceID:  ps.workspaceID,
+		ToolName:     p.ToolName,
+		Description:  p.Description,
+		InputPreview: truncateForStorage(p.InputPreview, toolCallInputPreviewMaxLen),
+		Status:       status,
+	})
+	if err != nil {
+		zlog.Error().Err(err).Str("request_id", p.RequestID).Str("tool", p.ToolName).Msg("failed to record tool call")
+		return 0
+	}
+	return tc.ID
 }
 
 func (ps *WorkspaceServer) cleanupRequest(requestID string) {
@@ -1188,6 +1254,10 @@ func (ps *WorkspaceServer) cleanupRequest(requestID string) {
 	ps.permissionResponsesMu.Lock()
 	delete(ps.permissionResponses, requestID)
 	ps.permissionResponsesMu.Unlock()
+
+	ps.toolCallIDsMu.Lock()
+	delete(ps.toolCallIDs, requestID)
+	ps.toolCallIDsMu.Unlock()
 }
 
 func (ps *WorkspaceServer) SendPermissionVerdict(ctx context.Context, taskID int64, requestID string, behavior string) error {
@@ -1283,6 +1353,21 @@ func (ps *WorkspaceServer) SendPermissionVerdict(ctx context.Context, taskID int
 		ps.emitTelemetry(ctx, ActionMCPNotification, "permission_manual_deny")
 	}
 
+	if ps.updateToolCallStatus != nil {
+		ps.toolCallIDsMu.RLock()
+		tcID, hasTC := ps.toolCallIDs[requestID]
+		ps.toolCallIDsMu.RUnlock()
+		if hasTC {
+			tcStatus := "denied"
+			if effectiveBehavior == "allow" {
+				tcStatus = "allowed"
+			}
+			if err := ps.updateToolCallStatus(ctx, tcID, tcStatus); err != nil {
+				zlog.Error().Err(err).Int64("tool_call_id", tcID).Msg("failed to update tool call status")
+			}
+		}
+	}
+
 	// Notify Claude Code session
 	params := map[string]any{
 		"request_id": requestID,
@@ -1356,6 +1441,9 @@ func (ps *WorkspaceServer) HandleCustomNotification(ctx context.Context, session
 		isAutoAllowed := ps.checkAutoAllow(p.ToolName, p.InputPreview)
 		ps.autoAllowedToolsMu.RUnlock()
 
+		// Resolve taskID: first from the payload, then from the session, then from the DB.
+		taskID, ok := ps.resolveTaskID(ctx, sessionID, p.TaskID)
+
 		if isAutoAllowed {
 			zlog.Info().Str("request_id", p.RequestID).Str("tool", p.ToolName).Msg("auto-allowing permission request (via custom notification)")
 			go func() {
@@ -1363,43 +1451,10 @@ func (ps *WorkspaceServer) HandleCustomNotification(ctx context.Context, session
 				_ = ps.SendPermissionVerdict(context.Background(), 0, p.RequestID, "allow")
 			}()
 			ps.emitTelemetry(context.Background(), ActionMCPNotification, "permission_auto_allow")
+			if ok {
+				ps.persistToolCall(ctx, taskID, p, "auto_allowed")
+			}
 			return
-		}
-
-		// Resolve taskID: first from the payload, then from the session, then from the DB.
-		var taskID int64
-		ok := false
-
-		// 1. From the incoming payload
-		if p.TaskID != "" {
-			if id := monoflake.IDFromBase62(p.TaskID); id != 0 {
-				if _, err := ps.getTask(ctx, id.Int64()); err == nil {
-					taskID = id.Int64()
-					ok = true
-				}
-			}
-		}
-
-		// 2. From the session mapping
-		if !ok {
-			ps.sessionTasksMu.RLock()
-			taskID, ok = ps.sessionTasks[sessionID]
-			ps.sessionTasksMu.RUnlock()
-		}
-
-		// 3. Fallback: query the DB for the workspace's current ongoing or blocked task.
-		if !ok {
-			if tasks, err := ps.listTasks(ctx, ListTasksFilter{Status: []string{"ongoing", "blocked"}, Limit: 1}); err == nil {
-				for _, t := range tasks {
-					taskID = t.ID
-					ok = true
-					ps.sessionTasksMu.Lock()
-					ps.sessionTasks[sessionID] = taskID
-					ps.sessionTasksMu.Unlock()
-					zlog.Debug().Str("session_id", sessionID).Int64("task_id", taskID).Msg("Session not found; resolved task from DB")
-					break
-				}
-			}
 		}
 
 		zlog.Debug().Str("session_id", sessionID).Int64("task_id", taskID).Bool("found", ok).Msg("Session to task mapping lookup")
@@ -1413,6 +1468,7 @@ func (ps *WorkspaceServer) HandleCustomNotification(ctx context.Context, session
 					_ = ps.SendPermissionVerdict(context.Background(), taskID, p.RequestID, "allow")
 				}()
 				ps.emitTelemetry(context.Background(), ActionMCPNotification, "permission_auto_allow")
+				ps.persistToolCall(ctx, taskID, p, "auto_allowed")
 				return
 			}
 
@@ -1429,6 +1485,12 @@ func (ps *WorkspaceServer) HandleCustomNotification(ctx context.Context, session
 			ps.requestTaskIDsMu.Lock()
 			ps.requestTaskIDs[p.RequestID] = taskID
 			ps.requestTaskIDsMu.Unlock()
+
+			if tcID := ps.persistToolCall(ctx, taskID, p, "pending"); tcID != 0 {
+				ps.toolCallIDsMu.Lock()
+				ps.toolCallIDs[p.RequestID] = tcID
+				ps.toolCallIDsMu.Unlock()
+			}
 
 			msgID, _ := ps.reply(ctx, monoflake.ID(taskID).String(), fmt.Sprintf("Permission requested for %s: %s", p.ToolName, p.Description), nil, metadata)
 			if msgID != 0 {

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -146,6 +146,19 @@ type (
 		Metadata    any
 	}
 
+	// ToolCall entity
+	// Status: "auto_allowed" | "pending" | "allowed" | "denied"
+	ToolCall struct {
+		ID           int64
+		CreatedAt    time.Time
+		TaskID       int64
+		WorkspaceID  int64
+		ToolName     string
+		Description  string
+		InputPreview string
+		Status       string
+	}
+
 	// Task entity
 	// CreatedBy: "human" | "agent"
 	// Status:    "notstarted" | "ongoing" | "completed" | "rejected" | "cron" | "blocked"
@@ -164,6 +177,7 @@ type (
 		ReplyText        string
 		Attachments      []Attachment
 		Messages         []Message
+		ToolCalls        []ToolCall
 		CronSchedule     string
 		ParentID         int64
 		SortOrder        float64
@@ -370,7 +384,7 @@ type (
 	WorkspaceStatsHeatmap struct {
 		Granularity    string        `json:"granularity"` // "hour" or "day"
 		RangeStart     int64         `json:"rangeStart"`  // unix timestamp
-		RangeEnd       int64         `json:"rangeEnd"`     // unix timestamp
+		RangeEnd       int64         `json:"rangeEnd"`    // unix timestamp
 		TasksCompleted []HeatmapStat `json:"tasksCompleted"`
 		Messages       []HeatmapStat `json:"messages"`
 	}

--- a/backend/internal/data/model/model.go
+++ b/backend/internal/data/model/model.go
@@ -43,7 +43,8 @@ type (
 		Response    string `gorm:"type:text"`
 		ReplyText   string `gorm:"type:text"`
 		Attachments datatypes.JSON
-		Messages    []Message `gorm:"foreignKey:TaskID"`
+		Messages    []Message  `gorm:"foreignKey:TaskID"`
+		ToolCalls   []ToolCall `gorm:"foreignKey:TaskID"`
 
 		CronSchedule     string  `gorm:"type:varchar(64)"`
 		ParentID         int64   `gorm:"index:idx_tasks_parent_id"`
@@ -51,6 +52,22 @@ type (
 		AllowAllCommands bool    `gorm:"default:false"`
 		TriggerID        int64   `gorm:"index:idx_tasks_trigger_id"` // event that caused this task
 		EventID          int64   `gorm:"index:idx_tasks_event_id"`   // event this task emits on completion
+	}
+
+	// ToolCall records a single tool-call permission decision for a task: either
+	// auto-allowed (matched a stored auto-allow rule, or the task has
+	// AllowAllCommands/"YOLO" enabled) or a manual request awaiting/resolved by a
+	// human verdict. This is the only place auto-allowed calls are recorded —
+	// they otherwise bypass the message thread entirely.
+	ToolCall struct {
+		ID           int64 `gorm:"primaryKey;autoIncrement:false"`
+		CreatedAt    time.Time
+		TaskID       int64  `gorm:"index:idx_tool_calls_task_id"`
+		WorkspaceID  int64  `gorm:"index:idx_tool_calls_workspace_id"`
+		ToolName     string `gorm:"type:varchar(128)"`
+		Description  string `gorm:"type:text"`
+		InputPreview string `gorm:"type:text"`
+		Status       string `gorm:"type:varchar(16)"` // "auto_allowed" | "pending" | "allowed" | "denied"
 	}
 
 	// Event defines a named event that agents can publish after completing a task.

--- a/backend/internal/data/view/api/view.go
+++ b/backend/internal/data/view/api/view.go
@@ -82,6 +82,17 @@ type (
 		Metadata    any          `json:"metadata,omitempty"`
 	}
 
+	// Status: "auto_allowed" | "pending" | "allowed" | "denied"
+	ToolCall struct {
+		ID           string    `json:"id"`
+		CreatedAt    time.Time `json:"createdAt"`
+		TaskID       string    `json:"taskId"`
+		ToolName     string    `json:"toolName"`
+		Description  string    `json:"description,omitempty"`
+		InputPreview string    `json:"inputPreview,omitempty"`
+		Status       string    `json:"status"`
+	}
+
 	// CreatedBy: "human" | "agent"
 	// Status:    "notstarted" | "ongoing" | "completed" | "rejected" | "cron" | "blocked"
 	Task struct {
@@ -100,6 +111,7 @@ type (
 		Attachments      []Attachment `json:"attachments,omitempty"`
 		Metadata         any          `json:"metadata,omitempty"`
 		Messages         []Message    `json:"messages,omitempty"`
+		ToolCalls        []ToolCall   `json:"toolCalls,omitempty"`
 		CronSchedule     string       `json:"cronSchedule,omitempty"`
 		ParentID         string       `json:"parentId,omitempty"`
 		SortOrder        float64      `json:"sortOrder"`

--- a/backend/internal/mapper/api/task.go
+++ b/backend/internal/mapper/api/task.go
@@ -300,6 +300,7 @@ func FromEntityTaskToView(t entity.Task) view.Task {
 		ReplyText:        t.ReplyText,
 		Attachments:      fromEntityAttachmentsToView(t.Attachments),
 		Messages:         fromEntityMessagesToView(t.Messages),
+		ToolCalls:        fromEntityToolCallsToView(t.ToolCalls),
 		CronSchedule:     t.CronSchedule,
 		SortOrder:        t.SortOrder,
 		AllowAllCommands: t.AllowAllCommands,
@@ -309,6 +310,22 @@ func FromEntityTaskToView(t entity.Task) view.Task {
 	}
 	if t.EventID != 0 {
 		res.EventID = monoflake.ID(t.EventID).String()
+	}
+	return res
+}
+
+func fromEntityToolCallsToView(tcs []entity.ToolCall) []view.ToolCall {
+	res := make([]view.ToolCall, len(tcs))
+	for i, tc := range tcs {
+		res[i] = view.ToolCall{
+			ID:           monoflake.ID(tc.ID).String(),
+			CreatedAt:    tc.CreatedAt,
+			TaskID:       monoflake.ID(tc.TaskID).String(),
+			ToolName:     tc.ToolName,
+			Description:  tc.Description,
+			InputPreview: tc.InputPreview,
+			Status:       tc.Status,
+		}
 	}
 	return res
 }
@@ -375,6 +392,19 @@ func FromModelTaskToView(t model.Task) view.Task {
 		}
 	}
 
+	toolCalls := make([]view.ToolCall, len(t.ToolCalls))
+	for i, tc := range t.ToolCalls {
+		toolCalls[i] = view.ToolCall{
+			ID:           monoflake.ID(tc.ID).String(),
+			CreatedAt:    tc.CreatedAt,
+			TaskID:       monoflake.ID(tc.TaskID).String(),
+			ToolName:     tc.ToolName,
+			Description:  tc.Description,
+			InputPreview: tc.InputPreview,
+			Status:       tc.Status,
+		}
+	}
+
 	res := view.Task{
 		ID:               monoflake.ID(t.ID).String(),
 		CreatedAt:        t.CreatedAt,
@@ -389,6 +419,7 @@ func FromModelTaskToView(t model.Task) view.Task {
 		ReplyText:        t.ReplyText,
 		Attachments:      atts,
 		Messages:         msgs,
+		ToolCalls:        toolCalls,
 		CronSchedule:     t.CronSchedule,
 		SortOrder:        t.SortOrder,
 		AllowAllCommands: t.AllowAllCommands,

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -37,6 +37,10 @@ type Repository interface {
 	UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte) error
 	GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64) ([]string, error)
 
+	// ToolCall
+	CreateToolCall(ctx context.Context, tc model.ToolCall) (model.ToolCall, error)
+	UpdateToolCallStatus(ctx context.Context, id int64, status string) (model.ToolCall, error)
+
 	SystemGetWorkspace(ctx context.Context, id int64) (model.Workspace, error)
 	SystemGetTask(ctx context.Context, id int64) (model.Task, error)
 	SystemGetMessage(ctx context.Context, id int64) (model.Message, error)
@@ -176,6 +180,7 @@ func (r *repository) GetTask(ctx context.Context, workspaceID, taskID int64, use
 	var t model.Task
 	err := r.conn(ctx).
 		Preload("Messages").
+		Preload("ToolCalls").
 		Where("id = ? AND workspace_id = ? AND user_id = ?", taskID, workspaceID, userID).
 		First(&t).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -357,6 +362,28 @@ func (r *repository) ListMessages(ctx context.Context, taskID int64) ([]model.Me
 
 func (r *repository) UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte) error {
 	return r.conn(ctx).Model(&model.Message{}).Where("id = ? AND task_id = ?", messageID, taskID).Update("metadata", metadata).Error
+}
+
+func (r *repository) CreateToolCall(ctx context.Context, tc model.ToolCall) (model.ToolCall, error) {
+	if err := r.conn(ctx).Create(&tc).Error; err != nil {
+		return model.ToolCall{}, err
+	}
+	return tc, nil
+}
+
+func (r *repository) UpdateToolCallStatus(ctx context.Context, id int64, status string) (model.ToolCall, error) {
+	var tc model.ToolCall
+	if err := r.conn(ctx).Where("id = ?", id).First(&tc).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return model.ToolCall{}, ErrNotFound
+		}
+		return model.ToolCall{}, err
+	}
+	tc.Status = status
+	if err := r.conn(ctx).Save(&tc).Error; err != nil {
+		return model.ToolCall{}, err
+	}
+	return tc, nil
 }
 
 func (r *repository) GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64) ([]string, error) {

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -65,6 +65,16 @@
                 </button>
               </div>
             </div>
+
+            <!-- Tool Calls button (deliberately separate from the message thread) -->
+            <button @click.stop="showToolCalls = true"
+                    @mouseenter="tooltipStore.show($event, 'View tool calls', 'bottom')"
+                    @mouseleave="tooltipStore.hide()"
+                    class="px-2 md:px-3 text-[8px] font-black text-gray-700 dark:text-zinc-200 bg-gray-100 dark:bg-zinc-800 rounded-lg border border-transparent hover:border-black/10 transition-all flex items-center gap-1.5 shadow-sm uppercase tracking-tighter h-7">
+              <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M11.42 15.17L17.25 21A2.652 2.652 0 1021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.929a2.548 2.548 0 00-3.586-3.586l-6.837 5.63m5.108-.929l-4.655 5.653" /></svg>
+              <span class="hidden md:inline">Tools</span>
+              <span v-if="sortedToolCalls.length > 0" class="min-w-[14px] h-3.5 px-1 rounded-full bg-gray-900 dark:bg-white text-white dark:text-black text-[7px] flex items-center justify-center font-black">{{ sortedToolCalls.length }}</span>
+            </button>
           </div>
         </div>
 
@@ -448,6 +458,38 @@
       </div>
     </div>
 
+    <!-- Tool Calls Modal -->
+    <div v-if="showToolCalls" class="fixed inset-0 z-[110] flex items-center justify-center p-4" @keydown.esc="showToolCalls = false">
+      <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="showToolCalls = false"></div>
+      <div class="relative w-full max-w-lg max-h-[80vh] bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-xl shadow-xl flex flex-col overflow-hidden">
+        <div class="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-zinc-800 shrink-0">
+          <h2 class="text-[11px] font-black uppercase tracking-widest text-gray-800 dark:text-zinc-200">Tool Calls</h2>
+          <button @click="showToolCalls = false" class="text-gray-400 hover:text-gray-700 dark:hover:text-zinc-200 transition-colors">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+          </button>
+        </div>
+        <div class="flex-1 overflow-y-auto custom-scrollbar p-2">
+          <div v-if="sortedToolCalls.length === 0" class="py-10 text-center text-[11px] text-gray-400 dark:text-zinc-500 font-medium">
+            No tool calls recorded yet.
+          </div>
+          <div v-for="tc in sortedToolCalls" :key="tc.id"
+               @click="toggleToolCallExpanded(tc.id)"
+               class="border border-gray-100 dark:border-zinc-800 rounded-lg mb-1.5 last:mb-0 cursor-pointer hover:border-gray-200 dark:hover:border-zinc-700 transition-colors overflow-hidden">
+            <div class="flex items-center gap-2.5 px-3 py-2">
+              <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="toolCallDotStyle(tc.status)"></span>
+              <span class="text-[11px] font-bold text-gray-800 dark:text-zinc-200 truncate flex-1">{{ tc.toolName }}</span>
+              <span class="text-[8px] font-black uppercase tracking-wider px-1.5 py-0.5 rounded shrink-0" :class="toolCallStatusStyle(tc.status)">{{ toolCallStatusLabel(tc.status) }}</span>
+              <span class="text-[9px] text-gray-400 dark:text-zinc-500 shrink-0">{{ formatDateTime(tc.createdAt) }}</span>
+            </div>
+            <div v-if="expandedToolCalls.has(tc.id)" class="px-3 pb-2.5 pt-0.5 border-t border-dashed border-gray-100 dark:border-zinc-800">
+              <p v-if="tc.description" class="text-[10px] text-gray-600 dark:text-zinc-400 italic mb-1.5">"{{ tc.description }}"</p>
+              <pre v-if="tc.inputPreview" class="text-[9px] font-mono bg-zinc-950 text-zinc-300 p-2 rounded overflow-x-auto whitespace-pre-wrap break-all">{{ tc.inputPreview }}</pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- Custom Tooltip -->
     <div v-if="tooltip.visible"
       class="fixed z-[100] px-3 py-1.5 text-[9px] font-semibold text-black dark:text-white bg-white dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 rounded-sm shadow-lg pointer-events-none transform -translate-x-1/2 whitespace-nowrap"
@@ -633,6 +675,57 @@ const sortedMessages = computed(() => {
   if (!task.value || !task.value.messages) return [];
   return [...task.value.messages].sort((a,b) => new Date(a.createdAt) - new Date(b.createdAt));
 });
+
+const showToolCalls = ref(false);
+const expandedToolCalls = ref(new Set());
+function toggleToolCallExpanded(id) {
+  const s = new Set(expandedToolCalls.value);
+  s.has(id) ? s.delete(id) : s.add(id);
+  expandedToolCalls.value = s;
+}
+
+const sortedToolCalls = computed(() => {
+  if (!task.value || !task.value.toolCalls) return [];
+  return [...task.value.toolCalls].sort((a,b) => new Date(b.createdAt) - new Date(a.createdAt));
+});
+
+function toolCallDotStyle(status) {
+  switch (status) {
+    case 'allowed':
+    case 'auto_allowed':
+      return 'bg-green-500';
+    case 'denied':
+      return 'bg-red-500';
+    case 'pending':
+      return 'bg-amber-400';
+    default:
+      return 'bg-gray-300 dark:bg-zinc-600';
+  }
+}
+
+function toolCallStatusStyle(status) {
+  switch (status) {
+    case 'allowed':
+    case 'auto_allowed':
+      return 'text-gray-600 dark:text-zinc-300 bg-gray-100 dark:bg-zinc-800';
+    case 'denied':
+      return 'text-red-700 dark:text-red-500 bg-red-50 dark:bg-red-500/10';
+    case 'pending':
+      return 'text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-500/10';
+    default:
+      return 'text-gray-500 dark:text-zinc-400 bg-gray-100 dark:bg-zinc-800';
+  }
+}
+
+function toolCallStatusLabel(status) {
+  switch (status) {
+    case 'allowed': return 'Allowed';
+    case 'auto_allowed': return 'Auto-allowed';
+    case 'denied': return 'Denied';
+    case 'pending': return 'Pending';
+    default: return status;
+  }
+}
 
 watch(() => sortedMessages.value.length, (count) => {
   if (count === 0 && task.value?.body) {


### PR DESCRIPTION
…m in a dedicated list

Auto-allowed tool calls (rule-based and task-level YOLO/AllowAllCommands) previously bypassed the message thread entirely with no record of what happened. Both are now persisted to a new ToolCall table, alongside manual requests (pending -> allowed/denied), so there's one consistent source for "what did the agent try to do" instead of splitting auto vs. manual across different places.

Frontend gets a "Tools" button on the task detail header (separate from the message thread, per the ask) that opens a concise list of tool calls with live updates over the existing task.updated SSE event.

AgentRQ: 0h6mdKGp6wr