### PR TITLE
feat: markdown preview + copy toggle for tool call history content

### DIFF
--- a/frontend/src/components/TrajectoryPanel.vue
+++ b/frontend/src/components/TrajectoryPanel.vue
@@ -97,8 +97,19 @@
             </div>
 
             <!-- Content (messages only) -->
-            <div v-else-if="activeTab === 'content'" class="text-[13px] font-medium text-gray-800 dark:text-zinc-200 leading-relaxed whitespace-pre-wrap break-all bg-gray-50 dark:bg-zinc-800/50 rounded-lg p-3">
-              {{ selectedItem.raw.text || '(empty message)' }}
+            <div v-else-if="activeTab === 'content'" class="bg-gray-50 dark:bg-zinc-800/50 rounded-lg p-3">
+              <div class="flex items-center justify-end gap-1 mb-2">
+                <button type="button" @click="toggleContentRaw(selectedItem.id)"
+                        :class="!rawContent.has(selectedItem.id) ? 'text-gray-700 dark:text-zinc-200' : 'text-gray-400 dark:text-zinc-500 hover:text-gray-600 dark:hover:text-zinc-300'"
+                        class="text-[8px] font-black uppercase tracking-wider transition-colors px-1 py-0.5 rounded">MD</button>
+                <button type="button" @click="copyContentText(selectedItem.id, selectedItem.raw.text)"
+                        class="text-gray-400 dark:text-zinc-500 hover:text-gray-600 dark:hover:text-zinc-300 transition-colors p-0.5 rounded" title="Copy raw text">
+                  <svg v-if="!copiedContent.has(selectedItem.id)" class="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                  <svg v-else class="w-2.5 h-2.5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                </button>
+              </div>
+              <div v-if="!rawContent.has(selectedItem.id)" class="md-body text-[13px] text-gray-800 dark:text-zinc-200" v-html="renderMarkdown(selectedItem.raw.text)"></div>
+              <div v-else class="text-[13px] font-medium text-gray-800 dark:text-zinc-200 leading-relaxed whitespace-pre-wrap break-all">{{ selectedItem.raw.text || '(empty message)' }}</div>
             </div>
           </div>
         </div>
@@ -108,6 +119,8 @@
 
 <script setup>
 import { ref, computed, watch } from 'vue';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
 
 const props = defineProps({
   messages: { type: Array, default: () => [] },
@@ -223,6 +236,29 @@ const formattedPayload = computed(() => {
     return raw;
   }
 });
+
+const rawContent = ref(new Set());
+function toggleContentRaw(id) {
+  const s = new Set(rawContent.value);
+  s.has(id) ? s.delete(id) : s.add(id);
+  rawContent.value = s;
+}
+function renderMarkdown(text) {
+  return DOMPurify.sanitize(marked.parse(text || '', { breaks: true }));
+}
+
+const copiedContent = ref(new Set());
+async function copyContentText(id, text) {
+  await navigator.clipboard.writeText(text || '');
+  const s = new Set(copiedContent.value);
+  s.add(id);
+  copiedContent.value = s;
+  setTimeout(() => {
+    const s2 = new Set(copiedContent.value);
+    s2.delete(id);
+    copiedContent.value = s2;
+  }, 1500);
+}
 
 function laneDotClass(it) {
   if (it.lane === 'tool') {


### PR DESCRIPTION
Mirrors the chat view's MD toggle and copy button on the trajectory panel's Content tab, which previously only rendered raw pre-wrapped text with no way to preview markdown or copy it.

Task: 0h9cXZ1sR9d