### PR TITLE
feat(events): allow editing event trigger details

### DIFF
--- a/backend/internal/controller/crud/event.go
+++ b/backend/internal/controller/crud/event.go
@@ -29,6 +29,7 @@ type EventTriggerController interface {
 	CreateEventTrigger(ctx context.Context, req entity.CreateEventTriggerRequest) (*entity.CreateEventTriggerResponse, error)
 	GetEventTrigger(ctx context.Context, req entity.GetEventTriggerRequest) (*entity.GetEventTriggerResponse, error)
 	ListEventTriggers(ctx context.Context, req entity.ListEventTriggersRequest) (*entity.ListEventTriggersResponse, error)
+	UpdateEventTrigger(ctx context.Context, req entity.UpdateEventTriggerRequest) (*entity.UpdateEventTriggerResponse, error)
 	DeleteEventTrigger(ctx context.Context, req entity.DeleteEventTriggerRequest) error
 	ListTasksFromEvent(ctx context.Context, req entity.ListTasksFromEventRequest) (*entity.ListTasksFromEventResponse, error)
 }
@@ -187,6 +188,52 @@ func (c *controller) ListEventTriggers(ctx context.Context, req entity.ListEvent
 		triggers[i] = mapper.FromModelEventTriggerToEntity(m)
 	}
 	return &entity.ListEventTriggersResponse{EventTriggers: triggers}, nil
+}
+
+func (c *controller) UpdateEventTrigger(ctx context.Context, req entity.UpdateEventTriggerRequest) (*entity.UpdateEventTriggerResponse, error) {
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	if uid == 0 {
+		return nil, fmt.Errorf("invalid userID")
+	}
+
+	if req.Title == "" {
+		return nil, fmt.Errorf("title is required")
+	}
+
+	// Verify the target workspace belongs to this user.
+	ok, err := c.repository.CheckWorkspaceAccess(ctx, req.WorkspaceID, uid)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("workspace not found")
+	}
+
+	if req.CronSchedule != "" {
+		if err := schedule.ValidateCronGranularity(req.CronSchedule); err != nil {
+			return nil, err
+		}
+	}
+
+	if req.EmitEventID != 0 {
+		if _, err := c.repository.GetEvent(ctx, req.EmitEventID, uid); err != nil {
+			return nil, fmt.Errorf("emit event not found")
+		}
+	}
+
+	updated, err := c.repository.UpdateEventTrigger(ctx, req.ID, uid, model.EventTrigger{
+		WorkspaceID:      req.WorkspaceID,
+		Title:            req.Title,
+		Body:             req.Body,
+		Assignee:         req.Assignee,
+		CronSchedule:     req.CronSchedule,
+		AllowAllCommands: req.AllowAllCommands,
+		EmitEventID:      req.EmitEventID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &entity.UpdateEventTriggerResponse{EventTrigger: mapper.FromModelEventTriggerToEntity(updated)}, nil
 }
 
 func (c *controller) DeleteEventTrigger(ctx context.Context, req entity.DeleteEventTriggerRequest) error {

--- a/backend/internal/controller/crud/event_test.go
+++ b/backend/internal/controller/crud/event_test.go
@@ -308,6 +308,127 @@ func TestCreateEventTrigger_EmitEventNotOwned(t *testing.T) {
 	}
 }
 
+// ── UpdateEventTrigger ────────────────────────────────────────────────────────
+
+func TestUpdateEventTrigger_Success(t *testing.T) {
+	e := newTestController(t)
+	now := time.Now()
+	updated := model.EventTrigger{
+		ID: 500, EventID: 100, WorkspaceID: 1, UserID: testUserID,
+		Title: "Updated title", Assignee: "agent", UpdatedAt: now,
+	}
+
+	e.repo.EXPECT().CheckWorkspaceAccess(gomock.Any(), int64(1), testUserID).Return(true, nil)
+	e.repo.EXPECT().UpdateEventTrigger(gomock.Any(), int64(500), testUserID, gomock.Any()).Return(updated, nil)
+
+	resp, err := e.controller.UpdateEventTrigger(context.Background(), entity.UpdateEventTriggerRequest{
+		ID:          500,
+		WorkspaceID: 1,
+		Title:       "Updated title",
+		Assignee:    "agent",
+		UserID:      testUserIDStr,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.EventTrigger.Title != "Updated title" {
+		t.Errorf("expected title 'Updated title', got %s", resp.EventTrigger.Title)
+	}
+}
+
+func TestUpdateEventTrigger_NotFound(t *testing.T) {
+	e := newTestController(t)
+	e.repo.EXPECT().CheckWorkspaceAccess(gomock.Any(), int64(1), testUserID).Return(true, nil)
+	e.repo.EXPECT().UpdateEventTrigger(gomock.Any(), int64(999), testUserID, gomock.Any()).Return(model.EventTrigger{}, base.ErrNotFound)
+
+	_, err := e.controller.UpdateEventTrigger(context.Background(), entity.UpdateEventTriggerRequest{
+		ID:          999,
+		WorkspaceID: 1,
+		Title:       "My trigger",
+		UserID:      testUserIDStr,
+	})
+	if err == nil {
+		t.Error("expected error for missing trigger")
+	}
+}
+
+func TestUpdateEventTrigger_WorkspaceNotOwned(t *testing.T) {
+	e := newTestController(t)
+	e.repo.EXPECT().CheckWorkspaceAccess(gomock.Any(), int64(99), testUserID).Return(false, nil)
+
+	_, err := e.controller.UpdateEventTrigger(context.Background(), entity.UpdateEventTriggerRequest{
+		ID:          500,
+		WorkspaceID: 99,
+		Title:       "My trigger",
+		UserID:      testUserIDStr,
+	})
+	if err == nil {
+		t.Error("expected error for unowned workspace")
+	}
+}
+
+func TestUpdateEventTrigger_InvalidCron(t *testing.T) {
+	e := newTestController(t)
+	e.repo.EXPECT().CheckWorkspaceAccess(gomock.Any(), int64(1), testUserID).Return(true, nil)
+
+	_, err := e.controller.UpdateEventTrigger(context.Background(), entity.UpdateEventTriggerRequest{
+		ID:           500,
+		WorkspaceID:  1,
+		Title:        "My trigger",
+		CronSchedule: "*/5 * * * *", // sub-hourly — rejected
+		UserID:       testUserIDStr,
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid cron schedule")
+	}
+	if !strings.Contains(err.Error(), "granularity too fine") {
+		t.Errorf("expected granularity error, got %v", err)
+	}
+}
+
+func TestUpdateEventTrigger_EmptyTitle(t *testing.T) {
+	e := newTestController(t)
+	_, err := e.controller.UpdateEventTrigger(context.Background(), entity.UpdateEventTriggerRequest{
+		ID:          500,
+		WorkspaceID: 1,
+		Title:       "",
+		UserID:      testUserIDStr,
+	})
+	if err == nil {
+		t.Error("expected error for empty title")
+	}
+}
+
+func TestUpdateEventTrigger_InvalidUserID(t *testing.T) {
+	e := newTestController(t)
+	_, err := e.controller.UpdateEventTrigger(context.Background(), entity.UpdateEventTriggerRequest{
+		ID:          500,
+		WorkspaceID: 1,
+		Title:       "My trigger",
+		UserID:      "",
+	})
+	if err == nil {
+		t.Error("expected error for invalid userID")
+	}
+}
+
+func TestUpdateEventTrigger_EmitEventNotOwned(t *testing.T) {
+	e := newTestController(t)
+	e.repo.EXPECT().CheckWorkspaceAccess(gomock.Any(), int64(1), testUserID).Return(true, nil)
+	e.repo.EXPECT().GetEvent(gomock.Any(), int64(999), testUserID).Return(model.Event{}, base.ErrNotFound)
+
+	_, err := e.controller.UpdateEventTrigger(context.Background(), entity.UpdateEventTriggerRequest{
+		ID:          500,
+		WorkspaceID: 1,
+		Title:       "My trigger",
+		EmitEventID: 999,
+		UserID:      testUserIDStr,
+	})
+	if err == nil {
+		t.Error("expected error when emit event not owned by user")
+	}
+}
+
 // ── ListEventTriggers ─────────────────────────────────────────────────────────
 
 func TestListEventTriggers_Success(t *testing.T) {

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -560,6 +560,22 @@ type (
 		EventTriggers []EventTrigger
 	}
 
+	UpdateEventTriggerRequest struct {
+		ID               int64
+		UserID           string
+		WorkspaceID      int64
+		Title            string
+		Body             string
+		Assignee         string
+		CronSchedule     string
+		AllowAllCommands bool
+		EmitEventID      int64
+	}
+
+	UpdateEventTriggerResponse struct {
+		EventTrigger EventTrigger
+	}
+
 	DeleteEventTriggerRequest struct {
 		ID     int64
 		UserID string

--- a/backend/internal/data/view/api/view.go
+++ b/backend/internal/data/view/api/view.go
@@ -322,6 +322,20 @@ type (
 		EventTrigger EventTrigger `json:"eventTrigger"`
 	}
 
+	UpdateEventTriggerRequest struct {
+		WorkspaceID      string `json:"workspaceId"`
+		Title            string `json:"title"`
+		Body             string `json:"body"`
+		Assignee         string `json:"assignee"`
+		CronSchedule     string `json:"cronSchedule,omitempty"`
+		AllowAllCommands bool   `json:"allowAllCommands"`
+		EmitEventID      string `json:"emitEventId,omitempty"`
+	}
+
+	UpdateEventTriggerResponse struct {
+		EventTrigger EventTrigger `json:"eventTrigger"`
+	}
+
 	ListEventTriggersResponse struct {
 		EventTriggers []EventTrigger `json:"eventTriggers"`
 	}

--- a/backend/internal/handler/api/event.go
+++ b/backend/internal/handler/api/event.go
@@ -21,6 +21,7 @@ func (h *handler) registerEventRoutes() {
 	h.router.Delete("/events/:id", h.deleteEvent())
 	h.router.Post("/events/:id/triggers", h.createEventTrigger())
 	h.router.Get("/events/:id/triggers", h.listEventTriggers())
+	h.router.Patch("/events/:id/triggers/:triggerID", h.updateEventTrigger())
 	h.router.Delete("/events/:id/triggers/:triggerID", h.deleteEventTrigger())
 	h.router.Get("/events/:id/tasks", h.listTasksFromEvent())
 }
@@ -185,6 +186,27 @@ func (h *handler) listEventTriggers() fiber.Handler {
 			return c.Send(e)
 		}
 		return c.Send(mapper.FromListEventTriggersResponseEntityToHTTPResponse(rs))
+	}
+}
+
+func (h *handler) updateEventTrigger() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		rq := mapper.FromHTTPRequestToUpdateEventTriggerRequestEntity(c)
+		if rq == nil {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		rq.UserID = c.Locals("user_id").(string)
+		ctx, cancel := newContext(c)
+		defer cancel()
+		rs, err := h.crud.UpdateEventTrigger(ctx, *rq)
+		if err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		return c.Send(mapper.FromUpdateEventTriggerResponseEntityToHTTPResponse(rs))
 	}
 }
 

--- a/backend/internal/handler/api/event_test.go
+++ b/backend/internal/handler/api/event_test.go
@@ -24,6 +24,7 @@ type mockEventCrud struct {
 	listEventsFunc         func(ctx context.Context, req entity.ListEventsRequest) (*entity.ListEventsResponse, error)
 	deleteEventFunc        func(ctx context.Context, req entity.DeleteEventRequest) error
 	createEventTriggerFunc func(ctx context.Context, req entity.CreateEventTriggerRequest) (*entity.CreateEventTriggerResponse, error)
+	updateEventTriggerFunc func(ctx context.Context, req entity.UpdateEventTriggerRequest) (*entity.UpdateEventTriggerResponse, error)
 	listEventTriggersFunc  func(ctx context.Context, req entity.ListEventTriggersRequest) (*entity.ListEventTriggersResponse, error)
 	deleteEventTriggerFunc func(ctx context.Context, req entity.DeleteEventTriggerRequest) error
 	listTasksFromEventFunc func(ctx context.Context, req entity.ListTasksFromEventRequest) (*entity.ListTasksFromEventResponse, error)
@@ -44,6 +45,9 @@ func (m *mockEventCrud) DeleteEvent(ctx context.Context, req entity.DeleteEventR
 }
 func (m *mockEventCrud) CreateEventTrigger(ctx context.Context, req entity.CreateEventTriggerRequest) (*entity.CreateEventTriggerResponse, error) {
 	return m.createEventTriggerFunc(ctx, req)
+}
+func (m *mockEventCrud) UpdateEventTrigger(ctx context.Context, req entity.UpdateEventTriggerRequest) (*entity.UpdateEventTriggerResponse, error) {
+	return m.updateEventTriggerFunc(ctx, req)
 }
 func (m *mockEventCrud) ListEventTriggers(ctx context.Context, req entity.ListEventTriggersRequest) (*entity.ListEventTriggersResponse, error) {
 	return m.listEventTriggersFunc(ctx, req)
@@ -88,6 +92,10 @@ func newEventApp(ctrl *mockEventCrud) *fiber.App {
 	app.Get("/events/:id/triggers", func(c *fiber.Ctx) error {
 		c.Locals("user_id", "user1")
 		return h.listEventTriggers()(c)
+	})
+	app.Patch("/events/:id/triggers/:triggerID", func(c *fiber.Ctx) error {
+		c.Locals("user_id", "user1")
+		return h.updateEventTrigger()(c)
 	})
 	app.Delete("/events/:id/triggers/:triggerID", func(c *fiber.Ctx) error {
 		c.Locals("user_id", "user1")
@@ -320,6 +328,71 @@ func TestCreateEventTrigger_EventNotOwned(t *testing.T) {
 
 	if resp.StatusCode != http.StatusNotFound {
 		t.Errorf("expected 404 for unowned event, got %d", resp.StatusCode)
+	}
+}
+
+// ── updateEventTrigger ────────────────────────────────────────────────────────
+
+func TestUpdateEventTrigger_OK(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.updateEventTriggerFunc = func(_ context.Context, req entity.UpdateEventTriggerRequest) (*entity.UpdateEventTriggerResponse, error) {
+		return &entity.UpdateEventTriggerResponse{
+			EventTrigger: entity.EventTrigger{ID: req.ID, Title: req.Title},
+		}, nil
+	}
+	app := newEventApp(ctrl)
+
+	wsID := monoflake.ID(1).String()
+	body := []byte(`{"workspaceId":"` + wsID + `","title":"Updated title","assignee":"agent"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/events/"+testEventID+"/triggers/"+testTriggerID, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestUpdateEventTrigger_InvalidPayload(t *testing.T) {
+	app := newEventApp(&mockEventCrud{})
+	// Missing title → mapper returns nil
+	body := []byte(`{"workspaceId":"` + monoflake.ID(1).String() + `"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/events/"+testEventID+"/triggers/"+testTriggerID, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d", resp.StatusCode)
+	}
+}
+
+func TestUpdateEventTrigger_InvalidID(t *testing.T) {
+	app := newEventApp(&mockEventCrud{})
+	body := []byte(`{"workspaceId":"` + monoflake.ID(1).String() + `","title":"x"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/events/"+testEventID+"/triggers/!!!", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d", resp.StatusCode)
+	}
+}
+
+func TestUpdateEventTrigger_NotFound(t *testing.T) {
+	ctrl := &mockEventCrud{}
+	ctrl.updateEventTriggerFunc = func(_ context.Context, _ entity.UpdateEventTriggerRequest) (*entity.UpdateEventTriggerResponse, error) {
+		return nil, base.ErrNotFound
+	}
+	app := newEventApp(ctrl)
+
+	wsID := monoflake.ID(1).String()
+	body := []byte(`{"workspaceId":"` + wsID + `","title":"My trigger","assignee":"agent"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/events/"+testEventID+"/triggers/"+testTriggerID, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
 	}
 }
 

--- a/backend/internal/mapper/api/event.go
+++ b/backend/internal/mapper/api/event.go
@@ -114,6 +114,40 @@ func FromCreateEventTriggerResponseEntityToHTTPResponse(rs *entity.CreateEventTr
 	return payload
 }
 
+func FromHTTPRequestToUpdateEventTriggerRequestEntity(c *fiber.Ctx) *entity.UpdateEventTriggerRequest {
+	id := monoflake.IDFromBase62(c.Params("triggerID")).Int64()
+	if id == 0 {
+		return nil
+	}
+	var payload view.UpdateEventTriggerRequest
+	if err := json.Unmarshal(c.BodyRaw(), &payload); err != nil {
+		return nil
+	}
+	workspaceID := monoflake.IDFromBase62(payload.WorkspaceID).Int64()
+	if payload.Title == "" || workspaceID == 0 {
+		return nil
+	}
+	assignee := payload.Assignee
+	if assignee == "" {
+		assignee = "agent"
+	}
+	return &entity.UpdateEventTriggerRequest{
+		ID:               id,
+		WorkspaceID:      workspaceID,
+		Title:            payload.Title,
+		Body:             payload.Body,
+		Assignee:         assignee,
+		CronSchedule:     payload.CronSchedule,
+		AllowAllCommands: payload.AllowAllCommands,
+		EmitEventID:      monoflake.IDFromBase62(payload.EmitEventID).Int64(),
+	}
+}
+
+func FromUpdateEventTriggerResponseEntityToHTTPResponse(rs *entity.UpdateEventTriggerResponse) []byte {
+	payload, _ := json.Marshal(view.UpdateEventTriggerResponse{EventTrigger: fromEntityEventTriggerToView(rs.EventTrigger)})
+	return payload
+}
+
 func FromListEventTriggersResponseEntityToHTTPResponse(rs *entity.ListEventTriggersResponse) []byte {
 	triggers := make([]view.EventTrigger, len(rs.EventTriggers))
 	for i, t := range rs.EventTriggers {

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -86,6 +86,7 @@ type Repository interface {
 	GetEventTrigger(ctx context.Context, id int64, userID int64) (model.EventTrigger, error)
 	ListEventTriggersByEvent(ctx context.Context, eventID int64, userID int64) ([]model.EventTrigger, error)
 	SystemListEventTriggersByEventID(ctx context.Context, eventID int64) ([]model.EventTrigger, error)
+	UpdateEventTrigger(ctx context.Context, id int64, userID int64, t model.EventTrigger) (model.EventTrigger, error)
 	DeleteEventTrigger(ctx context.Context, id int64, userID int64) error
 	ListTasksByTriggerID(ctx context.Context, triggerID int64, userID int64) ([]model.Task, error)
 
@@ -942,6 +943,29 @@ func (r *repository) SystemListEventTriggersByEventID(ctx context.Context, event
 	var triggers []model.EventTrigger
 	err := r.conn(ctx).Where("event_id = ?", eventID).Find(&triggers).Error
 	return triggers, err
+}
+
+func (r *repository) UpdateEventTrigger(ctx context.Context, id int64, userID int64, t model.EventTrigger) (model.EventTrigger, error) {
+	var existing model.EventTrigger
+	err := r.conn(ctx).Where("id = ? AND user_id = ?", id, userID).First(&existing).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return model.EventTrigger{}, ErrNotFound
+	}
+	if err != nil {
+		return model.EventTrigger{}, err
+	}
+	existing.WorkspaceID = t.WorkspaceID
+	existing.Title = t.Title
+	existing.Body = t.Body
+	existing.Assignee = t.Assignee
+	existing.CronSchedule = t.CronSchedule
+	existing.AllowAllCommands = t.AllowAllCommands
+	existing.EmitEventID = t.EmitEventID
+	existing.UpdatedAt = time.Now()
+	if err := r.conn(ctx).Save(&existing).Error; err != nil {
+		return model.EventTrigger{}, err
+	}
+	return existing, nil
 }
 
 func (r *repository) DeleteEventTrigger(ctx context.Context, id int64, userID int64) error {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -342,6 +342,18 @@ export async function createEventTrigger(eventId, { workspaceId, title, body, as
   return res.json();
 }
 
+export async function updateEventTrigger(eventId, triggerId, { workspaceId, title, body, assignee = 'agent', cronSchedule = '', allowAllCommands = false, emitEventId = '' }) {
+  const payload = { workspaceId, title, body, assignee, cronSchedule, allowAllCommands };
+  if (emitEventId) payload.emitEventId = emitEventId;
+  const res = await fetch(`${API_BASE_URL}/events/${eventId}/triggers/${triggerId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!res.ok) throw new Error('Failed to update event trigger');
+  return res.json();
+}
+
 export async function deleteEventTrigger(eventId, triggerId) {
   const res = await fetch(`${API_BASE_URL}/events/${eventId}/triggers/${triggerId}`, { method: 'DELETE' });
   if (!res.ok) throw new Error('Failed to delete event trigger');

--- a/frontend/src/views/EventDetailView.vue
+++ b/frontend/src/views/EventDetailView.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, computed, watch, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { getEvent, updateEvent, deleteEvent, fetchEvents, fetchEventTriggers, createEventTrigger, deleteEventTrigger, fetchEventTasks } from '../api'
+import { getEvent, updateEvent, deleteEvent, fetchEvents, fetchEventTriggers, createEventTrigger, updateEventTrigger, deleteEventTrigger, fetchEventTasks } from '../api'
 import { useToasts } from '../composables/useToasts'
 import { useCron } from '../composables/useCron'
 import { useWorkspaceStore } from '../stores/workspaceStore'
@@ -74,9 +74,10 @@ async function loadTriggers() {
   }
 }
 
-// create trigger form
+// create/edit trigger form
 const showTriggerForm = ref(false)
-const creatingTrigger = ref(false)
+const submittingTrigger = ref(false)
+const editingTriggerId = ref(null)
 
 const triggerForm = ref({
   workspaceId: '',
@@ -164,13 +165,41 @@ function resetTriggerForm() {
   triggerRepeatTime.value = '09:00'
   triggerSelectedDays.value = [1, 2, 3, 4, 5]
   showTriggerForm.value = false
+  editingTriggerId.value = null
 }
 
-async function handleCreateTrigger() {
+function toggleTriggerForm() {
+  if (showTriggerForm.value && !editingTriggerId.value) {
+    showTriggerForm.value = false
+    return
+  }
+  resetTriggerForm()
+  showTriggerForm.value = true
+}
+
+function startEditTrigger(t) {
+  triggerForm.value = {
+    workspaceId: t.workspaceId,
+    title: t.title,
+    body: t.body ?? '',
+    assignee: t.assignee ?? 'agent',
+    allowAllCommands: !!t.allowAllCommands,
+    cronSchedule: t.cronSchedule ?? '',
+    emitEventId: t.emitEventId ?? '',
+  }
+  // Leave the friendly cron picker untouched (default 'none') so the
+  // existing cronSchedule string above isn't overwritten by its watcher —
+  // it only fires when the user actually interacts with the picker.
+  triggerScheduleType.value = 'none'
+  editingTriggerId.value = t.id
+  showTriggerForm.value = true
+}
+
+async function handleSubmitTrigger() {
   if (!triggerForm.value.workspaceId || !triggerForm.value.title) return
-  creatingTrigger.value = true
+  submittingTrigger.value = true
   try {
-    const data = await createEventTrigger(eventId, {
+    const payload = {
       workspaceId: triggerForm.value.workspaceId,
       title: triggerForm.value.title,
       body: triggerForm.value.body,
@@ -178,14 +207,22 @@ async function handleCreateTrigger() {
       cronSchedule: triggerForm.value.cronSchedule,
       allowAllCommands: triggerForm.value.allowAllCommands,
       emitEventId: triggerForm.value.emitEventId,
-    })
-    triggers.value.unshift(data.eventTrigger)
-    notifySuccess('Trigger created')
+    }
+    if (editingTriggerId.value) {
+      const data = await updateEventTrigger(eventId, editingTriggerId.value, payload)
+      const idx = triggers.value.findIndex(t => t.id === editingTriggerId.value)
+      if (idx !== -1) triggers.value[idx] = data.eventTrigger
+      notifySuccess('Trigger updated')
+    } else {
+      const data = await createEventTrigger(eventId, payload)
+      triggers.value.unshift(data.eventTrigger)
+      notifySuccess('Trigger created')
+    }
     resetTriggerForm()
   } catch (e) {
     notifyError(e.message)
   } finally {
-    creatingTrigger.value = false
+    submittingTrigger.value = false
   }
 }
 
@@ -352,16 +389,16 @@ onMounted(async () => {
             <p class="text-[11px] text-gray-400 dark:text-zinc-500 mt-0.5">Workspaces that receive a task when this event fires.</p>
           </div>
           <button
-            @click="showTriggerForm = !showTriggerForm"
+            @click="toggleTriggerForm"
             class="px-4 py-2 bg-black dark:bg-white text-white dark:text-black text-[11px] font-black uppercase tracking-widest rounded-lg hover:opacity-80 transition-all active:scale-95 shrink-0">
             + Add Trigger
           </button>
         </div>
 
-        <!-- Create Trigger Form -->
+        <!-- Create/Edit Trigger Form -->
         <Transition name="slide-down">
           <div v-if="showTriggerForm" class="bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-xl p-5 space-y-4 mb-4">
-            <h3 class="text-xs font-bold text-gray-800 dark:text-zinc-200">New Trigger</h3>
+            <h3 class="text-xs font-bold text-gray-800 dark:text-zinc-200">{{ editingTriggerId ? 'Edit Trigger' : 'New Trigger' }}</h3>
 
             <!-- Workspace Picker -->
             <div>
@@ -456,10 +493,10 @@ onMounted(async () => {
             <!-- Form Actions -->
             <div class="flex items-center gap-2 pt-2 border-t border-gray-100 dark:border-zinc-800">
               <button
-                @click="handleCreateTrigger"
-                :disabled="creatingTrigger || !triggerForm.workspaceId || !triggerForm.title"
+                @click="handleSubmitTrigger"
+                :disabled="submittingTrigger || !triggerForm.workspaceId || !triggerForm.title"
                 class="px-4 py-2 bg-black dark:bg-white text-white dark:text-black text-[11px] font-black uppercase tracking-widest rounded-lg hover:opacity-80 transition-all active:scale-95 disabled:opacity-50">
-                {{ creatingTrigger ? 'Creating…' : 'Create Trigger' }}
+                {{ editingTriggerId ? (submittingTrigger ? 'Saving…' : 'Save Changes') : (submittingTrigger ? 'Creating…' : 'Create Trigger') }}
               </button>
               <button
                 @click="resetTriggerForm"
@@ -499,13 +536,22 @@ onMounted(async () => {
                 <code v-if="t.cronSchedule" class="text-[10px] font-mono text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-900/20 px-1.5 py-0.5 rounded">{{ t.cronSchedule }}</code>
               </div>
             </div>
-            <button
-              @click="confirmDeleteTrigger(t)"
-              class="p-1.5 text-gray-300 dark:text-zinc-600 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 rounded transition-all opacity-0 group-hover:opacity-100 shrink-0">
-              <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            <div class="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-all shrink-0">
+              <button
+                @click="startEditTrigger(t)"
+                class="p-1.5 text-gray-300 dark:text-zinc-600 hover:text-gray-700 dark:hover:text-zinc-300 hover:bg-gray-100 dark:hover:bg-zinc-800 rounded transition-all">
+                <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                </svg>
+              </button>
+              <button
+                @click="confirmDeleteTrigger(t)"
+                class="p-1.5 text-gray-300 dark:text-zinc-600 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 rounded transition-all">
+                <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Adds a full PATCH vertical slice (route -> handler -> controller -> repository -> entity -> view -> mapper) for EventTrigger, mirroring the existing Event update path, plus an edit (pencil) icon on each trigger row in the event detail page that opens the same form used for creation, pre-filled and re-labeled "Edit Trigger" / "Save Changes". Previously only delete was supported in the UI.

AgentRQ: 0hDsspdrZlh