### PR TITLE
chore: bump patch version to v0.3.20

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.3.19"
+	_appVersion   = "v0.3.20"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.3.19" {
-			t.Errorf("Expected version v0.3.19, got %s", s.Version())
+		if s.Version() != "v0.3.20" {
+			t.Errorf("Expected version v0.3.20, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.3.19",
+      "version": "0.3.20",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.3.19",
+  "version": "0.3.20",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
Changes since v0.3.19:

feat:
- Redesign tool call history (#308)
- markdown preview + copy toggle for tool call history content (#310)

fix:
- classify permission requests as tool calls in trajectory viewer (#309)

test:
- cover auto-allowed tool call persistence (#311)

docs:
- add DeepSeek Harness plugin to Chinese README (#307)

chore:
- release @agentrq/dsh-plugin-agentrq 0.2.0 (#304, #305)
- release @agentrq/dsh-plugin-agentrq 0.2.1 (#306)

AgentRQ: 0h9ecjnXTZh