### PR TITLE
fix(frontend): stop markdown preview from treating <word> text as an …

### DIFF
--- a/frontend/src/components/TrajectoryPanel.vue
+++ b/frontend/src/components/TrajectoryPanel.vue
@@ -119,8 +119,7 @@
 
 <script setup>
 import { ref, computed, watch } from 'vue';
-import { marked } from 'marked';
-import DOMPurify from 'dompurify';
+import { renderMarkdown } from '../utils/markdown';
 
 const props = defineProps({
   messages: { type: Array, default: () => [] },
@@ -243,10 +242,6 @@ function toggleContentRaw(id) {
   s.has(id) ? s.delete(id) : s.add(id);
   rawContent.value = s;
 }
-function renderMarkdown(text) {
-  return DOMPurify.sanitize(marked.parse(text || '', { breaks: true }));
-}
-
 const copiedContent = ref(new Set());
 async function copyContentText(id, text) {
   await navigator.clipboard.writeText(text || '');

--- a/frontend/src/utils/markdown.js
+++ b/frontend/src/utils/markdown.js
@@ -1,0 +1,22 @@
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// CommonMark treats any `<word ...>`-shaped text as raw inline HTML and passes
+// it through unescaped (e.g. `List<Item>`, `Vec<T>`), which DOMPurify then
+// silently drops as an unrecognized tag. Task/message content is plain
+// markdown, not embedded HTML, so every `html` token is escaped back to
+// visible text instead of being rendered as markup.
+marked.use({ renderer: { html({ text }) { return escapeHtml(text); } } });
+
+export function renderMarkdown(text) {
+  return DOMPurify.sanitize(marked.parse(text || '', { breaks: true }));
+}

--- a/frontend/src/views/ScheduledTaskInstancesView.vue
+++ b/frontend/src/views/ScheduledTaskInstancesView.vue
@@ -127,8 +127,7 @@
 import { ref, computed, onMounted, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import cronParser from 'cron-parser';
-import { marked } from 'marked';
-import DOMPurify from 'dompurify';
+import { renderMarkdown } from '../utils/markdown';
 import { fetchTasks, getWorkspace } from '../api';
 import { useCron } from '../composables/useCron';
 
@@ -157,10 +156,6 @@ function expandDescription() {
 
 function toggleTaskBodyRender() {
   isTaskBodyRaw.value = !isTaskBodyRaw.value;
-}
-
-function renderMarkdown(text) {
-  return DOMPurify.sanitize(marked.parse(text || '', { breaks: true }));
 }
 
 async function copyTaskBodyText() {

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -498,8 +498,7 @@ import { useToasts } from '../composables/useToasts';
 import { useViewport } from '../composables/useViewport';
 import { useSpeechToText } from '../composables/useSpeechToText';
 import { useEventBus } from '../useEventBus';
-import { marked } from 'marked';
-import DOMPurify from 'dompurify';
+import { renderMarkdown } from '../utils/markdown';
 import TrajectoryPanel from '../components/TrajectoryPanel.vue';
 
 const { notifyError, notifySuccess } = useToasts();
@@ -536,10 +535,6 @@ function toggleMessageRender(id) {
   s.has(id) ? s.delete(id) : s.add(id);
   rawMessages.value = s;
 }
-function renderMarkdown(text) {
-  return DOMPurify.sanitize(marked.parse(text || '', { breaks: true }));
-}
-
 const copiedMessages = ref(new Set());
 async function copyMessageText(id, text) {
   await navigator.clipboard.writeText(text || '');


### PR DESCRIPTION
…HTML tag

CommonMark treats any <word ...>-shaped text as raw inline HTML and marked passes it through unescaped (e.g. List<Item>, Vec<T>, a<b>c). DOMPurify then silently drops whatever isn't an allowed real tag, so generic-type syntax and comparisons like these were disappearing or rendering as unintended markup instead of showing as literal text.

Task/message content is plain markdown, not embedded HTML, so marked's `html` token is now always escaped back to visible text instead of rendered as markup. Verified live: List<Item>, Vec<T>, HashMap<String, Value>, a<b>c, and 5 < 10 all render as literal text now, while normal markdown (bold, code, links, lists) is unaffected.

Also de-duplicates the identical renderMarkdown/marked/DOMPurify glue that existed independently in three files into one shared frontend/src/utils/markdown.js, so the fix applies consistently and can't drift between them.

AgentRQ: 0hCBOxVS4mX