### PR TITLE
fix: atomic task dequeue and validate MCP status writes

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -328,9 +328,19 @@ func New(cfg Config) (*App, error) {
 			},
 			func(ctx context.Context, taskID int64, status string) (model.Task, error) {
 				uid := monoflake.IDFromBase62(workspaceOwner).Int64()
+
+				// Mirror the REST path (crud.UpdateTaskStatus) so the MCP write
+				// path cannot write unknown statuses or move cron templates.
+				if !crud.IsValidTaskStatus(status) {
+					return model.Task{}, fmt.Errorf("invalid task status: %s", status)
+				}
+
 				m, err := repo.GetTask(ctx, workspaceID, taskID, uid)
 				if err != nil {
 					return model.Task{}, err
+				}
+				if m.Status == "cron" {
+					return model.Task{}, fmt.Errorf("cannot update status of a cron task template; it must remain in 'cron' state")
 				}
 				if m.Status == status {
 					return m, nil
@@ -407,7 +417,49 @@ func New(cfg Config) (*App, error) {
 			},
 			func(ctx context.Context) (model.Task, error) {
 				uid := monoflake.IDFromBase62(workspaceOwner).Int64()
-				return repo.GetNextTask(ctx, workspaceID, uid)
+				t, err := repo.GetNextTask(ctx, workspaceID, uid)
+				if err != nil {
+					return model.Task{}, err
+				}
+
+				// The dequeue atomically claimed the task (status -> "ongoing").
+				// Surface that transition exactly like updateTaskStatus would — a
+				// thread message plus CRUD events — so the human UI flips the task
+				// to ongoing in real time (the frontend does not poll).
+				msgID := ids.NextID()
+				_ = repo.CreateMessage(ctx, model.Message{
+					ID:        msgID,
+					CreatedAt: time.Now(),
+					TaskID:    t.ID,
+					UserID:    uid,
+					Sender:    "agent",
+					Text:      fmt.Sprintf("Status updated to: %s", t.Status),
+				})
+				pubsubSvc.Publish(context.Background(), pubsub.PublishRequest{
+					PubSubID: entity.PubSubTopicCRUD,
+					Event: entity.CRUDEvent{
+						Action:       entity.ActionTaskUpdate,
+						WorkspaceID:  workspaceID,
+						UserID:       uid,
+						ResourceType: entity.ResourceTask,
+						ResourceID:   t.ID,
+						Actor:        entity.ActorAgent,
+						Origin:       entity.OriginMCP,
+					},
+				})
+				pubsubSvc.Publish(context.Background(), pubsub.PublishRequest{
+					PubSubID: entity.PubSubTopicCRUD,
+					Event: entity.CRUDEvent{
+						Action:       entity.ActionMessageCreate,
+						WorkspaceID:  workspaceID,
+						UserID:       uid,
+						ResourceType: entity.ResourceMessage,
+						ResourceID:   msgID,
+						Actor:        entity.ActorAgent,
+						Origin:       entity.OriginMCP,
+					},
+				})
+				return t, nil
 			},
 			func(ctx context.Context, chatID string, text string, attachments []entity.Attachment, metadata any) (int64, error) {
 				id := monoflake.IDFromBase62(chatID)

--- a/backend/internal/controller/crud/task.go
+++ b/backend/internal/controller/crud/task.go
@@ -67,7 +67,7 @@ func (c *controller) CreateTask(ctx context.Context, req entity.CreateTaskReques
 			status = "notstarted"
 		}
 	}
-	if !isValidTaskStatus(status) {
+	if !IsValidTaskStatus(status) {
 		return nil, fmt.Errorf("invalid task status: %s", status)
 	}
 
@@ -294,7 +294,7 @@ func (c *controller) UpdateTaskStatus(ctx context.Context, req entity.UpdateTask
 		return nil, fmt.Errorf("cannot update status of a chronic task template; it must remain in 'cron' state")
 	}
 
-	if !isValidTaskStatus(req.Status) {
+	if !IsValidTaskStatus(req.Status) {
 		return nil, fmt.Errorf("invalid task status: %s", req.Status)
 	}
 
@@ -774,7 +774,10 @@ func (c *controller) UpdateScheduledTask(ctx context.Context, req entity.UpdateS
 	return &entity.UpdateScheduledTaskResponse{Task: c.fromModelTaskToEntity(updated)}, nil
 }
 
-func isValidTaskStatus(status string) bool {
+// IsValidTaskStatus reports whether status is one of the legal task statuses:
+// notstarted, ongoing, completed, rejected, cron, blocked. It is shared by the
+// REST and MCP write paths so both entry points enforce identical validation.
+func IsValidTaskStatus(status string) bool {
 	switch status {
 	case "notstarted", "ongoing", "completed", "rejected", "cron", "blocked":
 		return true

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -301,8 +301,13 @@ func (r *repository) ListTasks(ctx context.Context, req entity.ListTasksRequest,
 	return tasks, nil
 }
 
+// GetNextTask atomically claims (dequeues) the next eligible task for an agent.
+// The claim is a guarded UPDATE (WHERE status = 'notstarted'): exactly one of N
+// concurrent claimers wins each task, and the losers retry with the next
+// candidate. The returned task has status "ongoing", so two agents can never be
+// handed the same task (the previous bare SELECT returned the top-of-queue task
+// to every caller without changing its status).
 func (r *repository) GetNextTask(ctx context.Context, workspaceID int64, userID int64) (model.Task, error) {
-	var t model.Task
 	dialect := r.conn(ctx).Dialector.Name()
 	var sortExpr string
 	if dialect == "sqlite" {
@@ -312,15 +317,36 @@ func (r *repository) GetNextTask(ctx context.Context, workspaceID int64, userID 
 		sortExpr = "(CASE WHEN sort_order > 0 THEN sort_order ELSE EXTRACT(EPOCH FROM created_at) END)"
 	}
 
-	err := r.conn(ctx).
-		Where("workspace_id = ? AND user_id = ? AND status = ? AND assignee = ?", workspaceID, userID, "notstarted", "agent").
-		Order(fmt.Sprintf("%s ASC, id ASC", sortExpr)).
-		First(&t).Error
+	for attempt := 0; attempt < 10; attempt++ {
+		var t model.Task
+		err := r.conn(ctx).
+			Where("workspace_id = ? AND user_id = ? AND status = ? AND assignee = ?", workspaceID, userID, "notstarted", "agent").
+			Order(fmt.Sprintf("%s ASC, id ASC", sortExpr)).
+			First(&t).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return model.Task{}, ErrNotFound
+		}
+		if err != nil {
+			return model.Task{}, err
+		}
 
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return model.Task{}, ErrNotFound
+		// Atomic claim: only the first claimer to flip the status wins the task;
+		// every other claimer sees 0 affected rows and moves on.
+		res := r.conn(ctx).
+			Model(&model.Task{}).
+			Where("id = ? AND status = ?", t.ID, "notstarted").
+			Update("status", "ongoing")
+		if res.Error != nil {
+			return model.Task{}, res.Error
+		}
+		if res.RowsAffected == 1 {
+			t.Status = "ongoing"
+			return t, nil
+		}
+		// Lost the claim race to another dequeue; try the next candidate.
 	}
-	return t, err
+
+	return model.Task{}, fmt.Errorf("failed to claim a task after repeated attempts")
 }
 
 func (r *repository) UpdateTask(ctx context.Context, t model.Task) (model.Task, error) {

--- a/backend/internal/repository/base/repository_test.go
+++ b/backend/internal/repository/base/repository_test.go
@@ -110,8 +110,13 @@ func TestRepository_GetNextTask(t *testing.T) {
 	if task.ID != 11 {
 		t.Errorf("expected task 11, got %d", task.ID)
 	}
+	// The dequeue atomically claims the task: it is returned as "ongoing" and is
+	// never handed out again.
+	if task.Status != "ongoing" {
+		t.Errorf("expected claimed task status 'ongoing', got %q", task.Status)
+	}
 
-	// Case 4: Tie-break by ID
+	// Case 4: A claimed task is not handed out again; tie-break by ID on fresh tasks.
 	db.Create(&model.Task{
 		ID:          13,
 		WorkspaceID: workspaceID,
@@ -121,10 +126,38 @@ func TestRepository_GetNextTask(t *testing.T) {
 		SortOrder:   5,
 		CreatedAt:   now.Add(3 * time.Hour),
 	})
-	// Now 11 and 13 have same SortOrder 5. ID 11 should come first.
-	task, _ = repo.GetNextTask(ctx, workspaceID, userID)
-	if task.ID != 11 {
-		t.Errorf("expected task 11 (tie-break by ID), got %d", task.ID)
+	db.Create(&model.Task{
+		ID:          14,
+		WorkspaceID: workspaceID,
+		UserID:      userID,
+		Status:      "notstarted",
+		Assignee:    "agent",
+		SortOrder:   5,
+		CreatedAt:   now.Add(4 * time.Hour),
+	})
+	// 13 and 14 share SortOrder 5; 13 (lower ID) is claimed first. Task 11 was
+	// already claimed in Case 3, so it must not be returned again.
+	task, err = repo.GetNextTask(ctx, workspaceID, userID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if task.ID != 13 {
+		t.Errorf("expected task 13 (tie-break by ID), got %d", task.ID)
+	}
+
+	// Case 5: each dequeue advances the queue until it is exhausted.
+	for _, want := range []int64{14, 12, 10} {
+		task, err = repo.GetNextTask(ctx, workspaceID, userID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if task.ID != want {
+			t.Errorf("expected task %d, got %d", want, task.ID)
+		}
+	}
+	_, err = repo.GetNextTask(ctx, workspaceID, userID)
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound after queue drained, got %v", err)
 	}
 }
 


### PR DESCRIPTION
- GetNextTask now atomically claims the next task (guarded UPDATE to 'ongoing'), so concurrent agents can never receive the same task
- MCP updateTaskStatus mirrors REST validation: unknown statuses and cron-template mutations are rejected
- claim surfaces a status message + CRUD events so the UI (SSE-only) still flips the task to ongoing in real time

Task: 229