### PR TITLE
fix(events): identify a workflow run by the publishing task, not by g…

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -557,19 +557,10 @@ func New(cfg Config) (*App, error) {
 					return fmt.Errorf("event %q not found", eventName)
 				}
 
-				// Naming a workflow explicitly starts a fresh run of it, which
-				// overrides whichever run the publishing task belonged to. Depth
-				// restarts with it: this is a new run, not a continuation, and
-				// inheriting the old count would retire it early.
-				workflowID, depth := run.WorkflowID, run.Depth
-				if run.WorkflowName != "" {
-					wf, wfErr := repo.GetWorkflowByName(ctx, run.WorkflowName, uid)
-					if wfErr != nil {
-						return fmt.Errorf("workflow %q not found", run.WorkflowName)
-					}
-					workflowID, depth = wf.ID, 0
-				}
-
+				// The run comes from the publishing task and nowhere else: the
+				// agent identifies its task, and the task row carries both the
+				// workflow and the hop count. A workflow is never named by the
+				// caller, so there is no second source to reconcile against.
 				pubsubSvc.Publish(ctx, pubsub.PublishRequest{
 					PubSubID: entity.PubSubTopicEvents,
 					Event: entity.EventPublishedPayload{
@@ -577,8 +568,8 @@ func New(cfg Config) (*App, error) {
 						Name:       ev.Name,
 						Payload:    payload,
 						FAQ:        faq,
-						WorkflowID: workflowID,
-						Depth:      depth,
+						WorkflowID: run.WorkflowID,
+						Depth:      run.Depth,
 					},
 				})
 				return nil

--- a/backend/internal/controller/event/event.go
+++ b/backend/internal/controller/event/event.go
@@ -11,6 +11,7 @@ import (
 	mapper "github.com/agentrq/agentrq/backend/internal/mapper/api"
 	"github.com/agentrq/agentrq/backend/internal/repository/base"
 	"github.com/agentrq/agentrq/backend/internal/service/eventbus"
+	"github.com/agentrq/agentrq/backend/internal/service/eventinstruction"
 	"github.com/agentrq/agentrq/backend/internal/service/idgen"
 	"github.com/agentrq/agentrq/backend/internal/service/pubsub"
 	"github.com/mustafaturan/monoflake"
@@ -144,20 +145,28 @@ func (c *controller) createTriggeredTask(ctx context.Context, trigger model.Even
 		return
 	}
 
-	// If the trigger chains to another event, append publish instruction to the body.
+	// The ID is claimed before the body is built so the instruction can tell the
+	// agent which task it is publishing for.
+	taskID := c.ids.NextID()
+
+	// If the trigger chains to another event, append publish instruction to the
+	// body. A global subscriber is outside any workflow, so no workflow is named.
 	if trigger.EmitEventID != 0 {
 		if emitEv, evErr := c.repo.GetEvent(ctx, trigger.EmitEventID, ws.UserID); evErr == nil {
-			instruction := fmt.Sprintf("\n\n[On completion: call publishEvent(\"%s\", \"<your output payload>\")]", emitEv.Name)
-			if emitEv.PayloadGuidelines != "" {
-				instruction += fmt.Sprintf("\nPayload guidelines: %s", emitEv.PayloadGuidelines)
-			}
-			body += instruction
+			body += eventinstruction.Build(eventinstruction.Params{
+				EventName:         emitEv.Name,
+				TaskID:            monoflake.ID(taskID).String(),
+				PayloadGuidelines: emitEv.PayloadGuidelines,
+			})
+		} else {
+			zlog.Warn().Err(evErr).Int64("emitEventID", trigger.EmitEventID).Int64("triggerID", trigger.ID).
+				Msg("[event-consumer] failed to resolve chained event, on-completion publishEvent instruction omitted")
 		}
 	}
 
 	now := time.Now()
 	task := model.Task{
-		ID:               c.ids.NextID(),
+		ID:               taskID,
 		CreatedAt:        now,
 		UpdatedAt:        now,
 		WorkspaceID:      trigger.WorkspaceID,
@@ -218,19 +227,30 @@ func (c *controller) createWorkflowTask(ctx context.Context, step model.Workflow
 		return
 	}
 
+	// The ID is claimed before the body is built so the instruction can tell the
+	// agent which task it is publishing for.
+	taskID := c.ids.NextID()
+
+	// Naming the task in the instruction is what keeps the run identifiable: the
+	// agent echoes it back on publish, and the workflow and hop count are read
+	// from that task, so the next hop no longer depends on the server resolving
+	// which task was publishing.
 	if step.EmitEventID != 0 {
 		if emitEv, evErr := c.repo.GetEvent(ctx, step.EmitEventID, ws.UserID); evErr == nil {
-			instruction := fmt.Sprintf("\n\n[On completion: call publishEvent(\"%s\", \"<your output payload>\")]", emitEv.Name)
-			if emitEv.PayloadGuidelines != "" {
-				instruction += fmt.Sprintf("\nPayload guidelines: %s", emitEv.PayloadGuidelines)
-			}
-			body += instruction
+			body += eventinstruction.Build(eventinstruction.Params{
+				EventName:         emitEv.Name,
+				TaskID:            monoflake.ID(taskID).String(),
+				PayloadGuidelines: emitEv.PayloadGuidelines,
+			})
+		} else {
+			zlog.Warn().Err(evErr).Int64("emitEventID", step.EmitEventID).Int64("stepID", step.ID).
+				Msg("[event-consumer] failed to resolve chained event, on-completion publishEvent instruction omitted")
 		}
 	}
 
 	now := time.Now()
 	task := model.Task{
-		ID:               c.ids.NextID(),
+		ID:               taskID,
 		CreatedAt:        now,
 		UpdatedAt:        now,
 		WorkspaceID:      step.WorkspaceID,

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -53,11 +53,10 @@ type UpdateWorkspaceAutoAllowedToolsFunc func(ctx context.Context, tools []strin
 // The zero value means "not part of a workflow run", which keeps the publish on
 // the original global-trigger path.
 type WorkflowRunContext struct {
+	// WorkflowID is the run the publishing task belongs to, read from the task
+	// itself. The task is the only thing that knows this: an agent is told which
+	// task it is publishing for, never which workflow that task sits in.
 	WorkflowID int64
-	// WorkflowName is set when the agent named a workflow explicitly. It starts
-	// a fresh run of that workflow and takes precedence over WorkflowID, which
-	// only says which run the publishing task already belonged to.
-	WorkflowName string
 	// Depth is how many hops already preceded the publishing task, carried so
 	// the consumer's runaway guard survives the task boundary.
 	Depth int
@@ -159,10 +158,10 @@ type CreateTaskParams struct {
 
 // PublishEventParams is the input to the publishEvent tool.
 type PublishEventParams struct {
-	Name     string            `json:"name" jsonschema:"The event name to publish (must match an existing event in this workspace's owner account)"`
-	Payload  string            `json:"payload,omitempty" jsonschema:"Unstructured text payload describing what happened"`
-	FAQ      []PublishEventFAQ `json:"faq,omitempty" jsonschema:"Optional question-answer pairs providing additional context"`
-	Workflow string            `json:"workflow,omitempty" jsonschema:"Optional workflow name to run. Without it the event fans out to whatever is globally subscribed; with it, only that workflow's steps run. Omit to continue a workflow you are already part of."`
+	Name    string            `json:"name" jsonschema:"The event name to publish (must match an existing event in this workspace's owner account)"`
+	Payload string            `json:"payload,omitempty" jsonschema:"Unstructured text payload describing what happened"`
+	TaskID  string            `json:"taskId,omitempty" jsonschema:"The ID of the task you are completing (base62). Copy it from that task's publishEvent instruction. It identifies which workflow run this publish continues, so omitting it can leave the run stranded."`
+	FAQ     []PublishEventFAQ `json:"faq,omitempty" jsonschema:"Optional question-answer pairs providing additional context"`
 }
 
 // PublishEventFAQ is a single question-answer pair in a publishEvent call.
@@ -340,7 +339,7 @@ func NewWorkspaceServer(
 
 	mcp.AddTool(mcpSrv, &mcp.Tool{
 		Name:        "publishEvent",
-		Description: "Publish a named event so that subscriber workspaces are notified and their trigger tasks are created automatically.",
+		Description: "Publish a named event so that subscriber workspaces are notified and their trigger tasks are created automatically. When the task you are completing includes a publishEvent instruction, copy the name and taskId from it exactly as written — taskId is what identifies the workflow run being continued. Write the payload yourself, plus an optional faq.",
 	}, ps.handlePublishEvent)
 
 	// Add middleware to handle incoming notifications (like permission_request)
@@ -558,7 +557,10 @@ func (ps *WorkspaceServer) StartPoller(repo base.Repository) {
 					return pendingTasks[i].ID < pendingTasks[j].ID
 				})
 				nextTask := pendingTasks[0]
-				msg := fmt.Sprintf("Next assigned task:\nTitle: %s\nDetails: %s", nextTask.Title, nextTask.Body)
+				// The ID is part of the push because a task body can instruct the
+				// agent to quote it back when publishing an event, and this path
+				// is how workflow-step tasks are delivered.
+				msg := fmt.Sprintf("Next assigned task:\nID: %s\nTitle: %s\nDetails: %s", monoflake.ID(nextTask.ID).String(), nextTask.Title, nextTask.Body)
 				if atts := formatModelAttachments(nextTask.Attachments); atts != "" {
 					msg += "\n" + atts
 				}
@@ -878,8 +880,7 @@ func (ps *WorkspaceServer) handlePublishEvent(ctx context.Context, req *mcp.Call
 	for i, f := range params.FAQ {
 		faq[i] = entity.EventFAQ{Q: f.Q, A: f.A}
 	}
-	run := ps.currentWorkflowRun(ctx, req)
-	run.WorkflowName = params.Workflow
+	run := ps.currentWorkflowRun(ctx, req, params.TaskID)
 	if err := ps.publishEvent(ctx, params.Name, params.Payload, faq, run); err != nil {
 		return &mcp.CallToolResult{
 			IsError: true,
@@ -897,16 +898,25 @@ func (ps *WorkspaceServer) handlePublishEvent(ctx context.Context, req *mcp.Call
 // so a chained event stays inside its own workflow instead of falling back to
 // the global triggers.
 //
-// Best effort by design: the agent never passes the workflow itself (it has no
-// reason to know one exists), so this leans on the same session→task resolution
-// the permission flow uses. If the task cannot be resolved, the zero value
-// means "not in a workflow" and the publish behaves exactly as it did before
-// workflows existed — a missed chain, never a wrong one.
-func (ps *WorkspaceServer) currentWorkflowRun(ctx context.Context, req *mcp.CallToolRequest) WorkflowRunContext {
-	if req == nil || req.GetSession() == nil {
+// paramTaskID is the task the agent says it is completing, copied out of that
+// task's own publishEvent instruction. It is preferred over session lookup
+// because it is the only source that names the run rather than reconstructing
+// it: the session→task map is mutated as a side effect by createTask, reply and
+// updateTaskStatus, so an agent that creates a follow-up task before publishing
+// would otherwise be resolved against that new task and lose its workflow.
+//
+// Falling back to session resolution keeps agents that omit the ID working, but
+// that path stays a guess — its last resort is "whichever task is ongoing" —
+// so it can return a different run rather than none.
+func (ps *WorkspaceServer) currentWorkflowRun(ctx context.Context, req *mcp.CallToolRequest, paramTaskID string) WorkflowRunContext {
+	sessID := ""
+	if req != nil && req.GetSession() != nil {
+		sessID = req.GetSession().ID()
+	}
+	if sessID == "" && paramTaskID == "" {
 		return WorkflowRunContext{}
 	}
-	taskID, ok := ps.resolveTaskID(ctx, req.GetSession().ID(), "")
+	taskID, ok := ps.resolveTaskID(ctx, sessID, paramTaskID)
 	if !ok {
 		return WorkflowRunContext{}
 	}
@@ -1221,18 +1231,25 @@ func (ps *WorkspaceServer) resolveTaskID(ctx context.Context, sessID, payloadTas
 		}
 	}
 
-	ps.sessionTasksMu.RLock()
-	taskID, ok := ps.sessionTasks[sessID]
-	ps.sessionTasksMu.RUnlock()
-	if ok {
-		return taskID, true
+	if sessID != "" {
+		ps.sessionTasksMu.RLock()
+		taskID, ok := ps.sessionTasks[sessID]
+		ps.sessionTasksMu.RUnlock()
+		if ok {
+			return taskID, true
+		}
 	}
 
 	if tasks, err := ps.listTasks(ctx, ListTasksFilter{Status: []string{"ongoing", "blocked"}, Limit: 1}); err == nil {
 		for _, t := range tasks {
-			ps.sessionTasksMu.Lock()
-			ps.sessionTasks[sessID] = t.ID
-			ps.sessionTasksMu.Unlock()
+			// Only cache under a real session key: a caller with no session
+			// would otherwise write an entry that every later sessionless
+			// caller reads back as its own task.
+			if sessID != "" {
+				ps.sessionTasksMu.Lock()
+				ps.sessionTasks[sessID] = t.ID
+				ps.sessionTasksMu.Unlock()
+			}
 			zlog.Debug().Str("session_id", sessID).Int64("task_id", t.ID).Msg("Session not found; resolved task from DB")
 			return t.ID, true
 		}

--- a/backend/internal/handler/api/task.go
+++ b/backend/internal/handler/api/task.go
@@ -14,6 +14,7 @@ import (
 	view "github.com/agentrq/agentrq/backend/internal/data/view/api"
 	mapper "github.com/agentrq/agentrq/backend/internal/mapper/api"
 	"github.com/agentrq/agentrq/backend/internal/service/eventbus"
+	"github.com/agentrq/agentrq/backend/internal/service/eventinstruction"
 	"github.com/gofiber/fiber/v2"
 	"github.com/mustafaturan/monoflake"
 )
@@ -105,13 +106,19 @@ func (h *handler) createTask() fiber.Handler {
 				if atts := formatAttachments(rs.Task.Attachments); atts != "" {
 					content += "\n" + atts
 				}
+				// A task bound to a workflow already carries it on the task row, so
+				// the instruction only has to name the task: publishing with that
+				// ID starts the run explicitly rather than by inference.
 				if rs.Task.EventID != 0 {
 					if ev, evErr := h.crud.GetEvent(ctx, entity.GetEventRequest{ID: rs.Task.EventID, UserID: rq.UserID}); evErr == nil {
-						instruction := fmt.Sprintf("\n\n[On completion: call publishEvent(\"%s\", \"<your output payload>\")]", ev.Event.Name)
-						if ev.Event.PayloadGuidelines != "" {
-							instruction += fmt.Sprintf("\nPayload guidelines: %s", ev.Event.PayloadGuidelines)
-						}
-						content += instruction
+						content += eventinstruction.Build(eventinstruction.Params{
+							EventName:         ev.Event.Name,
+							TaskID:            monoflake.ID(rs.Task.ID).String(),
+							PayloadGuidelines: ev.Event.PayloadGuidelines,
+						})
+					} else {
+						zlog.Warn().Err(evErr).Int64("eventID", rs.Task.EventID).Int64("taskID", rs.Task.ID).
+							Msg("failed to resolve linked event, on-completion publishEvent instruction omitted")
 					}
 				}
 				srv.SendChannelNotification(ctx, rs.Task.ID, content)

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -93,7 +93,6 @@ type Repository interface {
 	// Workflows
 	CreateWorkflow(ctx context.Context, w model.Workflow) (model.Workflow, error)
 	GetWorkflow(ctx context.Context, id int64, userID int64) (model.Workflow, error)
-	GetWorkflowByName(ctx context.Context, name string, userID int64) (model.Workflow, error)
 	ListWorkflowsByUser(ctx context.Context, userID int64) ([]model.Workflow, error)
 	UpdateWorkflow(ctx context.Context, w model.Workflow) (model.Workflow, error)
 	DeleteWorkflow(ctx context.Context, id int64, userID int64) error
@@ -997,15 +996,6 @@ func (r *repository) CreateWorkflow(ctx context.Context, w model.Workflow) (mode
 func (r *repository) GetWorkflow(ctx context.Context, id int64, userID int64) (model.Workflow, error) {
 	var w model.Workflow
 	err := r.conn(ctx).Where("id = ? AND user_id = ?", id, userID).First(&w).Error
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return model.Workflow{}, ErrNotFound
-	}
-	return w, err
-}
-
-func (r *repository) GetWorkflowByName(ctx context.Context, name string, userID int64) (model.Workflow, error) {
-	var w model.Workflow
-	err := r.conn(ctx).Where("name = ? AND user_id = ?", name, userID).First(&w).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return model.Workflow{}, ErrNotFound
 	}

--- a/backend/internal/service/eventinstruction/eventinstruction.go
+++ b/backend/internal/service/eventinstruction/eventinstruction.go
@@ -1,0 +1,65 @@
+// Package eventinstruction builds the "publish this event when you finish"
+// text appended to a task body.
+//
+// Three call sites need this string — the REST createTask handler, and the
+// event consumer's trigger and workflow-step paths — and they used to build it
+// independently, which let the wording drift. Keeping it here means an agent
+// sees the same contract however its task was created.
+package eventinstruction
+
+import "fmt"
+
+// Params describes the publish a task should perform when it finishes.
+type Params struct {
+	// EventName is the event to publish. Required; without it there is no
+	// instruction to give.
+	EventName string
+	// TaskID is the publishing task's own base62 ID. The agent echoes it back
+	// so the server can identify the run from the task itself rather than
+	// guessing from session state.
+	//
+	// This is the only run identifier the agent needs: the task row already
+	// carries the workflow and the hop count, so naming the workflow as well
+	// would be a second way to say the same thing — and a wrong or stale one
+	// would be taken as a request to start a different run.
+	TaskID string
+	// PayloadGuidelines is optional prose from the event definition.
+	PayloadGuidelines string
+}
+
+// Build returns the instruction to append to a task body, including the leading
+// blank line.
+//
+// The call is spelled out completely — every argument the agent must not invent
+// is written literally — because taskId is what identifies the run being
+// continued. Leaving it implicit is what made a chain depend on the server
+// guessing which task was publishing.
+//
+// Arguments are ordered fixed-then-free: name and taskId are copied verbatim,
+// so they come first and are done with, leaving payload and faq — the only
+// parts the agent actually composes — at the end where it can write freely
+// without having to step back over values it must not alter.
+func Build(p Params) string {
+	if p.EventName == "" {
+		return ""
+	}
+
+	args := fmt.Sprintf("name: %q", p.EventName)
+	if p.TaskID != "" {
+		args += fmt.Sprintf(", taskId: %q", p.TaskID)
+	}
+	args += ", payload: \"<what happened, in your words>\", faq: [{q, a}, ...]"
+
+	// The call above lists every argument to pass, so arguments it omits need no
+	// mention: spelling out what not to send would only name the thing the agent
+	// should never have been thinking about.
+	s := fmt.Sprintf("\n\n[On completion, before marking this task completed: call publishEvent(%s)]", args)
+	s += "\nCopy name and taskId exactly as written above — taskId is what tells the server which run this continues."
+	s += "\nWrite the payload yourself. faq is optional: question/answer pairs covering what subscribers are likely to ask —" +
+		" tasks triggered by this event can render both."
+
+	if p.PayloadGuidelines != "" {
+		s += fmt.Sprintf("\nPayload guidelines: %s", p.PayloadGuidelines)
+	}
+	return s
+}

--- a/backend/internal/service/eventinstruction/eventinstruction_test.go
+++ b/backend/internal/service/eventinstruction/eventinstruction_test.go
@@ -1,0 +1,82 @@
+package eventinstruction
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildNamesTheEventAndTask(t *testing.T) {
+	got := Build(Params{EventName: "blog_published", TaskID: "0hGlYcRCJTV"})
+
+	for _, want := range []string{
+		`name: "blog_published"`,
+		`taskId: "0hGlYcRCJTV"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("instruction missing %q\ngot: %s", want, got)
+		}
+	}
+}
+
+// The copy-exactly arguments come first so the agent is done with them before
+// it starts composing; the parts it writes itself trail the call.
+func TestBuildPutsFixedArgumentsBeforeAuthoredOnes(t *testing.T) {
+	got := Build(Params{EventName: "blog_published", TaskID: "0hGlYcRCJTV"})
+
+	taskID := strings.Index(got, "taskId:")
+	payload := strings.Index(got, "payload:")
+	faq := strings.Index(got, "faq:")
+
+	if taskID == -1 || payload == -1 || faq == -1 {
+		t.Fatalf("expected name, taskId, payload and faq in the call\ngot: %s", got)
+	}
+	if !(taskID < payload && payload < faq) {
+		t.Errorf("expected taskId before payload before faq\ngot: %s", got)
+	}
+}
+
+// taskId already carries the workflow and hop count, so a workflow argument
+// would be a second, conflicting way to name the run. The call lists everything
+// to pass, so the instruction simply never raises the subject — mentioning it,
+// even to forbid it, would put it back in front of the agent.
+func TestBuildNeverMentionsWorkflow(t *testing.T) {
+	got := Build(Params{EventName: "code_changed", TaskID: "0hGlYcRCJTV"})
+
+	if strings.Contains(strings.ToLower(got), "workflow") {
+		t.Errorf("instruction should not raise the workflow argument at all\ngot: %s", got)
+	}
+}
+
+// The payload and faq are the only things the agent supplies, so both have to
+// be asked for explicitly — faq going unmentioned is why {{EVENT_FAQ}} rendered
+// empty for subscribers.
+func TestBuildAsksForPayloadAndFAQ(t *testing.T) {
+	got := Build(Params{EventName: "code_changed"})
+
+	if !strings.Contains(got, "faq:") {
+		t.Errorf("instruction should offer the faq argument\ngot: %s", got)
+	}
+	if !strings.Contains(got, "payload:") {
+		t.Errorf("instruction should mark where the payload goes\ngot: %s", got)
+	}
+}
+
+func TestBuildAppendsPayloadGuidelinesOnlyWhenPresent(t *testing.T) {
+	with := Build(Params{EventName: "code_changed", PayloadGuidelines: "list the changed files"})
+	if !strings.Contains(with, "Payload guidelines: list the changed files") {
+		t.Errorf("guidelines should be appended\ngot: %s", with)
+	}
+
+	without := Build(Params{EventName: "code_changed"})
+	if strings.Contains(without, "Payload guidelines") {
+		t.Errorf("no guidelines means no guidelines line\ngot: %s", without)
+	}
+}
+
+// Callers append the result to a task body unconditionally, so an event-less
+// task must not gain a stray heading.
+func TestBuildWithoutEventReturnsNothing(t *testing.T) {
+	if got := Build(Params{TaskID: "0hGlYcRCJTV"}); got != "" {
+		t.Errorf("expected empty string, got: %s", got)
+	}
+}


### PR DESCRIPTION
…uessing

A workflow hop is task -> publishEvent -> task, and nothing carried the run across that boundary. publishEvent took no task, so the server reconstructed which task was publishing from an in-memory session map that createTask, reply and updateTaskStatus each overwrite as a side effect, with a last resort of "whichever task is ongoing".

So an agent that created a follow-up task before publishing was resolved against that new task, which has no workflow - MCP createTask cannot set one - and the run stopped there while the publish still reported success. An intervening reply happened to repair the mapping, so the same workflow succeeded or failed on the incidental order of unrelated tool calls. A cold map after a restart could also resolve a different ongoing task and continue the run under the wrong workflow and depth, which the comment on currentWorkflowRun claimed could not happen.

publishEvent now takes taskId and prefers it. That activates the payload branch of resolveTaskID, which was already written but unreachable from this caller, and the task row it resolves carries both the workflow and the hop count - so a run is stated rather than inferred.

Task bodies spell the whole call out: name and taskId to copy, payload and faq to write, in that order, so the copying is done before the composing starts. faq had never been mentioned anywhere, which is why {{EVENT_FAQ}} rendered empty for subscribers. "On completion" becomes "before marking this task completed", since publishing after completion is what left the fallback with no ongoing task to find.

The workflow argument is gone. taskId already names the run, no generated instruction asks for a workflow, and an agent has no way to learn a workflow name - getWorkspace does not list them and no tool enumerates them. It could only be filled by guessing, and a guess started a separate run at hop zero. Removing it also removes the second source the publish callback had to reconcile against, and with it GetWorkflowByName, whose only caller this was. Starting a run deliberately stays worth having, but it needs discovery designed first.

The instruction text lived in three places and had already drifted, so it moves into internal/service/eventinstruction with tests. The poller push now includes the task ID as well: it is how workflow-step tasks are delivered, and it previously sent only title and body, so an agent could not quote back an ID it was never given.

Task: 0hGlYcRCJTV