### PR TITLE
Feat/workflows backend

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+# Formats staged Go files with gofmt before the commit is created.
+#
+# Scoped to *staged* files on purpose. Formatting the whole tree would sweep
+# unrelated pre-existing reformatting into whatever commit happens to run next,
+# which makes diffs unreviewable.
+#
+# Install with: make hooks
+
+set -e
+
+staged_go_files=$(git diff --cached --name-only --diff-filter=ACMR | grep '\.go$' || true)
+[ -z "$staged_go_files" ] && exit 0
+
+# Only consider files that still exist in the worktree (a rename's old path
+# shows up above but is gone on disk).
+existing=""
+for file in $staged_go_files; do
+    [ -f "$file" ] && existing="$existing $file"
+done
+[ -z "$existing" ] && exit 0
+
+# shellcheck disable=SC2086
+unformatted=$(gofmt -l $existing || true)
+[ -z "$unformatted" ] && exit 0
+
+# A file staged only in part is the one case auto-formatting cannot handle
+# safely: re-adding it after gofmt would also commit the unstaged half, which
+# the author never chose to include. Refuse instead of silently widening the
+# commit.
+partial=""
+for file in $unformatted; do
+    if ! git diff --quiet -- "$file"; then
+        partial="$partial  $file
+"
+    fi
+done
+
+if [ -n "$partial" ]; then
+    printf 'pre-commit: these files need gofmt but are only partially staged:\n%s' "$partial"
+    printf 'Formatting them would also commit their unstaged changes.\n'
+    printf 'Run "make fmt", then stage the result yourself.\n'
+    exit 1
+fi
+
+for file in $unformatted; do
+    gofmt -w "$file"
+    git add "$file"
+    printf 'pre-commit: formatted %s\n' "$file"
+done
+
+exit 0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev backend frontend install stop mocks test
+.PHONY: dev backend frontend install stop mocks test fmt hooks
 
 remote-claude:
 	claude --dangerously-load-development-channels server:agentrq-0ZzhYQG2qtl
@@ -37,6 +37,20 @@ install:
 	@echo "Installing Dependencies..."
 	@cd backend && go mod download
 	@cd frontend && npm install
+	@make hooks
+
+# Point git at the tracked hooks in .githooks so every clone shares them
+# (.git/hooks itself is not version-controlled).
+hooks:
+	@git config core.hooksPath .githooks
+	@chmod +x .githooks/* 2>/dev/null || true
+	@echo "Git hooks installed (core.hooksPath -> .githooks)"
+
+# Format all Go sources. The pre-commit hook formats only staged files; this is
+# the whole-tree version for cleaning up in one deliberate pass.
+fmt:
+	@echo "Formatting Go sources..."
+	@gofmt -w backend/
 
 mocks:
 	@echo "Generating Mocks..."

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -187,6 +187,8 @@ func New(cfg Config) (*App, error) {
 		&model.PushSubscription{},
 		&model.Event{},
 		&model.EventTrigger{},
+		&model.Workflow{},
+		&model.WorkflowStep{},
 		&model.ToolCall{},
 	); err != nil {
 		return nil, fmt.Errorf("migrate db: %w", err)
@@ -537,7 +539,7 @@ func New(cfg Config) (*App, error) {
 					UserID:      monoflake.ID(workspace.UserID).String(),
 				})
 			},
-			func(ctx context.Context, eventName string, payload string, faq []entity.EventFAQ) error {
+			func(ctx context.Context, eventName string, payload string, faq []entity.EventFAQ, run mcp.WorkflowRunContext) error {
 				uid := monoflake.IDFromBase62(workspaceOwner).Int64()
 				ev, err := repo.GetEventByName(ctx, eventName, uid)
 				if err != nil {
@@ -546,10 +548,12 @@ func New(cfg Config) (*App, error) {
 				pubsubSvc.Publish(ctx, pubsub.PublishRequest{
 					PubSubID: entity.PubSubTopicEvents,
 					Event: entity.EventPublishedPayload{
-						EventID: ev.ID,
-						Name:    ev.Name,
-						Payload: payload,
-						FAQ:     faq,
+						EventID:    ev.ID,
+						Name:       ev.Name,
+						Payload:    payload,
+						FAQ:        faq,
+						WorkflowID: run.WorkflowID,
+						Depth:      run.Depth,
 					},
 				})
 				return nil

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -175,6 +175,17 @@ func New(cfg Config) (*App, error) {
 	// browser per workspace.
 	_ = db.Conn(context.Background()).Exec("DROP INDEX IF EXISTS uni_push_subscriptions_endpoint").Error
 
+	// idx_events_name_user_id / idx_workflows_name_user_id were created over
+	// `name` alone despite their names, because only the Name field carried
+	// the uniqueIndex tag. That made event and workflow names unique across
+	// every account rather than per user. AutoMigrate will not redefine an
+	// index that already exists, so the stale ones are dropped here and
+	// recreated as the composite the model now declares. Dropping is safe:
+	// the new index is strictly looser, so any data valid under the old one
+	// is valid under the new one.
+	_ = db.Conn(context.Background()).Exec("DROP INDEX IF EXISTS idx_events_name_user_id").Error
+	_ = db.Conn(context.Background()).Exec("DROP INDEX IF EXISTS idx_workflows_name_user_id").Error
+
 	if err := db.Conn(context.Background()).AutoMigrate(
 		&model.Workspace{},
 		&model.Task{},

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -545,6 +545,20 @@ func New(cfg Config) (*App, error) {
 				if err != nil {
 					return fmt.Errorf("event %q not found", eventName)
 				}
+
+				// Naming a workflow explicitly starts a fresh run of it, which
+				// overrides whichever run the publishing task belonged to. Depth
+				// restarts with it: this is a new run, not a continuation, and
+				// inheriting the old count would retire it early.
+				workflowID, depth := run.WorkflowID, run.Depth
+				if run.WorkflowName != "" {
+					wf, wfErr := repo.GetWorkflowByName(ctx, run.WorkflowName, uid)
+					if wfErr != nil {
+						return fmt.Errorf("workflow %q not found", run.WorkflowName)
+					}
+					workflowID, depth = wf.ID, 0
+				}
+
 				pubsubSvc.Publish(ctx, pubsub.PublishRequest{
 					PubSubID: entity.PubSubTopicEvents,
 					Event: entity.EventPublishedPayload{
@@ -552,8 +566,8 @@ func New(cfg Config) (*App, error) {
 						Name:       ev.Name,
 						Payload:    payload,
 						FAQ:        faq,
-						WorkflowID: run.WorkflowID,
-						Depth:      run.Depth,
+						WorkflowID: workflowID,
+						Depth:      depth,
 					},
 				})
 				return nil

--- a/backend/internal/controller/crud/crud.go
+++ b/backend/internal/controller/crud/crud.go
@@ -30,6 +30,7 @@ type (
 		EventTriggerController
 		WorkflowController
 		WorkflowStepController
+		WorkflowTextController
 	}
 
 	controller struct {

--- a/backend/internal/controller/crud/crud.go
+++ b/backend/internal/controller/crud/crud.go
@@ -28,6 +28,8 @@ type (
 		TaskController
 		EventController
 		EventTriggerController
+		WorkflowController
+		WorkflowStepController
 	}
 
 	controller struct {
@@ -66,7 +68,6 @@ func (c *controller) emitEvent(ctx context.Context, e entity.CRUDEvent) {
 		Event:    e,
 	})
 }
-
 
 // WorkspaceController defines workspace operations.
 type WorkspaceController interface {

--- a/backend/internal/controller/crud/dup_name_test.go
+++ b/backend/internal/controller/crud/dup_name_test.go
@@ -1,0 +1,94 @@
+package crud
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	"github.com/agentrq/agentrq/backend/internal/repository/base"
+	"github.com/glebarez/sqlite"
+	"github.com/mustafaturan/monoflake"
+	"gorm.io/gorm"
+)
+
+// openTestDB mirrors how the app opens its connection. TranslateError is the
+// part that matters: it converts a driver's own duplicate-key error into
+// gorm.ErrDuplicatedKey, and omitting it here is what let an earlier version of
+// these tests pass while production still answered 500.
+type realDB struct{ db *gorm.DB }
+
+func (m *realDB) Conn(ctx context.Context) *gorm.DB { return m.db }
+func (m *realDB) Close(ctx context.Context)         {}
+
+type seqIDGen struct{ n int64 }
+
+func (s *seqIDGen) NextID() int64        { s.n++; return s.n }
+func (s *seqIDGen) NextIDString() string { s.n++; return monoflake.ID(s.n).String() }
+
+// A name already taken by the same user must surface as ErrDuplicateName, not
+// as a bare internal error — a collision is the user's input, and the caller
+// has to be able to tell it apart from a real failure.
+func TestCreateEvent_DuplicateNameSameUser(t *testing.T) {
+	db, _ := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{TranslateError: true})
+	if err := db.AutoMigrate(&model.Event{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	c := &controller{repository: base.New(&realDB{db: db}), idgen: &seqIDGen{}}
+	ctx := context.Background()
+	user := monoflake.ID(4242).String()
+
+	if _, err := c.CreateEvent(ctx, entity.CreateEventRequest{Name: "deploy", UserID: user}); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+
+	_, err := c.CreateEvent(ctx, entity.CreateEventRequest{Name: "deploy", UserID: user})
+	if err == nil {
+		t.Fatal("expected a duplicate error")
+	}
+	t.Logf("raw error: %v", err)
+	if !errors.Is(err, ErrDuplicateName) {
+		t.Errorf("error must wrap ErrDuplicateName so the handler can answer 409, got: %v", err)
+	}
+}
+
+// The unique index is scoped per user, so two accounts may hold the same name.
+func TestCreateEvent_SameNameDifferentUsers(t *testing.T) {
+	db, _ := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{TranslateError: true})
+	if err := db.AutoMigrate(&model.Event{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	c := &controller{repository: base.New(&realDB{db: db}), idgen: &seqIDGen{}}
+	ctx := context.Background()
+
+	if _, err := c.CreateEvent(ctx, entity.CreateEventRequest{Name: "deploy", UserID: monoflake.ID(1).String()}); err != nil {
+		t.Fatalf("user 1: %v", err)
+	}
+	if _, err := c.CreateEvent(ctx, entity.CreateEventRequest{Name: "deploy", UserID: monoflake.ID(2).String()}); err != nil {
+		t.Errorf("a second user must be able to use the same name, got: %v", err)
+	}
+}
+
+// Deleting an event frees its name immediately: the row is hard-deleted, so
+// there is nothing left to collide with.
+func TestCreateEvent_NameReusableAfterDelete(t *testing.T) {
+	db, _ := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{TranslateError: true})
+	if err := db.AutoMigrate(&model.Event{}, &model.EventTrigger{}, &model.WorkflowStep{}, &model.Workflow{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	c := &controller{repository: base.New(&realDB{db: db}), idgen: &seqIDGen{}}
+	ctx := context.Background()
+	user := monoflake.ID(7).String()
+
+	created, err := c.CreateEvent(ctx, entity.CreateEventRequest{Name: "deploy", UserID: user})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := c.DeleteEvent(ctx, entity.DeleteEventRequest{ID: created.Event.ID, UserID: user}); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := c.CreateEvent(ctx, entity.CreateEventRequest{Name: "deploy", UserID: user}); err != nil {
+		t.Errorf("name must be reusable after delete, got: %v", err)
+	}
+}

--- a/backend/internal/controller/crud/event.go
+++ b/backend/internal/controller/crud/event.go
@@ -2,7 +2,9 @@ package crud
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
@@ -10,6 +12,7 @@ import (
 	mapper "github.com/agentrq/agentrq/backend/internal/mapper/api"
 	"github.com/agentrq/agentrq/backend/internal/service/schedule"
 	"github.com/mustafaturan/monoflake"
+	"gorm.io/gorm"
 )
 
 // EventController defines event operations.
@@ -53,6 +56,12 @@ func (c *controller) CreateEvent(ctx context.Context, req entity.CreateEventRequ
 
 	created, err := c.repository.CreateEvent(ctx, m)
 	if err != nil {
+		// A duplicate name is the user picking one that is taken, not a server
+		// fault. Without this it surfaced as a bare 500, which made a name
+		// collision impossible to tell apart from a real failure.
+		if isUniqueConstraintErr(err) {
+			return nil, fmt.Errorf("%w: %q", ErrDuplicateName, req.Name)
+		}
 		return nil, err
 	}
 	return &entity.CreateEventResponse{Event: mapper.FromModelEventToEntity(created)}, nil
@@ -199,6 +208,32 @@ func (c *controller) ListTasksFromEvent(ctx context.Context, req entity.ListTask
 }
 
 // ── Validation helpers ────────────────────────────────────────────────────────
+
+// ErrDuplicateName is returned when a name is already taken by another record
+// of the same kind for this user. Exported so handlers can answer 409 with the
+// name itself rather than a generic failure.
+var ErrDuplicateName = fmt.Errorf("name already exists")
+
+// isUniqueConstraintErr reports whether err is a unique-index violation.
+//
+// gorm.ErrDuplicatedKey is the real check: both drivers here open with
+// TranslateError, which converts the driver's own error into that sentinel.
+// The text matching below is only a fallback for a connection opened without
+// translation — which is exactly how an early version of this function's test
+// was written, so it passed while production still returned 500.
+func isUniqueConstraintErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unique constraint") ||
+		strings.Contains(msg, "duplicate key") ||
+		strings.Contains(msg, "unique_violation") ||
+		(strings.Contains(msg, "unique") && strings.Contains(msg, "constraint failed"))
+}
 
 // isValidResourceName enforces the shared identifier convention for names that
 // are referenced textually rather than by id — event names in publishEvent,

--- a/backend/internal/controller/crud/event.go
+++ b/backend/internal/controller/crud/event.go
@@ -37,7 +37,7 @@ func (c *controller) CreateEvent(ctx context.Context, req entity.CreateEventRequ
 	if uid == 0 {
 		return nil, fmt.Errorf("invalid userID")
 	}
-	if !isValidEventName(req.Name) {
+	if !isValidResourceName(req.Name) {
 		return nil, fmt.Errorf("invalid event name: must match ^[a-z][a-z0-9_]{0,128}$")
 	}
 
@@ -200,7 +200,11 @@ func (c *controller) ListTasksFromEvent(ctx context.Context, req entity.ListTask
 
 // ── Validation helpers ────────────────────────────────────────────────────────
 
-func isValidEventName(name string) bool {
+// isValidResourceName enforces the shared identifier convention for names that
+// are referenced textually rather than by id — event names in publishEvent,
+// and workflow and agent names in the workflow text format. Anything with a
+// space or a colon would be ambiguous to parse there, so the rule is one rule.
+func isValidResourceName(name string) bool {
 	if len(name) == 0 || len(name) > 129 {
 		return false
 	}

--- a/backend/internal/controller/crud/event_test.go
+++ b/backend/internal/controller/crud/event_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
-// ── isValidEventName ──────────────────────────────────────────────────────────
+// ── isValidResourceName ──────────────────────────────────────────────────────────
 
 func TestIsValidEventName(t *testing.T) {
 	valid := []string{"a", "abc", "a1", "a_b", "task_done", "a" + repeat("b", 128)}
 	for _, n := range valid {
-		if !isValidEventName(n) {
+		if !isValidResourceName(n) {
 			t.Errorf("expected %q to be valid", n)
 		}
 	}
@@ -26,7 +26,7 @@ func TestIsValidEventName(t *testing.T) {
 		"a" + repeat("b", 129), // 130 chars total — over limit
 	}
 	for _, n := range invalid {
-		if isValidEventName(n) {
+		if isValidResourceName(n) {
 			t.Errorf("expected %q to be invalid", n)
 		}
 	}

--- a/backend/internal/controller/crud/task.go
+++ b/backend/internal/controller/crud/task.go
@@ -106,23 +106,44 @@ func (c *controller) CreateTask(ctx context.Context, req entity.CreateTaskReques
 		req.Task.Body = appendSelfLearningNote(req.Task.Body, w.SelfLearningLoopNote)
 	}
 
+	// Choosing a workflow means "run this pipeline on completion", which fires
+	// the workflow's own start event — so the workflow choice expands into both
+	// fields, and the discriminator records which one the author picked.
+	eventID := req.Task.EventID
+	completionTrigger := entity.CompletionTriggerNone
+	if req.Task.WorkflowID != 0 {
+		wf, wfErr := c.repository.GetWorkflow(ctx, req.Task.WorkflowID, userID)
+		if wfErr != nil {
+			return nil, fmt.Errorf("workflow not found")
+		}
+		if wf.StartEventID == 0 {
+			return nil, fmt.Errorf("workflow %q has no start event yet", wf.Name)
+		}
+		eventID = wf.StartEventID
+		completionTrigger = entity.CompletionTriggerWorkflow
+	} else if eventID != 0 {
+		completionTrigger = entity.CompletionTriggerEvent
+	}
+
 	m := model.Task{
-		ID:               c.idgen.NextID(),
-		CreatedAt:        now,
-		UpdatedAt:        now,
-		UserID:           userID,
-		WorkspaceID:      req.Task.WorkspaceID,
-		CreatedBy:        req.Task.CreatedBy,
-		Assignee:         req.Task.Assignee,
-		Status:           status,
-		Title:            req.Task.Title,
-		Body:             req.Task.Body,
-		Attachments:      attachJSON,
-		CronSchedule:     req.Task.CronSchedule,
-		ParentID:         req.Task.ParentID,
-		SortOrder:        sortOrder,
-		AllowAllCommands: allowAll,
-		EventID:          req.Task.EventID,
+		ID:                    c.idgen.NextID(),
+		CreatedAt:             now,
+		UpdatedAt:             now,
+		UserID:                userID,
+		WorkspaceID:           req.Task.WorkspaceID,
+		CreatedBy:             req.Task.CreatedBy,
+		Assignee:              req.Task.Assignee,
+		Status:                status,
+		Title:                 req.Task.Title,
+		Body:                  req.Task.Body,
+		Attachments:           attachJSON,
+		CronSchedule:          req.Task.CronSchedule,
+		ParentID:              req.Task.ParentID,
+		SortOrder:             sortOrder,
+		AllowAllCommands:      allowAll,
+		EventID:               eventID,
+		WorkflowID:            req.Task.WorkflowID,
+		CompletionTriggerType: completionTrigger,
 	}
 	created, err := c.repository.CreateTask(ctx, m)
 	if err != nil {
@@ -648,26 +669,29 @@ func (c *controller) fromModelTaskToEntity(m model.Task) entity.Task {
 	}
 
 	return entity.Task{
-		ID:               m.ID,
-		CreatedAt:        m.CreatedAt,
-		UpdatedAt:        m.UpdatedAt,
-		WorkspaceID:      m.WorkspaceID,
-		UserID:           m.UserID,
-		CreatedBy:        m.CreatedBy,
-		Assignee:         m.Assignee,
-		Status:           m.Status,
-		Title:            m.Title,
-		Body:             m.Body,
-		Response:         m.Response,
-		ReplyText:        m.ReplyText,
-		Attachments:      atts,
-		Messages:         msgs,
-		ToolCalls:        toolCalls,
-		CronSchedule:     m.CronSchedule,
-		ParentID:         m.ParentID,
-		SortOrder:        m.SortOrder,
-		AllowAllCommands: m.AllowAllCommands,
-		EventID:          m.EventID,
+		ID:                    m.ID,
+		CreatedAt:             m.CreatedAt,
+		UpdatedAt:             m.UpdatedAt,
+		WorkspaceID:           m.WorkspaceID,
+		UserID:                m.UserID,
+		CreatedBy:             m.CreatedBy,
+		Assignee:              m.Assignee,
+		Status:                m.Status,
+		Title:                 m.Title,
+		Body:                  m.Body,
+		Response:              m.Response,
+		ReplyText:             m.ReplyText,
+		Attachments:           atts,
+		Messages:              msgs,
+		ToolCalls:             toolCalls,
+		CronSchedule:          m.CronSchedule,
+		ParentID:              m.ParentID,
+		SortOrder:             m.SortOrder,
+		AllowAllCommands:      m.AllowAllCommands,
+		EventID:               m.EventID,
+		WorkflowID:            m.WorkflowID,
+		WorkflowDepth:         m.WorkflowDepth,
+		CompletionTriggerType: m.CompletionTriggerType,
 	}
 }
 

--- a/backend/internal/controller/crud/workflow.go
+++ b/backend/internal/controller/crud/workflow.go
@@ -75,6 +75,9 @@ func (c *controller) CreateWorkflow(ctx context.Context, req entity.CreateWorkfl
 
 	created, err := c.repository.CreateWorkflow(ctx, m)
 	if err != nil {
+		if isUniqueConstraintErr(err) {
+			return nil, fmt.Errorf("%w: %q", ErrDuplicateName, req.Name)
+		}
 		return nil, err
 	}
 	return &entity.CreateWorkflowResponse{Workflow: mapper.FromModelWorkflowToEntity(created)}, nil

--- a/backend/internal/controller/crud/workflow.go
+++ b/backend/internal/controller/crud/workflow.go
@@ -1,0 +1,287 @@
+package crud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	mapper "github.com/agentrq/agentrq/backend/internal/mapper/api"
+	"github.com/mustafaturan/monoflake"
+	"gorm.io/datatypes"
+)
+
+// WorkflowController defines workflow operations (experimental).
+type WorkflowController interface {
+	CreateWorkflow(ctx context.Context, req entity.CreateWorkflowRequest) (*entity.CreateWorkflowResponse, error)
+	GetWorkflow(ctx context.Context, req entity.GetWorkflowRequest) (*entity.GetWorkflowResponse, error)
+	ListWorkflows(ctx context.Context, req entity.ListWorkflowsRequest) (*entity.ListWorkflowsResponse, error)
+	UpdateWorkflow(ctx context.Context, req entity.UpdateWorkflowRequest) (*entity.UpdateWorkflowResponse, error)
+	DeleteWorkflow(ctx context.Context, req entity.DeleteWorkflowRequest) error
+}
+
+// WorkflowStepController defines workflow step (graph edge) operations.
+type WorkflowStepController interface {
+	CreateWorkflowStep(ctx context.Context, req entity.CreateWorkflowStepRequest) (*entity.CreateWorkflowStepResponse, error)
+	ListWorkflowSteps(ctx context.Context, req entity.ListWorkflowStepsRequest) (*entity.ListWorkflowStepsResponse, error)
+	DeleteWorkflowStep(ctx context.Context, req entity.DeleteWorkflowStepRequest) error
+	ListTasksFromWorkflow(ctx context.Context, req entity.ListTasksFromWorkflowRequest) (*entity.ListTasksFromWorkflowResponse, error)
+}
+
+// ErrWorkflowCycle is returned when a step would close a loop in the workflow
+// graph. A cycle is rejected at setup rather than guarded at runtime because a
+// looping graph spawns tasks forever, and the editor can show the problem while
+// the user is still looking at the canvas.
+var ErrWorkflowCycle = fmt.Errorf("this step would create a cycle in the workflow")
+
+// ── Workflows ─────────────────────────────────────────────────────────────────
+
+func (c *controller) CreateWorkflow(ctx context.Context, req entity.CreateWorkflowRequest) (*entity.CreateWorkflowResponse, error) {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	if uid == 0 {
+		return nil, fmt.Errorf("invalid userID")
+	}
+	if req.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	// A start event is optional at create time so the editor can open an empty
+	// canvas, but a supplied one must exist and belong to this user.
+	if req.StartEventID != 0 {
+		if _, err := c.repository.GetEvent(ctx, req.StartEventID, uid); err != nil {
+			return nil, fmt.Errorf("start event not found")
+		}
+	}
+
+	now := time.Now()
+	m := model.Workflow{
+		ID:           c.idgen.NextID(),
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		UserID:       uid,
+		Name:         req.Name,
+		Description:  req.Description,
+		StartEventID: req.StartEventID,
+	}
+
+	created, err := c.repository.CreateWorkflow(ctx, m)
+	if err != nil {
+		return nil, err
+	}
+	return &entity.CreateWorkflowResponse{Workflow: mapper.FromModelWorkflowToEntity(created)}, nil
+}
+
+func (c *controller) GetWorkflow(ctx context.Context, req entity.GetWorkflowRequest) (*entity.GetWorkflowResponse, error) {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	w, err := c.repository.GetWorkflow(ctx, req.ID, uid)
+	if err != nil {
+		return nil, err
+	}
+	return &entity.GetWorkflowResponse{Workflow: mapper.FromModelWorkflowToEntity(w)}, nil
+}
+
+func (c *controller) ListWorkflows(ctx context.Context, req entity.ListWorkflowsRequest) (*entity.ListWorkflowsResponse, error) {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	models, err := c.repository.ListWorkflowsByUser(ctx, uid)
+	if err != nil {
+		return nil, err
+	}
+	workflows := make([]entity.Workflow, len(models))
+	for i, m := range models {
+		workflows[i] = mapper.FromModelWorkflowToEntity(m)
+	}
+	return &entity.ListWorkflowsResponse{Workflows: workflows}, nil
+}
+
+func (c *controller) UpdateWorkflow(ctx context.Context, req entity.UpdateWorkflowRequest) (*entity.UpdateWorkflowResponse, error) {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	if uid == 0 {
+		return nil, fmt.Errorf("invalid userID")
+	}
+
+	existing, err := c.repository.GetWorkflow(ctx, req.ID, uid)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.Name != nil {
+		if *req.Name == "" {
+			return nil, fmt.Errorf("name cannot be empty")
+		}
+		existing.Name = *req.Name
+	}
+	if req.Description != nil {
+		existing.Description = *req.Description
+	}
+	if req.StartEventID != nil {
+		if *req.StartEventID != 0 {
+			if _, err := c.repository.GetEvent(ctx, *req.StartEventID, uid); err != nil {
+				return nil, fmt.Errorf("start event not found")
+			}
+		}
+		existing.StartEventID = *req.StartEventID
+	}
+	if req.Layout != nil {
+		// Layout is opaque to the backend, but it is stored in a JSON column
+		// and echoed back inside a JSON response — so it has to parse.
+		if *req.Layout != "" && !json.Valid([]byte(*req.Layout)) {
+			return nil, fmt.Errorf("layout must be valid JSON")
+		}
+		existing.Layout = datatypes.JSON(*req.Layout)
+	}
+
+	updated, err := c.repository.UpdateWorkflow(ctx, existing)
+	if err != nil {
+		return nil, err
+	}
+	return &entity.UpdateWorkflowResponse{Workflow: mapper.FromModelWorkflowToEntity(updated)}, nil
+}
+
+func (c *controller) DeleteWorkflow(ctx context.Context, req entity.DeleteWorkflowRequest) error {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	return c.repository.DeleteWorkflow(ctx, req.ID, uid)
+}
+
+// ── WorkflowSteps ─────────────────────────────────────────────────────────────
+
+func (c *controller) CreateWorkflowStep(ctx context.Context, req entity.CreateWorkflowStepRequest) (*entity.CreateWorkflowStepResponse, error) {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	if uid == 0 {
+		return nil, fmt.Errorf("invalid userID")
+	}
+
+	if _, err := c.repository.GetWorkflow(ctx, req.WorkflowID, uid); err != nil {
+		return nil, fmt.Errorf("workflow not found")
+	}
+	if _, err := c.repository.GetEvent(ctx, req.EventID, uid); err != nil {
+		return nil, fmt.Errorf("event not found")
+	}
+
+	ok, err := c.repository.CheckWorkspaceAccess(ctx, req.WorkspaceID, uid)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("workspace not found")
+	}
+
+	if req.Title == "" {
+		return nil, fmt.Errorf("title is required")
+	}
+
+	if req.EmitEventID != 0 {
+		if _, err := c.repository.GetEvent(ctx, req.EmitEventID, uid); err != nil {
+			return nil, fmt.Errorf("emit event not found")
+		}
+	}
+
+	existing, err := c.repository.ListWorkflowStepsByWorkflow(ctx, req.WorkflowID, uid)
+	if err != nil {
+		return nil, err
+	}
+	if wouldCreateCycle(existing, req.EventID, req.EmitEventID) {
+		return nil, ErrWorkflowCycle
+	}
+
+	now := time.Now()
+	m := model.WorkflowStep{
+		ID:               c.idgen.NextID(),
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		WorkflowID:       req.WorkflowID,
+		UserID:           uid,
+		EventID:          req.EventID,
+		WorkspaceID:      req.WorkspaceID,
+		EmitEventID:      req.EmitEventID,
+		Title:            req.Title,
+		Body:             req.Body,
+		Assignee:         req.Assignee,
+		AllowAllCommands: req.AllowAllCommands,
+	}
+
+	created, err := c.repository.CreateWorkflowStep(ctx, m)
+	if err != nil {
+		return nil, err
+	}
+	return &entity.CreateWorkflowStepResponse{WorkflowStep: mapper.FromModelWorkflowStepToEntity(created)}, nil
+}
+
+func (c *controller) ListWorkflowSteps(ctx context.Context, req entity.ListWorkflowStepsRequest) (*entity.ListWorkflowStepsResponse, error) {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	models, err := c.repository.ListWorkflowStepsByWorkflow(ctx, req.WorkflowID, uid)
+	if err != nil {
+		return nil, err
+	}
+	steps := make([]entity.WorkflowStep, len(models))
+	for i, m := range models {
+		steps[i] = mapper.FromModelWorkflowStepToEntity(m)
+	}
+	return &entity.ListWorkflowStepsResponse{WorkflowSteps: steps}, nil
+}
+
+func (c *controller) DeleteWorkflowStep(ctx context.Context, req entity.DeleteWorkflowStepRequest) error {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	return c.repository.DeleteWorkflowStep(ctx, req.ID, uid)
+}
+
+func (c *controller) ListTasksFromWorkflow(ctx context.Context, req entity.ListTasksFromWorkflowRequest) (*entity.ListTasksFromWorkflowResponse, error) {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	models, err := c.repository.ListTasksByWorkflowID(ctx, req.WorkflowID, uid)
+	if err != nil {
+		return nil, err
+	}
+	tasks := make([]entity.Task, len(models))
+	for i, m := range models {
+		tasks[i] = c.fromModelTaskToEntity(m)
+	}
+	return &entity.ListTasksFromWorkflowResponse{Tasks: tasks}, nil
+}
+
+// ── Cycle detection ───────────────────────────────────────────────────────────
+
+// wouldCreateCycle reports whether adding an edge from fromEventID to
+// emitEventID closes a loop in the workflow's event graph.
+//
+// Only the event-to-event shape matters: a step is an edge
+// event → workspace → event, and the workspace is a pass-through, so a run
+// loops exactly when the events do. A step with no emit event is a leaf and can
+// never close a loop.
+//
+// Two steps may legitimately share a source event (fan-out) or a target event
+// (fan-in); neither is a cycle. What is rejected is emitEventID being able to
+// reach fromEventID through edges that already exist.
+func wouldCreateCycle(steps []model.WorkflowStep, fromEventID int64, emitEventID int64) bool {
+	if emitEventID == 0 {
+		return false
+	}
+	if emitEventID == fromEventID {
+		return true
+	}
+
+	// Adjacency over existing edges only; the candidate edge is represented by
+	// starting the walk at its target and looking for its source.
+	adjacency := make(map[int64][]int64, len(steps))
+	for _, s := range steps {
+		if s.EmitEventID != 0 {
+			adjacency[s.EventID] = append(adjacency[s.EventID], s.EmitEventID)
+		}
+	}
+
+	visited := make(map[int64]bool, len(adjacency))
+	stack := []int64{emitEventID}
+	for len(stack) > 0 {
+		current := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if current == fromEventID {
+			return true
+		}
+		if visited[current] {
+			continue
+		}
+		visited[current] = true
+		stack = append(stack, adjacency[current]...)
+	}
+	return false
+}

--- a/backend/internal/controller/crud/workflow.go
+++ b/backend/internal/controller/crud/workflow.go
@@ -36,6 +36,11 @@ type WorkflowStepController interface {
 // the user is still looking at the canvas.
 var ErrWorkflowCycle = fmt.Errorf("this step would create a cycle in the workflow")
 
+// ErrInvalidWorkflowName is returned when a workflow name breaks the shared
+// identifier convention. Exported so the handler can answer 422 with the rule
+// itself rather than a generic failure.
+var ErrInvalidWorkflowName = fmt.Errorf("invalid workflow name: must match ^[a-z][a-z0-9_]{0,128}$")
+
 // ── Workflows ─────────────────────────────────────────────────────────────────
 
 func (c *controller) CreateWorkflow(ctx context.Context, req entity.CreateWorkflowRequest) (*entity.CreateWorkflowResponse, error) {
@@ -43,8 +48,10 @@ func (c *controller) CreateWorkflow(ctx context.Context, req entity.CreateWorkfl
 	if uid == 0 {
 		return nil, fmt.Errorf("invalid userID")
 	}
-	if req.Name == "" {
-		return nil, fmt.Errorf("name is required")
+	// Workflows share the event naming convention: both are referenced by name
+	// from the text format, where a space or colon would be ambiguous to parse.
+	if !isValidResourceName(req.Name) {
+		return nil, ErrInvalidWorkflowName
 	}
 
 	// A start event is optional at create time so the editor can open an empty
@@ -107,8 +114,8 @@ func (c *controller) UpdateWorkflow(ctx context.Context, req entity.UpdateWorkfl
 	}
 
 	if req.Name != nil {
-		if *req.Name == "" {
-			return nil, fmt.Errorf("name cannot be empty")
+		if !isValidResourceName(*req.Name) {
+			return nil, ErrInvalidWorkflowName
 		}
 		existing.Name = *req.Name
 	}

--- a/backend/internal/controller/crud/workflow_test.go
+++ b/backend/internal/controller/crud/workflow_test.go
@@ -1,0 +1,133 @@
+package crud
+
+import (
+	"testing"
+
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+)
+
+// step builds an event→event edge; workspace is irrelevant to cycle detection
+// but set so the fixtures read like real rows.
+func step(eventID, emitEventID int64) model.WorkflowStep {
+	return model.WorkflowStep{
+		EventID:     eventID,
+		EmitEventID: emitEventID,
+		WorkspaceID: 900,
+	}
+}
+
+func TestWouldCreateCycle(t *testing.T) {
+	tests := []struct {
+		name        string
+		existing    []model.WorkflowStep
+		fromEventID int64
+		emitEventID int64
+		want        bool
+	}{
+		{
+			name:        "leaf step never cycles",
+			existing:    []model.WorkflowStep{step(1, 2)},
+			fromEventID: 2,
+			emitEventID: 0,
+			want:        false,
+		},
+		{
+			name:        "self loop",
+			existing:    nil,
+			fromEventID: 1,
+			emitEventID: 1,
+			want:        true,
+		},
+		{
+			name:        "first edge in an empty workflow",
+			existing:    nil,
+			fromEventID: 1,
+			emitEventID: 2,
+			want:        false,
+		},
+		{
+			name:        "linear chain stays acyclic",
+			existing:    []model.WorkflowStep{step(1, 2), step(2, 3)},
+			fromEventID: 3,
+			emitEventID: 4,
+			want:        false,
+		},
+		{
+			name:        "two-hop back edge closes the loop",
+			existing:    []model.WorkflowStep{step(1, 2)},
+			fromEventID: 2,
+			emitEventID: 1,
+			want:        true,
+		},
+		{
+			name:        "long chain back edge closes the loop",
+			existing:    []model.WorkflowStep{step(1, 2), step(2, 3), step(3, 4)},
+			fromEventID: 4,
+			emitEventID: 1,
+			want:        true,
+		},
+		{
+			name:        "back edge into the middle of a chain",
+			existing:    []model.WorkflowStep{step(1, 2), step(2, 3), step(3, 4)},
+			fromEventID: 4,
+			emitEventID: 2,
+			want:        true,
+		},
+		{
+			name:        "fan-out from one event is not a cycle",
+			existing:    []model.WorkflowStep{step(1, 2)},
+			fromEventID: 1,
+			emitEventID: 3,
+			want:        false,
+		},
+		{
+			name:        "fan-in to one event is not a cycle",
+			existing:    []model.WorkflowStep{step(1, 3)},
+			fromEventID: 2,
+			emitEventID: 3,
+			want:        false,
+		},
+		{
+			name: "diamond re-join is not a cycle",
+			existing: []model.WorkflowStep{
+				step(1, 2),
+				step(1, 3),
+				step(2, 4),
+			},
+			fromEventID: 3,
+			emitEventID: 4,
+			want:        false,
+		},
+		{
+			name: "disconnected component does not create a false positive",
+			existing: []model.WorkflowStep{
+				step(1, 2),
+				step(10, 11),
+			},
+			fromEventID: 11,
+			emitEventID: 12,
+			want:        false,
+		},
+		{
+			name: "edge into a separate existing cycle does not hang",
+			// A pre-existing cycle should be unreachable through the API, but
+			// the walk must still terminate if one is ever present in storage.
+			existing: []model.WorkflowStep{
+				step(10, 11),
+				step(11, 10),
+			},
+			fromEventID: 1,
+			emitEventID: 10,
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wouldCreateCycle(tt.existing, tt.fromEventID, tt.emitEventID)
+			if got != tt.want {
+				t.Errorf("wouldCreateCycle(%d -> %d) = %v, want %v", tt.fromEventID, tt.emitEventID, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/controller/crud/workflow_text.go
+++ b/backend/internal/controller/crud/workflow_text.go
@@ -1,0 +1,328 @@
+package crud
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// The text representation of a workflow graph, e.g.
+//
+//	workflow: new_feature
+//	event: code_changed
+//	- agent:doc
+//	  - event:doc_updated
+//	- agent:blog
+//	  - event:new_feature_added
+//	    - agent:twitter
+//	    - agent:hackernews
+//
+// The grammar alternates strictly: an event is consumed by agents, and each
+// agent may emit one event, which is in turn consumed by agents. That
+// alternation is the whole point of the format — there are no conditionals to
+// express, so nesting depth alone carries the structure.
+//
+// Indentation is two spaces per level. Every list line is `- <kind>:<name>`,
+// so a line's meaning never depends on its depth; a missing prefix is a
+// reported error rather than a silent reinterpretation.
+
+const textIndentWidth = 2
+
+// TextNode is one parsed line of a workflow text document: an agent
+// (workspace) or the event it emits, plus whatever it consumes in turn.
+type TextNode struct {
+	// Kind is "agent" or "event".
+	Kind string
+	// Name is the workspace name or event name.
+	Name string
+	// Line is the 1-based source line, so errors and editor markers can point
+	// at the exact input the user typed.
+	Line int
+	// Children are the nodes nested directly under this one: agents under an
+	// event, or the single emitted event under an agent.
+	Children []*TextNode
+}
+
+// ParsedWorkflowText is a whole workflow document.
+type ParsedWorkflowText struct {
+	Name       string
+	StartEvent string
+	// Roots are the agents consuming StartEvent.
+	Roots []*TextNode
+}
+
+// WorkflowTextError is a parse or validation failure carrying the source line,
+// so the editor can mark the offending row instead of showing a bare message.
+type WorkflowTextError struct {
+	Line int
+	Msg  string
+}
+
+func (e *WorkflowTextError) Error() string {
+	if e.Line > 0 {
+		return fmt.Sprintf("line %d: %s", e.Line, e.Msg)
+	}
+	return e.Msg
+}
+
+func textErr(line int, format string, args ...any) *WorkflowTextError {
+	return &WorkflowTextError{Line: line, Msg: fmt.Sprintf(format, args...)}
+}
+
+// ParseWorkflowText reads the text representation into a tree.
+//
+// It reports the first error it finds rather than accumulating: indentation
+// mistakes cascade, so a list of downstream errors caused by one bad line is
+// noise, not help.
+func ParseWorkflowText(input string) (*ParsedWorkflowText, error) {
+	lines := strings.Split(strings.ReplaceAll(input, "\r\n", "\n"), "\n")
+
+	parsed := &ParsedWorkflowText{}
+	// stack[i] is the node currently open at depth i; a child at depth d
+	// attaches to stack[d-1].
+	var stack []*TextNode
+	seenHeader := false
+
+	for i, raw := range lines {
+		lineNo := i + 1
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		if strings.HasPrefix(strings.TrimSpace(raw), "#") {
+			continue
+		}
+		if strings.Contains(raw, "\t") {
+			return nil, textErr(lineNo, "use spaces, not tabs, for indentation")
+		}
+
+		trimmed := strings.TrimLeft(raw, " ")
+		indent := len(raw) - len(trimmed)
+
+		// Header lines: `workflow: <name>` and `event: <name>`.
+		if !strings.HasPrefix(trimmed, "- ") {
+			if indent != 0 {
+				return nil, textErr(lineNo, "%q must not be indented", firstWord(trimmed))
+			}
+			key, value, ok := splitField(trimmed)
+			if !ok {
+				return nil, textErr(lineNo, "expected \"workflow: <name>\", \"event: <name>\", or a \"- agent:<name>\" list item")
+			}
+			switch key {
+			case "workflow":
+				if parsed.Name != "" {
+					return nil, textErr(lineNo, "workflow name already set to %q", parsed.Name)
+				}
+				if value == "" {
+					return nil, textErr(lineNo, "workflow name cannot be empty")
+				}
+				parsed.Name = value
+			case "event":
+				if parsed.StartEvent != "" {
+					return nil, textErr(lineNo, "start event already set to %q; nest later events under an agent", parsed.StartEvent)
+				}
+				if value == "" {
+					return nil, textErr(lineNo, "start event name cannot be empty")
+				}
+				parsed.StartEvent = value
+				seenHeader = true
+			default:
+				return nil, textErr(lineNo, "unknown field %q (expected \"workflow\" or \"event\")", key)
+			}
+			continue
+		}
+
+		if !seenHeader {
+			return nil, textErr(lineNo, "list items must come after a \"event: <name>\" line")
+		}
+
+		if indent%textIndentWidth != 0 {
+			return nil, textErr(lineNo, "indent by %d spaces per level (got %d)", textIndentWidth, indent)
+		}
+		depth := indent / textIndentWidth
+
+		if depth > len(stack) {
+			return nil, textErr(lineNo, "unexpected indentation: jumped %d levels", depth-len(stack))
+		}
+
+		node, err := parseListItem(trimmed, lineNo)
+		if err != nil {
+			return nil, err
+		}
+
+		// Enforce the alternation. Depth 0 sits under the start event, so it
+		// must be an agent; below that, a node's kind is fixed by its parent's.
+		if depth == 0 {
+			if node.Kind != "agent" {
+				return nil, textErr(lineNo, "expected \"- agent:<name>\" under event %q, got %q", parsed.StartEvent, node.Kind)
+			}
+		} else {
+			parent := stack[depth-1]
+			switch parent.Kind {
+			case "agent":
+				if node.Kind != "event" {
+					return nil, textErr(lineNo, "an agent may only emit an event; expected \"- event:<name>\" under agent %q", parent.Name)
+				}
+				if len(parent.Children) > 0 {
+					return nil, textErr(lineNo, "agent %q already emits event %q; an agent emits at most one event", parent.Name, parent.Children[0].Name)
+				}
+			case "event":
+				if node.Kind != "agent" {
+					return nil, textErr(lineNo, "expected \"- agent:<name>\" under event %q, got %q", parent.Name, node.Kind)
+				}
+			}
+		}
+
+		// Truncate to this depth, then attach.
+		stack = stack[:depth]
+		if depth == 0 {
+			parsed.Roots = append(parsed.Roots, node)
+		} else {
+			parent := stack[depth-1]
+			parent.Children = append(parent.Children, node)
+		}
+		stack = append(stack, node)
+	}
+
+	if parsed.Name == "" {
+		return nil, textErr(0, "missing \"workflow: <name>\" line")
+	}
+	if parsed.StartEvent == "" {
+		return nil, textErr(0, "missing \"event: <name>\" line naming the start event")
+	}
+	return parsed, nil
+}
+
+// parseListItem reads `- agent:name` / `- event:name`.
+func parseListItem(trimmed string, lineNo int) (*TextNode, error) {
+	body := strings.TrimSpace(strings.TrimPrefix(trimmed, "- "))
+	if body == "" {
+		return nil, textErr(lineNo, "list item is empty")
+	}
+
+	kind, name, ok := strings.Cut(body, ":")
+	if !ok {
+		return nil, textErr(lineNo, "expected \"agent:<name>\" or \"event:<name>\", got %q", body)
+	}
+	kind = strings.TrimSpace(kind)
+	name = strings.TrimSpace(name)
+
+	if kind != "agent" && kind != "event" {
+		return nil, textErr(lineNo, "unknown kind %q (expected \"agent\" or \"event\")", kind)
+	}
+	if name == "" {
+		return nil, textErr(lineNo, "%s name cannot be empty", kind)
+	}
+	return &TextNode{Kind: kind, Name: name, Line: lineNo}, nil
+}
+
+// splitField reads a `key: value` header line.
+func splitField(s string) (key string, value string, ok bool) {
+	key, value, ok = strings.Cut(s, ":")
+	if !ok {
+		return "", "", false
+	}
+	return strings.TrimSpace(key), strings.TrimSpace(value), true
+}
+
+func firstWord(s string) string {
+	if i := strings.IndexAny(s, " :"); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// ── Serialization ─────────────────────────────────────────────────────────────
+
+// TextStep is one edge, named rather than keyed by ID, so the serializer stays
+// independent of storage and can be unit-tested without a database.
+type TextStep struct {
+	EventName     string
+	WorkspaceName string
+	EmitEventName string
+}
+
+// RenderWorkflowText renders a workflow's steps back into the text format.
+//
+// It walks outward from the start event so the output mirrors how the graph
+// actually runs. A graph containing a cycle would walk forever, so each branch
+// stops if it revisits an event; setup-time validation should prevent that, but
+// the renderer must not hang on data that slipped past it.
+func RenderWorkflowText(name string, startEvent string, steps []TextStep) string {
+	byEvent := make(map[string][]TextStep, len(steps))
+	for _, s := range steps {
+		byEvent[s.EventName] = append(byEvent[s.EventName], s)
+	}
+	// Stable output regardless of row order, so the text is diffable.
+	for event := range byEvent {
+		group := byEvent[event]
+		sort.Slice(group, func(i, j int) bool {
+			if group[i].WorkspaceName != group[j].WorkspaceName {
+				return group[i].WorkspaceName < group[j].WorkspaceName
+			}
+			return group[i].EmitEventName < group[j].EmitEventName
+		})
+		byEvent[event] = group
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "workflow: %s\n", name)
+	if startEvent == "" {
+		return sb.String()
+	}
+	fmt.Fprintf(&sb, "event: %s\n", startEvent)
+
+	var walk func(event string, depth int, seen map[string]bool)
+	walk = func(event string, depth int, seen map[string]bool) {
+		if seen[event] {
+			return
+		}
+		seen[event] = true
+		defer delete(seen, event)
+
+		for _, step := range byEvent[event] {
+			indent := strings.Repeat(" ", depth*textIndentWidth)
+			fmt.Fprintf(&sb, "%s- agent:%s\n", indent, step.WorkspaceName)
+			if step.EmitEventName == "" {
+				continue
+			}
+			emitIndent := strings.Repeat(" ", (depth+1)*textIndentWidth)
+			fmt.Fprintf(&sb, "%s- event:%s\n", emitIndent, step.EmitEventName)
+			walk(step.EmitEventName, depth+2, seen)
+		}
+	}
+	walk(startEvent, 0, map[string]bool{})
+
+	return sb.String()
+}
+
+// FlattenWorkflowText turns a parsed tree back into a flat edge list.
+//
+// The tree can name the same event in more than one branch (a diamond re-join),
+// which would otherwise yield duplicate edges, so identical
+// event→workspace→emit triples are emitted once.
+func FlattenWorkflowText(parsed *ParsedWorkflowText) []TextStep {
+	var steps []TextStep
+	seen := make(map[TextStep]bool)
+
+	var walk func(eventName string, agents []*TextNode)
+	walk = func(eventName string, agents []*TextNode) {
+		for _, agent := range agents {
+			step := TextStep{EventName: eventName, WorkspaceName: agent.Name}
+			var emitted *TextNode
+			if len(agent.Children) > 0 {
+				emitted = agent.Children[0]
+				step.EmitEventName = emitted.Name
+			}
+			if !seen[step] {
+				seen[step] = true
+				steps = append(steps, step)
+			}
+			if emitted != nil {
+				walk(emitted.Name, emitted.Children)
+			}
+		}
+	}
+	walk(parsed.StartEvent, parsed.Roots)
+
+	return steps
+}

--- a/backend/internal/controller/crud/workflow_text.go
+++ b/backend/internal/controller/crud/workflow_text.go
@@ -115,6 +115,12 @@ func ParseWorkflowText(input string) (*ParsedWorkflowText, error) {
 				if value == "" {
 					return nil, textErr(lineNo, "workflow name cannot be empty")
 				}
+				// Same rule the REST path enforces. Checking it here too means
+				// a bad rename is reported against its line rather than as a
+				// bare failure after the graph has already been validated.
+				if !isValidResourceName(value) {
+					return nil, textErr(lineNo, "invalid workflow name %q: use lowercase letters, digits and underscores, starting with a letter", value)
+				}
 				parsed.Name = value
 			case "event":
 				if parsed.StartEvent != "" {

--- a/backend/internal/controller/crud/workflow_text_controller.go
+++ b/backend/internal/controller/crud/workflow_text_controller.go
@@ -1,0 +1,230 @@
+package crud
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	mapper "github.com/agentrq/agentrq/backend/internal/mapper/api"
+	"github.com/mustafaturan/monoflake"
+)
+
+// WorkflowTextController exposes the workflow graph as an editable document.
+//
+// The text format and the canvas are two views of one graph, so both go through
+// the same validation here rather than each enforcing its own rules — that is
+// what keeps them from drifting into disagreeing about what is legal.
+type WorkflowTextController interface {
+	GetWorkflowText(ctx context.Context, req entity.GetWorkflowTextRequest) (*entity.GetWorkflowTextResponse, error)
+	ReplaceWorkflowFromText(ctx context.Context, req entity.ReplaceWorkflowFromTextRequest) (*entity.ReplaceWorkflowFromTextResponse, error)
+}
+
+// defaultStepBody is used for steps created through text mode, which has no
+// syntax for a task template. It forwards the publisher's payload so a
+// text-authored workflow still produces a task the agent can act on.
+const defaultStepBody = "{{EVENT_PAYLOAD}}"
+
+func (c *controller) GetWorkflowText(ctx context.Context, req entity.GetWorkflowTextRequest) (*entity.GetWorkflowTextResponse, error) {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+
+	workflow, err := c.repository.GetWorkflow(ctx, req.ID, uid)
+	if err != nil {
+		return nil, err
+	}
+	steps, err := c.repository.ListWorkflowStepsByWorkflow(ctx, req.ID, uid)
+	if err != nil {
+		return nil, err
+	}
+
+	eventNames, err := c.eventNamesByID(ctx, uid)
+	if err != nil {
+		return nil, err
+	}
+	workspaceNames, err := c.workspaceNamesByID(ctx, uid)
+	if err != nil {
+		return nil, err
+	}
+
+	textSteps := make([]TextStep, 0, len(steps))
+	for _, s := range steps {
+		// A step naming a deleted event or workspace can no longer be rendered
+		// faithfully; skipping it keeps the document valid rather than emitting
+		// a line that would fail to parse on the way back in.
+		eventName, ok := eventNames[s.EventID]
+		if !ok {
+			continue
+		}
+		workspaceName, ok := workspaceNames[s.WorkspaceID]
+		if !ok {
+			continue
+		}
+		textSteps = append(textSteps, TextStep{
+			EventName:     eventName,
+			WorkspaceName: workspaceName,
+			EmitEventName: eventNames[s.EmitEventID],
+		})
+	}
+
+	text := RenderWorkflowText(workflow.Name, eventNames[workflow.StartEventID], textSteps)
+	return &entity.GetWorkflowTextResponse{Text: text}, nil
+}
+
+func (c *controller) ReplaceWorkflowFromText(ctx context.Context, req entity.ReplaceWorkflowFromTextRequest) (*entity.ReplaceWorkflowFromTextResponse, error) {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	if uid == 0 {
+		return nil, fmt.Errorf("invalid userID")
+	}
+
+	workflow, err := c.repository.GetWorkflow(ctx, req.ID, uid)
+	if err != nil {
+		return nil, err
+	}
+
+	parsed, err := ParseWorkflowText(req.Text)
+	if err != nil {
+		return nil, err
+	}
+
+	eventIDs, err := c.eventIDsByName(ctx, uid)
+	if err != nil {
+		return nil, err
+	}
+	workspaceIDs, err := c.workspaceIDsByName(ctx, uid)
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve every name before writing anything, so an unknown name on the
+	// last line cannot leave the graph half-replaced.
+	startEventID, ok := eventIDs[parsed.StartEvent]
+	if !ok {
+		return nil, textErr(0, "unknown event %q; create it first", parsed.StartEvent)
+	}
+	if err := validateTextNames(parsed.Roots, eventIDs, workspaceIDs); err != nil {
+		return nil, err
+	}
+
+	textSteps := FlattenWorkflowText(parsed)
+
+	// Re-check cycles here even though the parser produces a tree: the same
+	// event may appear in several branches, and those re-joins can close a loop
+	// that no single branch reveals.
+	var accumulated []model.WorkflowStep
+	for _, ts := range textSteps {
+		eventID := eventIDs[ts.EventName]
+		emitEventID := eventIDs[ts.EmitEventName]
+		if wouldCreateCycle(accumulated, eventID, emitEventID) {
+			return nil, textErr(0, "%s: %s -> %s closes a loop", ErrWorkflowCycle, ts.EventName, ts.EmitEventName)
+		}
+		accumulated = append(accumulated, model.WorkflowStep{EventID: eventID, EmitEventID: emitEventID})
+	}
+
+	now := time.Now()
+	steps := make([]model.WorkflowStep, 0, len(textSteps))
+	for _, ts := range textSteps {
+		steps = append(steps, model.WorkflowStep{
+			ID:          c.idgen.NextID(),
+			CreatedAt:   now,
+			UpdatedAt:   now,
+			WorkflowID:  req.ID,
+			UserID:      uid,
+			EventID:     eventIDs[ts.EventName],
+			WorkspaceID: workspaceIDs[ts.WorkspaceName],
+			EmitEventID: eventIDs[ts.EmitEventName],
+			// Text mode cannot express a per-step template, so the title names
+			// the triggering event and the body forwards its payload.
+			Title:    fmt.Sprintf("%s: %s", parsed.Name, ts.EventName),
+			Body:     defaultStepBody,
+			Assignee: "agent",
+		})
+	}
+
+	if err := c.repository.ReplaceWorkflowSteps(ctx, req.ID, uid, steps); err != nil {
+		return nil, err
+	}
+
+	// The document also carries the workflow's own name and start event, so a
+	// rename in text mode takes effect too.
+	workflow.Name = parsed.Name
+	workflow.StartEventID = startEventID
+	updated, err := c.repository.UpdateWorkflow(ctx, workflow)
+	if err != nil {
+		return nil, err
+	}
+
+	return &entity.ReplaceWorkflowFromTextResponse{
+		Workflow:  mapper.FromModelWorkflowToEntity(updated),
+		StepCount: len(steps),
+	}, nil
+}
+
+// validateTextNames walks the tree reporting the first unknown name with the
+// line that introduced it, so the editor can mark the exact row.
+func validateTextNames(agents []*TextNode, eventIDs map[string]int64, workspaceIDs map[string]int64) error {
+	for _, agent := range agents {
+		if _, ok := workspaceIDs[agent.Name]; !ok {
+			return textErr(agent.Line, "unknown workspace %q", agent.Name)
+		}
+		for _, emitted := range agent.Children {
+			if _, ok := eventIDs[emitted.Name]; !ok {
+				return textErr(emitted.Line, "unknown event %q; create it first", emitted.Name)
+			}
+			if err := validateTextNames(emitted.Children, eventIDs, workspaceIDs); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// ── Name/ID lookup tables ─────────────────────────────────────────────────────
+
+func (c *controller) eventNamesByID(ctx context.Context, userID int64) (map[int64]string, error) {
+	events, err := c.repository.ListEventsByUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	names := make(map[int64]string, len(events))
+	for _, e := range events {
+		names[e.ID] = e.Name
+	}
+	return names, nil
+}
+
+func (c *controller) eventIDsByName(ctx context.Context, userID int64) (map[string]int64, error) {
+	events, err := c.repository.ListEventsByUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	ids := make(map[string]int64, len(events))
+	for _, e := range events {
+		ids[e.Name] = e.ID
+	}
+	return ids, nil
+}
+
+func (c *controller) workspaceNamesByID(ctx context.Context, userID int64) (map[int64]string, error) {
+	workspaces, err := c.repository.ListWorkspaces(ctx, userID, false)
+	if err != nil {
+		return nil, err
+	}
+	names := make(map[int64]string, len(workspaces))
+	for _, w := range workspaces {
+		names[w.ID] = w.Name
+	}
+	return names, nil
+}
+
+func (c *controller) workspaceIDsByName(ctx context.Context, userID int64) (map[string]int64, error) {
+	workspaces, err := c.repository.ListWorkspaces(ctx, userID, false)
+	if err != nil {
+		return nil, err
+	}
+	ids := make(map[string]int64, len(workspaces))
+	for _, w := range workspaces {
+		ids[w.Name] = w.ID
+	}
+	return ids, nil
+}

--- a/backend/internal/controller/crud/workflow_text_test.go
+++ b/backend/internal/controller/crud/workflow_text_test.go
@@ -227,6 +227,26 @@ func TestParseWorkflowTextErrors(t *testing.T) {
 			wantLine: 2,
 			wantMsg:  "must not be indented",
 		},
+		{
+			// Workflows share the event naming convention: both are referenced
+			// by name from this format, where a space would be ambiguous.
+			name:     "workflow name with a space",
+			input:    "workflow: my workflow\nevent: s\n",
+			wantLine: 1,
+			wantMsg:  "invalid workflow name",
+		},
+		{
+			name:     "workflow name starting with a digit",
+			input:    "workflow: 1st_pipeline\nevent: s\n",
+			wantLine: 1,
+			wantMsg:  "invalid workflow name",
+		},
+		{
+			name:     "workflow name with uppercase",
+			input:    "workflow: NewFeature\nevent: s\n",
+			wantLine: 1,
+			wantMsg:  "invalid workflow name",
+		},
 	}
 
 	for _, tt := range tests {

--- a/backend/internal/controller/crud/workflow_text_test.go
+++ b/backend/internal/controller/crud/workflow_text_test.go
@@ -1,0 +1,416 @@
+package crud
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// The example from the feature request, in its corrected form.
+const canonicalDoc = `workflow: new_feature
+event: code_changed
+- agent:doc
+  - event:doc_updated
+- agent:blog
+  - event:new_feature_added
+    - agent:twitter
+    - agent:hackernews
+    - agent:linkedin
+`
+
+func TestParseWorkflowTextCanonical(t *testing.T) {
+	parsed, err := ParseWorkflowText(canonicalDoc)
+	if err != nil {
+		t.Fatalf("ParseWorkflowText: %v", err)
+	}
+
+	if parsed.Name != "new_feature" {
+		t.Errorf("Name = %q, want %q", parsed.Name, "new_feature")
+	}
+	if parsed.StartEvent != "code_changed" {
+		t.Errorf("StartEvent = %q, want %q", parsed.StartEvent, "code_changed")
+	}
+	if len(parsed.Roots) != 2 {
+		t.Fatalf("len(Roots) = %d, want 2", len(parsed.Roots))
+	}
+
+	doc := parsed.Roots[0]
+	if doc.Kind != "agent" || doc.Name != "doc" {
+		t.Errorf("Roots[0] = %s:%s, want agent:doc", doc.Kind, doc.Name)
+	}
+	if len(doc.Children) != 1 || doc.Children[0].Name != "doc_updated" {
+		t.Fatalf("doc should emit doc_updated, got %+v", doc.Children)
+	}
+	if len(doc.Children[0].Children) != 0 {
+		t.Errorf("doc_updated should have no consumers, got %d", len(doc.Children[0].Children))
+	}
+
+	blog := parsed.Roots[1]
+	if blog.Name != "blog" {
+		t.Fatalf("Roots[1] = %q, want blog", blog.Name)
+	}
+	emitted := blog.Children[0]
+	if emitted.Kind != "event" || emitted.Name != "new_feature_added" {
+		t.Fatalf("blog should emit event:new_feature_added, got %s:%s", emitted.Kind, emitted.Name)
+	}
+	if len(emitted.Children) != 3 {
+		t.Fatalf("new_feature_added should have 3 consumers, got %d", len(emitted.Children))
+	}
+	for i, want := range []string{"twitter", "hackernews", "linkedin"} {
+		if got := emitted.Children[i].Name; got != want {
+			t.Errorf("consumer[%d] = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestParseWorkflowTextFlatten(t *testing.T) {
+	parsed, err := ParseWorkflowText(canonicalDoc)
+	if err != nil {
+		t.Fatalf("ParseWorkflowText: %v", err)
+	}
+	steps := FlattenWorkflowText(parsed)
+
+	want := []TextStep{
+		{EventName: "code_changed", WorkspaceName: "doc", EmitEventName: "doc_updated"},
+		{EventName: "code_changed", WorkspaceName: "blog", EmitEventName: "new_feature_added"},
+		{EventName: "new_feature_added", WorkspaceName: "twitter"},
+		{EventName: "new_feature_added", WorkspaceName: "hackernews"},
+		{EventName: "new_feature_added", WorkspaceName: "linkedin"},
+	}
+	if len(steps) != len(want) {
+		t.Fatalf("got %d steps, want %d: %+v", len(steps), len(want), steps)
+	}
+	for i := range want {
+		if steps[i] != want[i] {
+			t.Errorf("step[%d] = %+v, want %+v", i, steps[i], want[i])
+		}
+	}
+}
+
+func TestParseWorkflowTextRequiresKindPrefix(t *testing.T) {
+	// Every list item carries its kind, so a line's meaning never depends on
+	// its depth. A bare name is a typo, and reporting it beats guessing —
+	// guessing is how a workflow silently routes somewhere the author did not
+	// intend.
+	bare := `workflow: w
+event: start
+- agent:doc
+  - doc_updated
+`
+	err := mustParseError(t, bare)
+	if !strings.Contains(err.Error(), "event:<name>") {
+		t.Errorf("error should point at the prefixed form, got %q", err)
+	}
+	if err.Line != 4 {
+		t.Errorf("Line = %d, want 4", err.Line)
+	}
+}
+
+// mustParseError asserts the input fails to parse and returns the typed error.
+func mustParseError(t *testing.T, input string) *WorkflowTextError {
+	t.Helper()
+	_, err := ParseWorkflowText(input)
+	if err == nil {
+		t.Fatal("expected a parse error, got nil")
+	}
+	te, ok := err.(*WorkflowTextError)
+	if !ok {
+		t.Fatalf("expected *WorkflowTextError, got %T", err)
+	}
+	return te
+}
+
+func TestParseWorkflowTextErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantLine int
+		wantMsg  string
+	}{
+		{
+			name:    "missing workflow line",
+			input:   "event: start\n- agent:a\n",
+			wantMsg: "missing \"workflow:",
+		},
+		{
+			name:    "missing start event",
+			input:   "workflow: w\n",
+			wantMsg: "missing \"event:",
+		},
+		{
+			name:     "tabs rejected",
+			input:    "workflow: w\nevent: s\n- agent:a\n\t- event:e\n",
+			wantLine: 4,
+			wantMsg:  "tabs",
+		},
+		{
+			name:     "odd indentation",
+			input:    "workflow: w\nevent: s\n- agent:a\n   - event:e\n",
+			wantLine: 4,
+			wantMsg:  "indent by 2 spaces",
+		},
+		{
+			name:     "indentation jump",
+			input:    "workflow: w\nevent: s\n- agent:a\n    - event:e\n",
+			wantLine: 4,
+			wantMsg:  "jumped",
+		},
+		{
+			name:     "agent under agent breaks alternation",
+			input:    "workflow: w\nevent: s\n- agent:a\n  - agent:b\n",
+			wantLine: 4,
+			wantMsg:  "may only emit an event",
+		},
+		{
+			name:     "event under event breaks alternation",
+			input:    "workflow: w\nevent: s\n- agent:a\n  - event:e\n    - event:e2\n",
+			wantLine: 5,
+			wantMsg:  "expected \"- agent:",
+		},
+		{
+			name:     "event at root breaks alternation",
+			input:    "workflow: w\nevent: s\n- event:e\n",
+			wantLine: 3,
+			wantMsg:  "expected \"- agent:",
+		},
+		{
+			name:     "agent emitting two events",
+			input:    "workflow: w\nevent: s\n- agent:a\n  - event:e1\n  - event:e2\n",
+			wantLine: 5,
+			wantMsg:  "at most one event",
+		},
+		{
+			name:     "unknown kind",
+			input:    "workflow: w\nevent: s\n- robot:a\n",
+			wantLine: 3,
+			wantMsg:  "unknown kind",
+		},
+		{
+			name:     "missing colon in list item",
+			input:    "workflow: w\nevent: s\n- doc\n",
+			wantLine: 3,
+			wantMsg:  "expected \"agent:<name>\"",
+		},
+		{
+			name:     "empty agent name",
+			input:    "workflow: w\nevent: s\n- agent:\n",
+			wantLine: 3,
+			wantMsg:  "name cannot be empty",
+		},
+		{
+			name:     "duplicate start event",
+			input:    "workflow: w\nevent: s\nevent: s2\n",
+			wantLine: 3,
+			wantMsg:  "already set",
+		},
+		{
+			name:     "duplicate workflow name",
+			input:    "workflow: w\nworkflow: w2\n",
+			wantLine: 2,
+			wantMsg:  "already set",
+		},
+		{
+			name:     "unknown header field",
+			input:    "workflow: w\nnope: x\n",
+			wantLine: 2,
+			wantMsg:  "unknown field",
+		},
+		{
+			name:     "list item before start event",
+			input:    "workflow: w\n- agent:a\n",
+			wantLine: 2,
+			wantMsg:  "must come after",
+		},
+		{
+			name:     "indented header",
+			input:    "workflow: w\n  event: s\n",
+			wantLine: 2,
+			wantMsg:  "must not be indented",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseWorkflowText(tt.input)
+			if err == nil {
+				t.Fatalf("expected an error containing %q", tt.wantMsg)
+			}
+			if !strings.Contains(err.Error(), tt.wantMsg) {
+				t.Errorf("error = %q, want it to contain %q", err, tt.wantMsg)
+			}
+			if tt.wantLine > 0 {
+				te, ok := err.(*WorkflowTextError)
+				if !ok {
+					t.Fatalf("error should be *WorkflowTextError so the editor can mark the line, got %T", err)
+				}
+				if te.Line != tt.wantLine {
+					t.Errorf("Line = %d, want %d", te.Line, tt.wantLine)
+				}
+			}
+		})
+	}
+}
+
+func TestParseWorkflowTextIgnoresBlanksAndComments(t *testing.T) {
+	input := `# the release pipeline
+
+workflow: w
+
+event: start
+
+# docs first
+- agent:doc
+
+  - event:doc_updated
+`
+	parsed, err := ParseWorkflowText(input)
+	if err != nil {
+		t.Fatalf("ParseWorkflowText: %v", err)
+	}
+	if len(parsed.Roots) != 1 || parsed.Roots[0].Name != "doc" {
+		t.Fatalf("expected one agent:doc root, got %+v", parsed.Roots)
+	}
+	if len(parsed.Roots[0].Children) != 1 {
+		t.Fatalf("doc should still emit its event across the blank line")
+	}
+}
+
+func TestParseWorkflowTextDedentBackToRoot(t *testing.T) {
+	// After descending three levels, a root-level item must reattach to the
+	// start event rather than to whatever was last open.
+	input := `workflow: w
+event: start
+- agent:a
+  - event:mid
+    - agent:b
+- agent:c
+`
+	parsed, err := ParseWorkflowText(input)
+	if err != nil {
+		t.Fatalf("ParseWorkflowText: %v", err)
+	}
+	if len(parsed.Roots) != 2 {
+		t.Fatalf("len(Roots) = %d, want 2", len(parsed.Roots))
+	}
+	if parsed.Roots[1].Name != "c" {
+		t.Errorf("Roots[1] = %q, want c", parsed.Roots[1].Name)
+	}
+}
+
+func TestRenderWorkflowText(t *testing.T) {
+	steps := []TextStep{
+		{EventName: "code_changed", WorkspaceName: "doc", EmitEventName: "doc_updated"},
+		{EventName: "code_changed", WorkspaceName: "blog", EmitEventName: "new_feature_added"},
+		{EventName: "new_feature_added", WorkspaceName: "twitter"},
+		{EventName: "new_feature_added", WorkspaceName: "hackernews"},
+		{EventName: "new_feature_added", WorkspaceName: "linkedin"},
+	}
+	got := RenderWorkflowText("new_feature", "code_changed", steps)
+
+	// Sorted within each event group, so output is stable and diffable.
+	want := `workflow: new_feature
+event: code_changed
+- agent:blog
+  - event:new_feature_added
+    - agent:hackernews
+    - agent:linkedin
+    - agent:twitter
+- agent:doc
+  - event:doc_updated
+`
+	if got != want {
+		t.Errorf("RenderWorkflowText mismatch:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+func TestRenderWorkflowTextRoundTrip(t *testing.T) {
+	parsed, err := ParseWorkflowText(canonicalDoc)
+	if err != nil {
+		t.Fatalf("ParseWorkflowText: %v", err)
+	}
+	steps := FlattenWorkflowText(parsed)
+
+	rendered := RenderWorkflowText(parsed.Name, parsed.StartEvent, steps)
+
+	reparsed, err := ParseWorkflowText(rendered)
+	if err != nil {
+		t.Fatalf("rendered output must re-parse, got %v\n%s", err, rendered)
+	}
+	got := FlattenWorkflowText(reparsed)
+
+	if len(got) != len(steps) {
+		t.Fatalf("round trip changed step count: %d -> %d", len(steps), len(got))
+	}
+	// Compare as sets: rendering sorts, so order legitimately differs.
+	original := make(map[TextStep]bool, len(steps))
+	for _, s := range steps {
+		original[s] = true
+	}
+	for _, s := range got {
+		if !original[s] {
+			t.Errorf("round trip produced a step that was not in the original: %+v", s)
+		}
+	}
+}
+
+func TestRenderWorkflowTextTerminatesOnCycle(t *testing.T) {
+	// Cycles are rejected at setup, but the renderer must not hang if one ever
+	// reaches storage another way.
+	steps := []TextStep{
+		{EventName: "a", WorkspaceName: "w1", EmitEventName: "b"},
+		{EventName: "b", WorkspaceName: "w2", EmitEventName: "a"},
+	}
+
+	done := make(chan string, 1)
+	go func() { done <- RenderWorkflowText("looped", "a", steps) }()
+
+	select {
+	case got := <-done:
+		if !strings.Contains(got, "agent:w1") || !strings.Contains(got, "agent:w2") {
+			t.Errorf("expected both agents in output, got:\n%s", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RenderWorkflowText did not terminate on a cyclic graph")
+	}
+}
+
+func TestRenderWorkflowTextEmpty(t *testing.T) {
+	if got := RenderWorkflowText("w", "", nil); got != "workflow: w\n" {
+		t.Errorf("a workflow with no start event should render just its name, got %q", got)
+	}
+
+	got := RenderWorkflowText("w", "start", nil)
+	want := "workflow: w\nevent: start\n"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFlattenWorkflowTextDeduplicates(t *testing.T) {
+	// A diamond: two agents emit the same event, so its consumers appear under
+	// both branches but must produce one edge each.
+	input := `workflow: w
+event: start
+- agent:a
+  - event:mid
+    - agent:shared
+- agent:b
+  - event:mid
+    - agent:shared
+`
+	parsed, err := ParseWorkflowText(input)
+	if err != nil {
+		t.Fatalf("ParseWorkflowText: %v", err)
+	}
+	steps := FlattenWorkflowText(parsed)
+
+	count := 0
+	for _, s := range steps {
+		if s.EventName == "mid" && s.WorkspaceName == "shared" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("mid->shared emitted %d times, want 1 (steps: %+v)", count, steps)
+	}
+}

--- a/backend/internal/controller/event/event.go
+++ b/backend/internal/controller/event/event.go
@@ -87,20 +87,24 @@ const maxWorkflowDepth = 32
 func (c *controller) processEvent(ctx context.Context, ev entity.EventPublishedPayload) {
 	faqText := renderFAQ(ev.FAQ)
 
-	// A publish carrying a workflow stays inside that workflow: its steps
-	// decide the fan-out, not the global triggers. This is what makes a
-	// workflow an isolated graph rather than an edit to global event behavior.
+	// A publish carrying a workflow additionally runs that workflow's steps.
 	if ev.WorkflowID != 0 {
 		c.processWorkflowEvent(ctx, ev, faqText)
-		return
 	}
 
+	// Global triggers fire either way: the event was genuinely published, so
+	// anything subscribed to it hears about it, workflow or not. A workflow
+	// adds routing on top of an event rather than replacing it.
 	triggers, err := c.repo.SystemListEventTriggersByEventID(ctx, ev.EventID)
 	if err != nil || len(triggers) == 0 {
 		return
 	}
 
 	for _, trigger := range triggers {
+		// Deliberately not carrying the workflow onto these tasks. A global
+		// subscriber is outside the workflow, so its own chain continues
+		// through global triggers; inheriting the workflow would drag an
+		// unrelated pipeline into a graph that never declared it.
 		c.createTriggeredTask(ctx, trigger, ev.Payload, faqText)
 	}
 }

--- a/backend/internal/controller/event/event.go
+++ b/backend/internal/controller/event/event.go
@@ -76,16 +76,53 @@ func (c *controller) Start(ctx context.Context) error {
 	return nil
 }
 
+// maxWorkflowDepth bounds how many hops one workflow run may take.
+//
+// Cycles are rejected when a step is created, so a well-formed graph can never
+// reach this. It is a backstop for the cases setup validation cannot see: a
+// graph edited mid-run, or rows written before that validation existed. Without
+// it, one bad edge spawns tasks forever.
+const maxWorkflowDepth = 32
+
 func (c *controller) processEvent(ctx context.Context, ev entity.EventPublishedPayload) {
+	faqText := renderFAQ(ev.FAQ)
+
+	// A publish carrying a workflow stays inside that workflow: its steps
+	// decide the fan-out, not the global triggers. This is what makes a
+	// workflow an isolated graph rather than an edit to global event behavior.
+	if ev.WorkflowID != 0 {
+		c.processWorkflowEvent(ctx, ev, faqText)
+		return
+	}
+
 	triggers, err := c.repo.SystemListEventTriggersByEventID(ctx, ev.EventID)
 	if err != nil || len(triggers) == 0 {
 		return
 	}
 
-	faqText := renderFAQ(ev.FAQ)
-
 	for _, trigger := range triggers {
 		c.createTriggeredTask(ctx, trigger, ev.Payload, faqText)
+	}
+}
+
+// processWorkflowEvent advances one hop of a workflow run.
+func (c *controller) processWorkflowEvent(ctx context.Context, ev entity.EventPublishedPayload, faqText string) {
+	if ev.Depth >= maxWorkflowDepth {
+		zlog.Warn().
+			Int64("workflowID", ev.WorkflowID).
+			Int64("eventID", ev.EventID).
+			Int("depth", ev.Depth).
+			Msg("[event-consumer] workflow hop limit reached, stopping run")
+		return
+	}
+
+	steps, err := c.repo.SystemListWorkflowStepsByEvent(ctx, ev.WorkflowID, ev.EventID)
+	if err != nil || len(steps) == 0 {
+		return
+	}
+
+	for _, step := range steps {
+		c.createWorkflowTask(ctx, step, ev, faqText)
 	}
 }
 
@@ -153,6 +190,81 @@ func (c *controller) createTriggeredTask(ctx context.Context, trigger model.Even
 	})
 
 	c.bus.Publish(trigger.WorkspaceID, ownerID, eventbus.Event{
+		Type:    "task.created",
+		Payload: mapper.FromModelTaskToView(created),
+	})
+}
+
+// createWorkflowTask creates one task for a workflow step and, when the step
+// chains onward, arms that task to publish the next event.
+//
+// Mirrors createTriggeredTask, but stamps the workflow and its hop count onto
+// the task so the run keeps its identity across the task boundary.
+func (c *controller) createWorkflowTask(ctx context.Context, step model.WorkflowStep, ev entity.EventPublishedPayload, faqText string) {
+	title := strings.TrimSpace(step.Title)
+	if title == "" {
+		zlog.Warn().Int64("stepID", step.ID).Msg("[event-consumer] rendered title is empty, skipping")
+		return
+	}
+	body := renderTemplate(step.Body, ev.Payload, faqText)
+
+	ws, err := c.repo.SystemGetWorkspace(ctx, step.WorkspaceID)
+	if err != nil {
+		zlog.Warn().Err(err).Int64("workspaceID", step.WorkspaceID).Msg("[event-consumer] workspace not found")
+		return
+	}
+
+	if step.EmitEventID != 0 {
+		if emitEv, evErr := c.repo.GetEvent(ctx, step.EmitEventID, ws.UserID); evErr == nil {
+			instruction := fmt.Sprintf("\n\n[On completion: call publishEvent(\"%s\", \"<your output payload>\")]", emitEv.Name)
+			if emitEv.PayloadGuidelines != "" {
+				instruction += fmt.Sprintf("\nPayload guidelines: %s", emitEv.PayloadGuidelines)
+			}
+			body += instruction
+		}
+	}
+
+	now := time.Now()
+	task := model.Task{
+		ID:               c.ids.NextID(),
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		WorkspaceID:      step.WorkspaceID,
+		UserID:           ws.UserID,
+		CreatedBy:        "agent",
+		Assignee:         step.Assignee,
+		Status:           "notstarted",
+		Title:            title,
+		Body:             body,
+		AllowAllCommands: step.AllowAllCommands,
+		TriggerID:        step.EventID,
+		EventID:          step.EmitEventID,
+		WorkflowID:       step.WorkflowID,
+		WorkflowDepth:    ev.Depth + 1,
+	}
+
+	created, err := c.repo.CreateTask(ctx, task)
+	if err != nil {
+		zlog.Warn().Err(err).Int64("stepID", step.ID).Msg("[event-consumer] failed to create task")
+		return
+	}
+
+	ownerID := monoflake.ID(ws.UserID).String()
+
+	c.pubsub.Publish(ctx, pubsub.PublishRequest{
+		PubSubID: entity.PubSubTopicCRUD,
+		Event: entity.CRUDEvent{
+			Action:       entity.ActionTaskCreate,
+			WorkspaceID:  step.WorkspaceID,
+			UserID:       ws.UserID,
+			ResourceType: entity.ResourceTask,
+			ResourceID:   created.ID,
+			Actor:        entity.ActorAgent,
+			Origin:       entity.OriginAPI,
+		},
+	})
+
+	c.bus.Publish(step.WorkspaceID, ownerID, eventbus.Event{
 		Type:    "task.created",
 		Payload: mapper.FromModelTaskToView(created),
 	})

--- a/backend/internal/controller/event/event_test.go
+++ b/backend/internal/controller/event/event_test.go
@@ -290,3 +290,112 @@ func TestProcessEvent_WithCronSchedule(t *testing.T) {
 		Name:    "deploy_done",
 	})
 }
+
+// ── Workflow runs ─────────────────────────────────────────────────────────────
+
+// A workflow publish runs the workflow's own steps AND the event's global
+// subscribers. The event was genuinely published, so anything subscribed to it
+// hears about it; a workflow adds routing on top of an event, it does not
+// replace it.
+func TestProcessEvent_WorkflowRunsStepsAndGlobalTriggers(t *testing.T) {
+	c, mockRepo, mockPubSub, mockIDGen := newTestController(t)
+
+	mockRepo.EXPECT().
+		SystemListWorkflowStepsByEvent(gomock.Any(), int64(7), int64(42)).
+		Return([]model.WorkflowStep{
+			{ID: 1, WorkflowID: 7, EventID: 42, WorkspaceID: 10, Title: "workflow step", Assignee: "agent"},
+		}, nil)
+
+	mockRepo.EXPECT().
+		SystemListEventTriggersByEventID(gomock.Any(), int64(42)).
+		Return([]model.EventTrigger{
+			{ID: 2, EventID: 42, WorkspaceID: 20, Title: "global subscriber", Assignee: "agent"},
+		}, nil)
+
+	mockRepo.EXPECT().SystemGetWorkspace(gomock.Any(), int64(10)).Return(model.Workspace{ID: 10, UserID: 100}, nil)
+	mockRepo.EXPECT().SystemGetWorkspace(gomock.Any(), int64(20)).Return(model.Workspace{ID: 20, UserID: 100}, nil)
+	mockIDGen.EXPECT().NextID().Return(int64(111))
+	mockIDGen.EXPECT().NextID().Return(int64(222))
+
+	created := make(map[string]model.Task)
+	mockRepo.EXPECT().
+		CreateTask(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, task model.Task) (model.Task, error) {
+			created[task.Title] = task
+			task.CreatedAt = time.Now()
+			return task, nil
+		}).Times(2)
+
+	mockPubSub.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(&pubsub.PublishResponse{}, nil).Times(2)
+
+	c.processEvent(context.Background(), entity.EventPublishedPayload{
+		EventID:    42,
+		Name:       "code_changed",
+		Payload:    "v1",
+		WorkflowID: 7,
+	})
+
+	if len(created) != 2 {
+		t.Fatalf("expected both a workflow step task and a global trigger task, got %d: %v", len(created), created)
+	}
+
+	// The workflow task carries the run forward so the chain continues.
+	step := created["workflow step"]
+	if step.WorkflowID != 7 {
+		t.Errorf("workflow step task WorkflowID = %d, want 7", step.WorkflowID)
+	}
+	if step.WorkflowDepth != 1 {
+		t.Errorf("workflow step task WorkflowDepth = %d, want 1", step.WorkflowDepth)
+	}
+
+	// The global subscriber sits outside the workflow, so it must NOT inherit
+	// it — otherwise an unrelated pipeline gets dragged into a graph that never
+	// declared it.
+	global := created["global subscriber"]
+	if global.WorkflowID != 0 {
+		t.Errorf("global trigger task WorkflowID = %d, want 0 (must not inherit the workflow)", global.WorkflowID)
+	}
+}
+
+// A publish with no workflow keeps the original behavior exactly.
+func TestProcessEvent_NoWorkflowSkipsWorkflowLookup(t *testing.T) {
+	c, mockRepo, mockPubSub, mockIDGen := newTestController(t)
+
+	// SystemListWorkflowStepsByEvent must not be called at all.
+	mockRepo.EXPECT().
+		SystemListEventTriggersByEventID(gomock.Any(), int64(42)).
+		Return([]model.EventTrigger{
+			{ID: 1, EventID: 42, WorkspaceID: 10, Title: "global only", Assignee: "agent"},
+		}, nil)
+	mockRepo.EXPECT().SystemGetWorkspace(gomock.Any(), int64(10)).Return(model.Workspace{ID: 10, UserID: 100}, nil)
+	mockIDGen.EXPECT().NextID().Return(int64(1))
+	mockRepo.EXPECT().CreateTask(gomock.Any(), gomock.Any()).Return(model.Task{ID: 1}, nil)
+	mockPubSub.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(&pubsub.PublishResponse{}, nil)
+
+	c.processEvent(context.Background(), entity.EventPublishedPayload{EventID: 42, Name: "deploy_done"})
+}
+
+// The hop cap stops a runaway run. Cycles are refused at setup, so this only
+// fires for rows that reached storage another way — but it must still stop, and
+// it must not suppress the event's global subscribers, which are not part of
+// the loop.
+func TestProcessEvent_WorkflowDepthLimit(t *testing.T) {
+	c, mockRepo, mockPubSub, mockIDGen := newTestController(t)
+
+	mockRepo.EXPECT().
+		SystemListEventTriggersByEventID(gomock.Any(), int64(42)).
+		Return([]model.EventTrigger{
+			{ID: 1, EventID: 42, WorkspaceID: 10, Title: "global still runs", Assignee: "agent"},
+		}, nil)
+	mockRepo.EXPECT().SystemGetWorkspace(gomock.Any(), int64(10)).Return(model.Workspace{ID: 10, UserID: 100}, nil)
+	mockIDGen.EXPECT().NextID().Return(int64(1))
+	mockRepo.EXPECT().CreateTask(gomock.Any(), gomock.Any()).Return(model.Task{ID: 1}, nil)
+	mockPubSub.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(&pubsub.PublishResponse{}, nil)
+
+	c.processEvent(context.Background(), entity.EventPublishedPayload{
+		EventID:    42,
+		Name:       "looped",
+		WorkflowID: 7,
+		Depth:      maxWorkflowDepth,
+	})
+}

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -48,7 +48,20 @@ type GetNextTaskFunc func(ctx context.Context) (model.Task, error)
 type ReplyFunc func(ctx context.Context, chatID string, text string, attachments []entity.Attachment, metadata any) (int64, error)
 type UpdateMessageMetadataFunc func(ctx context.Context, taskID int64, messageID int64, metadata any) error
 type UpdateWorkspaceAutoAllowedToolsFunc func(ctx context.Context, tools []string) error
-type PublishEventFunc func(ctx context.Context, eventName string, payload string, faq []entity.EventFAQ) error
+
+// WorkflowRunContext identifies the workflow run a publishing task belongs to.
+// The zero value means "not part of a workflow run", which keeps the publish on
+// the original global-trigger path.
+type WorkflowRunContext struct {
+	WorkflowID int64
+	// Depth is how many hops already preceded the publishing task, carried so
+	// the consumer's runaway guard survives the task boundary.
+	Depth int
+}
+
+// PublishEventFunc fires a named event. run scopes the consumer's fan-out to a
+// single workflow's steps instead of the global triggers.
+type PublishEventFunc func(ctx context.Context, eventName string, payload string, faq []entity.EventFAQ, run WorkflowRunContext) error
 
 // RecordToolCallFunc persists a tool-call permission decision (auto-allowed or
 // pending a manual verdict) so it can be shown as a "tool calls" list, separate
@@ -860,7 +873,7 @@ func (ps *WorkspaceServer) handlePublishEvent(ctx context.Context, req *mcp.Call
 	for i, f := range params.FAQ {
 		faq[i] = entity.EventFAQ{Q: f.Q, A: f.A}
 	}
-	if err := ps.publishEvent(ctx, params.Name, params.Payload, faq); err != nil {
+	if err := ps.publishEvent(ctx, params.Name, params.Payload, faq, ps.currentWorkflowRun(ctx, req)); err != nil {
 		return &mcp.CallToolResult{
 			IsError: true,
 			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("failed to publish event: %v", err)}},
@@ -871,6 +884,30 @@ func (ps *WorkspaceServer) handlePublishEvent(ctx context.Context, req *mcp.Call
 			Text: fmt.Sprintf("event %q published", params.Name),
 		}},
 	}, nil, nil
+}
+
+// currentWorkflowRun reports the workflow run the publishing task belongs to,
+// so a chained event stays inside its own workflow instead of falling back to
+// the global triggers.
+//
+// Best effort by design: the agent never passes the workflow itself (it has no
+// reason to know one exists), so this leans on the same session→task resolution
+// the permission flow uses. If the task cannot be resolved, the zero value
+// means "not in a workflow" and the publish behaves exactly as it did before
+// workflows existed — a missed chain, never a wrong one.
+func (ps *WorkspaceServer) currentWorkflowRun(ctx context.Context, req *mcp.CallToolRequest) WorkflowRunContext {
+	if req == nil || req.GetSession() == nil {
+		return WorkflowRunContext{}
+	}
+	taskID, ok := ps.resolveTaskID(ctx, req.GetSession().ID(), "")
+	if !ok {
+		return WorkflowRunContext{}
+	}
+	task, err := ps.getTask(ctx, taskID)
+	if err != nil {
+		return WorkflowRunContext{}
+	}
+	return WorkflowRunContext{WorkflowID: task.WorkflowID, Depth: task.WorkflowDepth}
 }
 
 func (ps *WorkspaceServer) handleGetWorkspace(ctx context.Context, req *mcp.CallToolRequest, params any) (*mcp.CallToolResult, any, error) {

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -54,6 +54,10 @@ type UpdateWorkspaceAutoAllowedToolsFunc func(ctx context.Context, tools []strin
 // the original global-trigger path.
 type WorkflowRunContext struct {
 	WorkflowID int64
+	// WorkflowName is set when the agent named a workflow explicitly. It starts
+	// a fresh run of that workflow and takes precedence over WorkflowID, which
+	// only says which run the publishing task already belonged to.
+	WorkflowName string
 	// Depth is how many hops already preceded the publishing task, carried so
 	// the consumer's runaway guard survives the task boundary.
 	Depth int
@@ -155,9 +159,10 @@ type CreateTaskParams struct {
 
 // PublishEventParams is the input to the publishEvent tool.
 type PublishEventParams struct {
-	Name    string            `json:"name" jsonschema:"The event name to publish (must match an existing event in this workspace's owner account)"`
-	Payload string            `json:"payload,omitempty" jsonschema:"Unstructured text payload describing what happened"`
-	FAQ     []PublishEventFAQ `json:"faq,omitempty" jsonschema:"Optional question-answer pairs providing additional context"`
+	Name     string            `json:"name" jsonschema:"The event name to publish (must match an existing event in this workspace's owner account)"`
+	Payload  string            `json:"payload,omitempty" jsonschema:"Unstructured text payload describing what happened"`
+	FAQ      []PublishEventFAQ `json:"faq,omitempty" jsonschema:"Optional question-answer pairs providing additional context"`
+	Workflow string            `json:"workflow,omitempty" jsonschema:"Optional workflow name to run. Without it the event fans out to whatever is globally subscribed; with it, only that workflow's steps run. Omit to continue a workflow you are already part of."`
 }
 
 // PublishEventFAQ is a single question-answer pair in a publishEvent call.
@@ -873,7 +878,9 @@ func (ps *WorkspaceServer) handlePublishEvent(ctx context.Context, req *mcp.Call
 	for i, f := range params.FAQ {
 		faq[i] = entity.EventFAQ{Q: f.Q, A: f.A}
 	}
-	if err := ps.publishEvent(ctx, params.Name, params.Payload, faq, ps.currentWorkflowRun(ctx, req)); err != nil {
+	run := ps.currentWorkflowRun(ctx, req)
+	run.WorkflowName = params.Workflow
+	if err := ps.publishEvent(ctx, params.Name, params.Payload, faq, run); err != nil {
 		return &mcp.CallToolResult{
 			IsError: true,
 			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("failed to publish event: %v", err)}},

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -163,28 +163,29 @@ type (
 	// CreatedBy: "human" | "agent"
 	// Status:    "notstarted" | "ongoing" | "completed" | "rejected" | "cron" | "blocked"
 	Task struct {
-		ID               int64
-		CreatedAt        time.Time
-		UpdatedAt        time.Time
-		UserID           int64
-		WorkspaceID      int64
-		CreatedBy        string
-		Assignee         string
-		Status           string
-		Title            string
-		Body             string
-		Response         string
-		ReplyText        string
-		Attachments      []Attachment
-		Messages         []Message
-		ToolCalls        []ToolCall
-		CronSchedule     string
-		ParentID         int64
-		SortOrder        float64
-		AllowAllCommands bool
-		EventID          int64
-		WorkflowID       int64
-		WorkflowDepth    int
+		ID                    int64
+		CreatedAt             time.Time
+		UpdatedAt             time.Time
+		UserID                int64
+		WorkspaceID           int64
+		CreatedBy             string
+		Assignee              string
+		Status                string
+		Title                 string
+		Body                  string
+		Response              string
+		ReplyText             string
+		Attachments           []Attachment
+		Messages              []Message
+		ToolCalls             []ToolCall
+		CronSchedule          string
+		ParentID              int64
+		SortOrder             float64
+		AllowAllCommands      bool
+		EventID               int64
+		WorkflowID            int64
+		WorkflowDepth         int
+		CompletionTriggerType int16
 	}
 
 	CreateTaskRequest struct {

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -183,6 +183,8 @@ type (
 		SortOrder        float64
 		AllowAllCommands bool
 		EventID          int64
+		WorkflowID       int64
+		WorkflowDepth    int
 	}
 
 	CreateTaskRequest struct {
@@ -570,6 +572,125 @@ type (
 	ListTasksFromEventResponse struct {
 		Tasks []Task
 	}
+
+	// Workflow entities (experimental)
+
+	Workflow struct {
+		ID           int64
+		CreatedAt    time.Time
+		UpdatedAt    time.Time
+		UserID       int64
+		Name         string
+		Description  string
+		StartEventID int64
+		Layout       string
+	}
+
+	CreateWorkflowRequest struct {
+		Name         string
+		Description  string
+		StartEventID int64
+		UserID       string
+	}
+
+	CreateWorkflowResponse struct {
+		Workflow Workflow
+	}
+
+	GetWorkflowRequest struct {
+		ID     int64
+		UserID string
+	}
+
+	GetWorkflowResponse struct {
+		Workflow Workflow
+	}
+
+	ListWorkflowsRequest struct {
+		UserID string
+	}
+
+	ListWorkflowsResponse struct {
+		Workflows []Workflow
+	}
+
+	// UpdateWorkflowRequest carries only the mutable fields. Each is a pointer
+	// so a PATCH can distinguish "not supplied" from "set to empty" — a layout
+	// save must not blank the description, and vice versa.
+	UpdateWorkflowRequest struct {
+		ID           int64
+		UserID       string
+		Name         *string
+		Description  *string
+		StartEventID *int64
+		Layout       *string
+	}
+
+	UpdateWorkflowResponse struct {
+		Workflow Workflow
+	}
+
+	DeleteWorkflowRequest struct {
+		ID     int64
+		UserID string
+	}
+
+	// WorkflowStep entities
+
+	WorkflowStep struct {
+		ID               int64
+		CreatedAt        time.Time
+		UpdatedAt        time.Time
+		WorkflowID       int64
+		UserID           int64
+		EventID          int64
+		WorkspaceID      int64
+		EmitEventID      int64
+		Title            string
+		Body             string
+		Assignee         string
+		AllowAllCommands bool
+	}
+
+	CreateWorkflowStepRequest struct {
+		WorkflowID       int64
+		EventID          int64
+		WorkspaceID      int64
+		EmitEventID      int64
+		Title            string
+		Body             string
+		Assignee         string
+		AllowAllCommands bool
+		UserID           string
+	}
+
+	CreateWorkflowStepResponse struct {
+		WorkflowStep WorkflowStep
+	}
+
+	ListWorkflowStepsRequest struct {
+		WorkflowID int64
+		UserID     string
+	}
+
+	ListWorkflowStepsResponse struct {
+		WorkflowSteps []WorkflowStep
+	}
+
+	DeleteWorkflowStepRequest struct {
+		ID         int64
+		WorkflowID int64
+		UserID     string
+	}
+
+	ListTasksFromWorkflowRequest struct {
+		WorkflowID int64
+		UserID     string
+	}
+
+	ListTasksFromWorkflowResponse struct {
+		Tasks []Task
+	}
 )
 
 const (
@@ -584,6 +705,13 @@ type EventPublishedPayload struct {
 	Name    string
 	Payload string
 	FAQ     []EventFAQ
+	// WorkflowID is set when the publishing task was part of a workflow run.
+	// It scopes the consumer's fan-out to that workflow's steps instead of the
+	// global event triggers; zero keeps the original global behavior.
+	WorkflowID int64
+	// Depth counts how many hops this run has already taken, so a cyclic graph
+	// exhausts a budget instead of spawning tasks forever.
+	Depth int
 }
 
 const (

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -691,12 +691,43 @@ type (
 	ListTasksFromWorkflowResponse struct {
 		Tasks []Task
 	}
+
+	// Workflow text mode
+
+	GetWorkflowTextRequest struct {
+		ID     int64
+		UserID string
+	}
+
+	GetWorkflowTextResponse struct {
+		Text string
+	}
+
+	ReplaceWorkflowFromTextRequest struct {
+		ID     int64
+		UserID string
+		Text   string
+	}
+
+	ReplaceWorkflowFromTextResponse struct {
+		Workflow  Workflow
+		StepCount int
+	}
 )
 
 const (
 	PubSubTopicCRUD   int64 = 1
 	PubSubTopicMCP    int64 = 2
 	PubSubTopicEvents int64 = 3
+)
+
+// What a task fires when it completes. Stored on Task.CompletionTriggerType to
+// record the author's choice, which a non-zero WorkflowID alone cannot express:
+// choosing a workflow also sets EventID to that workflow's start event.
+const (
+	CompletionTriggerNone     int16 = 0
+	CompletionTriggerEvent    int16 = 1
+	CompletionTriggerWorkflow int16 = 2
 )
 
 // EventPublishedPayload is the message sent on PubSubTopicEvents when an event fires.

--- a/backend/internal/data/model/model.go
+++ b/backend/internal/data/model/model.go
@@ -63,6 +63,13 @@ type (
 		// without it the runaway-guard counter would reset to zero each hop and
 		// never trip.
 		WorkflowDepth int `gorm:"default:0"`
+		// CompletionTriggerType records what the author actually chose on the
+		// task form: CompletionTriggerNone/Event/Workflow. Strictly it is
+		// derivable (a non-zero WorkflowID implies a workflow), but choosing a
+		// workflow also sets EventID to that workflow's start event — so
+		// without this the UI cannot tell "they picked workflow new_feature"
+		// from "they picked event code_changed" and would label it wrong.
+		CompletionTriggerType int16 `gorm:"default:0"`
 	}
 
 	// ToolCall records a single tool-call permission decision for a task: either

--- a/backend/internal/data/model/model.go
+++ b/backend/internal/data/model/model.go
@@ -91,11 +91,16 @@ type (
 	// Event defines a named event that agents can publish after completing a task.
 	// Other workspaces can subscribe to it via EventTrigger.
 	Event struct {
-		ID                int64 `gorm:"primaryKey;autoIncrement:false"`
-		CreatedAt         time.Time
-		UpdatedAt         time.Time
-		UserID            int64  `gorm:"index:idx_events_user_id"`
-		Name              string `gorm:"type:varchar(140);uniqueIndex:idx_events_name_user_id"`
+		ID        int64 `gorm:"primaryKey;autoIncrement:false"`
+		CreatedAt time.Time
+		UpdatedAt time.Time
+		// The unique index spans (name, user_id): both fields carry the same
+		// index name, which is what makes it composite. Tagging only Name —
+		// even with a name mentioning user_id — silently produces a unique
+		// index on `name` alone, making event names global across every
+		// account, so one user taking "deploy" locks it for everyone.
+		UserID            int64  `gorm:"index:idx_events_user_id;uniqueIndex:idx_events_name_user_id,priority:2"`
+		Name              string `gorm:"type:varchar(140);uniqueIndex:idx_events_name_user_id,priority:1"`
 		PayloadGuidelines string `gorm:"type:text"`
 	}
 
@@ -125,11 +130,12 @@ type (
 	// StartEventID; from there WorkflowStep rows decide the fan-out, and each
 	// spawned task carries the workflow ID onward so the chain continues.
 	Workflow struct {
-		ID          int64 `gorm:"primaryKey;autoIncrement:false"`
-		CreatedAt   time.Time
-		UpdatedAt   time.Time
-		UserID      int64  `gorm:"index:idx_workflows_user_id"`
-		Name        string `gorm:"type:varchar(140);uniqueIndex:idx_workflows_name_user_id"`
+		ID        int64 `gorm:"primaryKey;autoIncrement:false"`
+		CreatedAt time.Time
+		UpdatedAt time.Time
+		// Composite with Name, for the same reason as Event above.
+		UserID      int64  `gorm:"index:idx_workflows_user_id;uniqueIndex:idx_workflows_name_user_id,priority:2"`
+		Name        string `gorm:"type:varchar(140);uniqueIndex:idx_workflows_name_user_id,priority:1"`
 		Description string `gorm:"type:text"`
 		// StartEventID is the event that begins a run of this workflow.
 		StartEventID int64 `gorm:"index:idx_workflows_start_event_id"`

--- a/backend/internal/data/model/model.go
+++ b/backend/internal/data/model/model.go
@@ -52,6 +52,17 @@ type (
 		AllowAllCommands bool    `gorm:"default:false"`
 		TriggerID        int64   `gorm:"index:idx_tasks_trigger_id"` // event that caused this task
 		EventID          int64   `gorm:"index:idx_tasks_event_id"`   // event this task emits on completion
+		// WorkflowID carries workflow context through a run: when this task
+		// publishes its event, the consumer routes the fan-out through this
+		// workflow's steps instead of the global triggers, and stamps the same
+		// ID on every task it spawns. Zero means "not part of a workflow run".
+		WorkflowID int64 `gorm:"index:idx_tasks_workflow_id"`
+		// WorkflowDepth is how many hops preceded this task in its run. It has
+		// to be persisted rather than tracked in memory because every hop
+		// crosses a task boundary — the chain is task → publish → task — so
+		// without it the runaway-guard counter would reset to zero each hop and
+		// never trip.
+		WorkflowDepth int `gorm:"default:0"`
 	}
 
 	// ToolCall records a single tool-call permission decision for a task: either
@@ -98,7 +109,50 @@ type (
 		EmitEventID      int64  `gorm:"index:idx_event_triggers_emit_event_id"` // event this trigger's task emits on completion
 	}
 
-	// Message is an entry in a task's chat history
+	// Workflow is a named, self-contained graph of events and workspaces
+	// (experimental). It composes the same edge shape as EventTrigger, but
+	// scoped to one workflow so editing a workflow never changes global event
+	// behavior, and two workflows may route the same event differently.
+	//
+	// A run starts when a task carrying this workflow's ID publishes
+	// StartEventID; from there WorkflowStep rows decide the fan-out, and each
+	// spawned task carries the workflow ID onward so the chain continues.
+	Workflow struct {
+		ID          int64 `gorm:"primaryKey;autoIncrement:false"`
+		CreatedAt   time.Time
+		UpdatedAt   time.Time
+		UserID      int64  `gorm:"index:idx_workflows_user_id"`
+		Name        string `gorm:"type:varchar(140);uniqueIndex:idx_workflows_name_user_id"`
+		Description string `gorm:"type:text"`
+		// StartEventID is the event that begins a run of this workflow.
+		StartEventID int64 `gorm:"index:idx_workflows_start_event_id"`
+		// Layout holds canvas node positions for the graph editor, keyed by
+		// node id ("event:<base62>" / "workspace:<base62>"). Purely
+		// presentational: the executable graph lives in WorkflowStep, so a
+		// missing or stale layout degrades to auto-placement, never to wrong
+		// routing.
+		Layout datatypes.JSON `gorm:"type:text"`
+	}
+
+	// WorkflowStep is one edge of a Workflow: when EventID fires inside this
+	// workflow, create a task in WorkspaceID from the stored template, and
+	// optionally have that task publish EmitEventID on completion (which
+	// advances the run to the next step).
+	WorkflowStep struct {
+		ID               int64 `gorm:"primaryKey;autoIncrement:false"`
+		CreatedAt        time.Time
+		UpdatedAt        time.Time
+		WorkflowID       int64  `gorm:"index:idx_workflow_steps_workflow_id"`
+		UserID           int64  `gorm:"index:idx_workflow_steps_user_id"`
+		EventID          int64  `gorm:"index:idx_workflow_steps_event_id"`
+		WorkspaceID      int64  `gorm:"index:idx_workflow_steps_workspace_id"`
+		EmitEventID      int64  `gorm:"index:idx_workflow_steps_emit_event_id"`
+		Title            string `gorm:"type:varchar(255)"`
+		Body             string `gorm:"type:text"`
+		Assignee         string `gorm:"type:varchar(16)"`
+		AllowAllCommands bool   `gorm:"default:false"`
+	}
+
 	// Message is an entry in a task's chat history
 	Message struct {
 		ID          int64 `gorm:"primaryKey;autoIncrement:false"`

--- a/backend/internal/data/view/api/view.go
+++ b/backend/internal/data/view/api/view.go
@@ -398,4 +398,31 @@ type (
 	ListWorkflowStepsResponse struct {
 		WorkflowSteps []WorkflowStep `json:"workflowSteps"`
 	}
+
+	// Workflow text mode
+
+	GetWorkflowTextResponse struct {
+		Text string `json:"text"`
+	}
+
+	ReplaceWorkflowFromTextRequest struct {
+		Text string `json:"text"`
+	}
+
+	ReplaceWorkflowFromTextResponse struct {
+		Workflow  Workflow `json:"workflow"`
+		StepCount int      `json:"stepCount"`
+	}
+
+	// WorkflowTextError reports a parse or validation failure with the source
+	// line, so the editor can mark the offending row rather than showing a bare
+	// message above the document.
+	WorkflowTextError struct {
+		Message string `json:"message"`
+		Line    int    `json:"line,omitempty"`
+	}
+
+	WorkflowTextErrorResponse struct {
+		Error WorkflowTextError `json:"error"`
+	}
 )

--- a/backend/internal/data/view/api/view.go
+++ b/backend/internal/data/view/api/view.go
@@ -1,6 +1,9 @@
 package api
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 type (
 	// Workspace views
@@ -315,5 +318,84 @@ type (
 
 	ListEventTriggersResponse struct {
 		EventTriggers []EventTrigger `json:"eventTriggers"`
+	}
+
+	// Workflow views (experimental)
+
+	Workflow struct {
+		ID           string    `json:"id"`
+		CreatedAt    time.Time `json:"createdAt"`
+		UpdatedAt    time.Time `json:"updatedAt"`
+		Name         string    `json:"name"`
+		Description  string    `json:"description"`
+		StartEventID string    `json:"startEventId,omitempty"`
+		// Layout is opaque canvas state owned by the editor: raw JSON, stored
+		// and returned verbatim so the graph editor can evolve its own shape
+		// without a backend change.
+		Layout json.RawMessage `json:"layout,omitempty"`
+	}
+
+	CreateWorkflowRequest struct {
+		Name         string `json:"name"`
+		Description  string `json:"description"`
+		StartEventID string `json:"startEventId,omitempty"`
+	}
+
+	CreateWorkflowResponse struct {
+		Workflow Workflow `json:"workflow"`
+	}
+
+	// UpdateWorkflowRequest uses pointers so an omitted field stays unchanged:
+	// saving a canvas layout must not blank the name or description.
+	UpdateWorkflowRequest struct {
+		Name         *string          `json:"name,omitempty"`
+		Description  *string          `json:"description,omitempty"`
+		StartEventID *string          `json:"startEventId,omitempty"`
+		Layout       *json.RawMessage `json:"layout,omitempty"`
+	}
+
+	UpdateWorkflowResponse struct {
+		Workflow Workflow `json:"workflow"`
+	}
+
+	GetWorkflowResponse struct {
+		Workflow Workflow `json:"workflow"`
+	}
+
+	ListWorkflowsResponse struct {
+		Workflows []Workflow `json:"workflows"`
+	}
+
+	// WorkflowStep views
+
+	WorkflowStep struct {
+		ID               string    `json:"id"`
+		CreatedAt        time.Time `json:"createdAt"`
+		WorkflowID       string    `json:"workflowId"`
+		EventID          string    `json:"eventId"`
+		WorkspaceID      string    `json:"workspaceId"`
+		EmitEventID      string    `json:"emitEventId,omitempty"`
+		Title            string    `json:"title"`
+		Body             string    `json:"body"`
+		Assignee         string    `json:"assignee"`
+		AllowAllCommands bool      `json:"allowAllCommands"`
+	}
+
+	CreateWorkflowStepRequest struct {
+		EventID          string `json:"eventId"`
+		WorkspaceID      string `json:"workspaceId"`
+		EmitEventID      string `json:"emitEventId,omitempty"`
+		Title            string `json:"title"`
+		Body             string `json:"body"`
+		Assignee         string `json:"assignee"`
+		AllowAllCommands bool   `json:"allowAllCommands"`
+	}
+
+	CreateWorkflowStepResponse struct {
+		WorkflowStep WorkflowStep `json:"workflowStep"`
+	}
+
+	ListWorkflowStepsResponse struct {
+		WorkflowSteps []WorkflowStep `json:"workflowSteps"`
 	}
 )

--- a/backend/internal/data/view/api/view.go
+++ b/backend/internal/data/view/api/view.go
@@ -120,6 +120,12 @@ type (
 		SortOrder        float64      `json:"sortOrder"`
 		AllowAllCommands bool         `json:"allowAllCommands"`
 		EventID          string       `json:"eventId,omitempty"`
+		// WorkflowID runs a whole named pipeline on completion instead of
+		// firing a single event. Choosing one also sets EventID to that
+		// workflow's start event, so CompletionTriggerType records which of the
+		// two the author actually picked.
+		WorkflowID            string `json:"workflowId,omitempty"`
+		CompletionTriggerType int16  `json:"completionTriggerType,omitempty"`
 	}
 
 	CreateTaskRequest struct {

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -113,6 +113,7 @@ func New(p Params) (Handler, error) {
 		return nil, err
 	}
 	h.registerEventRoutes()
+	h.registerWorkflowRoutes()
 	if p.PushCtrl != nil {
 		h.registerPushRoutes(p.PushCtrl)
 	}

--- a/backend/internal/handler/api/event.go
+++ b/backend/internal/handler/api/event.go
@@ -1,7 +1,10 @@
 package api
 
 import (
+	"errors"
 	"net/http"
+
+	_crud "github.com/agentrq/agentrq/backend/internal/controller/crud"
 
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	mapper "github.com/agentrq/agentrq/backend/internal/mapper/api"
@@ -35,6 +38,13 @@ func (h *handler) createEvent() fiber.Handler {
 		defer cancel()
 		rs, err := h.crud.CreateEvent(ctx, *rq)
 		if err != nil {
+			// A taken name is the user's input, not a server fault. It used to
+			// surface as a bare 500, which made a collision impossible to tell
+			// apart from a real failure.
+			if errors.Is(err, _crud.ErrDuplicateName) {
+				c.Status(http.StatusConflict)
+				return c.Send(mapper.FromMessageToHTTPResponse(err.Error(), http.StatusConflict))
+			}
 			e, status := mapper.FromErrorToHTTPResponse(err)
 			c.Status(status)
 			return c.Send(e)

--- a/backend/internal/handler/api/workflow.go
+++ b/backend/internal/handler/api/workflow.go
@@ -1,0 +1,223 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	_crud "github.com/agentrq/agentrq/backend/internal/controller/crud"
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	mapper "github.com/agentrq/agentrq/backend/internal/mapper/api"
+	"github.com/gofiber/fiber/v2"
+)
+
+// registerWorkflowRoutes mounts the experimental workflow graph API.
+//
+// These are Fiber routes only. The stdlib mux in app.go takes precedence for
+// exact path matches, so registering any of these there would silently shadow
+// the handler and hang the request — see the routing pitfall in AGENTS.md.
+func (h *handler) registerWorkflowRoutes() {
+	h.router.Post("/workflows", h.createWorkflow())
+	h.router.Get("/workflows", h.listWorkflows())
+	h.router.Get("/workflows/:id", h.getWorkflow())
+	h.router.Patch("/workflows/:id", h.updateWorkflow())
+	h.router.Delete("/workflows/:id", h.deleteWorkflow())
+	h.router.Post("/workflows/:id/steps", h.createWorkflowStep())
+	h.router.Get("/workflows/:id/steps", h.listWorkflowSteps())
+	h.router.Delete("/workflows/:id/steps/:stepID", h.deleteWorkflowStep())
+	h.router.Get("/workflows/:id/tasks", h.listTasksFromWorkflow())
+}
+
+func (h *handler) createWorkflow() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		rq := mapper.FromHTTPRequestToCreateWorkflowRequestEntity(c)
+		if rq == nil {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		rq.UserID = c.Locals("user_id").(string)
+		ctx, cancel := newContext(c)
+		defer cancel()
+		rs, err := h.crud.CreateWorkflow(ctx, *rq)
+		if err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		c.Status(http.StatusCreated)
+		return c.Send(mapper.FromCreateWorkflowResponseEntityToHTTPResponse(rs))
+	}
+}
+
+func (h *handler) listWorkflows() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		ctx, cancel := newContext(c)
+		defer cancel()
+		rs, err := h.crud.ListWorkflows(ctx, entity.ListWorkflowsRequest{
+			UserID: c.Locals("user_id").(string),
+		})
+		if err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		return c.Send(mapper.FromListWorkflowsResponseEntityToHTTPResponse(rs))
+	}
+}
+
+func (h *handler) getWorkflow() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		rq := mapper.FromHTTPRequestToGetWorkflowRequestEntity(c)
+		if rq == nil {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		rq.UserID = c.Locals("user_id").(string)
+		ctx, cancel := newContext(c)
+		defer cancel()
+		rs, err := h.crud.GetWorkflow(ctx, *rq)
+		if err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		return c.Send(mapper.FromGetWorkflowResponseEntityToHTTPResponse(rs))
+	}
+}
+
+func (h *handler) updateWorkflow() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		rq := mapper.FromHTTPRequestToUpdateWorkflowRequestEntity(c)
+		if rq == nil {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		rq.UserID = c.Locals("user_id").(string)
+		ctx, cancel := newContext(c)
+		defer cancel()
+		rs, err := h.crud.UpdateWorkflow(ctx, *rq)
+		if err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		return c.Send(mapper.FromUpdateWorkflowResponseEntityToHTTPResponse(rs))
+	}
+}
+
+func (h *handler) deleteWorkflow() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		rq := mapper.FromHTTPRequestToDeleteWorkflowRequestEntity(c)
+		if rq == nil {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		rq.UserID = c.Locals("user_id").(string)
+		ctx, cancel := newContext(c)
+		defer cancel()
+		if err := h.crud.DeleteWorkflow(ctx, *rq); err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		c.Status(http.StatusNoContent)
+		return nil
+	}
+}
+
+func (h *handler) createWorkflowStep() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		rq := mapper.FromHTTPRequestToCreateWorkflowStepRequestEntity(c)
+		if rq == nil {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		rq.UserID = c.Locals("user_id").(string)
+		ctx, cancel := newContext(c)
+		defer cancel()
+		rs, err := h.crud.CreateWorkflowStep(ctx, *rq)
+		if err != nil {
+			// A rejected cycle is the user drawing an invalid graph, not a
+			// server fault: surface it as 409 so the editor can point at the
+			// offending edge instead of showing a generic failure.
+			if errors.Is(err, _crud.ErrWorkflowCycle) {
+				e, _ := mapper.FromErrorToHTTPResponse(err)
+				c.Status(http.StatusConflict)
+				return c.Send(e)
+			}
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		c.Status(http.StatusCreated)
+		return c.Send(mapper.FromCreateWorkflowStepResponseEntityToHTTPResponse(rs))
+	}
+}
+
+func (h *handler) listWorkflowSteps() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		rq := mapper.FromHTTPRequestToListWorkflowStepsRequestEntity(c)
+		if rq == nil {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		rq.UserID = c.Locals("user_id").(string)
+		ctx, cancel := newContext(c)
+		defer cancel()
+		rs, err := h.crud.ListWorkflowSteps(ctx, *rq)
+		if err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		return c.Send(mapper.FromListWorkflowStepsResponseEntityToHTTPResponse(rs))
+	}
+}
+
+func (h *handler) deleteWorkflowStep() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		rq := mapper.FromHTTPRequestToDeleteWorkflowStepRequestEntity(c)
+		if rq == nil {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		rq.UserID = c.Locals("user_id").(string)
+		ctx, cancel := newContext(c)
+		defer cancel()
+		if err := h.crud.DeleteWorkflowStep(ctx, *rq); err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		c.Status(http.StatusNoContent)
+		return nil
+	}
+}
+
+func (h *handler) listTasksFromWorkflow() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		rq := mapper.FromHTTPRequestToListTasksFromWorkflowRequestEntity(c)
+		if rq == nil {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		rq.UserID = c.Locals("user_id").(string)
+		ctx, cancel := newContext(c)
+		defer cancel()
+		rs, err := h.crud.ListTasksFromWorkflow(ctx, *rq)
+		if err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		return c.Send(mapper.FromListTasksFromWorkflowResponseEntityToHTTPResponse(rs))
+	}
+}

--- a/backend/internal/handler/api/workflow.go
+++ b/backend/internal/handler/api/workflow.go
@@ -48,6 +48,10 @@ func (h *handler) createWorkflow() fiber.Handler {
 				c.Status(http.StatusUnprocessableEntity)
 				return c.Send(mapper.FromMessageToHTTPResponse(err.Error(), http.StatusUnprocessableEntity))
 			}
+			if errors.Is(err, _crud.ErrDuplicateName) {
+				c.Status(http.StatusConflict)
+				return c.Send(mapper.FromMessageToHTTPResponse(err.Error(), http.StatusConflict))
+			}
 			e, status := mapper.FromErrorToHTTPResponse(err)
 			c.Status(status)
 			return c.Send(e)

--- a/backend/internal/handler/api/workflow.go
+++ b/backend/internal/handler/api/workflow.go
@@ -25,6 +25,8 @@ func (h *handler) registerWorkflowRoutes() {
 	h.router.Get("/workflows/:id/steps", h.listWorkflowSteps())
 	h.router.Delete("/workflows/:id/steps/:stepID", h.deleteWorkflowStep())
 	h.router.Get("/workflows/:id/tasks", h.listTasksFromWorkflow())
+	h.router.Get("/workflows/:id/text", h.getWorkflowText())
+	h.router.Put("/workflows/:id/text", h.replaceWorkflowFromText())
 }
 
 func (h *handler) createWorkflow() fiber.Handler {
@@ -198,6 +200,55 @@ func (h *handler) deleteWorkflowStep() fiber.Handler {
 		}
 		c.Status(http.StatusNoContent)
 		return nil
+	}
+}
+
+func (h *handler) getWorkflowText() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		rq := mapper.FromHTTPRequestToGetWorkflowTextRequestEntity(c)
+		if rq == nil {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		rq.UserID = c.Locals("user_id").(string)
+		ctx, cancel := newContext(c)
+		defer cancel()
+		rs, err := h.crud.GetWorkflowText(ctx, *rq)
+		if err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		return c.Send(mapper.FromGetWorkflowTextResponseEntityToHTTPResponse(rs))
+	}
+}
+
+func (h *handler) replaceWorkflowFromText() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		rq := mapper.FromHTTPRequestToReplaceWorkflowFromTextRequestEntity(c)
+		if rq == nil {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		rq.UserID = c.Locals("user_id").(string)
+		ctx, cancel := newContext(c)
+		defer cancel()
+		rs, err := h.crud.ReplaceWorkflowFromText(ctx, *rq)
+		if err != nil {
+			// A malformed document is the user mistyping, not a server fault.
+			// 422 with the line number lets the editor mark the exact row.
+			var textErr *_crud.WorkflowTextError
+			if errors.As(err, &textErr) {
+				c.Status(http.StatusUnprocessableEntity)
+				return c.Send(mapper.FromWorkflowTextErrorToHTTPResponse(textErr.Msg, textErr.Line))
+			}
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		return c.Send(mapper.FromReplaceWorkflowFromTextResponseEntityToHTTPResponse(rs))
 	}
 }
 

--- a/backend/internal/handler/api/workflow.go
+++ b/backend/internal/handler/api/workflow.go
@@ -42,6 +42,12 @@ func (h *handler) createWorkflow() fiber.Handler {
 		defer cancel()
 		rs, err := h.crud.CreateWorkflow(ctx, *rq)
 		if err != nil {
+			// A malformed name is the user's input, not a server fault; answer
+			// with the rule so the form can show what is actually allowed.
+			if errors.Is(err, _crud.ErrInvalidWorkflowName) {
+				c.Status(http.StatusUnprocessableEntity)
+				return c.Send(mapper.FromMessageToHTTPResponse(err.Error(), http.StatusUnprocessableEntity))
+			}
 			e, status := mapper.FromErrorToHTTPResponse(err)
 			c.Status(status)
 			return c.Send(e)
@@ -102,6 +108,10 @@ func (h *handler) updateWorkflow() fiber.Handler {
 		defer cancel()
 		rs, err := h.crud.UpdateWorkflow(ctx, *rq)
 		if err != nil {
+			if errors.Is(err, _crud.ErrInvalidWorkflowName) {
+				c.Status(http.StatusUnprocessableEntity)
+				return c.Send(mapper.FromMessageToHTTPResponse(err.Error(), http.StatusUnprocessableEntity))
+			}
 			e, status := mapper.FromErrorToHTTPResponse(err)
 			c.Status(status)
 			return c.Send(e)
@@ -145,12 +155,11 @@ func (h *handler) createWorkflowStep() fiber.Handler {
 		rs, err := h.crud.CreateWorkflowStep(ctx, *rq)
 		if err != nil {
 			// A rejected cycle is the user drawing an invalid graph, not a
-			// server fault: surface it as 409 so the editor can point at the
-			// offending edge instead of showing a generic failure.
+			// server fault: 409 with the real reason, so the editor can say
+			// which connection was refused rather than "something failed".
 			if errors.Is(err, _crud.ErrWorkflowCycle) {
-				e, _ := mapper.FromErrorToHTTPResponse(err)
 				c.Status(http.StatusConflict)
-				return c.Send(e)
+				return c.Send(mapper.FromMessageToHTTPResponse(err.Error(), http.StatusConflict))
 			}
 			e, status := mapper.FromErrorToHTTPResponse(err)
 			c.Status(status)

--- a/backend/internal/mapper/api/error.go
+++ b/backend/internal/mapper/api/error.go
@@ -34,3 +34,17 @@ func FromErrorToHTTPResponse(err error) ([]byte, int) {
 	b, _ := json.Marshal(e)
 	return b, code
 }
+
+// FromMessageToHTTPResponse renders an error whose text is meant for the user.
+//
+// FromErrorToHTTPResponse deliberately replaces unrecognized errors with a
+// generic message so internals never leak; this is the opt-in for the cases
+// where the message *is* the point — a rejected workflow cycle has to say which
+// connection was refused, or the editor can only report that something failed.
+func FromMessageToHTTPResponse(message string, code int) []byte {
+	e := httpError{}
+	e.Error.Code = code
+	e.Error.Message = message
+	b, _ := json.Marshal(e)
+	return b
+}

--- a/backend/internal/mapper/api/task.go
+++ b/backend/internal/mapper/api/task.go
@@ -46,6 +46,7 @@ func FromHTTPRequestToCreateTaskRequestEntity(c *fiber.Ctx) *entity.CreateTaskRe
 			SortOrder:        payload.Task.SortOrder,
 			AllowAllCommands: payload.Task.AllowAllCommands,
 			EventID:          monoflake.IDFromBase62(payload.Task.EventID).Int64(),
+			WorkflowID:       monoflake.IDFromBase62(payload.Task.WorkflowID).Int64(),
 		},
 	}
 }
@@ -311,6 +312,12 @@ func FromEntityTaskToView(t entity.Task) view.Task {
 	if t.EventID != 0 {
 		res.EventID = monoflake.ID(t.EventID).String()
 	}
+	// Both are needed to label the task: a workflow choice also sets EventID to
+	// that workflow's start event, so the id alone cannot say which was picked.
+	if t.WorkflowID != 0 {
+		res.WorkflowID = monoflake.ID(t.WorkflowID).String()
+	}
+	res.CompletionTriggerType = t.CompletionTriggerType
 	return res
 }
 
@@ -430,6 +437,13 @@ func FromModelTaskToView(t model.Task) view.Task {
 	if t.EventID != 0 {
 		res.EventID = monoflake.ID(t.EventID).String()
 	}
+	// Live SSE pushes go through this mapper too, so a task that appears via
+	// the event stream must carry the same trigger labelling as one fetched
+	// over REST — otherwise the same row renders differently by arrival path.
+	if t.WorkflowID != 0 {
+		res.WorkflowID = monoflake.ID(t.WorkflowID).String()
+	}
+	res.CompletionTriggerType = t.CompletionTriggerType
 	return res
 }
 func FromHTTPRequestToUpdateScheduledTaskRequestEntity(c *fiber.Ctx) *entity.UpdateScheduledTaskRequest {

--- a/backend/internal/mapper/api/workflow.go
+++ b/backend/internal/mapper/api/workflow.go
@@ -175,6 +175,51 @@ func FromListTasksFromWorkflowResponseEntityToHTTPResponse(rs *entity.ListTasksF
 	return payload
 }
 
+// ── Workflow text HTTP mappers ────────────────────────────────────────────────
+
+func FromHTTPRequestToGetWorkflowTextRequestEntity(c *fiber.Ctx) *entity.GetWorkflowTextRequest {
+	id := monoflake.IDFromBase62(c.Params("id")).Int64()
+	if id == 0 {
+		return nil
+	}
+	return &entity.GetWorkflowTextRequest{ID: id}
+}
+
+func FromGetWorkflowTextResponseEntityToHTTPResponse(rs *entity.GetWorkflowTextResponse) []byte {
+	payload, _ := json.Marshal(view.GetWorkflowTextResponse{Text: rs.Text})
+	return payload
+}
+
+func FromHTTPRequestToReplaceWorkflowFromTextRequestEntity(c *fiber.Ctx) *entity.ReplaceWorkflowFromTextRequest {
+	id := monoflake.IDFromBase62(c.Params("id")).Int64()
+	if id == 0 {
+		return nil
+	}
+	var payload view.ReplaceWorkflowFromTextRequest
+	if err := json.Unmarshal(c.BodyRaw(), &payload); err != nil {
+		return nil
+	}
+	return &entity.ReplaceWorkflowFromTextRequest{ID: id, Text: payload.Text}
+}
+
+func FromReplaceWorkflowFromTextResponseEntityToHTTPResponse(rs *entity.ReplaceWorkflowFromTextResponse) []byte {
+	payload, _ := json.Marshal(view.ReplaceWorkflowFromTextResponse{
+		Workflow:  fromEntityWorkflowToView(rs.Workflow),
+		StepCount: rs.StepCount,
+	})
+	return payload
+}
+
+// FromWorkflowTextErrorToHTTPResponse renders a parse failure with its line
+// number preserved, so the editor can point at the row instead of making the
+// user re-read the whole document.
+func FromWorkflowTextErrorToHTTPResponse(message string, line int) []byte {
+	payload, _ := json.Marshal(view.WorkflowTextErrorResponse{
+		Error: view.WorkflowTextError{Message: message, Line: line},
+	})
+	return payload
+}
+
 // ── Internal model↔entity mappers ─────────────────────────────────────────────
 
 func FromModelWorkflowToEntity(m model.Workflow) entity.Workflow {

--- a/backend/internal/mapper/api/workflow.go
+++ b/backend/internal/mapper/api/workflow.go
@@ -1,0 +1,248 @@
+package api
+
+import (
+	"encoding/json"
+
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	view "github.com/agentrq/agentrq/backend/internal/data/view/api"
+	"github.com/gofiber/fiber/v2"
+	"github.com/mustafaturan/monoflake"
+)
+
+// ── Workflow HTTP mappers ─────────────────────────────────────────────────────
+
+func FromHTTPRequestToCreateWorkflowRequestEntity(c *fiber.Ctx) *entity.CreateWorkflowRequest {
+	var payload view.CreateWorkflowRequest
+	if err := json.Unmarshal(c.BodyRaw(), &payload); err != nil {
+		return nil
+	}
+	if payload.Name == "" {
+		return nil
+	}
+	return &entity.CreateWorkflowRequest{
+		Name:         payload.Name,
+		Description:  payload.Description,
+		StartEventID: monoflake.IDFromBase62(payload.StartEventID).Int64(),
+	}
+}
+
+func FromCreateWorkflowResponseEntityToHTTPResponse(rs *entity.CreateWorkflowResponse) []byte {
+	payload, _ := json.Marshal(view.CreateWorkflowResponse{Workflow: fromEntityWorkflowToView(rs.Workflow)})
+	return payload
+}
+
+func FromHTTPRequestToGetWorkflowRequestEntity(c *fiber.Ctx) *entity.GetWorkflowRequest {
+	id := monoflake.IDFromBase62(c.Params("id")).Int64()
+	if id == 0 {
+		return nil
+	}
+	return &entity.GetWorkflowRequest{ID: id}
+}
+
+func FromGetWorkflowResponseEntityToHTTPResponse(rs *entity.GetWorkflowResponse) []byte {
+	payload, _ := json.Marshal(view.GetWorkflowResponse{Workflow: fromEntityWorkflowToView(rs.Workflow)})
+	return payload
+}
+
+func FromListWorkflowsResponseEntityToHTTPResponse(rs *entity.ListWorkflowsResponse) []byte {
+	workflows := make([]view.Workflow, len(rs.Workflows))
+	for i, w := range rs.Workflows {
+		workflows[i] = fromEntityWorkflowToView(w)
+	}
+	payload, _ := json.Marshal(view.ListWorkflowsResponse{Workflows: workflows})
+	return payload
+}
+
+// FromHTTPRequestToUpdateWorkflowRequestEntity carries each field through as a
+// pointer so the controller can tell "omitted" from "cleared": the graph editor
+// PATCHes only `layout` on every node drag, and that must not wipe the name.
+func FromHTTPRequestToUpdateWorkflowRequestEntity(c *fiber.Ctx) *entity.UpdateWorkflowRequest {
+	id := monoflake.IDFromBase62(c.Params("id")).Int64()
+	if id == 0 {
+		return nil
+	}
+	var payload view.UpdateWorkflowRequest
+	if err := json.Unmarshal(c.BodyRaw(), &payload); err != nil {
+		return nil
+	}
+	rq := &entity.UpdateWorkflowRequest{
+		ID:          id,
+		Name:        payload.Name,
+		Description: payload.Description,
+	}
+	if payload.StartEventID != nil {
+		startEventID := monoflake.IDFromBase62(*payload.StartEventID).Int64()
+		rq.StartEventID = &startEventID
+	}
+	if payload.Layout != nil {
+		layout := string(*payload.Layout)
+		rq.Layout = &layout
+	}
+	return rq
+}
+
+func FromUpdateWorkflowResponseEntityToHTTPResponse(rs *entity.UpdateWorkflowResponse) []byte {
+	payload, _ := json.Marshal(view.UpdateWorkflowResponse{Workflow: fromEntityWorkflowToView(rs.Workflow)})
+	return payload
+}
+
+func FromHTTPRequestToDeleteWorkflowRequestEntity(c *fiber.Ctx) *entity.DeleteWorkflowRequest {
+	id := monoflake.IDFromBase62(c.Params("id")).Int64()
+	if id == 0 {
+		return nil
+	}
+	return &entity.DeleteWorkflowRequest{ID: id}
+}
+
+// ── WorkflowStep HTTP mappers ─────────────────────────────────────────────────
+
+func FromHTTPRequestToCreateWorkflowStepRequestEntity(c *fiber.Ctx) *entity.CreateWorkflowStepRequest {
+	workflowID := monoflake.IDFromBase62(c.Params("id")).Int64()
+	if workflowID == 0 {
+		return nil
+	}
+	var payload view.CreateWorkflowStepRequest
+	if err := json.Unmarshal(c.BodyRaw(), &payload); err != nil {
+		return nil
+	}
+	eventID := monoflake.IDFromBase62(payload.EventID).Int64()
+	workspaceID := monoflake.IDFromBase62(payload.WorkspaceID).Int64()
+	if payload.Title == "" || eventID == 0 || workspaceID == 0 {
+		return nil
+	}
+	assignee := payload.Assignee
+	if assignee == "" {
+		assignee = "agent"
+	}
+	return &entity.CreateWorkflowStepRequest{
+		WorkflowID:       workflowID,
+		EventID:          eventID,
+		WorkspaceID:      workspaceID,
+		EmitEventID:      monoflake.IDFromBase62(payload.EmitEventID).Int64(),
+		Title:            payload.Title,
+		Body:             payload.Body,
+		Assignee:         assignee,
+		AllowAllCommands: payload.AllowAllCommands,
+	}
+}
+
+func FromCreateWorkflowStepResponseEntityToHTTPResponse(rs *entity.CreateWorkflowStepResponse) []byte {
+	payload, _ := json.Marshal(view.CreateWorkflowStepResponse{WorkflowStep: fromEntityWorkflowStepToView(rs.WorkflowStep)})
+	return payload
+}
+
+func FromHTTPRequestToListWorkflowStepsRequestEntity(c *fiber.Ctx) *entity.ListWorkflowStepsRequest {
+	workflowID := monoflake.IDFromBase62(c.Params("id")).Int64()
+	if workflowID == 0 {
+		return nil
+	}
+	return &entity.ListWorkflowStepsRequest{WorkflowID: workflowID}
+}
+
+func FromListWorkflowStepsResponseEntityToHTTPResponse(rs *entity.ListWorkflowStepsResponse) []byte {
+	steps := make([]view.WorkflowStep, len(rs.WorkflowSteps))
+	for i, s := range rs.WorkflowSteps {
+		steps[i] = fromEntityWorkflowStepToView(s)
+	}
+	payload, _ := json.Marshal(view.ListWorkflowStepsResponse{WorkflowSteps: steps})
+	return payload
+}
+
+func FromHTTPRequestToDeleteWorkflowStepRequestEntity(c *fiber.Ctx) *entity.DeleteWorkflowStepRequest {
+	workflowID := monoflake.IDFromBase62(c.Params("id")).Int64()
+	id := monoflake.IDFromBase62(c.Params("stepID")).Int64()
+	if workflowID == 0 || id == 0 {
+		return nil
+	}
+	return &entity.DeleteWorkflowStepRequest{ID: id, WorkflowID: workflowID}
+}
+
+func FromHTTPRequestToListTasksFromWorkflowRequestEntity(c *fiber.Ctx) *entity.ListTasksFromWorkflowRequest {
+	workflowID := monoflake.IDFromBase62(c.Params("id")).Int64()
+	if workflowID == 0 {
+		return nil
+	}
+	return &entity.ListTasksFromWorkflowRequest{WorkflowID: workflowID}
+}
+
+func FromListTasksFromWorkflowResponseEntityToHTTPResponse(rs *entity.ListTasksFromWorkflowResponse) []byte {
+	tasks := make([]view.Task, len(rs.Tasks))
+	for i, t := range rs.Tasks {
+		tasks[i] = FromEntityTaskToView(t)
+	}
+	payload, _ := json.Marshal(view.ListTasksResponse{Tasks: tasks})
+	return payload
+}
+
+// ── Internal model↔entity mappers ─────────────────────────────────────────────
+
+func FromModelWorkflowToEntity(m model.Workflow) entity.Workflow {
+	return entity.Workflow{
+		ID:           m.ID,
+		CreatedAt:    m.CreatedAt,
+		UpdatedAt:    m.UpdatedAt,
+		UserID:       m.UserID,
+		Name:         m.Name,
+		Description:  m.Description,
+		StartEventID: m.StartEventID,
+		Layout:       string(m.Layout),
+	}
+}
+
+func FromModelWorkflowStepToEntity(m model.WorkflowStep) entity.WorkflowStep {
+	return entity.WorkflowStep{
+		ID:               m.ID,
+		CreatedAt:        m.CreatedAt,
+		UpdatedAt:        m.UpdatedAt,
+		WorkflowID:       m.WorkflowID,
+		UserID:           m.UserID,
+		EventID:          m.EventID,
+		WorkspaceID:      m.WorkspaceID,
+		EmitEventID:      m.EmitEventID,
+		Title:            m.Title,
+		Body:             m.Body,
+		Assignee:         m.Assignee,
+		AllowAllCommands: m.AllowAllCommands,
+	}
+}
+
+// ── Internal entity↔view mappers ──────────────────────────────────────────────
+
+func fromEntityWorkflowToView(w entity.Workflow) view.Workflow {
+	v := view.Workflow{
+		ID:          monoflake.ID(w.ID).String(),
+		CreatedAt:   w.CreatedAt,
+		UpdatedAt:   w.UpdatedAt,
+		Name:        w.Name,
+		Description: w.Description,
+	}
+	if w.StartEventID != 0 {
+		v.StartEventID = monoflake.ID(w.StartEventID).String()
+	}
+	// Emit the stored layout only when it is valid JSON: it lands in a
+	// json.RawMessage, so a malformed value would corrupt the whole response
+	// body rather than just this field.
+	if json.Valid([]byte(w.Layout)) {
+		v.Layout = json.RawMessage(w.Layout)
+	}
+	return v
+}
+
+func fromEntityWorkflowStepToView(s entity.WorkflowStep) view.WorkflowStep {
+	v := view.WorkflowStep{
+		ID:               monoflake.ID(s.ID).String(),
+		CreatedAt:        s.CreatedAt,
+		WorkflowID:       monoflake.ID(s.WorkflowID).String(),
+		EventID:          monoflake.ID(s.EventID).String(),
+		WorkspaceID:      monoflake.ID(s.WorkspaceID).String(),
+		Title:            s.Title,
+		Body:             s.Body,
+		Assignee:         s.Assignee,
+		AllowAllCommands: s.AllowAllCommands,
+	}
+	if s.EmitEventID != 0 {
+		v.EmitEventID = monoflake.ID(s.EmitEventID).String()
+	}
+	return v
+}

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -890,7 +890,27 @@ func (r *repository) DeleteEvent(ctx context.Context, id int64, userID int64) er
 			Update("emit_event_id", 0).Error; err != nil {
 			return err
 		}
-		return nil
+
+		// Workflow steps need the same cleanup as triggers. A step whose source
+		// event no longer exists can never fire, and one still naming the
+		// deleted event as its emit target would arm a task to publish
+		// something gone — both would sit invisibly in a workflow that looks
+		// intact.
+		if err := tx.Where("event_id = ? AND user_id = ?", id, userID).Delete(&model.WorkflowStep{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&model.WorkflowStep{}).
+			Where("emit_event_id = ? AND user_id = ?", id, userID).
+			Update("emit_event_id", 0).Error; err != nil {
+			return err
+		}
+
+		// A workflow that started on this event has no entry point left.
+		// Clearing it surfaces the "Pick a start event" prompt instead of
+		// rendering an empty canvas with no explanation.
+		return tx.Model(&model.Workflow{}).
+			Where("start_event_id = ? AND user_id = ?", id, userID).
+			Update("start_event_id", 0).Error
 	})
 }
 

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -92,6 +92,7 @@ type Repository interface {
 	// Workflows
 	CreateWorkflow(ctx context.Context, w model.Workflow) (model.Workflow, error)
 	GetWorkflow(ctx context.Context, id int64, userID int64) (model.Workflow, error)
+	GetWorkflowByName(ctx context.Context, name string, userID int64) (model.Workflow, error)
 	ListWorkflowsByUser(ctx context.Context, userID int64) ([]model.Workflow, error)
 	UpdateWorkflow(ctx context.Context, w model.Workflow) (model.Workflow, error)
 	DeleteWorkflow(ctx context.Context, id int64, userID int64) error
@@ -105,6 +106,7 @@ type Repository interface {
 	// request and keys off the workflow the originating task already carried.
 	SystemListWorkflowStepsByEvent(ctx context.Context, workflowID int64, eventID int64) ([]model.WorkflowStep, error)
 	ListTasksByWorkflowID(ctx context.Context, workflowID int64, userID int64) ([]model.Task, error)
+	ReplaceWorkflowSteps(ctx context.Context, workflowID int64, userID int64, steps []model.WorkflowStep) error
 }
 
 type repository struct {
@@ -957,6 +959,15 @@ func (r *repository) GetWorkflow(ctx context.Context, id int64, userID int64) (m
 	return w, err
 }
 
+func (r *repository) GetWorkflowByName(ctx context.Context, name string, userID int64) (model.Workflow, error) {
+	var w model.Workflow
+	err := r.conn(ctx).Where("name = ? AND user_id = ?", name, userID).First(&w).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return model.Workflow{}, ErrNotFound
+	}
+	return w, err
+}
+
 func (r *repository) ListWorkflowsByUser(ctx context.Context, userID int64) ([]model.Workflow, error) {
 	var workflows []model.Workflow
 	err := r.conn(ctx).Where("user_id = ?", userID).Order("created_at desc").Find(&workflows).Error
@@ -1038,4 +1049,22 @@ func (r *repository) ListTasksByWorkflowID(ctx context.Context, workflowID int64
 	var tasks []model.Task
 	err := r.conn(ctx).Where("workflow_id = ? AND user_id = ?", workflowID, userID).Order("created_at desc").Find(&tasks).Error
 	return tasks, err
+}
+
+// ReplaceWorkflowSteps swaps a workflow's whole edge set in one transaction.
+//
+// Text mode edits the graph as a document, so the save is a replace rather than
+// a diff. Doing it transactionally matters: a partial apply would leave a
+// half-rewired graph live, and the consumer reads these rows the moment an
+// event fires.
+func (r *repository) ReplaceWorkflowSteps(ctx context.Context, workflowID int64, userID int64, steps []model.WorkflowStep) error {
+	return r.conn(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("workflow_id = ? AND user_id = ?", workflowID, userID).Delete(&model.WorkflowStep{}).Error; err != nil {
+			return err
+		}
+		if len(steps) == 0 {
+			return nil
+		}
+		return tx.Create(&steps).Error
+	})
 }

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -88,6 +88,23 @@ type Repository interface {
 	SystemListEventTriggersByEventID(ctx context.Context, eventID int64) ([]model.EventTrigger, error)
 	DeleteEventTrigger(ctx context.Context, id int64, userID int64) error
 	ListTasksByTriggerID(ctx context.Context, triggerID int64, userID int64) ([]model.Task, error)
+
+	// Workflows
+	CreateWorkflow(ctx context.Context, w model.Workflow) (model.Workflow, error)
+	GetWorkflow(ctx context.Context, id int64, userID int64) (model.Workflow, error)
+	ListWorkflowsByUser(ctx context.Context, userID int64) ([]model.Workflow, error)
+	UpdateWorkflow(ctx context.Context, w model.Workflow) (model.Workflow, error)
+	DeleteWorkflow(ctx context.Context, id int64, userID int64) error
+
+	// WorkflowSteps
+	CreateWorkflowStep(ctx context.Context, s model.WorkflowStep) (model.WorkflowStep, error)
+	ListWorkflowStepsByWorkflow(ctx context.Context, workflowID int64, userID int64) ([]model.WorkflowStep, error)
+	DeleteWorkflowStep(ctx context.Context, id int64, userID int64) error
+	// SystemListWorkflowStepsByEvent resolves the fan-out for one hop of a
+	// workflow run. Deliberately userID-free: the consumer runs outside any
+	// request and keys off the workflow the originating task already carried.
+	SystemListWorkflowStepsByEvent(ctx context.Context, workflowID int64, eventID int64) ([]model.WorkflowStep, error)
+	ListTasksByWorkflowID(ctx context.Context, workflowID int64, userID int64) ([]model.Task, error)
 }
 
 type repository struct {
@@ -919,5 +936,106 @@ func (r *repository) DeleteEventTrigger(ctx context.Context, id int64, userID in
 func (r *repository) ListTasksByTriggerID(ctx context.Context, triggerID int64, userID int64) ([]model.Task, error) {
 	var tasks []model.Task
 	err := r.conn(ctx).Where("trigger_id = ? AND user_id = ?", triggerID, userID).Order("created_at desc").Find(&tasks).Error
+	return tasks, err
+}
+
+// ── Workflows ──────────────────────────────────────────────────────────────────
+
+func (r *repository) CreateWorkflow(ctx context.Context, w model.Workflow) (model.Workflow, error) {
+	if err := r.conn(ctx).Create(&w).Error; err != nil {
+		return model.Workflow{}, err
+	}
+	return w, nil
+}
+
+func (r *repository) GetWorkflow(ctx context.Context, id int64, userID int64) (model.Workflow, error) {
+	var w model.Workflow
+	err := r.conn(ctx).Where("id = ? AND user_id = ?", id, userID).First(&w).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return model.Workflow{}, ErrNotFound
+	}
+	return w, err
+}
+
+func (r *repository) ListWorkflowsByUser(ctx context.Context, userID int64) ([]model.Workflow, error) {
+	var workflows []model.Workflow
+	err := r.conn(ctx).Where("user_id = ?", userID).Order("created_at desc").Find(&workflows).Error
+	return workflows, err
+}
+
+// UpdateWorkflow persists the mutable fields of an existing workflow. The
+// caller supplies a whole model, but only name/description/startEventId/layout
+// are written — ownership and creation time are never reassigned.
+func (r *repository) UpdateWorkflow(ctx context.Context, w model.Workflow) (model.Workflow, error) {
+	var existing model.Workflow
+	err := r.conn(ctx).Where("id = ? AND user_id = ?", w.ID, w.UserID).First(&existing).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return model.Workflow{}, ErrNotFound
+	}
+	if err != nil {
+		return model.Workflow{}, err
+	}
+	existing.Name = w.Name
+	existing.Description = w.Description
+	existing.StartEventID = w.StartEventID
+	existing.Layout = w.Layout
+	existing.UpdatedAt = time.Now()
+	if err := r.conn(ctx).Save(&existing).Error; err != nil {
+		return model.Workflow{}, err
+	}
+	return existing, nil
+}
+
+// DeleteWorkflow removes a workflow and its steps together. Tasks already
+// spawned by past runs keep their workflow_id: they are historical records, and
+// blanking them would lose the only trace of why they exist.
+func (r *repository) DeleteWorkflow(ctx context.Context, id int64, userID int64) error {
+	return r.conn(ctx).Transaction(func(tx *gorm.DB) error {
+		res := tx.Where("id = ? AND user_id = ?", id, userID).Delete(&model.Workflow{})
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return ErrNotFound
+		}
+		return tx.Where("workflow_id = ? AND user_id = ?", id, userID).Delete(&model.WorkflowStep{}).Error
+	})
+}
+
+// ── WorkflowSteps ──────────────────────────────────────────────────────────────
+
+func (r *repository) CreateWorkflowStep(ctx context.Context, s model.WorkflowStep) (model.WorkflowStep, error) {
+	if err := r.conn(ctx).Create(&s).Error; err != nil {
+		return model.WorkflowStep{}, err
+	}
+	return s, nil
+}
+
+func (r *repository) ListWorkflowStepsByWorkflow(ctx context.Context, workflowID int64, userID int64) ([]model.WorkflowStep, error) {
+	var steps []model.WorkflowStep
+	err := r.conn(ctx).Where("workflow_id = ? AND user_id = ?", workflowID, userID).Order("created_at asc").Find(&steps).Error
+	return steps, err
+}
+
+func (r *repository) DeleteWorkflowStep(ctx context.Context, id int64, userID int64) error {
+	res := r.conn(ctx).Where("id = ? AND user_id = ?", id, userID).Delete(&model.WorkflowStep{})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *repository) SystemListWorkflowStepsByEvent(ctx context.Context, workflowID int64, eventID int64) ([]model.WorkflowStep, error) {
+	var steps []model.WorkflowStep
+	err := r.conn(ctx).Where("workflow_id = ? AND event_id = ?", workflowID, eventID).Find(&steps).Error
+	return steps, err
+}
+
+func (r *repository) ListTasksByWorkflowID(ctx context.Context, workflowID int64, userID int64) ([]model.Task, error) {
+	var tasks []model.Task
+	err := r.conn(ctx).Where("workflow_id = ? AND user_id = ?", workflowID, userID).Order("created_at desc").Find(&tasks).Error
 	return tasks, err
 }

--- a/backend/internal/repository/base/repository_test.go
+++ b/backend/internal/repository/base/repository_test.go
@@ -357,7 +357,7 @@ func TestRepository_Event_CRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to connect database: %v", err)
 	}
-	_ = db.AutoMigrate(&model.Event{}, &model.EventTrigger{})
+	_ = db.AutoMigrate(&model.Event{}, &model.EventTrigger{}, &model.Workflow{}, &model.WorkflowStep{})
 	repo := New(&mockDB{db: db})
 
 	ctx := context.Background()
@@ -442,7 +442,7 @@ func TestRepository_DeleteEvent_CascadesTriggers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to connect database: %v", err)
 	}
-	_ = db.AutoMigrate(&model.Event{}, &model.EventTrigger{})
+	_ = db.AutoMigrate(&model.Event{}, &model.EventTrigger{}, &model.Workflow{}, &model.WorkflowStep{})
 	repo := New(&mockDB{db: db})
 
 	ctx := context.Background()
@@ -479,7 +479,7 @@ func TestRepository_EventTrigger_CRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to connect database: %v", err)
 	}
-	_ = db.AutoMigrate(&model.Event{}, &model.EventTrigger{}, &model.Task{})
+	_ = db.AutoMigrate(&model.Event{}, &model.EventTrigger{}, &model.Task{}, &model.Workflow{}, &model.WorkflowStep{})
 	repo := New(&mockDB{db: db})
 
 	ctx := context.Background()
@@ -592,4 +592,3 @@ func TestRepository_ListTasksByTriggerID(t *testing.T) {
 		}
 	}
 }
-

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -201,6 +201,19 @@
             </svg>
             <span v-if="!isCollapsed || isMobileMenuOpen">Events</span>
           </router-link>
+
+          <router-link to="/workflows"
+              @mouseenter="showTooltip($event, 'Workflows')" @mouseleave="hideTooltip"
+              class="flex items-center gap-2.5 px-2 py-1.5 text-xs transition-all duration-150 rounded-md"
+              :class="[
+                (isCollapsed && !isMobileMenuOpen) ? 'justify-center' : '',
+                $route.path.startsWith('/workflows') ? 'bg-gray-200 dark:bg-zinc-800 text-black dark:text-white' : 'text-gray-500 dark:text-zinc-400 hover:bg-gray-200 dark:hover:bg-zinc-700 hover:text-gray-900 dark:hover:text-zinc-50'
+              ]">
+            <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 6.878V6a2.25 2.25 0 012.25-2.25h7.5A2.25 2.25 0 0118 6v.878m-12 0c.235-.083.487-.128.75-.128h10.5c.263 0 .515.045.75.128m-12 0A2.25 2.25 0 004.5 9v.878m13.5-3A2.25 2.25 0 0119.5 9v.878m0 0a2.246 2.246 0 00-.75-.128H5.25c-.263 0-.515.045-.75.128m15 0A2.25 2.25 0 0121 12v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6c0-.98.626-1.813 1.5-2.122" />
+            </svg>
+            <span v-if="!isCollapsed || isMobileMenuOpen">Workflows</span>
+          </router-link>
         </div>
 
         <!-- Sidebar Footer -->
@@ -455,6 +468,8 @@ watch(() => route.fullPath, (fullPath) => {
   const path = route.path;
   if (path === '/') document.title = 'Workspaces | AgentRQ';
   else if (path === '/login') document.title = 'Login | AgentRQ';
+  else if (path.startsWith('/events')) document.title = 'Events | AgentRQ';
+  else if (path.startsWith('/workflows')) document.title = 'Workflows | AgentRQ';
   else if (path.startsWith('/tasks/')) {
     const filter = route.params.filter || '';
     const title = filter ? filter.charAt(0).toUpperCase() + filter.slice(1) : 'All';

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -210,7 +210,7 @@
                 $route.path.startsWith('/workflows') ? 'bg-gray-200 dark:bg-zinc-800 text-black dark:text-white' : 'text-gray-500 dark:text-zinc-400 hover:bg-gray-200 dark:hover:bg-zinc-700 hover:text-gray-900 dark:hover:text-zinc-50'
               ]">
             <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6 6.878V6a2.25 2.25 0 012.25-2.25h7.5A2.25 2.25 0 0118 6v.878m-12 0c.235-.083.487-.128.75-.128h10.5c.263 0 .515.045.75.128m-12 0A2.25 2.25 0 004.5 9v.878m13.5-3A2.25 2.25 0 0119.5 9v.878m0 0a2.246 2.246 0 00-.75-.128H5.25c-.263 0-.515.045-.75.128m15 0A2.25 2.25 0 0121 12v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6c0-.98.626-1.813 1.5-2.122" />
+              <path stroke-linecap="round" stroke-linejoin="round" d="M7.217 10.907a2.25 2.25 0 100 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.769-.283 1.093m0-2.186l9.566-5.314m-9.566 7.5l9.566 5.314m0 0a2.25 2.25 0 103.935 2.186 2.25 2.25 0 00-3.935-2.186zm0-12.814a2.25 2.25 0 103.933-2.185 2.25 2.25 0 00-3.933 2.185z" />
             </svg>
             <span v-if="!isCollapsed || isMobileMenuOpen">Workflows</span>
           </router-link>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -87,9 +87,12 @@ export async function getTask(workspaceId, taskId) {
   return res.json();
 }
 
-export async function createTask(workspaceId, title, body, assignee = 'agent', attachments = [], status = 'notstarted', cronSchedule = '', allowAllCommands = false, eventId = '') {
+// The trailing eventId/workflowId are mutually exclusive: they are the two
+// forms of "what fires when this completes", and the form only lets one be set.
+export async function createTask(workspaceId, title, body, assignee = 'agent', attachments = [], status = 'notstarted', cronSchedule = '', allowAllCommands = false, eventId = '', workflowId = '') {
   const task = { title, body, createdBy: 'human', assignee, attachments, status, cronSchedule, allowAllCommands };
   if (eventId) task.eventId = eventId;
+  if (workflowId) task.workflowId = workflowId;
   const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -350,3 +350,113 @@ export async function fetchEventTasks(eventId) {
   if (!res.ok) throw new Error('Failed to fetch event tasks');
   return res.json();
 }
+
+// ── Workflows (experimental) ─────────────────────────────────────────────────
+
+export async function fetchWorkflows() {
+  const res = await fetch(`${API_BASE_URL}/workflows`);
+  if (!res.ok) throw new Error('Failed to fetch workflows');
+  return res.json();
+}
+
+export async function getWorkflow(id) {
+  const res = await fetch(`${API_BASE_URL}/workflows/${id}`);
+  if (!res.ok) throw new Error('Failed to fetch workflow');
+  return res.json();
+}
+
+export async function createWorkflow({ name, description = '', startEventId = '' }) {
+  const payload = { name, description };
+  if (startEventId) payload.startEventId = startEventId;
+  const res = await fetch(`${API_BASE_URL}/workflows`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error?.message || body.error || `Failed to create workflow (${res.status})`);
+  }
+  return res.json();
+}
+
+// Fields are omitted rather than sent empty so a layout save cannot blank the
+// name; the backend treats an absent field as unchanged.
+export async function updateWorkflow(id, { name, description, startEventId, layout } = {}) {
+  const payload = {};
+  if (name !== undefined) payload.name = name;
+  if (description !== undefined) payload.description = description;
+  if (startEventId !== undefined) payload.startEventId = startEventId;
+  if (layout !== undefined) payload.layout = layout;
+  const res = await fetch(`${API_BASE_URL}/workflows/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!res.ok) throw new Error('Failed to update workflow');
+  return res.json();
+}
+
+export async function deleteWorkflow(id) {
+  const res = await fetch(`${API_BASE_URL}/workflows/${id}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error('Failed to delete workflow');
+  return true;
+}
+
+export async function fetchWorkflowSteps(workflowId) {
+  const res = await fetch(`${API_BASE_URL}/workflows/${workflowId}/steps`);
+  if (!res.ok) throw new Error('Failed to fetch workflow steps');
+  return res.json();
+}
+
+export async function createWorkflowStep(workflowId, { eventId, workspaceId, emitEventId = '', title, body = '', assignee = 'agent', allowAllCommands = false }) {
+  const payload = { eventId, workspaceId, title, body, assignee, allowAllCommands };
+  if (emitEventId) payload.emitEventId = emitEventId;
+  const res = await fetch(`${API_BASE_URL}/workflows/${workflowId}/steps`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!res.ok) {
+    // 409 is a rejected cycle: surface the backend's reason so the editor can
+    // explain which connection was refused, not just that something failed.
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error?.message || body.error || `Failed to create workflow step (${res.status})`);
+  }
+  return res.json();
+}
+
+export async function deleteWorkflowStep(workflowId, stepId) {
+  const res = await fetch(`${API_BASE_URL}/workflows/${workflowId}/steps/${stepId}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error('Failed to delete workflow step');
+  return true;
+}
+
+export async function fetchWorkflowTasks(workflowId) {
+  const res = await fetch(`${API_BASE_URL}/workflows/${workflowId}/tasks`);
+  if (!res.ok) throw new Error('Failed to fetch workflow tasks');
+  return res.json();
+}
+
+export async function fetchWorkflowText(workflowId) {
+  const res = await fetch(`${API_BASE_URL}/workflows/${workflowId}/text`);
+  if (!res.ok) throw new Error('Failed to fetch workflow text');
+  return res.json();
+}
+
+// Rejects with a `.line` property when the backend reports a parse error, so
+// the editor can mark the offending row.
+export async function replaceWorkflowFromText(workflowId, text) {
+  const res = await fetch(`${API_BASE_URL}/workflows/${workflowId}/text`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text })
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    const err = new Error(body.error?.message || body.error || `Failed to save workflow (${res.status})`);
+    if (body.error?.line) err.line = body.error.line;
+    throw err;
+  }
+  return res.json();
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -35,6 +35,9 @@ const routes = [
   { path: '/events', component: () => import('./views/EventsView.vue') },
   { path: '/events/:id', component: () => import('./views/EventDetailView.vue') },
 
+  { path: '/workflows', component: () => import('./views/WorkflowsView.vue') },
+  { path: '/workflows/:id', component: () => import('./views/WorkflowDetailView.vue') },
+
   { path: '/login', component: () => import('./views/LoginView.vue'), meta: { public: true } }
 ]
 

--- a/frontend/src/views/TaskFormView.vue
+++ b/frontend/src/views/TaskFormView.vue
@@ -207,21 +207,52 @@
                    </div>
                 </div>
 
-                <!-- Emit Event Dropdown -->
-                <div class="relative" v-if="!isEditMode && events.length > 0" v-click-outside="() => showEventMenu = false">
+                <!-- On-completion trigger: a single event, or a whole workflow -->
+                <div class="relative" v-if="!isEditMode && (events.length > 0 || workflows.length > 0)" v-click-outside="() => showEventMenu = false">
                    <button type="button" @click="showEventMenu = !showEventMenu; showScheduleMenu = false; tooltipStore.hide()"
-                           @mouseenter="tooltipStore.show($event, selectedEventId ? 'Event Emitted on Completion' : 'Emit Event on Completion', 'top')"
+                           @mouseenter="tooltipStore.show($event, completionTriggerLabel, 'top')"
                            @mouseleave="tooltipStore.hide()"
-                           :class="selectedEventId ? 'bg-purple-50 text-purple-700 border-purple-200 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-800 shadow-sm' : 'bg-gray-100 dark:bg-zinc-800 text-gray-500 dark:text-zinc-400 hover:text-gray-900 dark:hover:text-zinc-50 hover:bg-gray-200 dark:hover:bg-zinc-700 border border-gray-200 dark:border-zinc-700'"
+                           :class="(selectedEventId || selectedWorkflowId) ? 'bg-purple-50 text-purple-700 border-purple-200 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-800 shadow-sm' : 'bg-gray-100 dark:bg-zinc-800 text-gray-500 dark:text-zinc-400 hover:text-gray-900 dark:hover:text-zinc-50 hover:bg-gray-200 dark:hover:bg-zinc-700 border border-gray-200 dark:border-zinc-700'"
                            class="flex items-center justify-center w-7 h-7 rounded-md transition-all">
                      <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" /></svg>
                    </button>
-                   <div v-if="showEventMenu" class="fixed sm:absolute left-4 right-4 sm:left-auto sm:right-0 bottom-4 sm:bottom-full mb-3 w-auto sm:w-[240px] bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-xl shadow-2xl z-50 p-4 animate-in fade-in slide-in-from-bottom-2">
-                       <h3 class="text-[10px] font-bold uppercase tracking-wider text-gray-500 dark:text-zinc-400 mb-3 border-b border-gray-100 dark:border-zinc-800 pb-2">Emit Event on Completion</h3>
-                       <select v-model="selectedEventId" class="w-full bg-gray-50 dark:bg-zinc-950 border border-gray-200 dark:border-zinc-800 rounded-md px-2 py-2 text-[11px] font-semibold text-gray-900 dark:text-zinc-100 outline-none">
+                   <div v-if="showEventMenu" class="fixed sm:absolute left-4 right-4 sm:left-auto sm:right-0 bottom-4 sm:bottom-full mb-3 w-auto sm:w-[260px] bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-xl shadow-2xl z-50 p-4 animate-in fade-in slide-in-from-bottom-2">
+                       <h3 class="text-[10px] font-bold uppercase tracking-wider text-gray-500 dark:text-zinc-400 mb-3 border-b border-gray-100 dark:border-zinc-800 pb-2">On Completion</h3>
+
+                       <!-- One control, two kinds. Selecting either clears the
+                            other, so an impossible "both" state cannot be built. -->
+                       <div class="flex p-1 bg-gray-100 dark:bg-zinc-950 border border-gray-200 dark:border-zinc-800 rounded-lg mb-3">
+                         <button type="button" @click="completionKind = 'event'; selectedWorkflowId = ''"
+                                 class="grow px-3 py-1 rounded-md text-[10px] font-semibold transition-all"
+                                 :class="completionKind === 'event' ? 'bg-white dark:bg-zinc-800 text-gray-900 dark:text-white shadow-sm border border-gray-200 dark:border-zinc-700' : 'text-gray-500 dark:text-zinc-500 border border-transparent'">
+                           Event
+                         </button>
+                         <button type="button" @click="completionKind = 'workflow'; selectedEventId = ''"
+                                 class="grow px-3 py-1 rounded-md text-[10px] font-semibold transition-all"
+                                 :class="completionKind === 'workflow' ? 'bg-white dark:bg-zinc-800 text-gray-900 dark:text-white shadow-sm border border-gray-200 dark:border-zinc-700' : 'text-gray-500 dark:text-zinc-500 border border-transparent'">
+                           Workflow
+                         </button>
+                       </div>
+
+                       <select v-if="completionKind === 'event'" v-model="selectedEventId" class="w-full bg-gray-50 dark:bg-zinc-950 border border-gray-200 dark:border-zinc-800 rounded-md px-2 py-2 text-[11px] font-semibold text-gray-900 dark:text-zinc-100 outline-none">
                          <option value="">None</option>
                          <option v-for="ev in events" :key="ev.id" :value="ev.id">{{ ev.name }}</option>
                        </select>
+
+                       <template v-else>
+                         <select v-model="selectedWorkflowId" class="w-full bg-gray-50 dark:bg-zinc-950 border border-gray-200 dark:border-zinc-800 rounded-md px-2 py-2 text-[11px] font-semibold text-gray-900 dark:text-zinc-100 outline-none">
+                           <option value="">None</option>
+                           <!-- A workflow with no start event cannot run, so it
+                                is offered as disabled rather than hidden: the
+                                absence would otherwise look like a bug. -->
+                           <option v-for="wf in workflows" :key="wf.id" :value="wf.id" :disabled="!wf.startEventId">
+                             {{ wf.name }}{{ wf.startEventId ? '' : ' (no start event)' }}
+                           </option>
+                         </select>
+                         <p class="text-[10px] text-gray-400 dark:text-zinc-500 mt-2 leading-snug">
+                           Runs the whole pipeline, not just one event
+                         </p>
+                       </template>
                    </div>
                 </div>
 
@@ -248,7 +279,7 @@
 <script setup>
 import { ref, computed, watch, onMounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { getWorkspace, createTask, updateScheduledTask, getTask, fetchEvents } from '../api';
+import { getWorkspace, createTask, updateScheduledTask, getTask, fetchEvents, fetchWorkflows } from '../api';
 import { useToasts } from '../composables/useToasts';
 import { useCron } from '../composables/useCron';
 import { useSpeechToText } from '../composables/useSpeechToText';
@@ -304,10 +335,23 @@ const {
   generateTitle
 } = useAutoTitle(bodyRef, titleRef);
 
-// Event-on-completion
+// What fires when the task completes: a single event, or a whole workflow.
+// Mutually exclusive by construction — picking one clears the other.
 const events = ref([]);
+const workflows = ref([]);
 const selectedEventId = ref('');
+const selectedWorkflowId = ref('');
+const completionKind = ref('event');
 const showEventMenu = ref(false);
+
+const completionTriggerLabel = computed(() => {
+  if (selectedWorkflowId.value) {
+    const wf = workflows.value.find(w => w.id === selectedWorkflowId.value);
+    return `Runs workflow ${wf?.name ?? ''} on completion`;
+  }
+  if (selectedEventId.value) return 'Event Emitted on Completion';
+  return 'Emit Event or Run Workflow on Completion';
+});
 
 // Scheduling state
 const scheduleType = ref('none');
@@ -329,12 +373,16 @@ function handleDrop(e) {
 
 onMounted(async () => {
   try {
-    const [wsRes, eventsRes] = await Promise.all([
+    // Both pickers degrade to empty rather than blocking the form: a task can
+    // always be created without an on-completion trigger.
+    const [wsRes, eventsRes, workflowsRes] = await Promise.all([
       getWorkspace(workspaceId),
       fetchEvents().catch(() => ({ events: [] })),
+      fetchWorkflows().catch(() => ({ workflows: [] })),
     ]);
     workspace.value = wsRes.workspace;
     events.value = eventsRes.events ?? [];
+    workflows.value = workflowsRes.workflows ?? [];
 
     if (isEditMode.value) {
       const taskRes = await getTask(workspaceId, taskId);
@@ -514,7 +562,7 @@ async function submitHumanTask() {
       workspaceId, newTask.value.title, newTask.value.body,
       newTask.value.assignee, newTaskAttachments.value,
       status, newTask.value.cronSchedule, newTask.value.allowAllCommands,
-      selectedEventId.value
+      selectedEventId.value, selectedWorkflowId.value
     );
     notifySuccess('Task Created successfully');
     goBack(status === 'cron');

--- a/frontend/src/views/WorkflowDetailView.vue
+++ b/frontend/src/views/WorkflowDetailView.vue
@@ -1,0 +1,783 @@
+<script setup>
+import { ref, computed, onMounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import {
+  getWorkflow, updateWorkflow, fetchWorkflowSteps, createWorkflowStep,
+  deleteWorkflowStep, fetchWorkflowTasks, fetchWorkflowText, replaceWorkflowFromText,
+  fetchEvents,
+} from '../api';
+import { useWorkspaceStore } from '../stores/workspaceStore';
+import { useToasts } from '../composables/useToasts';
+import DeleteModal from '../components/DeleteModal.vue';
+import LoadingState from '../components/LoadingState.vue';
+
+const route = useRoute();
+const router = useRouter();
+const workspaceStore = useWorkspaceStore();
+const { notifyError, notifySuccess } = useToasts();
+
+const workflowId = route.params.id;
+
+const workflow = ref(null);
+const steps = ref([]);
+const events = ref([]);
+const loading = ref(true);
+
+const mode = ref('graph');
+
+// ── Layout geometry ───────────────────────────────────────────────────────────
+// Nodes are auto-placed in alternating columns (event, workspaces, event, …) so
+// the graph is readable without anyone arranging it. A node the user has
+// dragged gets an entry in `positions` and stops being auto-placed; clearing
+// that entry returns it to the automatic spot.
+
+const COLUMN_WIDTH = 260;
+const ROW_HEIGHT = 96;
+const NODE_WIDTH = 200;
+const NODE_HEIGHT = 56;
+const CANVAS_PADDING = 32;
+
+const positions = ref({});
+
+function nodeKey(node) {
+  return node.kind === 'event' ? `event:${node.eventId}` : `step:${node.stepId}`;
+}
+
+// ── Graph model ───────────────────────────────────────────────────────────────
+// Derived entirely from steps, so the canvas can never disagree with what will
+// actually run.
+
+const eventsById = computed(() => {
+  const map = {};
+  for (const ev of events.value) map[ev.id] = ev;
+  return map;
+});
+
+const workspacesById = computed(() => {
+  const map = {};
+  for (const ws of workspaceStore.workspaces) map[ws.id] = ws;
+  return map;
+});
+
+function eventName(id) {
+  return eventsById.value[id]?.name ?? '(deleted event)';
+}
+
+function workspaceName(id) {
+  return workspacesById.value[id]?.name ?? '(deleted workspace)';
+}
+
+// stepsByEvent groups the fan-out for each event.
+const stepsByEvent = computed(() => {
+  const map = {};
+  for (const s of steps.value) {
+    (map[s.eventId] ||= []).push(s);
+  }
+  return map;
+});
+
+/**
+ * Walks outward from the start event assigning each node a column.
+ *
+ * An event reachable by several paths is placed once, at its deepest column, so
+ * a diamond re-join renders as one node with two incoming edges rather than as
+ * duplicates. The visited set also stops the walk on a cyclic graph — cycles
+ * are rejected on save, but the canvas must not hang on data that predates that.
+ */
+const graph = computed(() => {
+  const startId = workflow.value?.startEventId;
+  if (!startId) return { nodes: [], edges: [], width: 0, height: 0 };
+
+  const eventColumn = {};
+  const order = [];
+
+  const queue = [{ eventId: startId, column: 0 }];
+  const guard = new Set();
+  while (queue.length) {
+    const { eventId, column } = queue.shift();
+    const seenKey = `${eventId}@${column}`;
+    if (guard.has(seenKey)) continue;
+    guard.add(seenKey);
+
+    if (eventColumn[eventId] === undefined) order.push(eventId);
+    eventColumn[eventId] = Math.max(eventColumn[eventId] ?? 0, column);
+
+    for (const step of stepsByEvent.value[eventId] ?? []) {
+      if (step.emitEventId) queue.push({ eventId: step.emitEventId, column: column + 2 });
+    }
+  }
+
+  const nodes = [];
+  const edges = [];
+  const rowCursor = {};
+
+  function place(column) {
+    const row = rowCursor[column] ?? 0;
+    rowCursor[column] = row + 1;
+    return row;
+  }
+
+  // Events first so their rows are assigned before the steps that hang off them.
+  const eventNodes = {};
+  for (const eventId of order) {
+    const column = eventColumn[eventId];
+    const node = {
+      kind: 'event',
+      eventId,
+      label: eventName(eventId),
+      column,
+      row: place(column),
+      isStart: eventId === startId,
+    };
+    eventNodes[eventId] = node;
+    nodes.push(node);
+  }
+
+  for (const step of steps.value) {
+    const source = eventNodes[step.eventId];
+    if (!source) continue; // orphaned step: its source event is unreachable
+    const column = source.column + 1;
+    const node = {
+      kind: 'step',
+      stepId: step.id,
+      step,
+      label: workspaceName(step.workspaceId),
+      column,
+      row: place(column),
+    };
+    nodes.push(node);
+    edges.push({ from: source, to: node });
+    if (step.emitEventId && eventNodes[step.emitEventId]) {
+      edges.push({ from: node, to: eventNodes[step.emitEventId] });
+    }
+  }
+
+  for (const node of nodes) {
+    const override = positions.value[nodeKey(node)];
+    node.x = override?.x ?? CANVAS_PADDING + node.column * COLUMN_WIDTH;
+    node.y = override?.y ?? CANVAS_PADDING + node.row * ROW_HEIGHT;
+  }
+
+  const width = Math.max(...nodes.map(n => n.x + NODE_WIDTH), 0) + CANVAS_PADDING;
+  const height = Math.max(...nodes.map(n => n.y + NODE_HEIGHT), 0) + CANVAS_PADDING;
+
+  return { nodes, edges, width, height };
+});
+
+// Orphans are steps whose source event no longer sits on any path from the
+// start event — usually because the start event changed. They would silently
+// never fire, so they get called out rather than hidden.
+const orphanSteps = computed(() => {
+  const drawn = new Set(graph.value.nodes.filter(n => n.kind === 'step').map(n => n.stepId));
+  return steps.value.filter(s => !drawn.has(s.id));
+});
+
+// Dead ends: an event that nothing consumes. Legal, but usually a mistake, so
+// it is surfaced as a warning rather than an error.
+const deadEndEvents = computed(() => {
+  const consumed = new Set(steps.value.map(s => s.eventId));
+  const emitted = steps.value.filter(s => s.emitEventId).map(s => s.emitEventId);
+  return [...new Set(emitted.filter(id => !consumed.has(id)))];
+});
+
+// ── Cycle prevention ──────────────────────────────────────────────────────────
+
+/** Whether `fromEventId -> emitEventId` would close a loop in the current graph. */
+function wouldCreateCycle(fromEventId, emitEventId) {
+  if (!emitEventId) return false;
+  if (emitEventId === fromEventId) return true;
+  const adjacency = {};
+  for (const s of steps.value) {
+    if (s.emitEventId) (adjacency[s.eventId] ||= []).push(s.emitEventId);
+  }
+  const seen = new Set();
+  const stack = [emitEventId];
+  while (stack.length) {
+    const current = stack.pop();
+    if (current === fromEventId) return true;
+    if (seen.has(current)) continue;
+    seen.add(current);
+    stack.push(...(adjacency[current] ?? []));
+  }
+  return false;
+}
+
+/** Events a step may legally emit: everything that would not close a loop. */
+function legalEmitEvents(step) {
+  return events.value.filter(ev => !wouldCreateCycle(step.eventId, ev.id));
+}
+
+// ── Drag and drop ─────────────────────────────────────────────────────────────
+// Palette items carry their kind, and a node only accepts the kind the
+// alternation allows — a workspace onto an event, an event onto a workspace.
+// Illegal targets never highlight, so a mistake is not expressible.
+
+const dragItem = ref(null);
+const dropTarget = ref(null);
+
+function startPaletteDrag(kind, id, e) {
+  dragItem.value = { kind, id };
+  try { e.dataTransfer.setData('text/plain', `${kind}:${id}`); } catch { /* Firefox */ }
+  e.dataTransfer.effectAllowed = 'copy';
+}
+
+function canDropOn(node) {
+  if (!dragItem.value) return false;
+  if (node.kind === 'event') return dragItem.value.kind === 'workspace';
+  if (node.kind === 'step') {
+    if (dragItem.value.kind !== 'event') return false;
+    if (node.step.emitEventId) return false; // a step emits at most one event
+    return !wouldCreateCycle(node.step.eventId, dragItem.value.id);
+  }
+  return false;
+}
+
+function onNodeDragOver(node, e) {
+  if (!canDropOn(node)) return;
+  e.preventDefault();
+  e.dataTransfer.dropEffect = 'copy';
+  dropTarget.value = nodeKey(node);
+}
+
+function onNodeDragLeave(node) {
+  if (dropTarget.value === nodeKey(node)) dropTarget.value = null;
+}
+
+async function onNodeDrop(node, e) {
+  e.preventDefault();
+  const item = dragItem.value;
+  dropTarget.value = null;
+  dragItem.value = null;
+  if (!item || !canDropOn(node)) return;
+
+  if (node.kind === 'event' && item.kind === 'workspace') {
+    await addStep(node.eventId, item.id);
+  } else if (node.kind === 'step' && item.kind === 'event') {
+    await setStepEmit(node.step, item.id);
+  }
+}
+
+// ── Node repositioning ────────────────────────────────────────────────────────
+
+const draggingNode = ref(null);
+
+function startNodeDrag(node, e) {
+  // Left button only, and never from the palette-drop path.
+  if (e.button !== 0) return;
+  draggingNode.value = {
+    key: nodeKey(node),
+    offsetX: e.clientX - node.x,
+    offsetY: e.clientY - node.y,
+  };
+  window.addEventListener('pointermove', onNodeDragMove);
+  window.addEventListener('pointerup', endNodeDrag, { once: true });
+}
+
+function onNodeDragMove(e) {
+  const drag = draggingNode.value;
+  if (!drag) return;
+  positions.value = {
+    ...positions.value,
+    [drag.key]: {
+      x: Math.max(0, Math.round(e.clientX - drag.offsetX)),
+      y: Math.max(0, Math.round(e.clientY - drag.offsetY)),
+    },
+  };
+}
+
+async function endNodeDrag() {
+  window.removeEventListener('pointermove', onNodeDragMove);
+  if (!draggingNode.value) return;
+  draggingNode.value = null;
+  await persistLayout();
+}
+
+async function persistLayout() {
+  try {
+    await updateWorkflow(workflowId, { layout: JSON.stringify(positions.value) });
+  } catch {
+    // Layout is presentational: a failed save costs the arrangement, not the
+    // graph, so it is not worth interrupting the user with a toast.
+  }
+}
+
+async function resetLayout() {
+  positions.value = {};
+  await persistLayout();
+  notifySuccess('Layout reset');
+}
+
+// ── Mutations ─────────────────────────────────────────────────────────────────
+
+async function addStep(eventId, workspaceId) {
+  try {
+    const data = await createWorkflowStep(workflowId, {
+      eventId,
+      workspaceId,
+      title: `${workflow.value.name}: ${eventName(eventId)}`,
+      body: '{{EVENT_PAYLOAD}}',
+    });
+    steps.value = [...steps.value, data.workflowStep];
+  } catch (e) {
+    notifyError(e.message);
+  }
+}
+
+// A step's emitted event is part of the row, and there is no PATCH for a step,
+// so changing it is a delete plus a create. Ordering matters: create first
+// would momentarily double the fan-out for that event.
+async function setStepEmit(step, emitEventId) {
+  try {
+    await deleteWorkflowStep(workflowId, step.id);
+    const data = await createWorkflowStep(workflowId, {
+      eventId: step.eventId,
+      workspaceId: step.workspaceId,
+      emitEventId,
+      title: step.title,
+      body: step.body,
+      assignee: step.assignee,
+      allowAllCommands: step.allowAllCommands,
+    });
+    steps.value = [...steps.value.filter(s => s.id !== step.id), data.workflowStep];
+  } catch (e) {
+    notifyError(e.message);
+    await loadSteps();
+  }
+}
+
+async function removeStep(step) {
+  try {
+    await deleteWorkflowStep(workflowId, step.id);
+    steps.value = steps.value.filter(s => s.id !== step.id);
+  } catch (e) {
+    notifyError(e.message);
+  }
+}
+
+async function clearStepEmit(step) {
+  await setStepEmit(step, '');
+}
+
+async function setStartEvent(eventId) {
+  try {
+    const data = await updateWorkflow(workflowId, { startEventId: eventId });
+    workflow.value = data.workflow;
+  } catch (e) {
+    notifyError(e.message);
+  }
+}
+
+// ── Text mode ─────────────────────────────────────────────────────────────────
+
+const text = ref('');
+const textDirty = ref(false);
+const textError = ref(null);
+const savingText = ref(false);
+
+async function loadText() {
+  try {
+    const data = await fetchWorkflowText(workflowId);
+    text.value = data.text ?? '';
+    textDirty.value = false;
+    textError.value = null;
+  } catch (e) {
+    notifyError(e.message);
+  }
+}
+
+async function switchMode(next) {
+  if (next === mode.value) return;
+  if (next === 'text') await loadText();
+  if (next === 'graph' && textDirty.value) {
+    notifyError('Save or discard your text changes first');
+    return;
+  }
+  mode.value = next;
+}
+
+async function saveText() {
+  savingText.value = true;
+  textError.value = null;
+  try {
+    await replaceWorkflowFromText(workflowId, text.value);
+    notifySuccess('Workflow saved');
+    textDirty.value = false;
+    await Promise.all([loadWorkflow(), loadSteps()]);
+  } catch (e) {
+    textError.value = { message: e.message, line: e.line ?? null };
+  } finally {
+    savingText.value = false;
+  }
+}
+
+async function discardText() {
+  await loadText();
+}
+
+// ── Tasks ─────────────────────────────────────────────────────────────────────
+
+const TASKS_PAGE_SIZE = 10;
+const tasks = ref([]);
+const loadingTasks = ref(false);
+const visibleTaskCount = ref(TASKS_PAGE_SIZE);
+const visibleTasks = computed(() => tasks.value.slice(0, visibleTaskCount.value));
+const hasMoreTasks = computed(() => visibleTaskCount.value < tasks.value.length);
+
+function loadMoreTasks() {
+  visibleTaskCount.value += TASKS_PAGE_SIZE;
+}
+
+async function loadTasks() {
+  loadingTasks.value = true;
+  try {
+    const data = await fetchWorkflowTasks(workflowId);
+    tasks.value = data.tasks ?? [];
+    visibleTaskCount.value = TASKS_PAGE_SIZE;
+  } catch (e) {
+    notifyError(e.message);
+  } finally {
+    loadingTasks.value = false;
+  }
+}
+
+function statusColor(status) {
+  return {
+    notstarted: 'text-gray-400 dark:text-zinc-500',
+    ongoing: 'text-sky-500 dark:text-sky-400',
+    completed: 'text-emerald-500 dark:text-emerald-400',
+    rejected: 'text-red-500 dark:text-red-400',
+    blocked: 'text-amber-500 dark:text-amber-400',
+    cron: 'text-violet-500 dark:text-violet-400',
+  }[status] ?? 'text-gray-400 dark:text-zinc-500';
+}
+
+// ── Loading ───────────────────────────────────────────────────────────────────
+
+async function loadWorkflow() {
+  const data = await getWorkflow(workflowId);
+  workflow.value = data.workflow;
+  if (data.workflow.layout) {
+    // Layout is opaque to the backend, so a malformed blob is possible; an
+    // unreadable arrangement should fall back to auto-layout, not break the view.
+    try {
+      positions.value = typeof data.workflow.layout === 'string'
+        ? JSON.parse(data.workflow.layout)
+        : data.workflow.layout;
+    } catch {
+      positions.value = {};
+    }
+  }
+}
+
+async function loadSteps() {
+  const data = await fetchWorkflowSteps(workflowId);
+  steps.value = data.workflowSteps ?? [];
+}
+
+const showDeleteStepModal = ref(false);
+const deletingStep = ref(null);
+
+function confirmDeleteStep(step) {
+  deletingStep.value = step;
+  showDeleteStepModal.value = true;
+}
+
+async function handleDeleteStep() {
+  if (deletingStep.value) await removeStep(deletingStep.value);
+  showDeleteStepModal.value = false;
+  deletingStep.value = null;
+}
+
+onMounted(async () => {
+  loading.value = true;
+  try {
+    if (!workspaceStore.workspaces.length) await workspaceStore.fetchWorkspaces();
+    const [, , eventsRes] = await Promise.all([
+      loadWorkflow(),
+      loadSteps(),
+      fetchEvents().catch(() => ({ events: [] })),
+    ]);
+    events.value = eventsRes.events ?? [];
+    await loadTasks();
+  } catch (e) {
+    notifyError(e.message);
+  } finally {
+    loading.value = false;
+  }
+});
+</script>
+
+<template>
+  <div class="flex flex-col h-full w-full overflow-y-auto custom-scrollbar">
+    <!-- Header -->
+    <div class="w-full px-4 py-2 mb-6 shrink-0 flex flex-row items-center justify-between gap-4">
+      <div class="min-w-0">
+        <h1 class="text-lg md:text-2xl font-black text-gray-800 dark:text-zinc-200 tracking-tight leading-tight truncate">
+          <span class="opacity-50 cursor-pointer hover:opacity-100 transition-opacity" @click="router.push('/workflows')">Workflows</span>
+          <span class="mx-1.5 text-gray-300 dark:text-zinc-700 font-medium">/</span>
+          <span class="font-mono">{{ workflow?.name }}</span>
+        </h1>
+        <p v-if="workflow?.description" class="text-xs text-gray-500 dark:text-zinc-400 mt-0.5">{{ workflow.description }}</p>
+      </div>
+
+      <div class="flex items-center gap-2 shrink-0">
+        <div class="flex p-1 bg-gray-100 dark:bg-zinc-950 border border-gray-200 dark:border-zinc-800 rounded-lg w-fit">
+          <button
+            @click="switchMode('graph')"
+            class="px-5 py-1.5 rounded-md text-[10px] font-semibold transition-all"
+            :class="mode === 'graph' ? 'bg-white dark:bg-zinc-800 text-gray-900 dark:text-white shadow-sm border border-gray-200 dark:border-zinc-700' : 'text-gray-500 dark:text-zinc-500 border border-transparent'">
+            Graph
+          </button>
+          <button
+            @click="switchMode('text')"
+            class="px-5 py-1.5 rounded-md text-[10px] font-semibold transition-all"
+            :class="mode === 'text' ? 'bg-white dark:bg-zinc-800 text-gray-900 dark:text-white shadow-sm border border-gray-200 dark:border-zinc-700' : 'text-gray-500 dark:text-zinc-500 border border-transparent'">
+            Text
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <LoadingState v-if="loading" label="Loading workflow…" class="py-20" />
+
+    <div v-else class="px-4 space-y-8 pb-10">
+      <!-- No start event yet -->
+      <div v-if="!workflow?.startEventId" class="bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-xl p-5 space-y-3">
+        <div>
+          <h2 class="text-sm font-bold text-gray-800 dark:text-zinc-200">Pick a start event</h2>
+          <p class="text-[11px] text-gray-400 dark:text-zinc-500 mt-0.5">
+            A run begins when this event fires. Everything else hangs off it.
+          </p>
+        </div>
+        <select
+          @change="setStartEvent($event.target.value)"
+          class="w-full px-3 py-2 text-sm border border-gray-200 dark:border-zinc-700 rounded-lg bg-white dark:bg-zinc-800 text-gray-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white transition-all">
+          <option value="">Choose an event…</option>
+          <option v-for="ev in events" :key="ev.id" :value="ev.id">{{ ev.name }}</option>
+        </select>
+      </div>
+
+      <!-- ── Graph mode ── -->
+      <template v-else-if="mode === 'graph'">
+        <div class="flex gap-4 items-start">
+          <!-- Palette -->
+          <div class="shrink-0 w-48 space-y-4">
+            <div>
+              <h3 class="text-[11px] font-bold text-gray-500 dark:text-zinc-400 uppercase tracking-widest mb-2">Workspaces</h3>
+              <p class="text-[10px] text-gray-400 dark:text-zinc-500 mb-2 leading-snug">Drag onto an event to subscribe it</p>
+              <div class="space-y-1 max-h-52 overflow-y-auto custom-scrollbar pr-1">
+                <div
+                  v-for="ws in workspaceStore.workspaces"
+                  :key="ws.id"
+                  draggable="true"
+                  @dragstart="startPaletteDrag('workspace', ws.id, $event)"
+                  @dragend="dragItem = null; dropTarget = null"
+                  class="px-2.5 py-1.5 text-[11px] font-semibold text-gray-700 dark:text-zinc-300 bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-lg cursor-grab active:cursor-grabbing hover:border-gray-300 dark:hover:border-zinc-600 transition-all truncate">
+                  {{ ws.name }}
+                </div>
+              </div>
+            </div>
+
+            <div>
+              <h3 class="text-[11px] font-bold text-gray-500 dark:text-zinc-400 uppercase tracking-widest mb-2">Events</h3>
+              <p class="text-[10px] text-gray-400 dark:text-zinc-500 mb-2 leading-snug">Drag onto a workspace to emit it on completion</p>
+              <div class="space-y-1 max-h-52 overflow-y-auto custom-scrollbar pr-1">
+                <div
+                  v-for="ev in events"
+                  :key="ev.id"
+                  draggable="true"
+                  @dragstart="startPaletteDrag('event', ev.id, $event)"
+                  @dragend="dragItem = null; dropTarget = null"
+                  class="px-2.5 py-1.5 text-[11px] font-mono font-semibold text-violet-700 dark:text-violet-400 bg-violet-50 dark:bg-violet-900/20 border border-violet-100 dark:border-violet-900/40 rounded-lg cursor-grab active:cursor-grabbing hover:border-violet-300 dark:hover:border-violet-700 transition-all truncate">
+                  {{ ev.name }}
+                </div>
+              </div>
+            </div>
+
+            <button
+              @click="resetLayout"
+              class="w-full px-3 py-1.5 bg-white dark:bg-zinc-800 text-gray-700 dark:text-zinc-300 border border-gray-200 dark:border-zinc-700 text-[10px] font-black uppercase tracking-widest rounded-lg hover:bg-gray-50 dark:hover:bg-zinc-700 transition-all active:scale-95">
+              Reset Layout
+            </button>
+          </div>
+
+          <!-- Canvas -->
+          <div class="grow min-w-0 overflow-auto custom-scrollbar border border-gray-200 dark:border-zinc-800 rounded-xl bg-gray-50/50 dark:bg-zinc-950/50">
+            <div class="relative" :style="{ width: graph.width + 'px', height: Math.max(graph.height, 240) + 'px' }">
+              <!-- Edges. currentColor + a text class is how the rest of the app
+                   gets theme-aware SVG. -->
+              <svg class="absolute inset-0 pointer-events-none text-gray-300 dark:text-zinc-700" :width="graph.width" :height="Math.max(graph.height, 240)">
+                <defs>
+                  <marker id="wf-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+                    <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" />
+                  </marker>
+                </defs>
+                <path
+                  v-for="(edge, i) in graph.edges"
+                  :key="i"
+                  :d="`M ${edge.from.x + 200} ${edge.from.y + 28} C ${edge.from.x + 230} ${edge.from.y + 28}, ${edge.to.x - 30} ${edge.to.y + 28}, ${edge.to.x} ${edge.to.y + 28}`"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  marker-end="url(#wf-arrow)" />
+              </svg>
+
+              <!-- Nodes -->
+              <div
+                v-for="node in graph.nodes"
+                :key="nodeKey(node)"
+                class="absolute select-none rounded-xl border transition-shadow"
+                :style="{ left: node.x + 'px', top: node.y + 'px', width: '200px' }"
+                :class="[
+                  node.kind === 'event'
+                    ? 'bg-violet-50 dark:bg-violet-900/20 border-violet-200 dark:border-violet-900/50'
+                    : 'bg-white dark:bg-zinc-900 border-gray-200 dark:border-zinc-800',
+                  dropTarget === nodeKey(node) ? 'ring-2 ring-black dark:ring-white shadow-lg' : '',
+                  dragItem && !canDropOn(node) ? 'opacity-40' : '',
+                ]"
+                @dragover="onNodeDragOver(node, $event)"
+                @dragleave="onNodeDragLeave(node)"
+                @drop="onNodeDrop(node, $event)">
+                <div class="flex items-center gap-2 px-3 py-2 cursor-grab active:cursor-grabbing" @pointerdown="startNodeDrag(node, $event)">
+                  <span
+                    class="shrink-0 text-[9px] font-black uppercase tracking-wider px-1.5 py-0.5 rounded"
+                    :class="node.kind === 'event'
+                      ? 'text-violet-700 dark:text-violet-300 bg-violet-100 dark:bg-violet-900/40'
+                      : 'text-gray-600 dark:text-zinc-300 bg-gray-100 dark:bg-zinc-800'">
+                    {{ node.kind === 'event' ? 'event' : 'agent' }}
+                  </span>
+                  <span class="min-w-0 grow truncate text-[11px] font-mono font-semibold text-gray-900 dark:text-zinc-100">{{ node.label }}</span>
+                  <span v-if="node.isStart" class="shrink-0 text-[9px] font-bold uppercase text-emerald-600 dark:text-emerald-400">start</span>
+                  <button
+                    v-if="node.kind === 'step'"
+                    @click.stop="confirmDeleteStep(node.step)"
+                    class="shrink-0 p-0.5 text-gray-300 dark:text-zinc-600 hover:text-red-500 dark:hover:text-red-400 rounded transition-all">
+                    <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
+                <div v-if="node.kind === 'step' && node.step.emitEventId" class="px-3 pb-1.5 -mt-1">
+                  <button
+                    @click.stop="clearStepEmit(node.step)"
+                    class="text-[9px] text-gray-400 dark:text-zinc-500 hover:text-red-500 dark:hover:text-red-400 transition-colors">
+                    emits {{ eventName(node.step.emitEventId) }} · clear
+                  </button>
+                </div>
+              </div>
+
+              <div v-if="graph.nodes.length <= 1" class="absolute inset-0 flex items-center justify-center pointer-events-none">
+                <p class="text-xs text-gray-400 dark:text-zinc-500">Drag a workspace onto the start event to begin</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Warnings -->
+        <div v-if="orphanSteps.length || deadEndEvents.length" class="space-y-2">
+          <div v-if="orphanSteps.length" class="px-4 py-3 bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/30 rounded-xl">
+            <p class="text-[11px] font-bold text-amber-700 dark:text-amber-400 uppercase tracking-widest mb-1">Unreachable steps</p>
+            <p class="text-xs text-amber-700/80 dark:text-amber-400/80">
+              {{ orphanSteps.length }} step(s) subscribe to an event no run can reach from the start event, so they will never fire.
+            </p>
+            <div class="mt-2 space-y-1">
+              <div v-for="s in orphanSteps" :key="s.id" class="flex items-center gap-2 text-[11px] font-mono text-amber-800 dark:text-amber-300">
+                <span>{{ eventName(s.eventId) }} → {{ workspaceName(s.workspaceId) }}</span>
+                <button @click="removeStep(s)" class="underline hover:no-underline">remove</button>
+              </div>
+            </div>
+          </div>
+
+          <div v-if="deadEndEvents.length" class="px-4 py-3 bg-gray-50 dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-xl">
+            <p class="text-[11px] font-bold text-gray-500 dark:text-zinc-400 uppercase tracking-widest mb-1">Dead ends</p>
+            <p class="text-xs text-gray-500 dark:text-zinc-400">
+              Nothing in this workflow consumes
+              <span class="font-mono">{{ deadEndEvents.map(eventName).join(', ') }}</span>.
+              That is fine if the run should stop there.
+            </p>
+          </div>
+        </div>
+      </template>
+
+      <!-- ── Text mode ── -->
+      <template v-else>
+        <div class="space-y-3">
+          <div class="flex items-start justify-between gap-4">
+            <p class="text-[11px] text-gray-400 dark:text-zinc-500 leading-snug">
+              Two spaces per level. Every item is <span class="font-mono">- agent:name</span> or <span class="font-mono">- event:name</span>,
+              alternating: an event is consumed by agents, and each agent may emit one event.
+            </p>
+            <div class="flex items-center gap-2 shrink-0">
+              <button
+                @click="discardText"
+                :disabled="!textDirty || savingText"
+                class="px-4 py-2 bg-white dark:bg-zinc-800 text-gray-700 dark:text-zinc-300 border border-gray-200 dark:border-zinc-700 text-[11px] font-black uppercase tracking-widest rounded-lg hover:bg-gray-50 dark:hover:bg-zinc-700 transition-all active:scale-95 disabled:opacity-50">
+                Discard
+              </button>
+              <button
+                @click="saveText"
+                :disabled="savingText"
+                class="px-4 py-2 bg-black dark:bg-white text-white dark:text-black text-[11px] font-black uppercase tracking-widest rounded-lg hover:opacity-80 transition-all active:scale-95 disabled:opacity-50">
+                {{ savingText ? 'Saving…' : 'Save' }}
+              </button>
+            </div>
+          </div>
+
+          <textarea
+            v-model="text"
+            @input="textDirty = true; textError = null"
+            spellcheck="false"
+            rows="18"
+            class="w-full px-3 py-2 text-[12px] font-mono leading-relaxed border rounded-lg bg-white dark:bg-zinc-900 text-gray-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white transition-all resize-y"
+            :class="textError ? 'border-red-400' : 'border-gray-200 dark:border-zinc-700'"></textarea>
+
+          <div v-if="textError" class="px-3 py-2 bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/30 rounded-lg">
+            <p class="text-[11px] text-red-600 dark:text-red-400">
+              <span v-if="textError.line" class="font-bold">Line {{ textError.line }}: </span>{{ textError.message }}
+            </p>
+          </div>
+        </div>
+      </template>
+
+      <!-- Resulting tasks -->
+      <div class="space-y-2">
+        <div>
+          <h2 class="text-sm font-bold text-gray-800 dark:text-zinc-200">Tasks from this workflow</h2>
+          <p class="text-[11px] text-gray-400 dark:text-zinc-500 mt-0.5">Created by runs of this pipeline</p>
+        </div>
+
+        <LoadingState v-if="loadingTasks" label="Loading tasks…" class="py-4" />
+
+        <div v-else-if="tasks.length === 0" class="py-8 px-4 border border-dashed border-gray-200 dark:border-zinc-800 rounded-xl text-center">
+          <p class="text-xs text-gray-400 dark:text-zinc-500">No runs yet</p>
+        </div>
+
+        <div v-else class="space-y-2">
+          <router-link
+            v-for="t in visibleTasks"
+            :key="t.id"
+            :to="`/workspaces/${t.workspaceId}/tasks/${t.id}`"
+            class="flex items-center gap-3 px-4 py-2.5 bg-white dark:bg-zinc-900 border border-gray-100 dark:border-zinc-800 rounded-xl hover:border-gray-200 dark:hover:border-zinc-700 transition-all">
+            <span class="shrink-0 text-[10px] font-bold uppercase tracking-wider" :class="statusColor(t.status)">{{ t.status }}</span>
+            <span class="min-w-0 grow truncate text-xs text-gray-800 dark:text-zinc-200">{{ t.title }}</span>
+            <span class="shrink-0 text-[10px] text-gray-400 dark:text-zinc-500 font-mono">{{ workspaceName(t.workspaceId) }}</span>
+          </router-link>
+
+          <button
+            v-if="hasMoreTasks"
+            @click="loadMoreTasks"
+            class="w-full py-2 text-[11px] font-bold uppercase tracking-widest text-gray-500 dark:text-zinc-400 hover:text-gray-800 dark:hover:text-zinc-200 border border-gray-100 dark:border-zinc-800 rounded-xl hover:border-gray-200 dark:hover:border-zinc-700 transition-all">
+            Load more ({{ tasks.length - visibleTaskCount }} remaining)
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <DeleteModal
+      :show="showDeleteStepModal"
+      title="Remove Step"
+      :taskTitle="deletingStep ? workspaceName(deletingStep.workspaceId) : ''"
+      @close="showDeleteStepModal = false; deletingStep = null"
+      @confirm="handleDeleteStep" />
+  </div>
+</template>

--- a/frontend/src/views/WorkflowDetailView.vue
+++ b/frontend/src/views/WorkflowDetailView.vue
@@ -7,6 +7,7 @@ import {
   fetchEvents,
 } from '../api';
 import { useWorkspaceStore } from '../stores/workspaceStore';
+import { useTooltipStore } from '../stores/tooltipStore';
 import { useToasts } from '../composables/useToasts';
 import DeleteModal from '../components/DeleteModal.vue';
 import LoadingState from '../components/LoadingState.vue';
@@ -14,6 +15,7 @@ import LoadingState from '../components/LoadingState.vue';
 const route = useRoute();
 const router = useRouter();
 const workspaceStore = useWorkspaceStore();
+const tooltipStore = useTooltipStore();
 const { notifyError, notifySuccess } = useToasts();
 
 const workflowId = route.params.id;
@@ -709,11 +711,22 @@ onMounted(async () => {
                     </svg>
                   </button>
                 </div>
-                <div v-if="node.kind === 'step' && node.step.emitEventId" class="px-3 pb-1.5 -mt-1">
+                <div v-if="node.kind === 'step' && node.step.emitEventId" class="flex items-center gap-1.5 px-3 pb-1.5 -mt-1">
+                  <span class="min-w-0 grow truncate text-[9px] text-gray-400 dark:text-zinc-500">
+                    emits <span class="font-mono">{{ eventName(node.step.emitEventId) }}</span>
+                  </span>
+                  <!-- Removing the emitted event breaks the chain here, so the
+                       control is coloured as the destructive action it is
+                       rather than reading as part of the label. -->
                   <button
                     @click.stop="clearStepEmit(node.step)"
-                    class="text-[9px] text-gray-400 dark:text-zinc-500 hover:text-red-500 dark:hover:text-red-400 transition-colors">
-                    emits {{ eventName(node.step.emitEventId) }} · clear
+                    @mouseenter="tooltipStore.show($event, 'Stop emitting this event', 'top')"
+                    @mouseleave="tooltipStore.hide()"
+                    class="shrink-0 flex items-center gap-0.5 px-1 py-0.5 rounded text-[9px] font-bold uppercase tracking-wider text-amber-600 dark:text-amber-400 hover:text-white dark:hover:text-white hover:bg-red-500 dark:hover:bg-red-500 transition-all">
+                    <svg class="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
+                    </svg>
+                    clear
                   </button>
                 </div>
               </div>

--- a/frontend/src/views/WorkflowDetailView.vue
+++ b/frontend/src/views/WorkflowDetailView.vue
@@ -1,10 +1,10 @@
 <script setup>
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed, watch, onMounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import {
   getWorkflow, updateWorkflow, fetchWorkflowSteps, createWorkflowStep,
   deleteWorkflowStep, fetchWorkflowTasks, fetchWorkflowText, replaceWorkflowFromText,
-  fetchEvents,
+  fetchEvents, fetchEventTriggers,
 } from '../api';
 import { useWorkspaceStore } from '../stores/workspaceStore';
 import { useTooltipStore } from '../stores/tooltipStore';
@@ -45,7 +45,9 @@ const CANVAS_PADDING = 32;
 const positions = ref({});
 
 function nodeKey(node) {
-  return node.kind === 'event' ? `event:${node.eventId}` : `step:${node.stepId}`;
+  if (node.kind === 'event') return `event:${node.eventId}`;
+  if (node.kind === 'global') return `global:${node.triggerId}`;
+  return `step:${node.stepId}`;
 }
 
 // ── Graph model ───────────────────────────────────────────────────────────────
@@ -80,6 +82,51 @@ const stepsByEvent = computed(() => {
   }
   return map;
 });
+
+// Global subscribers to the events this workflow passes through, keyed by
+// event id. These are `EventTrigger` rows owned by /events, not by this
+// workflow — but they DO run when a workflow publishes their event, so hiding
+// them would misrepresent what a run actually does. They are drawn locked.
+const globalTriggers = ref({});
+
+/** Every event this workflow touches: its start plus everything emitted. */
+const graphEventIds = computed(() => {
+  const ids = new Set();
+  if (workflow.value?.startEventId) ids.add(workflow.value.startEventId);
+  for (const s of steps.value) {
+    ids.add(s.eventId);
+    if (s.emitEventId) ids.add(s.emitEventId);
+  }
+  return [...ids];
+});
+
+// Refetch whenever the set of events changes rather than after each mutation:
+// adding a step, clearing an emit, or a text-mode save can all bring a new
+// event into the graph, and a watch cannot be forgotten at one of those sites.
+watch(graphEventIds, (ids, previous) => {
+  if (previous && ids.length === previous.length && ids.every(id => previous.includes(id))) return;
+  loadGlobalTriggers();
+});
+
+async function loadGlobalTriggers() {
+  const ids = graphEventIds.value;
+  if (ids.length === 0) {
+    globalTriggers.value = {};
+    return;
+  }
+  // One request per event: a graph has a handful of them, and there is no bulk
+  // endpoint. Failures degrade to "no global subscribers" rather than blocking
+  // the canvas — the workflow's own steps are the part the user is editing.
+  const results = await Promise.all(ids.map(async id => {
+    try {
+      const data = await fetchEventTriggers(id);
+      return [id, data.eventTriggers ?? []];
+    } catch {
+      return [id, []];
+    }
+  }));
+  globalTriggers.value = Object.fromEntries(results.filter(([, list]) => list.length > 0));
+}
 
 /**
  * Walks outward from the start event assigning each node a column.
@@ -119,6 +166,7 @@ const graph = computed(() => {
   // rows and crossed the edges between them.
   const eventRow = {};
   const stepRow = {};
+  const globalRow = {};
   const visiting = new Set();
   let nextRow = 0;
 
@@ -130,7 +178,8 @@ const graph = computed(() => {
     visiting.add(eventId);
 
     const childSteps = stepsByEvent.value[eventId] ?? [];
-    if (childSteps.length === 0) {
+    const childGlobals = globalTriggers.value[eventId] ?? [];
+    if (childSteps.length === 0 && childGlobals.length === 0) {
       eventRow[eventId] = nextRow++;
     } else {
       const rows = [];
@@ -145,6 +194,13 @@ const graph = computed(() => {
           stepRow[step.id] = nextRow++;
         }
         rows.push(stepRow[step.id]);
+      }
+      // Global subscribers are always leaves here. Their own onward chain runs
+      // through global triggers, not this workflow, so drawing it would grow
+      // the canvas without describing this graph.
+      for (const trigger of childGlobals) {
+        globalRow[trigger.id] = nextRow++;
+        rows.push(globalRow[trigger.id]);
       }
       eventRow[eventId] = rows.reduce((sum, r) => sum + r, 0) / rows.length;
     }
@@ -189,6 +245,26 @@ const graph = computed(() => {
     edges.push({ from: source, to: node });
     if (step.emitEventId && eventNodes[step.emitEventId]) {
       edges.push({ from: node, to: eventNodes[step.emitEventId] });
+    }
+  }
+
+  // Locked nodes for the event's global subscribers.
+  for (const [eventId, triggers] of Object.entries(globalTriggers.value)) {
+    const source = eventNodes[eventId];
+    if (!source) continue;
+    for (const trigger of triggers) {
+      const node = {
+        kind: 'global',
+        triggerId: trigger.id,
+        trigger,
+        eventId,
+        label: workspaceName(trigger.workspaceId),
+        column: source.column + 1,
+        row: globalRow[trigger.id] ?? nextRow++,
+        height: trigger.emitEventId ? NODE_HEIGHT_WITH_EMIT : NODE_HEIGHT,
+      };
+      nodes.push(node);
+      edges.push({ from: source, to: node, global: true });
     }
   }
 
@@ -277,6 +353,9 @@ function startPaletteDrag(kind, id, e) {
 // silently do nothing.
 function canDropOn(node, item = dragItem.value) {
   if (!item) return false;
+  // A global subscriber belongs to the event, not this workflow, so nothing
+  // dropped here could be saved.
+  if (node.kind === 'global') return false;
   if (node.kind === 'event') return item.kind === 'workspace';
   if (node.kind === 'step') {
     if (item.kind !== 'event') return false;
@@ -552,7 +631,7 @@ onMounted(async () => {
       fetchEvents().catch(() => ({ events: [] })),
     ]);
     events.value = eventsRes.events ?? [];
-    await loadTasks();
+    await Promise.all([loadTasks(), loadGlobalTriggers()]);
   } catch (e) {
     notifyError(e.message);
   } finally {
@@ -673,6 +752,8 @@ onMounted(async () => {
                   fill="none"
                   stroke="currentColor"
                   stroke-width="1.5"
+                  :stroke-dasharray="edge.global ? '4 3' : undefined"
+                  :opacity="edge.global ? 0.6 : 1"
                   marker-end="url(#wf-arrow)" />
               </svg>
 
@@ -685,7 +766,11 @@ onMounted(async () => {
                 :class="[
                   node.kind === 'event'
                     ? 'bg-violet-50 dark:bg-violet-900/20 border-violet-200 dark:border-violet-900/50'
-                    : 'bg-white dark:bg-zinc-900 border-gray-200 dark:border-zinc-800',
+                    : node.kind === 'global'
+                      // Dashed and dimmed: it runs, but this workflow does not
+                      // own it, so it cannot be edited from here.
+                      ? 'bg-gray-50/60 dark:bg-zinc-900/40 border-dashed border-gray-300 dark:border-zinc-700'
+                      : 'bg-white dark:bg-zinc-900 border-gray-200 dark:border-zinc-800',
                   dropTarget === nodeKey(node) ? 'ring-2 ring-black dark:ring-white shadow-lg' : '',
                   dragItem && !canDropOn(node) ? 'opacity-40' : '',
                 ]"
@@ -697,11 +782,31 @@ onMounted(async () => {
                     class="shrink-0 text-[9px] font-black uppercase tracking-wider px-1.5 py-0.5 rounded"
                     :class="node.kind === 'event'
                       ? 'text-violet-700 dark:text-violet-300 bg-violet-100 dark:bg-violet-900/40'
-                      : 'text-gray-600 dark:text-zinc-300 bg-gray-100 dark:bg-zinc-800'">
+                      : node.kind === 'global'
+                        ? 'text-gray-500 dark:text-zinc-500 bg-gray-100 dark:bg-zinc-800'
+                        : 'text-gray-600 dark:text-zinc-300 bg-gray-100 dark:bg-zinc-800'">
                     {{ node.kind === 'event' ? 'event' : 'agent' }}
                   </span>
-                  <span class="min-w-0 grow truncate text-[11px] font-mono font-semibold text-gray-900 dark:text-zinc-100">{{ node.label }}</span>
+                  <span
+                    class="min-w-0 grow truncate text-[11px] font-mono font-semibold"
+                    :class="node.kind === 'global' ? 'text-gray-500 dark:text-zinc-400' : 'text-gray-900 dark:text-zinc-100'">
+                    {{ node.label }}
+                  </span>
                   <span v-if="node.isStart" class="shrink-0 text-[9px] font-bold uppercase text-emerald-600 dark:text-emerald-400">start</span>
+                  <!-- Managed on the event, not here: link out rather than
+                       offering a delete this view cannot honour. -->
+                  <router-link
+                    v-if="node.kind === 'global'"
+                    :to="`/events/${node.eventId}`"
+                    @click.stop
+                    @mouseenter="tooltipStore.show($event, 'Global subscriber — always runs on this event. Managed in Events.', 'top')"
+                    @mouseleave="tooltipStore.hide()"
+                    class="shrink-0 flex items-center gap-0.5 text-[9px] font-bold uppercase tracking-wider text-gray-400 dark:text-zinc-500 hover:text-gray-700 dark:hover:text-zinc-300 transition-colors">
+                    <svg class="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+                    </svg>
+                    global
+                  </router-link>
                   <button
                     v-if="node.kind === 'step'"
                     @click.stop="confirmDeleteStep(node.step)"
@@ -710,6 +815,13 @@ onMounted(async () => {
                       <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
                     </svg>
                   </button>
+                </div>
+                <!-- A global subscriber may chain onward, but through global
+                     triggers rather than this workflow — shown, not drawn. -->
+                <div v-if="node.kind === 'global' && node.trigger.emitEventId" class="px-3 pb-1.5 -mt-1">
+                  <span class="text-[9px] text-gray-400 dark:text-zinc-500">
+                    emits <span class="font-mono">{{ eventName(node.trigger.emitEventId) }}</span> outside this workflow
+                  </span>
                 </div>
                 <div v-if="node.kind === 'step' && node.step.emitEventId" class="flex items-center gap-1.5 px-3 pb-1.5 -mt-1">
                   <span class="min-w-0 grow truncate text-[9px] text-gray-400 dark:text-zinc-500">

--- a/frontend/src/views/WorkflowDetailView.vue
+++ b/frontend/src/views/WorkflowDetailView.vue
@@ -32,9 +32,12 @@ const mode = ref('graph');
 // that entry returns it to the automatic spot.
 
 const COLUMN_WIDTH = 260;
-const ROW_HEIGHT = 96;
+const ROW_HEIGHT = 104;
 const NODE_WIDTH = 200;
 const NODE_HEIGHT = 56;
+// A step that emits an event renders a second line, so it is taller than the
+// base node. Row spacing has to clear the taller one or branches collide.
+const NODE_HEIGHT_WITH_EMIT = 78;
 const CANVAS_PADDING = 32;
 
 const positions = ref({});
@@ -107,26 +110,59 @@ const graph = computed(() => {
     }
   }
 
+  // Rows are assigned as a tidy tree rather than by a per-column counter:
+  // each leaf takes the next free row and every parent centers on its own
+  // children. A flat counter packed each column independently, which kept
+  // nodes from colliding but scattered a fan-out's branches across unrelated
+  // rows and crossed the edges between them.
+  const eventRow = {};
+  const stepRow = {};
+  const visiting = new Set();
+  let nextRow = 0;
+
+  function assignRows(eventId) {
+    if (eventRow[eventId] !== undefined) return eventRow[eventId];
+    // Defensive: cycles are refused on save, but the canvas must not recurse
+    // forever on data that reached storage another way.
+    if (visiting.has(eventId)) return nextRow;
+    visiting.add(eventId);
+
+    const childSteps = stepsByEvent.value[eventId] ?? [];
+    if (childSteps.length === 0) {
+      eventRow[eventId] = nextRow++;
+    } else {
+      const rows = [];
+      for (const step of childSteps) {
+        const emitted = step.emitEventId;
+        // A step sits on the same row as the event it emits — they are 1:1, so
+        // aligning them makes each branch read as one straight line. A re-join
+        // onto an already-placed event gets its own row instead.
+        if (emitted && eventRow[emitted] === undefined && !visiting.has(emitted)) {
+          stepRow[step.id] = assignRows(emitted);
+        } else {
+          stepRow[step.id] = nextRow++;
+        }
+        rows.push(stepRow[step.id]);
+      }
+      eventRow[eventId] = rows.reduce((sum, r) => sum + r, 0) / rows.length;
+    }
+    visiting.delete(eventId);
+    return eventRow[eventId];
+  }
+  assignRows(startId);
+
   const nodes = [];
   const edges = [];
-  const rowCursor = {};
-
-  function place(column) {
-    const row = rowCursor[column] ?? 0;
-    rowCursor[column] = row + 1;
-    return row;
-  }
-
-  // Events first so their rows are assigned before the steps that hang off them.
   const eventNodes = {};
+
   for (const eventId of order) {
-    const column = eventColumn[eventId];
     const node = {
       kind: 'event',
       eventId,
       label: eventName(eventId),
-      column,
-      row: place(column),
+      column: eventColumn[eventId],
+      row: eventRow[eventId] ?? nextRow++,
+      height: NODE_HEIGHT,
       isStart: eventId === startId,
     };
     eventNodes[eventId] = node;
@@ -136,14 +172,16 @@ const graph = computed(() => {
   for (const step of steps.value) {
     const source = eventNodes[step.eventId];
     if (!source) continue; // orphaned step: its source event is unreachable
-    const column = source.column + 1;
     const node = {
       kind: 'step',
       stepId: step.id,
       step,
       label: workspaceName(step.workspaceId),
-      column,
-      row: place(column),
+      column: source.column + 1,
+      row: stepRow[step.id] ?? nextRow++,
+      // A step that emits carries a second line, so its box is taller. Edges
+      // anchor to the middle, which only lands right if the height is real.
+      height: step.emitEventId ? NODE_HEIGHT_WITH_EMIT : NODE_HEIGHT,
     };
     nodes.push(node);
     edges.push({ from: source, to: node });
@@ -159,10 +197,20 @@ const graph = computed(() => {
   }
 
   const width = Math.max(...nodes.map(n => n.x + NODE_WIDTH), 0) + CANVAS_PADDING;
-  const height = Math.max(...nodes.map(n => n.y + NODE_HEIGHT), 0) + CANVAS_PADDING;
+  const height = Math.max(...nodes.map(n => n.y + n.height), 0) + CANVAS_PADDING;
 
   return { nodes, edges, width, height };
 });
+
+/** A curve from the right edge of one node to the left edge of the next. */
+function edgePath(edge) {
+  const x1 = edge.from.x + NODE_WIDTH;
+  const y1 = edge.from.y + edge.from.height / 2;
+  const x2 = edge.to.x;
+  const y2 = edge.to.y + edge.to.height / 2;
+  const bend = Math.max(30, (x2 - x1) / 2);
+  return `M ${x1} ${y1} C ${x1 + bend} ${y1}, ${x2 - bend} ${y2}, ${x2} ${y2}`;
+}
 
 // Orphans are steps whose source event no longer sits on any path from the
 // start event — usually because the start event changed. They would silently
@@ -221,13 +269,17 @@ function startPaletteDrag(kind, id, e) {
   e.dataTransfer.effectAllowed = 'copy';
 }
 
-function canDropOn(node) {
-  if (!dragItem.value) return false;
-  if (node.kind === 'event') return dragItem.value.kind === 'workspace';
+// The item is passed explicitly rather than read from `dragItem`, because the
+// drop handler has to clear that state before awaiting the API call — reading
+// the ref here made every drop evaluate against an already-cleared item and
+// silently do nothing.
+function canDropOn(node, item = dragItem.value) {
+  if (!item) return false;
+  if (node.kind === 'event') return item.kind === 'workspace';
   if (node.kind === 'step') {
-    if (dragItem.value.kind !== 'event') return false;
+    if (item.kind !== 'event') return false;
     if (node.step.emitEventId) return false; // a step emits at most one event
-    return !wouldCreateCycle(node.step.eventId, dragItem.value.id);
+    return !wouldCreateCycle(node.step.eventId, item.id);
   }
   return false;
 }
@@ -248,7 +300,7 @@ async function onNodeDrop(node, e) {
   const item = dragItem.value;
   dropTarget.value = null;
   dragItem.value = null;
-  if (!item || !canDropOn(node)) return;
+  if (!canDropOn(node, item)) return;
 
   if (node.kind === 'event' && item.kind === 'workspace') {
     await addStep(node.eventId, item.id);
@@ -615,7 +667,7 @@ onMounted(async () => {
                 <path
                   v-for="(edge, i) in graph.edges"
                   :key="i"
-                  :d="`M ${edge.from.x + 200} ${edge.from.y + 28} C ${edge.from.x + 230} ${edge.from.y + 28}, ${edge.to.x - 30} ${edge.to.y + 28}, ${edge.to.x} ${edge.to.y + 28}`"
+                  :d="edgePath(edge)"
                   fill="none"
                   stroke="currentColor"
                   stroke-width="1.5"

--- a/frontend/src/views/WorkflowDetailView.vue
+++ b/frontend/src/views/WorkflowDetailView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, watch, onMounted } from 'vue';
+import { ref, computed, watch, nextTick, onMounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import {
   getWorkflow, updateWorkflow, fetchWorkflowSteps, createWorkflowStep,
@@ -47,6 +47,7 @@ const positions = ref({});
 function nodeKey(node) {
   if (node.kind === 'event') return `event:${node.eventId}`;
   if (node.kind === 'global') return `global:${node.triggerId}`;
+  if (node.kind === 'global-event') return `global-event:${node.triggerId}:${node.eventId}`;
   return `step:${node.stepId}`;
 }
 
@@ -261,10 +262,30 @@ const graph = computed(() => {
         label: workspaceName(trigger.workspaceId),
         column: source.column + 1,
         row: globalRow[trigger.id] ?? nextRow++,
-        height: trigger.emitEventId ? NODE_HEIGHT_WITH_EMIT : NODE_HEIGHT,
+        height: NODE_HEIGHT,
       };
       nodes.push(node);
       edges.push({ from: source, to: node, global: true });
+
+      if (!trigger.emitEventId) continue;
+
+      // The event this subscriber publishes gets its own node rather than an
+      // edge into the workflow's node of the same name. That distinction is
+      // load-bearing: a global subscriber's task does not carry the workflow,
+      // so when it publishes, only that event's *global* subscribers run — the
+      // workflow's own steps for it do not. Drawing into the workflow node
+      // would claim the run continues here when it has actually left.
+      const emitted = {
+        kind: 'global-event',
+        triggerId: trigger.id,
+        eventId: trigger.emitEventId,
+        label: eventName(trigger.emitEventId),
+        column: node.column + 1,
+        row: node.row,
+        height: NODE_HEIGHT,
+      };
+      nodes.push(emitted);
+      edges.push({ from: node, to: emitted, global: true });
     }
   }
 
@@ -355,7 +376,7 @@ function canDropOn(node, item = dragItem.value) {
   if (!item) return false;
   // A global subscriber belongs to the event, not this workflow, so nothing
   // dropped here could be saved.
-  if (node.kind === 'global') return false;
+  if (node.kind === 'global' || node.kind === 'global-event') return false;
   if (node.kind === 'event') return item.kind === 'workspace';
   if (node.kind === 'step') {
     if (item.kind !== 'event') return false;
@@ -384,7 +405,7 @@ async function onNodeDrop(node, e) {
   if (!canDropOn(node, item)) return;
 
   if (node.kind === 'event' && item.kind === 'workspace') {
-    await addStep(node.eventId, item.id);
+    openStepFormForNew(node.eventId, item.id);
   } else if (node.kind === 'step' && item.kind === 'event') {
     await setStepEmit(node.step, item.id);
   }
@@ -442,17 +463,117 @@ async function resetLayout() {
 
 // ── Mutations ─────────────────────────────────────────────────────────────────
 
-async function addStep(eventId, workspaceId) {
+// ── Step editor ───────────────────────────────────────────────────────────────
+// A step is a task template, so its title and instructions are the substance of
+// what the agent will actually be asked to do. Generating them silently made
+// every step say the same uninformative thing, so a drop opens this form
+// instead of writing a placeholder.
+
+// Template tokens the consumer substitutes at fire time. Declared here rather
+// than inline: a literal {{ in a template is parsed as interpolation, even
+// quoted inside an attribute.
+const TOKEN_PAYLOAD = '{' + '{EVENT_PAYLOAD}' + '}';
+const TOKEN_FAQ = '{' + '{EVENT_FAQ}' + '}';
+
+const stepForm = ref(null);
+const savingStep = ref(false);
+const bodyInputRef = ref(null);
+
+/** Open the editor for a workspace being added to an event. */
+function openStepFormForNew(eventId, workspaceId) {
+  stepForm.value = {
+    mode: 'create',
+    eventId,
+    workspaceId,
+    title: `${eventName(eventId)} → ${workspaceName(workspaceId)}`,
+    body: TOKEN_PAYLOAD,
+    assignee: 'agent',
+    allowAllCommands: false,
+    emitEventId: '',
+    stepId: null,
+  };
+}
+
+/** Open the editor for an existing step, so instructions stay changeable. */
+function openStepFormForEdit(step) {
+  stepForm.value = {
+    mode: 'edit',
+    eventId: step.eventId,
+    workspaceId: step.workspaceId,
+    title: step.title,
+    body: step.body,
+    assignee: step.assignee || 'agent',
+    allowAllCommands: !!step.allowAllCommands,
+    emitEventId: step.emitEventId || '',
+    stepId: step.id,
+  };
+}
+
+function closeStepForm() {
+  stepForm.value = null;
+}
+
+/** Insert a template token at the caret rather than always appending. */
+function insertToken(token) {
+  const form = stepForm.value;
+  if (!form) return;
+  const el = bodyInputRef.value;
+  if (!el || typeof el.selectionStart !== 'number') {
+    form.body = `${form.body}${form.body && !form.body.endsWith('\n') ? '\n' : ''}${token}`;
+    return;
+  }
+  const start = el.selectionStart;
+  const end = el.selectionEnd;
+  form.body = form.body.slice(0, start) + token + form.body.slice(end);
+  nextTick(() => {
+    el.focus();
+    el.setSelectionRange(start + token.length, start + token.length);
+  });
+}
+
+async function saveStepForm() {
+  const form = stepForm.value;
+  if (!form) return;
+  if (!form.title.trim()) {
+    notifyError('Title is required');
+    return;
+  }
+  savingStep.value = true;
   try {
-    const data = await createWorkflowStep(workflowId, {
-      eventId,
-      workspaceId,
-      title: `${workflow.value.name}: ${eventName(eventId)}`,
-      body: '{{EVENT_PAYLOAD}}',
-    });
-    steps.value = [...steps.value, data.workflowStep];
+    const payload = {
+      eventId: form.eventId,
+      workspaceId: form.workspaceId,
+      emitEventId: form.emitEventId,
+      title: form.title.trim(),
+      body: form.body,
+      assignee: form.assignee,
+      allowAllCommands: form.allowAllCommands,
+    };
+
+    if (form.mode === 'edit') {
+      // No PATCH for a step, so an edit is delete-then-create. Delete first:
+      // creating first would briefly double the fan-out for this event.
+      await deleteWorkflowStep(workflowId, form.stepId);
+      const data = await createWorkflowStep(workflowId, payload);
+      // Carry the manual position across, or the node would jump back to its
+      // automatic slot purely because its id changed.
+      const previous = positions.value[`step:${form.stepId}`];
+      if (previous) {
+        const { [`step:${form.stepId}`]: _dropped, ...rest } = positions.value;
+        positions.value = { ...rest, [`step:${data.workflowStep.id}`]: previous };
+        persistLayout();
+      }
+      steps.value = [...steps.value.filter(s => s.id !== form.stepId), data.workflowStep];
+    } else {
+      const data = await createWorkflowStep(workflowId, payload);
+      steps.value = [...steps.value, data.workflowStep];
+    }
+    closeStepForm();
   } catch (e) {
     notifyError(e.message);
+    if (form.mode === 'edit') await loadSteps(); // the delete may have landed
+  } finally {
+    savingStep.value = false;
   }
 }
 
@@ -766,7 +887,9 @@ onMounted(async () => {
                 :class="[
                   node.kind === 'event'
                     ? 'bg-violet-50 dark:bg-violet-900/20 border-violet-200 dark:border-violet-900/50'
-                    : node.kind === 'global'
+                    : node.kind === 'global-event'
+                      ? 'bg-violet-50/40 dark:bg-violet-900/10 border-dashed border-violet-200/70 dark:border-violet-900/40'
+                      : node.kind === 'global'
                       // Dashed and dimmed: it runs, but this workflow does not
                       // own it, so it cannot be edited from here.
                       ? 'bg-gray-50/60 dark:bg-zinc-900/40 border-dashed border-gray-300 dark:border-zinc-700'
@@ -782,14 +905,16 @@ onMounted(async () => {
                     class="shrink-0 text-[9px] font-black uppercase tracking-wider px-1.5 py-0.5 rounded"
                     :class="node.kind === 'event'
                       ? 'text-violet-700 dark:text-violet-300 bg-violet-100 dark:bg-violet-900/40'
-                      : node.kind === 'global'
+                      : node.kind === 'global-event'
+                        ? 'text-violet-600/70 dark:text-violet-400/70 bg-violet-100/60 dark:bg-violet-900/25'
+                        : node.kind === 'global'
                         ? 'text-gray-500 dark:text-zinc-500 bg-gray-100 dark:bg-zinc-800'
                         : 'text-gray-600 dark:text-zinc-300 bg-gray-100 dark:bg-zinc-800'">
-                    {{ node.kind === 'event' ? 'event' : 'agent' }}
+                    {{ node.kind === 'event' || node.kind === 'global-event' ? 'event' : 'agent' }}
                   </span>
                   <span
                     class="min-w-0 grow truncate text-[11px] font-mono font-semibold"
-                    :class="node.kind === 'global' ? 'text-gray-500 dark:text-zinc-400' : 'text-gray-900 dark:text-zinc-100'">
+                    :class="node.kind === 'global' || node.kind === 'global-event' ? 'text-gray-500 dark:text-zinc-400' : 'text-gray-900 dark:text-zinc-100'">
                     {{ node.label }}
                   </span>
                   <span v-if="node.isStart" class="shrink-0 text-[9px] font-bold uppercase text-emerald-600 dark:text-emerald-400">start</span>
@@ -809,19 +934,22 @@ onMounted(async () => {
                   </router-link>
                   <button
                     v-if="node.kind === 'step'"
+                    @click.stop="openStepFormForEdit(node.step)"
+                    @mouseenter="tooltipStore.show($event, 'Edit task title and instructions', 'top')"
+                    @mouseleave="tooltipStore.hide()"
+                    class="shrink-0 p-0.5 text-gray-300 dark:text-zinc-600 hover:text-gray-700 dark:hover:text-zinc-200 rounded transition-all">
+                    <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z" />
+                    </svg>
+                  </button>
+                  <button
+                    v-if="node.kind === 'step'"
                     @click.stop="confirmDeleteStep(node.step)"
                     class="shrink-0 p-0.5 text-gray-300 dark:text-zinc-600 hover:text-red-500 dark:hover:text-red-400 rounded transition-all">
                     <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
                     </svg>
                   </button>
-                </div>
-                <!-- A global subscriber may chain onward, but through global
-                     triggers rather than this workflow — shown, not drawn. -->
-                <div v-if="node.kind === 'global' && node.trigger.emitEventId" class="px-3 pb-1.5 -mt-1">
-                  <span class="text-[9px] text-gray-400 dark:text-zinc-500">
-                    emits <span class="font-mono">{{ eventName(node.trigger.emitEventId) }}</span> outside this workflow
-                  </span>
                 </div>
                 <div v-if="node.kind === 'step' && node.step.emitEventId" class="flex items-center gap-1.5 px-3 pb-1.5 -mt-1">
                   <span class="min-w-0 grow truncate text-[9px] text-gray-400 dark:text-zinc-500">
@@ -845,6 +973,97 @@ onMounted(async () => {
 
               <div v-if="graph.nodes.length <= 1" class="absolute inset-0 flex items-center justify-center pointer-events-none">
                 <p class="text-xs text-gray-400 dark:text-zinc-500">Drag a workspace onto the start event to begin</p>
+              </div>
+            </div>
+
+            <!-- Step editor. The task template is what the agent is actually
+                 asked to do, so it is entered rather than generated. -->
+            <div v-if="stepForm" class="absolute inset-0 z-20 flex items-start justify-center bg-white/70 dark:bg-zinc-950/70 p-4 overflow-y-auto custom-scrollbar">
+              <div class="w-full max-w-md bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-xl p-5 space-y-4 shadow-2xl">
+                <div>
+                  <h3 class="text-sm font-bold text-gray-800 dark:text-zinc-200">
+                    {{ stepForm.mode === 'edit' ? 'Edit step' : 'Add step' }}
+                  </h3>
+                  <p class="text-[11px] text-gray-400 dark:text-zinc-500 mt-0.5">
+                    When <span class="font-mono text-violet-600 dark:text-violet-400">{{ eventName(stepForm.eventId) }}</span> fires,
+                    create this task in <span class="font-mono">{{ workspaceName(stepForm.workspaceId) }}</span>
+                  </p>
+                </div>
+
+                <div>
+                  <label class="block text-[11px] font-bold text-gray-500 dark:text-zinc-400 uppercase tracking-widest mb-1">
+                    Task title <span class="text-red-500">*</span>
+                  </label>
+                  <input
+                    v-model="stepForm.title"
+                    type="text"
+                    placeholder="Update the changelog"
+                    class="w-full px-3 py-2 text-sm border border-gray-200 dark:border-zinc-700 rounded-lg bg-white dark:bg-zinc-800 text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white transition-all" />
+                </div>
+
+                <div>
+                  <label class="block text-[11px] font-bold text-gray-500 dark:text-zinc-400 uppercase tracking-widest mb-1">Instructions</label>
+                  <textarea
+                    ref="bodyInputRef"
+                    v-model="stepForm.body"
+                    rows="5"
+                    placeholder="What should the agent do when this fires?"
+                    class="w-full px-3 py-2 text-sm font-mono border border-gray-200 dark:border-zinc-700 rounded-lg bg-white dark:bg-zinc-800 text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white transition-all resize-y"></textarea>
+                  <div class="flex items-center gap-1.5 mt-2">
+                    <span class="text-[10px] text-gray-400 dark:text-zinc-500">Insert:</span>
+                    <button
+                      type="button"
+                      @click="insertToken(TOKEN_PAYLOAD)"
+                      @mouseenter="tooltipStore.show($event, 'Replaced with the payload the publisher sent', 'top')"
+                      @mouseleave="tooltipStore.hide()"
+                      class="text-[10px] font-mono text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-900/20 hover:bg-violet-100 dark:hover:bg-violet-900/40 px-1.5 py-0.5 rounded transition-colors">
+                      {{ TOKEN_PAYLOAD }}
+                    </button>
+                    <button
+                      type="button"
+                      @click="insertToken(TOKEN_FAQ)"
+                      @mouseenter="tooltipStore.show($event, 'Replaced with the publisher\'s question/answer context', 'top')"
+                      @mouseleave="tooltipStore.hide()"
+                      class="text-[10px] font-mono text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-900/20 hover:bg-violet-100 dark:hover:bg-violet-900/40 px-1.5 py-0.5 rounded transition-colors">
+                      {{ TOKEN_FAQ }}
+                    </button>
+                  </div>
+                </div>
+
+                <div class="flex items-center gap-4">
+                  <div>
+                    <label class="block text-[11px] font-bold text-gray-500 dark:text-zinc-400 uppercase tracking-widest mb-1">Assignee</label>
+                    <div class="flex p-1 bg-gray-100 dark:bg-zinc-950 border border-gray-200 dark:border-zinc-800 rounded-lg w-fit">
+                      <button
+                        type="button"
+                        v-for="who in ['agent', 'human']"
+                        :key="who"
+                        @click="stepForm.assignee = who"
+                        class="px-4 py-1 rounded-md text-[10px] font-semibold uppercase transition-all"
+                        :class="stepForm.assignee === who ? 'bg-white dark:bg-zinc-800 text-gray-900 dark:text-white shadow-sm border border-gray-200 dark:border-zinc-700' : 'text-gray-500 dark:text-zinc-500 border border-transparent'">
+                        {{ who }}
+                      </button>
+                    </div>
+                  </div>
+                  <label class="flex items-center gap-2 pt-4 cursor-pointer">
+                    <input type="checkbox" v-model="stepForm.allowAllCommands" class="accent-black dark:accent-white" />
+                    <span class="text-[11px] font-semibold text-gray-600 dark:text-zinc-400">Allow all commands</span>
+                  </label>
+                </div>
+
+                <div class="flex items-center gap-2 pt-2 border-t border-gray-100 dark:border-zinc-800">
+                  <button
+                    @click="saveStepForm"
+                    :disabled="savingStep"
+                    class="px-4 py-2 bg-black dark:bg-white text-white dark:text-black text-[11px] font-black uppercase tracking-widest rounded-lg hover:opacity-80 transition-all active:scale-95 disabled:opacity-50">
+                    {{ savingStep ? 'Saving…' : (stepForm.mode === 'edit' ? 'Save' : 'Add step') }}
+                  </button>
+                  <button
+                    @click="closeStepForm"
+                    class="px-4 py-2 bg-white dark:bg-zinc-800 text-gray-700 dark:text-zinc-300 border border-gray-200 dark:border-zinc-700 text-[11px] font-black uppercase tracking-widest rounded-lg hover:bg-gray-50 dark:hover:bg-zinc-700 transition-all active:scale-95">
+                    Cancel
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/frontend/src/views/WorkflowsView.vue
+++ b/frontend/src/views/WorkflowsView.vue
@@ -1,0 +1,265 @@
+<script setup>
+import { ref, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import { fetchWorkflows, createWorkflow, deleteWorkflow, fetchEvents } from '../api';
+import { useToasts } from '../composables/useToasts';
+import DeleteModal from '../components/DeleteModal.vue';
+import LoadingState from '../components/LoadingState.vue';
+
+const router = useRouter();
+const { notifyError, notifySuccess } = useToasts();
+
+const workflows = ref([]);
+const events = ref([]);
+const loading = ref(true);
+
+const showCreateForm = ref(false);
+const creating = ref(false);
+const formName = ref('');
+const formNameError = ref('');
+const formDescription = ref('');
+const formStartEventId = ref('');
+
+// Same identifier rule as events: workflows are referenced by name from the
+// text format and from publishEvent, so they cannot contain spaces.
+const WORKFLOW_NAME_RE = /^[a-z][a-z0-9_]*$/;
+
+function sanitizeName(value) {
+  return value.toLowerCase().replace(/\s+/g, '_').replace(/[^a-z0-9_]/g, '');
+}
+
+function onNameInput(e) {
+  formName.value = sanitizeName(e.target.value);
+  formNameError.value = '';
+}
+
+async function loadWorkflows() {
+  loading.value = true;
+  try {
+    const data = await fetchWorkflows();
+    workflows.value = data.workflows ?? [];
+  } catch (e) {
+    notifyError(e.message);
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function loadEvents() {
+  try {
+    const data = await fetchEvents();
+    events.value = data.events ?? [];
+  } catch {
+    // A workflow can be created without a start event and given one later, so
+    // failing to load the picker must not block the form.
+    events.value = [];
+  }
+}
+
+function resetForm() {
+  showCreateForm.value = false;
+  formName.value = '';
+  formNameError.value = '';
+  formDescription.value = '';
+  formStartEventId.value = '';
+}
+
+async function handleCreate() {
+  const name = formName.value.trim();
+  if (!name) {
+    formNameError.value = 'Name is required';
+    return;
+  }
+  if (!WORKFLOW_NAME_RE.test(name)) {
+    formNameError.value = 'Use lowercase letters, digits and underscores; must start with a letter';
+    return;
+  }
+  creating.value = true;
+  try {
+    const data = await createWorkflow({
+      name,
+      description: formDescription.value.trim(),
+      startEventId: formStartEventId.value,
+    });
+    notifySuccess('Workflow created');
+    resetForm();
+    // Straight into the editor: a workflow with no steps has nothing to show
+    // in the list, so the next thing the user wants is always the canvas.
+    router.push(`/workflows/${data.workflow.id}`);
+  } catch (e) {
+    notifyError(e.message);
+  } finally {
+    creating.value = false;
+  }
+}
+
+const showDeleteModal = ref(false);
+const deletingWorkflow = ref(null);
+const deleting = ref(false);
+
+function confirmDelete(wf) {
+  deletingWorkflow.value = wf;
+  showDeleteModal.value = true;
+}
+
+async function handleDelete() {
+  if (!deletingWorkflow.value) return;
+  deleting.value = true;
+  try {
+    await deleteWorkflow(deletingWorkflow.value.id);
+    notifySuccess('Workflow deleted');
+    workflows.value = workflows.value.filter(w => w.id !== deletingWorkflow.value.id);
+  } catch (e) {
+    notifyError(e.message);
+  } finally {
+    deleting.value = false;
+    showDeleteModal.value = false;
+    deletingWorkflow.value = null;
+  }
+}
+
+function eventName(id) {
+  return events.value.find(e => e.id === id)?.name ?? '';
+}
+
+onMounted(async () => {
+  await Promise.all([loadWorkflows(), loadEvents()]);
+});
+</script>
+
+<template>
+  <div class="flex flex-col h-full w-full overflow-y-auto custom-scrollbar">
+    <div class="w-full px-4 py-2 mb-6 shrink-0 flex flex-row items-center justify-between gap-4">
+      <div class="min-w-0">
+        <h1 class="text-lg md:text-2xl font-black text-gray-800 dark:text-zinc-200 truncate leading-tight">Workflows</h1>
+        <p class="text-xs text-gray-500 dark:text-zinc-400 mt-0.5">
+          Chain events and workspaces into a named pipeline
+        </p>
+      </div>
+      <button
+        v-if="!showCreateForm"
+        @click="showCreateForm = true"
+        class="shrink-0 px-4 py-2 bg-black dark:bg-white text-white dark:text-black text-[11px] font-black uppercase tracking-widest rounded-lg hover:opacity-80 transition-all active:scale-95">
+        New Workflow
+      </button>
+    </div>
+
+    <div class="px-4 space-y-6 pb-10">
+      <Transition name="slide-down">
+        <div v-if="showCreateForm" class="bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-xl p-5 space-y-4">
+          <div>
+            <label class="block text-[11px] font-bold text-gray-500 dark:text-zinc-400 uppercase tracking-widest mb-1">
+              Name <span class="text-red-500">*</span>
+            </label>
+            <input
+              :value="formName"
+              @input="onNameInput"
+              type="text"
+              placeholder="release_pipeline"
+              class="w-full px-3 py-2 text-sm font-mono border rounded-lg bg-white dark:bg-zinc-800 text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white transition-all"
+              :class="formNameError ? 'border-red-400' : 'border-gray-200 dark:border-zinc-700'" />
+            <p v-if="formNameError" class="text-[11px] text-red-500 mt-1">{{ formNameError }}</p>
+            <p v-else class="text-[11px] text-gray-400 dark:text-zinc-500 mt-1">
+              Lowercase letters, digits and underscores
+            </p>
+          </div>
+
+          <div>
+            <label class="block text-[11px] font-bold text-gray-500 dark:text-zinc-400 uppercase tracking-widest mb-1">Description</label>
+            <textarea
+              v-model="formDescription"
+              rows="2"
+              placeholder="What this pipeline does"
+              class="w-full px-3 py-2 text-sm border border-gray-200 dark:border-zinc-700 rounded-lg bg-white dark:bg-zinc-800 text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white transition-all resize-none"></textarea>
+          </div>
+
+          <div>
+            <label class="block text-[11px] font-bold text-gray-500 dark:text-zinc-400 uppercase tracking-widest mb-1">Start Event</label>
+            <select
+              v-model="formStartEventId"
+              class="w-full px-3 py-2 text-sm border border-gray-200 dark:border-zinc-700 rounded-lg bg-white dark:bg-zinc-800 text-gray-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white transition-all">
+              <option value="">Choose later</option>
+              <option v-for="ev in events" :key="ev.id" :value="ev.id">{{ ev.name }}</option>
+            </select>
+            <p class="text-[11px] text-gray-400 dark:text-zinc-500 mt-1">
+              The event that begins a run of this workflow
+            </p>
+          </div>
+
+          <div class="flex items-center gap-2 pt-2 border-t border-gray-100 dark:border-zinc-800">
+            <button
+              @click="handleCreate"
+              :disabled="creating"
+              class="px-4 py-2 bg-black dark:bg-white text-white dark:text-black text-[11px] font-black uppercase tracking-widest rounded-lg hover:opacity-80 transition-all active:scale-95 disabled:opacity-50">
+              {{ creating ? 'Creating…' : 'Create' }}
+            </button>
+            <button
+              @click="resetForm"
+              class="px-4 py-2 bg-white dark:bg-zinc-800 text-gray-700 dark:text-zinc-300 border border-gray-200 dark:border-zinc-700 text-[11px] font-black uppercase tracking-widest rounded-lg hover:bg-gray-50 dark:hover:bg-zinc-700 transition-all active:scale-95">
+              Cancel
+            </button>
+          </div>
+        </div>
+      </Transition>
+
+      <LoadingState v-if="loading" label="Loading workflows…" class="py-8" />
+
+      <div v-else-if="workflows.length === 0 && !showCreateForm" class="py-12 px-4 border border-dashed border-gray-200 dark:border-zinc-800 rounded-xl text-center">
+        <p class="text-sm font-semibold text-gray-500 dark:text-zinc-400 mb-1">No workflows yet</p>
+        <p class="text-xs text-gray-400 dark:text-zinc-500">
+          A workflow chains events and workspaces into one named, reviewable pipeline
+        </p>
+      </div>
+
+      <div v-else class="space-y-2">
+        <div
+          v-for="wf in workflows"
+          :key="wf.id"
+          @click="router.push(`/workflows/${wf.id}`)"
+          class="group flex items-center gap-4 px-4 py-3 bg-white dark:bg-zinc-900 border border-gray-100 dark:border-zinc-800 rounded-xl hover:border-gray-200 dark:hover:border-zinc-700 transition-all cursor-pointer">
+          <div class="shrink-0 w-8 h-8 flex items-center justify-center rounded-lg bg-gray-50 dark:bg-zinc-800 border border-gray-100 dark:border-zinc-700">
+            <svg class="w-4 h-4 text-gray-500 dark:text-zinc-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 6.878V6a2.25 2.25 0 012.25-2.25h7.5A2.25 2.25 0 0118 6v.878m-12 0c.235-.083.487-.128.75-.128h10.5c.263 0 .515.045.75.128m-12 0A2.25 2.25 0 004.5 9v.878m13.5-3A2.25 2.25 0 0119.5 9v.878m0 0a2.246 2.246 0 00-.75-.128H5.25c-.263 0-.515.045-.75.128m15 0A2.25 2.25 0 0121 12v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6c0-.98.626-1.813 1.5-2.122" />
+            </svg>
+          </div>
+
+          <div class="min-w-0 grow">
+            <p class="text-sm font-mono font-semibold text-gray-900 dark:text-zinc-100 truncate">{{ wf.name }}</p>
+            <p v-if="wf.description" class="text-xs text-gray-500 dark:text-zinc-400 truncate mt-0.5">{{ wf.description }}</p>
+            <p v-else-if="wf.startEventId" class="text-[11px] text-gray-400 dark:text-zinc-500 truncate mt-0.5">
+              starts on <span class="font-mono">{{ eventName(wf.startEventId) || '—' }}</span>
+            </p>
+          </div>
+
+          <span
+            v-if="!wf.startEventId"
+            class="shrink-0 text-[10px] font-bold uppercase tracking-wider text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-500/10 px-2 py-1 rounded">
+            No start event
+          </span>
+
+          <button
+            @click.stop="confirmDelete(wf)"
+            class="shrink-0 p-1.5 text-gray-300 dark:text-zinc-600 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 rounded transition-all opacity-0 group-hover:opacity-100">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <DeleteModal
+      :show="showDeleteModal"
+      title="Delete Workflow"
+      :taskTitle="deletingWorkflow?.name ?? ''"
+      @close="showDeleteModal = false; deletingWorkflow = null"
+      @confirm="handleDelete" />
+  </div>
+</template>
+
+<style scoped>
+.slide-down-enter-active,
+.slide-down-leave-active { transition: all 0.2s ease; }
+.slide-down-enter-from,
+.slide-down-leave-to { opacity: 0; transform: translateY(-8px); }
+</style>

--- a/frontend/src/views/WorkflowsView.vue
+++ b/frontend/src/views/WorkflowsView.vue
@@ -219,7 +219,7 @@ onMounted(async () => {
           class="group flex items-center gap-4 px-4 py-3 bg-white dark:bg-zinc-900 border border-gray-100 dark:border-zinc-800 rounded-xl hover:border-gray-200 dark:hover:border-zinc-700 transition-all cursor-pointer">
           <div class="shrink-0 w-8 h-8 flex items-center justify-center rounded-lg bg-gray-50 dark:bg-zinc-800 border border-gray-100 dark:border-zinc-700">
             <svg class="w-4 h-4 text-gray-500 dark:text-zinc-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6 6.878V6a2.25 2.25 0 012.25-2.25h7.5A2.25 2.25 0 0118 6v.878m-12 0c.235-.083.487-.128.75-.128h10.5c.263 0 .515.045.75.128m-12 0A2.25 2.25 0 004.5 9v.878m13.5-3A2.25 2.25 0 0119.5 9v.878m0 0a2.246 2.246 0 00-.75-.128H5.25c-.263 0-.515.045-.75.128m15 0A2.25 2.25 0 0121 12v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6c0-.98.626-1.813 1.5-2.122" />
+              <path stroke-linecap="round" stroke-linejoin="round" d="M7.217 10.907a2.25 2.25 0 100 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.769-.283 1.093m0-2.186l9.566-5.314m-9.566 7.5l9.566 5.314m0 0a2.25 2.25 0 103.935 2.186 2.25 2.25 0 00-3.935-2.186zm0-12.814a2.25 2.25 0 103.933-2.185 2.25 2.25 0 00-3.933 2.185z" />
             </svg>
           </div>
 


### PR DESCRIPTION
## What

Adds experimental **Workflows**: named, reviewable graphs of `event → workspace → event`, editable as a drag-and-drop canvas or as an indented text document.

- **Model**: `Workflow` + `WorkflowStep` (one edge each), `Task.WorkflowID/WorkflowDepth/CompletionTriggerType`.
- **Editor**: auto-laid-out graph (tidy tree, left-to-right), drag from a palette to connect, per-step task title/instructions with `{{EVENT_PAYLOAD}}` / `{{EVENT_FAQ}}`.
- **Text mode**: `GET/PUT /workflows/:id/text` round-trips the same graph as a document, with line-numbered parse errors.
- **Triggering**: a task can run a workflow on completion; an agent can start one via an optional `workflow` arg on `publishEvent`.

## Why

An `EventTrigger` was already an edge — event → workspace → next event — so multi-hop pipelines existed implicitly but couldn't be named, viewed, or reused. This makes that graph a first-class object without changing how events already behave: a publish with no workflow takes the original path, `workflow_id` defaults to 0, no backfill.

## Notable decisions

- **Cycles are rejected at setup**, not guarded at runtime — a looping graph spawns tasks forever, and the editor can point at the offending edge while the user is still looking at it. Fan-out, fan-in and diamond re-joins stay legal.
- **The parser lives in Go, not JS** — indentation parsing needs real tests, and the frontend has no test framework.
- **Global subscribers still fire during a workflow** and are drawn locked, so the run is represented honestly rather than as if the workflow replaced the event.

## Also included

- Fixes a pre-existing multi-tenancy bug: the "per-user" unique index on event names was actually on `name` alone, so one account taking a name locked it for everyone. Same bug existed in `Workflow`. Duplicates also returned a bare 500; now a 409.
- A gofmt pre-commit hook (separate commit).

## Testing

Backend suite green (25 packages, ~55 new tests). Verified against a running instance: migration, graph rendering, cycle refusal, text round-trip, workflow-triggered task creation.

AgentRQ: 0hDP9vgiKJt