### PR TITLE
chore: bump minor version to v0.4.0

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.3.20"
+	_appVersion   = "v0.4.0"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -16,14 +16,14 @@ func TestConfig(t *testing.T) {
 	oldConfigPath := _configPath
 	// We can't change _configPath because it's a constant.
 	// But we can change working directory!
-	
+
 	origWd, _ := os.Getwd()
 	os.Chdir(tmpDir)
 	defer os.Chdir(origWd)
 
 	// Setup _config
 	os.Mkdir("_config", 0755)
-	
+
 	baseYaml := `
 app:
   name: "BaseApp"
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.3.20" {
-			t.Errorf("Expected version v0.3.20, got %s", s.Version())
+		if s.Version() != "v0.4.0" {
+			t.Errorf("Expected version v0.4.0, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())
@@ -101,13 +101,13 @@ database:
 	t.Run("EnvVarOverride", func(t *testing.T) {
 		os.Setenv("ENV", "production")
 		defer os.Unsetenv("ENV")
-		
+
 		prodYaml := `
 database:
   host: "prod-db"
 `
 		os.WriteFile("_config/production.yaml", []byte(prodYaml), 0644)
-		
+
 		s, err := New()
 		if err != nil {
 			t.Fatal(err)
@@ -124,21 +124,21 @@ database:
 		if err == nil {
 			t.Error("expected error for missing base.yaml")
 		}
-		
+
 		os.WriteFile("_config/base.yaml", []byte("invalid: yaml: :"), 0644)
 		_, err = New()
 		if err == nil {
 			t.Error("expected error for invalid base.yaml")
 		}
 	})
-	
+
 	_ = oldConfigPath // avoid unused warning in mind
 }
 
 func TestMergeMaps(t *testing.T) {
 	a := map[string]any{"k1": "v1", "k2": map[string]any{"s1": "v2"}}
 	b := map[string]any{"k1": "v1-over", "k2": map[string]any{"s2": "v3"}}
-	
+
 	merged := mergeMaps(a, b)
 	if merged["k1"] != "v1-over" {
 		t.Errorf("k1 mismatch: %v", merged["k1"])

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.3.20",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.3.20",
+      "version": "0.4.0",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.3.20",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
Minor rather than patch: this release adds Workflows, a new top-level feature with its own tables, API surface and navigation entry, and changes how the DeepSeek Harness plugin maps sessions to tasks.

feat:
- Workflows: chain events and workspaces into one named, reviewable pipeline. Adds `workflows` / `workflow_steps` tables, full CRUD under /api/v1/workflows, a drag-and-drop graph editor and an indentation-based text format for the same graph. Steps are cycle-checked on save, agents start a run through the existing publishEvent tool, and tasks carry the workflow they belong to. (#322)
- dsh web onboarding: document and support setting up DeepSeek Harness through `dsh web`, with the setup tab defaulting to it. (#314)

fix:
- Workflow canvas drew only one hop of the global-trigger chain, hiding second-order subscribers entirely. It now fetches and walks the chain to the end, cycle-guarded and depth-capped. (#323)
- Markdown preview treated `<word>` as an HTML tag and swallowed it, in both the task view and the history/trajectory panel. (#321)
- DeepSeek Harness now opens a dedicated dsh session per AgentRQ task instead of continuing whatever session was open, and gives each one a real cwd, model, title and workspace grouping. (#317, #319, #320)

style:
- Replaced plain-text loading states with a shared LoadingState spinner. (#316)

docs:
- Document pnpm as a hard prerequisite for `dsh plugin add`. (#313)

Task: 0hDr4M1sj4r