### PR TITLE
ui: replace plain-text loading states with a shared LoadingState spinner

### DIFF
--- a/frontend/src/components/LoadingState.vue
+++ b/frontend/src/components/LoadingState.vue
@@ -1,0 +1,17 @@
+<script setup>
+// Reusable loading state: a spinner + optional label, centered by default.
+// Pass extra classes (e.g. "py-20") via the class attribute for spacing.
+defineProps({
+  label: {
+    type: String,
+    default: 'Loading...'
+  }
+})
+</script>
+
+<template>
+  <div class="flex flex-col items-center justify-center gap-3">
+    <div class="w-10 h-10 rounded-full border-4 border-gray-200 dark:border-zinc-700 border-t-gray-900 dark:border-t-white animate-spin"></div>
+    <p v-if="label" class="text-[10px] font-semibold text-gray-500 dark:text-zinc-500">{{ label }}</p>
+  </div>
+</template>

--- a/frontend/src/views/EventDetailView.vue
+++ b/frontend/src/views/EventDetailView.vue
@@ -6,6 +6,7 @@ import { useToasts } from '../composables/useToasts'
 import { useCron } from '../composables/useCron'
 import { useWorkspaceStore } from '../stores/workspaceStore'
 import DeleteModal from '../components/DeleteModal.vue'
+import LoadingState from '../components/LoadingState.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -470,7 +471,9 @@ onMounted(async () => {
         </Transition>
 
         <!-- Triggers List -->
-        <div v-if="loadingTriggers" class="text-sm text-gray-500 dark:text-zinc-400 py-4 text-center">Loading triggers…</div>
+        <div v-if="loadingTriggers" class="py-4">
+          <LoadingState label="Loading triggers…" />
+        </div>
         <div v-else-if="triggers.length === 0 && !showTriggerForm"
           class="py-8 px-4 border border-dashed border-gray-200 dark:border-zinc-800 rounded-xl text-center">
           <p class="text-sm font-semibold text-gray-500 dark:text-zinc-400">No triggers yet</p>
@@ -514,7 +517,9 @@ onMounted(async () => {
           <p class="text-[11px] text-gray-400 dark:text-zinc-500 mt-0.5">Tasks automatically spawned each time this event fired.</p>
         </div>
 
-        <div v-if="loadingTasks" class="text-sm text-gray-500 dark:text-zinc-400 py-4 text-center">Loading tasks…</div>
+        <div v-if="loadingTasks" class="py-4">
+          <LoadingState label="Loading tasks…" />
+        </div>
         <div v-else-if="tasks.length === 0"
           class="py-8 px-4 border border-dashed border-gray-200 dark:border-zinc-800 rounded-xl text-center">
           <p class="text-sm font-semibold text-gray-500 dark:text-zinc-400">No tasks yet</p>

--- a/frontend/src/views/EventsView.vue
+++ b/frontend/src/views/EventsView.vue
@@ -4,6 +4,7 @@ import { useRouter } from 'vue-router'
 import { fetchEvents, createEvent, deleteEvent } from '../api'
 import { useToasts } from '../composables/useToasts'
 import DeleteModal from '../components/DeleteModal.vue'
+import LoadingState from '../components/LoadingState.vue'
 
 const router = useRouter()
 const { notifyError, notifySuccess } = useToasts()
@@ -181,7 +182,9 @@ onMounted(loadEvents)
 
       <!-- Events List -->
       <div>
-        <div v-if="loading" class="text-sm text-gray-500 dark:text-zinc-400 py-8 text-center">Loading events…</div>
+        <div v-if="loading" class="py-8">
+          <LoadingState label="Loading events…" />
+        </div>
 
         <div v-else-if="events.length === 0 && !showCreateForm"
              class="py-12 px-4 border border-dashed border-gray-200 dark:border-zinc-800 rounded-xl text-center">

--- a/frontend/src/views/KanbanBoardView.vue
+++ b/frontend/src/views/KanbanBoardView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col h-full w-full bg-transparent min-h-0">
-    <div v-if="loading" class="flex-1 flex items-center justify-center py-20 text-sm font-bold text-gray-500 dark:text-zinc-500 animate-pulse">
-      Loading board...
+    <div v-if="loading" class="flex-1 flex items-center justify-center py-20">
+      <LoadingState label="Loading board..." />
     </div>
 
     <div v-else class="flex-1 flex gap-2 md:gap-3 p-3 md:p-4 min-h-0">
@@ -72,6 +72,7 @@ import { fetchTasks, updateTaskStatus, updateTaskOrder } from '../api';
 import { useEventBus } from '../useEventBus';
 import { useToasts } from '../composables/useToasts';
 import { useWorkspaceStore } from '../stores/workspaceStore';
+import LoadingState from '../components/LoadingState.vue';
 
 const route = useRoute();
 const router = useRouter();

--- a/frontend/src/views/TaskListView.vue
+++ b/frontend/src/views/TaskListView.vue
@@ -43,8 +43,8 @@
       <div v-show="!selectedTaskId || !isMobile" class="w-full md:w-96 shrink-0 h-full flex flex-col min-h-0 bg-transparent md:border-r border-gray-100 dark:border-zinc-800">
         
         <!-- Task List -->
-        <div v-if="loading" class="flex-1 overflow-y-auto custom-scrollbar min-h-0 px-2 pb-20 relative">
-          Loading tasks...
+        <div v-if="loading" class="flex-1 overflow-y-auto custom-scrollbar min-h-0 px-2 pb-20 relative flex items-center justify-center">
+          <LoadingState label="Loading tasks..." />
         </div>
         
         <div v-else class="space-y-6 pb-6 overflow-y-auto custom-scrollbar px-4">
@@ -161,6 +161,7 @@ import { useTooltipStore } from '../stores/tooltipStore';
 import { useCron } from '../composables/useCron';
 import { useEventBus } from '../useEventBus';
 import { useViewport } from '../composables/useViewport';
+import LoadingState from '../components/LoadingState.vue';
 
 const { getNextRunLabel, getNextRunDateTime, getNextRunDate } = useCron();
 const route = useRoute();

--- a/frontend/src/views/WorkspaceDetailView.vue
+++ b/frontend/src/views/WorkspaceDetailView.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="flex flex-col h-full w-full bg-transparent">
     
-    <div v-if="loading" class="flex-1 flex flex-col items-center justify-center py-20 text-sm font-bold text-gray-500 dark:text-zinc-500 animate-pulse">
-      Loading workspace context...
+    <div v-if="loading" class="flex-1 flex items-center justify-center py-20">
+      <LoadingState label="Loading workspace context..." />
     </div>
     
     <div v-else-if="error" class="flex-1 text-center py-6 text-sm font-bold text-red-600 border border-red-300 bg-red-50 p-4 rounded-sm">
@@ -177,6 +177,7 @@ import { useViewport } from '../composables/useViewport';
 import { useWorkspaceStore } from '../stores/workspaceStore';
 import { useFormat } from '../composables/useFormat';
 import TaskFeed from '../components/TaskFeed.vue';
+import LoadingState from '../components/LoadingState.vue';
 
 const { toKebabCase } = useFormat();
 

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -59,9 +59,8 @@
 
     <!-- Workspace list -->
     <div class="flex-1 overflow-y-auto px-4 pb-10 custom-scrollbar">
-      <div v-if="loadingWorkspaces" class="text-[10px] font-black text-gray-500 dark:text-zinc-500 animate-pulse flex items-center gap-3 py-8 justify-center">
-        <div class="w-5 h-5 border-2 border-gray-300 border-t-gray-500 rounded-full animate-spin"></div>
-        Loading Workspaces...
+      <div v-if="loadingWorkspaces" class="py-8">
+        <LoadingState label="Loading Workspaces..." />
       </div>
 
       <div v-else class="space-y-12">
@@ -233,6 +232,7 @@ import { useEventBus } from '../useEventBus';
 import { useWorkspaceStore } from '../stores/workspaceStore';
 import { useFormat } from '../composables/useFormat';
 import { useTooltipStore } from '../stores/tooltipStore';
+import LoadingState from '../components/LoadingState.vue';
 
 const { toKebabCase, liveKebabCase } = useFormat();
 const tooltipStore = useTooltipStore();


### PR DESCRIPTION
Add a reusable LoadingState component and use it across the task list, kanban board, workspace list/detail, and events views, so page loads show a consistent animated spinner instead of bare 'Loading ...' text.

Task: 286