### PR TITLE
docs(dsh-plugin): document pnpm as a hard prerequisite for dsh plugin…

### DIFF
--- a/plugins/deepseek-harness/README.md
+++ b/plugins/deepseek-harness/README.md
@@ -6,6 +6,8 @@ Create, manage, and automatically receive [AgentRQ](https://agentrq.com) tasks w
 
 ## Install
 
+**Requires pnpm.** `dsh plugin` is a thin forwarder to `pnpm` for every profile — installing any plugin, this one included, fails with `pnpm not found on PATH` unless pnpm is already installed (`npm install -g pnpm`, `corepack enable pnpm`, or `brew install pnpm`). This is a DeepSeek Harness CLI requirement, not something this plugin can opt out of.
+
 **One profile per workspace.** A profile serves one AgentRQ workspace and carries its own endpoint, so name it after the workspace rather than using `default` — that is what makes [several workspaces](#multiple-workspaces) work. Your workspace's **Settings → Setup → DeepSeek Harness** page prints every command and config block below already filled in.
 
 ```sh


### PR DESCRIPTION
… add

Root-caused the "dsh: pnpm not found on PATH" error users hit installing this plugin: it's not our package requiring pnpm (our package.json has no pnpm dependency at all) — it's @deepseek-ai/dsh itself. Its `dsh plugin` subcommand is, per its own source, "a thin pnpm forwarder": it always shells out to `pnpm <args>` in the profile directory for every plugin install, regardless of which plugin is requested. There's nothing in this repo to change; the reliance is baked into the upstream harness CLI.

Documents pnpm as an explicit prerequisite up front so users install it before running `dsh plugin add` instead of hitting the error blind.

Task: 0h9ryF10pZB