### PR TITLE
fix(oauth): bind redirect_uri to the registered client (CIMD + DCR)

### DIFF
--- a/backend/internal/handler/coremcp/coremcp.go
+++ b/backend/internal/handler/coremcp/coremcp.go
@@ -11,16 +11,18 @@ import (
 
 	"github.com/agentrq/agentrq/backend/internal/controller/crud"
 	"github.com/agentrq/agentrq/backend/internal/service/auth"
-	"github.com/mustafaturan/monoflake"
 	zlog "github.com/rs/zerolog/log"
 )
 
 type Params struct {
 	Crud     crud.Controller
 	TokenSvc auth.TokenService
-	BaseURL  string
-	Domain   string
-	Mux      *http.ServeMux
+	// CIMD resolves Client ID Metadata Document URLs. Optional: a default
+	// network-backed resolver is used when nil.
+	CIMD    auth.CIMDResolver
+	BaseURL string
+	Domain  string
+	Mux     *http.ServeMux
 }
 
 type Handler interface{}
@@ -28,6 +30,7 @@ type Handler interface{}
 type handler struct {
 	coremcpServer *WorkspaceServer
 	tokenSvc      auth.TokenService
+	cimd          auth.CIMDResolver
 	baseURL       string
 	domain        string
 }
@@ -55,9 +58,15 @@ func corsWrapper(h http.Handler) http.Handler {
 }
 
 func New(p Params) (Handler, error) {
+	cimd := p.CIMD
+	if cimd == nil {
+		cimd = auth.NewCIMDResolver()
+	}
+
 	h := &handler{
 		coremcpServer: NewServer(p.Crud, p.BaseURL),
 		tokenSvc:      p.TokenSvc,
+		cimd:          cimd,
 		baseURL:       p.BaseURL,
 		domain:        p.Domain,
 	}
@@ -123,6 +132,44 @@ func sendJSONRPCError(w http.ResponseWriter, message string, code int, httpStatu
 	})
 }
 
+// registrationError writes an RFC 7591 §3.2.2 client registration error
+// response.
+func registrationError(w http.ResponseWriter, errorCode, description string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusBadRequest)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"error":             errorCode,
+		"error_description": description,
+	})
+}
+
+// parseRegisteredRedirectURIs extracts and validates the RFC 7591 §2
+// "redirect_uris" client metadata field. A client that doesn't declare any
+// redirect_uris is allowed through (ok=true, empty slice) so registration
+// stays permissive; a malformed field is rejected outright.
+func parseRegisteredRedirectURIs(payload map[string]interface{}) (uris []string, ok bool) {
+	raw, present := payload["redirect_uris"]
+	if !present {
+		return nil, true
+	}
+	items, isArray := raw.([]interface{})
+	if !isArray {
+		return nil, false
+	}
+	for _, item := range items {
+		s, isString := item.(string)
+		if !isString || s == "" {
+			return nil, false
+		}
+		if _, err := url.Parse(s); err != nil {
+			return nil, false
+		}
+		uris = append(uris, s)
+	}
+	return uris, true
+}
+
 func (h *handler) oauthRegisterHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
@@ -131,18 +178,41 @@ func (h *handler) oauthRegisterHandler() http.Handler {
 		}
 
 		var payload map[string]interface{}
-		_ = json.NewDecoder(r.Body).Decode(&payload)
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			registrationError(w, "invalid_client_metadata", "request body must be a JSON object")
+			return
+		}
 
 		if payload == nil {
 			payload = make(map[string]interface{})
 		}
 
-		clientID := "coremcp-" + monoflake.ID(time.Now().UnixNano()).String()
+		redirectURIs, ok := parseRegisteredRedirectURIs(payload)
+		if !ok {
+			registrationError(w, "invalid_redirect_uri", "redirect_uris must be an array of non-empty URI strings")
+			return
+		}
+
+		// The client_id IS a signed credential carrying the client's
+		// registered redirect_uris, so /oauth2/authorize can later bind the
+		// authorization request's redirect_uri to what this client actually
+		// registered (RFC 6749 §3.1.2.3) instead of accepting any value.
+		clientID, err := h.tokenSvc.CreateClientRegistrationToken(redirectURIs)
+		if err != nil {
+			registrationError(w, "invalid_client_metadata", "failed to register client")
+			return
+		}
 		payload["client_id"] = clientID
 		payload["client_id_issued_at"] = time.Now().Unix()
+		// These are always public clients (no client_secret is ever issued),
+		// per RFC 7591 §2's token_endpoint_auth_method metadata field.
+		if _, hasAuthMethod := payload["token_endpoint_auth_method"]; !hasAuthMethod {
+			payload["token_endpoint_auth_method"] = "none"
+		}
 		payload["client_secret_expires_at"] = 0
 
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
 		w.WriteHeader(http.StatusCreated)
 		json.NewEncoder(w).Encode(payload)
 	})
@@ -222,13 +292,20 @@ func (h *handler) oauthMetadataHandler() http.Handler {
 		regEndpoint := baseURL + pathPrefix + "/oauth2/register"
 
 		metadata := map[string]interface{}{
-			"issuer":                                baseURL,
-			"authorization_endpoint":                authEndpoint,
-			"token_endpoint":                        tokenEndpoint,
-			"registration_endpoint":                 regEndpoint,
+			"issuer":                   baseURL,
+			"authorization_endpoint":   authEndpoint,
+			"token_endpoint":           tokenEndpoint,
+			"registration_endpoint":    regEndpoint,
+			"response_types_supported": []string{"code"},
+			"grant_types_supported":    []string{"authorization_code", "refresh_token"},
+			// Registered clients are always public (DCR never issues a
+			// client_secret); advertise "none" rather than letting clients
+			// assume the RFC 8414 default of client_secret_basic.
+			"token_endpoint_auth_methods_supported": []string{"none"},
+			// See draft-ietf-oauth-client-id-metadata-document §6: a client_id
+			// that is itself an https URL is resolved as a client metadata
+			// document (oauthAuthorizeHandler's CIMDResolver backs this).
 			"client_id_metadata_document_supported": true,
-			"response_types_supported":              []string{"code"},
-			"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
 			"logo_uri":                              h.baseURL + "/agentrq.png",
 		}
 
@@ -270,11 +347,52 @@ func (h *handler) oauthAuthorizeHandler() http.Handler {
 			}
 		}
 
+		clientID := r.URL.Query().Get("client_id")
 		redirectURI := r.URL.Query().Get("redirect_uri")
 		state := r.URL.Query().Get("state")
 
-		// Validate redirectURI to prevent open redirect
-		if redirectURI != "" {
+		// Bind the requested redirect_uri to whatever this client actually
+		// registered (RFC 6749 §3.1.2.3), instead of accepting any value —
+		// this is what makes client registration meaningful instead of
+		// decorative, and it closes custom-scheme redirect_uris (e.g.
+		// "evilapp://callback") that the heuristic below never checked.
+		// client_id can be registered two ways: a Client ID Metadata
+		// Document URL (draft-ietf-oauth-client-id-metadata-document), or a
+		// client_id minted by our own /oauth2/register (RFC 7591 DCR).
+		var registeredRedirectURIs []string
+		switch {
+		case clientID != "" && h.cimd.IsClientIDURL(clientID):
+			metadata, err := h.cimd.Resolve(r.Context(), clientID)
+			if err != nil {
+				// The draft requires aborting the authorization request when
+				// the client's metadata document can't be fetched/validated.
+				zlog.Warn().Err(err).Str("client_id", clientID).Msg("CIMD resolution failed")
+				http.Error(w, "invalid_client: could not resolve client_id metadata document", http.StatusBadRequest)
+				return
+			}
+			registeredRedirectURIs = metadata.RedirectURIs
+		case clientID != "":
+			if claims, err := h.tokenSvc.ValidateClientRegistrationToken(clientID); err == nil {
+				registeredRedirectURIs = claims.RedirectURIs
+			}
+		}
+
+		if redirectURI != "" && len(registeredRedirectURIs) > 0 {
+			matched := false
+			for _, registered := range registeredRedirectURIs {
+				if registered == redirectURI {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				http.Error(w, "invalid redirect_uri: not registered for this client_id", http.StatusBadRequest)
+				return
+			}
+		} else if redirectURI != "" {
+			// No DCR-registered client to bind to: fall back to the
+			// same-origin heuristic below, preserving behavior for legacy /
+			// first-party callers that don't use client_id-scoped redirects.
 			if strings.HasPrefix(redirectURI, "/") && !strings.HasPrefix(redirectURI, "//") && !strings.HasPrefix(redirectURI, "/\\") {
 				// OK: local path
 			} else {
@@ -297,7 +415,19 @@ func (h *handler) oauthAuthorizeHandler() http.Handler {
 
 					isCustomScheme := pRedirect.Scheme != "" && pRedirect.Scheme != "http" && pRedirect.Scheme != "https"
 
-					if !isCustomScheme {
+					if isCustomScheme {
+						// A private-use scheme has no origin to validate
+						// against, so an unregistered one is only accepted if
+						// it belongs to a known native client. Accepting any
+						// scheme here would make the whole check moot: a
+						// caller could present an unrecognized client_id and
+						// have the code delivered to a scheme of their
+						// choosing.
+						if !auth.IsAllowedNativeRedirectScheme(pRedirect.Scheme) {
+							http.Error(w, "invalid redirect_uri: unrecognized custom scheme; register the redirect_uri to use it", http.StatusBadRequest)
+							return
+						}
+					} else {
 						if pRedirect.Scheme != "https" && !isLocal {
 							http.Error(w, "invalid redirect_uri: https required for non-localhost", http.StatusBadRequest)
 							return
@@ -346,6 +476,9 @@ func (h *handler) oauthAuthorizeHandler() http.Handler {
 func (h *handler) oauthTokenHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		// RFC 6749 §5.1: token responses MUST NOT be cached.
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Pragma", "no-cache")
 
 		err := r.ParseForm()
 		if err != nil {

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -29,8 +29,11 @@ type Params struct {
 	MCPManager *mcpctrl.Manager
 	Crud       crud.Controller
 	TokenSvc   auth.TokenService
-	BaseURL    string
-	Mux        *http.ServeMux
+	// CIMD resolves Client ID Metadata Document URLs. Optional: a default
+	// network-backed resolver is used when nil.
+	CIMD    auth.CIMDResolver
+	BaseURL string
+	Mux     *http.ServeMux
 }
 
 type Handler interface{}
@@ -39,6 +42,7 @@ type handler struct {
 	mcpManager *mcpctrl.Manager
 	crud       crud.Controller
 	tokenSvc   auth.TokenService
+	cimd       auth.CIMDResolver
 	baseURL    string
 }
 
@@ -58,10 +62,16 @@ func corsWrapper(h http.Handler) http.Handler {
 }
 
 func New(p Params) (Handler, error) {
+	cimd := p.CIMD
+	if cimd == nil {
+		cimd = auth.NewCIMDResolver()
+	}
+
 	h := &handler{
 		mcpManager: p.MCPManager,
 		crud:       p.Crud,
 		tokenSvc:   p.TokenSvc,
+		cimd:       cimd,
 		baseURL:    p.BaseURL,
 	}
 
@@ -71,6 +81,13 @@ func New(p Params) (Handler, error) {
 
 	// discovery endpoints (path-based)
 	p.Mux.Handle("/mcp/{workspaceID}/.well-known/oauth-authorization-server", corsWrapper(h.oauthMetadataHandler()))
+	// RFC 8414 §3.1: the well-known suffix MUST be inserted between the host
+	// and any path component of the issuer, not appended after it. This
+	// server's issuer for a given workspace is {baseURL}/mcp/{workspaceID},
+	// so the discovery URL a strictly-compliant client actually computes is
+	// this one — the path-suffixed route above exists only for backward
+	// compatibility with clients that resolve it via oauth-protected-resource.
+	p.Mux.Handle("/.well-known/oauth-authorization-server/mcp/{workspaceID}", corsWrapper(h.oauthMetadataHandler()))
 	p.Mux.Handle("/mcp/{workspaceID}/.well-known/oauth-protected-resource", corsWrapper(h.oauthProtectedResourceHandler()))
 	p.Mux.Handle("/.well-known/oauth-protected-resource/mcp/{workspaceID}", corsWrapper(h.oauthProtectedResourceHandler()))
 
@@ -125,6 +142,44 @@ func sendJSONRPCError(w http.ResponseWriter, message string, code int, httpStatu
 	})
 }
 
+// registrationError writes an RFC 7591 §3.2.2 client registration error
+// response.
+func registrationError(w http.ResponseWriter, errorCode, description string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusBadRequest)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"error":             errorCode,
+		"error_description": description,
+	})
+}
+
+// parseRegisteredRedirectURIs extracts and validates the RFC 7591 §2
+// "redirect_uris" client metadata field. A client that doesn't declare any
+// redirect_uris is allowed through (ok=true, empty slice) so registration
+// stays permissive; a malformed field is rejected outright.
+func parseRegisteredRedirectURIs(payload map[string]interface{}) (uris []string, ok bool) {
+	raw, present := payload["redirect_uris"]
+	if !present {
+		return nil, true
+	}
+	items, isArray := raw.([]interface{})
+	if !isArray {
+		return nil, false
+	}
+	for _, item := range items {
+		s, isString := item.(string)
+		if !isString || s == "" {
+			return nil, false
+		}
+		if _, err := url.Parse(s); err != nil {
+			return nil, false
+		}
+		uris = append(uris, s)
+	}
+	return uris, true
+}
+
 func (h *handler) oauthRegisterHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
@@ -133,20 +188,41 @@ func (h *handler) oauthRegisterHandler() http.Handler {
 		}
 
 		var payload map[string]interface{}
-		_ = json.NewDecoder(r.Body).Decode(&payload)
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			registrationError(w, "invalid_client_metadata", "request body must be a JSON object")
+			return
+		}
 
 		if payload == nil {
 			payload = make(map[string]interface{})
 		}
 
-		// Strictly stateless/stateless-like: issue a dynamic auto-generated PKCE clientId string
-		clientID := "dynamic-" + monoflake.ID(time.Now().UnixNano()).String()
+		redirectURIs, ok := parseRegisteredRedirectURIs(payload)
+		if !ok {
+			registrationError(w, "invalid_redirect_uri", "redirect_uris must be an array of non-empty URI strings")
+			return
+		}
+
+		// The client_id IS a signed credential carrying the client's
+		// registered redirect_uris, so /oauth2/authorize can later bind the
+		// authorization request's redirect_uri to what this client actually
+		// registered (RFC 6749 §3.1.2.3) instead of accepting any value.
+		clientID, err := h.tokenSvc.CreateClientRegistrationToken(redirectURIs)
+		if err != nil {
+			registrationError(w, "invalid_client_metadata", "failed to register client")
+			return
+		}
 		payload["client_id"] = clientID
 		payload["client_id_issued_at"] = time.Now().Unix()
-		// Implicitly public clients, so no strictly enforced client_secret, but we set expires_at=0 to satisfy strict SDK parsers
+		// These are always public clients (no client_secret is ever issued),
+		// per RFC 7591 §2's token_endpoint_auth_method metadata field.
+		if _, hasAuthMethod := payload["token_endpoint_auth_method"]; !hasAuthMethod {
+			payload["token_endpoint_auth_method"] = "none"
+		}
 		payload["client_secret_expires_at"] = 0
 
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
 		w.WriteHeader(http.StatusCreated)
 		json.NewEncoder(w).Encode(payload)
 	})
@@ -302,9 +378,12 @@ func (h *handler) oauthProtectedResourceHandler() http.Handler {
 			resource = baseURL
 		}
 
+		// Per RFC 8414 §3.1, the well-known suffix belongs between the host
+		// and the issuer's path component, not after it — this is the URL a
+		// strictly-compliant client computes directly from the issuer.
 		authServer := baseURL + "/.well-known/oauth-authorization-server"
 		if !strings.Contains(r.Host, ".mcp.") {
-			authServer = baseURL + "/mcp/" + workspaceIDBase62 + "/.well-known/oauth-authorization-server"
+			authServer = baseURL + "/.well-known/oauth-authorization-server/mcp/" + workspaceIDBase62
 		}
 
 		json.NewEncoder(w).Encode(map[string]interface{}{
@@ -330,6 +409,13 @@ func (h *handler) oauthMetadataHandler() http.Handler {
 
 		baseURL := proto + r.Host
 
+		// issuer MUST identify this specific workspace's authorization
+		// server (RFC 8414 §3.3: "the issuer value returned MUST be
+		// identical to the issuer value... used to construct the URL").
+		// Every workspace shares the same baseURL/host in the path-based
+		// (non-subdomain) case, so the workspace path segment has to be part
+		// of the issuer or every workspace would claim the same identity.
+		issuer := baseURL
 		authEndpoint := baseURL + "/oauth2/authorize"
 		tokenEndpoint := baseURL + "/oauth2/token"
 		regEndpoint := baseURL + "/oauth2/register"
@@ -337,19 +423,27 @@ func (h *handler) oauthMetadataHandler() http.Handler {
 		// If accessed without a subdomain (e.g. localhost or a custom domain root), append the workspace route
 		if !strings.Contains(r.Host, ".mcp.") {
 			workspaceIDBase62 := monoflake.ID(workspaceID).String()
+			issuer = baseURL + "/mcp/" + workspaceIDBase62
 			authEndpoint = baseURL + "/mcp/" + workspaceIDBase62 + "/oauth2/authorize"
 			tokenEndpoint = baseURL + "/mcp/" + workspaceIDBase62 + "/oauth2/token"
 			regEndpoint = baseURL + "/mcp/" + workspaceIDBase62 + "/oauth2/register"
 		}
 
 		metadata := map[string]interface{}{
-			"issuer":                                baseURL,
-			"authorization_endpoint":                authEndpoint,
-			"token_endpoint":                        tokenEndpoint,
-			"registration_endpoint":                 regEndpoint,
+			"issuer":                   issuer,
+			"authorization_endpoint":   authEndpoint,
+			"token_endpoint":           tokenEndpoint,
+			"registration_endpoint":    regEndpoint,
+			"response_types_supported": []string{"code"},
+			"grant_types_supported":    []string{"authorization_code", "refresh_token"},
+			// Registered clients are always public (DCR never issues a
+			// client_secret); advertise "none" rather than letting clients
+			// assume the RFC 8414 default of client_secret_basic.
+			"token_endpoint_auth_methods_supported": []string{"none"},
+			// See draft-ietf-oauth-client-id-metadata-document §6: a client_id
+			// that is itself an https URL is resolved as a client metadata
+			// document (oauthAuthorizeHandler's CIMDResolver backs this).
 			"client_id_metadata_document_supported": true,
-			"response_types_supported":              []string{"code"},
-			"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
 		}
 
 		importJson := json.NewEncoder(w)
@@ -375,13 +469,52 @@ func (h *handler) oauthAuthorizeHandler() http.Handler {
 			}
 		}
 
-		// Optional clientID validation can be added here
-		_ = r.URL.Query().Get("client_id")
+		clientID := r.URL.Query().Get("client_id")
 		redirectURI := r.URL.Query().Get("redirect_uri")
 		state := r.URL.Query().Get("state")
 
-		// Validate redirectURI to prevent open redirect
-		if redirectURI != "" {
+		// Bind the requested redirect_uri to whatever this client actually
+		// registered (RFC 6749 §3.1.2.3), instead of accepting any value —
+		// this is what makes client registration meaningful instead of
+		// decorative, and it closes custom-scheme redirect_uris (e.g.
+		// "evilapp://callback") that the heuristic below never checked.
+		// client_id can be registered two ways: a Client ID Metadata
+		// Document URL (draft-ietf-oauth-client-id-metadata-document), or a
+		// client_id minted by our own /oauth2/register (RFC 7591 DCR).
+		var registeredRedirectURIs []string
+		switch {
+		case clientID != "" && h.cimd.IsClientIDURL(clientID):
+			metadata, err := h.cimd.Resolve(r.Context(), clientID)
+			if err != nil {
+				// The draft requires aborting the authorization request when
+				// the client's metadata document can't be fetched/validated.
+				zlog.Warn().Err(err).Str("client_id", clientID).Msg("CIMD resolution failed")
+				http.Error(w, "invalid_client: could not resolve client_id metadata document", http.StatusBadRequest)
+				return
+			}
+			registeredRedirectURIs = metadata.RedirectURIs
+		case clientID != "":
+			if claims, err := h.tokenSvc.ValidateClientRegistrationToken(clientID); err == nil {
+				registeredRedirectURIs = claims.RedirectURIs
+			}
+		}
+
+		if redirectURI != "" && len(registeredRedirectURIs) > 0 {
+			matched := false
+			for _, registered := range registeredRedirectURIs {
+				if registered == redirectURI {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				http.Error(w, "invalid redirect_uri: not registered for this client_id", http.StatusBadRequest)
+				return
+			}
+		} else if redirectURI != "" {
+			// No registered client to bind to: fall back to the same-origin
+			// heuristic below, preserving behavior for legacy / first-party
+			// callers that don't use client_id-scoped redirects.
 			if strings.HasPrefix(redirectURI, "/") && !strings.HasPrefix(redirectURI, "//") && !strings.HasPrefix(redirectURI, "/\\") {
 				// OK: local path
 			} else {
@@ -404,7 +537,19 @@ func (h *handler) oauthAuthorizeHandler() http.Handler {
 
 					isCustomScheme := pRedirect.Scheme != "" && pRedirect.Scheme != "http" && pRedirect.Scheme != "https"
 
-					if !isCustomScheme {
+					if isCustomScheme {
+						// A private-use scheme has no origin to validate
+						// against, so an unregistered one is only accepted if
+						// it belongs to a known native client. Accepting any
+						// scheme here would make the whole check moot: a
+						// caller could present an unrecognized client_id and
+						// have the code delivered to a scheme of their
+						// choosing.
+						if !auth.IsAllowedNativeRedirectScheme(pRedirect.Scheme) {
+							http.Error(w, "invalid redirect_uri: unrecognized custom scheme; register the redirect_uri to use it", http.StatusBadRequest)
+							return
+						}
+					} else {
 						if pRedirect.Scheme != "https" && !isLocal {
 							http.Error(w, "invalid redirect_uri: https required for non-localhost", http.StatusBadRequest)
 							return
@@ -475,6 +620,9 @@ func (h *handler) oauthAuthorizeHandler() http.Handler {
 func (h *handler) oauthTokenHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		// RFC 6749 §5.1: token responses MUST NOT be cached.
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Pragma", "no-cache")
 
 		err := r.ParseForm()
 		if err != nil {

--- a/backend/internal/handler/mcp/mcp_test.go
+++ b/backend/internal/handler/mcp/mcp_test.go
@@ -46,6 +46,14 @@ func (m *mockTokenSvc) CreateMCPToken(userID, workspaceID, tokenType string) (st
 	return m.validToken, nil
 }
 
+func (m *mockTokenSvc) ValidateClientRegistrationToken(tokenStr string) (*auth.ClientRegistrationClaims, error) {
+	return nil, jwt.ErrSignatureInvalid
+}
+
+func (m *mockTokenSvc) CreateClientRegistrationToken(redirectURIs []string) (string, error) {
+	return "mocked-client-id-" + strings.Join(redirectURIs, ","), nil
+}
+
 type mockRepo struct {
 	base.Repository
 }

--- a/backend/internal/handler/mcp/oauth_client_binding_test.go
+++ b/backend/internal/handler/mcp/oauth_client_binding_test.go
@@ -1,0 +1,362 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/agentrq/agentrq/backend/internal/service/auth"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/mustafaturan/monoflake"
+)
+
+// bindingTokenSvc extends the shared mock with a client registration whose
+// redirect_uris the authorize handler is expected to enforce.
+type bindingTokenSvc struct {
+	mockTokenSvc
+	registeredClientID string
+	registeredURIs     []string
+}
+
+func (m *bindingTokenSvc) ValidateClientRegistrationToken(tokenStr string) (*auth.ClientRegistrationClaims, error) {
+	if tokenStr != "" && tokenStr == m.registeredClientID {
+		return &auth.ClientRegistrationClaims{RedirectURIs: m.registeredURIs}, nil
+	}
+	return nil, jwt.ErrSignatureInvalid
+}
+
+// fakeCIMD stands in for the network-backed resolver so authorize-handler
+// tests never make outbound requests.
+type fakeCIMD struct {
+	metadata map[string]*auth.ClientMetadata
+	err      error
+}
+
+func (f *fakeCIMD) IsClientIDURL(clientID string) bool {
+	return strings.HasPrefix(clientID, "https://")
+}
+
+func (f *fakeCIMD) Resolve(ctx context.Context, clientID string) (*auth.ClientMetadata, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if m, ok := f.metadata[clientID]; ok {
+		return m, nil
+	}
+	return nil, fmt.Errorf("no metadata document for %q", clientID)
+}
+
+func setupBindingRouter(tokenSvc auth.TokenService, cimd auth.CIMDResolver) *http.ServeMux {
+	mux := http.NewServeMux()
+	New(Params{
+		TokenSvc: tokenSvc,
+		Crud:     &mockCrud{},
+		CIMD:     cimd,
+		BaseURL:  "https://agentrq.com",
+		Mux:      mux,
+	})
+	return mux
+}
+
+func authorizeRequest(clientID, redirectURI string) *http.Request {
+	req := httptest.NewRequest("GET", "/mcp/12345/oauth2/authorize?client_id="+url.QueryEscape(clientID)+
+		"&redirect_uri="+url.QueryEscape(redirectURI), nil)
+	req.SetPathValue("workspaceID", "12345")
+	req.Host = "12345.mcp.agentrq.com"
+	req.AddCookie(&http.Cookie{Name: "at", Value: "valid-auth-cookie"})
+	return req
+}
+
+// A client that registered redirect_uris via DCR must only be redirected to
+// one of those exact URIs — otherwise registration is decorative and an
+// attacker can supply any redirect the loose heuristic happens to allow.
+func TestAuthorize_DCRRegisteredRedirectURIIsEnforced(t *testing.T) {
+	tokenSvc := &bindingTokenSvc{
+		registeredClientID: "registered-client",
+		registeredURIs:     []string{"cursor://callback"},
+	}
+	mux := setupBindingRouter(tokenSvc, &fakeCIMD{})
+
+	t.Run("registered redirect_uri is allowed", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, authorizeRequest("registered-client", "cursor://callback"))
+		if w.Code != http.StatusFound {
+			t.Fatalf("expected 302 for a registered redirect_uri, got %d", w.Code)
+		}
+	})
+
+	// Without binding, this custom-scheme URI would sail through the
+	// same-origin heuristic, which only inspects http/https redirects.
+	t.Run("unregistered custom-scheme redirect_uri is rejected", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, authorizeRequest("registered-client", "attacker://callback"))
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for an unregistered redirect_uri, got %d", w.Code)
+		}
+	})
+
+	t.Run("unregistered https redirect_uri is rejected", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, authorizeRequest("registered-client", "https://agentrq.com/callback"))
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for an unregistered redirect_uri, got %d", w.Code)
+		}
+	})
+}
+
+// Without an allowlist, the redirect binding is bypassable by simply not
+// presenting a recognizable client_id: control falls through to the
+// same-origin heuristic, which skips every check for custom schemes. These
+// cases pin that hole shut while keeping the native editors working.
+func TestAuthorize_UnregisteredCustomSchemes(t *testing.T) {
+	mux := setupBindingRouter(&bindingTokenSvc{}, &fakeCIMD{})
+
+	tests := []struct {
+		name        string
+		clientID    string
+		redirectURI string
+		wantStatus  int
+	}{
+		// The attack: no usable client_id, arbitrary scheme.
+		{"unknown scheme, no client_id", "", "attacker://callback", http.StatusBadRequest},
+		{"unknown scheme, unrecognized client_id", "garbage", "attacker://callback", http.StatusBadRequest},
+		{"unknown scheme, exfiltration-looking host", "", "evil://x.example.com/steal", http.StatusBadRequest},
+
+		// Native editors keep working with no registration at all.
+		{"cursor", "", "cursor://callback", http.StatusFound},
+		{"vscode", "", "vscode://callback", http.StatusFound},
+		{"zed", "", "zed://callback", http.StatusFound},
+		// Schemes are case-insensitive per RFC 3986 §3.1.
+		{"uppercase scheme still matched", "", "VSCode://callback", http.StatusFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, authorizeRequest(tt.clientID, tt.redirectURI))
+			if w.Code != tt.wantStatus {
+				t.Errorf("redirect_uri %q: got %d, want %d", tt.redirectURI, w.Code, tt.wantStatus)
+			}
+		})
+	}
+}
+
+// Registration is the escape hatch: a client that declares an unusual scheme
+// can still use it, so the allowlist never blocks a new integration.
+func TestAuthorize_RegisteredClientMayUseAnyScheme(t *testing.T) {
+	tokenSvc := &bindingTokenSvc{
+		registeredClientID: "registered-client",
+		registeredURIs:     []string{"someneweditor://callback"},
+	}
+	mux := setupBindingRouter(tokenSvc, &fakeCIMD{})
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, authorizeRequest("registered-client", "someneweditor://callback"))
+	if w.Code != http.StatusFound {
+		t.Fatalf("a registered redirect_uri must be honored regardless of scheme, got %d", w.Code)
+	}
+
+	// ...but registering one scheme does not open the rest.
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, authorizeRequest("registered-client", "attacker://callback"))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("an unregistered scheme must still be refused, got %d", w.Code)
+	}
+}
+
+// An https client_id is a Client ID Metadata Document URL: its published
+// redirect_uris are what the authorize handler must enforce.
+func TestAuthorize_CIMDRedirectURIIsEnforced(t *testing.T) {
+	const clientID = "https://client.example.com/oauth-client"
+	cimd := &fakeCIMD{metadata: map[string]*auth.ClientMetadata{
+		clientID: {ClientID: clientID, RedirectURIs: []string{"https://client.example.com/callback"}},
+	}}
+	mux := setupBindingRouter(&bindingTokenSvc{}, cimd)
+
+	t.Run("redirect_uri published in the document is allowed", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, authorizeRequest(clientID, "https://client.example.com/callback"))
+		if w.Code != http.StatusFound {
+			t.Fatalf("expected 302 for a published redirect_uri, got %d", w.Code)
+		}
+		if loc := w.Header().Get("Location"); !strings.HasPrefix(loc, "https://client.example.com/callback") {
+			t.Errorf("expected redirect to the client callback, got %s", loc)
+		}
+	})
+
+	t.Run("redirect_uri absent from the document is rejected", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, authorizeRequest(clientID, "https://evil.example.com/callback"))
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for an unpublished redirect_uri, got %d", w.Code)
+		}
+	})
+}
+
+// The draft requires aborting the authorization request when the client's
+// metadata document can't be fetched or validated.
+func TestAuthorize_CIMDResolutionFailureAborts(t *testing.T) {
+	cimd := &fakeCIMD{err: fmt.Errorf("fetch failed")}
+	mux := setupBindingRouter(&bindingTokenSvc{}, cimd)
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, authorizeRequest("https://client.example.com/oauth-client", "https://client.example.com/callback"))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 when the metadata document cannot be resolved, got %d", w.Code)
+	}
+}
+
+// Registration must hand back a client_id that actually carries the
+// redirect_uris, and must reject malformed metadata per RFC 7591 §3.2.2.
+func TestRegister_RFC7591(t *testing.T) {
+	mux := setupBindingRouter(&bindingTokenSvc{}, &fakeCIMD{})
+
+	t.Run("valid registration returns a client_id and no-store", func(t *testing.T) {
+		body := strings.NewReader(`{"redirect_uris":["https://client.example.com/callback"],"client_name":"Test"}`)
+		req := httptest.NewRequest("POST", "/mcp/12345/oauth2/register", body)
+		req.SetPathValue("workspaceID", "12345")
+		req.Host = "12345.mcp.agentrq.com"
+
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		if w.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d (%s)", w.Code, w.Body.String())
+		}
+		if cc := w.Header().Get("Cache-Control"); cc != "no-store" {
+			t.Errorf("expected Cache-Control: no-store, got %q", cc)
+		}
+
+		var out map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out["client_id"] == "" || out["client_id"] == nil {
+			t.Error("expected a client_id in the registration response")
+		}
+		// Public clients only: DCR never issues a secret.
+		if out["token_endpoint_auth_method"] != "none" {
+			t.Errorf("expected token_endpoint_auth_method=none, got %v", out["token_endpoint_auth_method"])
+		}
+	})
+
+	t.Run("malformed redirect_uris is rejected with invalid_redirect_uri", func(t *testing.T) {
+		body := strings.NewReader(`{"redirect_uris":"not-an-array"}`)
+		req := httptest.NewRequest("POST", "/mcp/12345/oauth2/register", body)
+		req.SetPathValue("workspaceID", "12345")
+		req.Host = "12345.mcp.agentrq.com"
+
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+		var out map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out["error"] != "invalid_redirect_uri" {
+			t.Errorf("expected error=invalid_redirect_uri, got %v", out["error"])
+		}
+	})
+
+	t.Run("malformed JSON is rejected with invalid_client_metadata", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/mcp/12345/oauth2/register", strings.NewReader(`{oops`))
+		req.SetPathValue("workspaceID", "12345")
+		req.Host = "12345.mcp.agentrq.com"
+
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+		var out map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out["error"] != "invalid_client_metadata" {
+			t.Errorf("expected error=invalid_client_metadata, got %v", out["error"])
+		}
+	})
+}
+
+// RFC 8414 §3.1 puts the well-known suffix between the host and the issuer's
+// path, and §3.3 requires the issuer to match the URL used to fetch it.
+func TestMetadata_RFC8414IssuerAndWellKnownPath(t *testing.T) {
+	mux := setupBindingRouter(&bindingTokenSvc{}, &fakeCIMD{})
+
+	req := httptest.NewRequest("GET", "/.well-known/oauth-authorization-server/mcp/12345", nil)
+	req.Host = "agentrq.com"
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected the RFC 8414 well-known path to be served, got %d", w.Code)
+	}
+
+	var meta map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &meta); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Without the workspace segment every workspace would claim the same
+	// issuer identity.
+	wantIssuer := "https://agentrq.com/mcp/" + monoflake.IDFromBase62("12345").String()
+	if meta["issuer"] != wantIssuer {
+		t.Errorf("issuer = %v, want %s", meta["issuer"], wantIssuer)
+	}
+	if meta["client_id_metadata_document_supported"] != true {
+		t.Error("expected client_id_metadata_document_supported to be advertised")
+	}
+	methods, _ := meta["token_endpoint_auth_methods_supported"].([]any)
+	if len(methods) != 1 || methods[0] != "none" {
+		t.Errorf("expected token_endpoint_auth_methods_supported=[none], got %v", meta["token_endpoint_auth_methods_supported"])
+	}
+}
+
+// The protected-resource document must point at the same RFC 8414 URL the
+// metadata handler is actually mounted on.
+func TestProtectedResource_PointsAtRFC8414AuthServerURL(t *testing.T) {
+	mux := setupBindingRouter(&bindingTokenSvc{}, &fakeCIMD{})
+
+	req := httptest.NewRequest("GET", "/.well-known/oauth-protected-resource/mcp/12345", nil)
+	req.SetPathValue("workspaceID", "12345")
+	req.Host = "agentrq.com"
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	authServer, _ := doc["authorization_server"].(string)
+	want := "https://agentrq.com/.well-known/oauth-authorization-server/mcp/" + monoflake.IDFromBase62("12345").String()
+	if authServer != want {
+		t.Errorf("authorization_server = %q, want %q", authServer, want)
+	}
+
+	// Following that URL must actually resolve.
+	followReq := httptest.NewRequest("GET", strings.TrimPrefix(authServer, "https://agentrq.com"), nil)
+	followReq.Host = "agentrq.com"
+	followW := httptest.NewRecorder()
+	mux.ServeHTTP(followW, followReq)
+	if followW.Code != http.StatusOK {
+		t.Errorf("advertised authorization_server URL returned %d, expected it to resolve", followW.Code)
+	}
+}

--- a/backend/internal/service/auth/cimd.go
+++ b/backend/internal/service/auth/cimd.go
@@ -1,0 +1,349 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ClientMetadata is the subset of RFC 7591 client metadata fields this
+// server needs from a Client ID Metadata Document (CIMD), as defined by
+// draft-ietf-oauth-client-id-metadata-document.
+type ClientMetadata struct {
+	ClientID                string   `json:"client_id"`
+	RedirectURIs            []string `json:"redirect_uris,omitempty"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+}
+
+const (
+	cimdMaxBodyBytes = 5 * 1024 // draft-ietf-oauth-client-id-metadata-document §2: "recommended maximum size to read is 5 kilobytes"
+	cimdFetchTimeout = 5 * time.Second
+	cimdDefaultTTL   = 10 * time.Minute
+	cimdMinTTL       = 60 * time.Second
+	cimdMaxTTL       = 24 * time.Hour
+)
+
+// CIMDResolver fetches and validates Client ID Metadata Documents so a
+// client_id can itself be the client's registration, with no server-side
+// persistence required (see draft-ietf-oauth-client-id-metadata-document).
+type CIMDResolver interface {
+	// IsClientIDURL reports whether clientID has the shape of a Client ID
+	// Metadata Document URL (an https URL with a path, no userinfo/fragment).
+	// It does not fetch anything.
+	IsClientIDURL(clientID string) bool
+	// Resolve fetches (or returns a cached, previously-validated copy of) the
+	// client metadata document at the clientID URL. Callers MUST abort the
+	// authorization request on error, per the draft's guidance.
+	Resolve(ctx context.Context, clientID string) (*ClientMetadata, error)
+}
+
+type cimdCacheEntry struct {
+	metadata  *ClientMetadata
+	expiresAt time.Time
+}
+
+type cimdResolver struct {
+	client *http.Client
+
+	mu    sync.Mutex
+	cache map[string]cimdCacheEntry
+}
+
+// NewCIMDResolver returns a CIMDResolver that fetches documents over a
+// transport hardened against SSRF: it resolves DNS itself and refuses to
+// connect to loopback/private/link-local/unspecified addresses, and it never
+// follows HTTP redirects (both required by the draft).
+func NewCIMDResolver() CIMDResolver {
+	dialer := &net.Dialer{Timeout: cimdFetchTimeout}
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+			ips, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
+			if err != nil {
+				return nil, err
+			}
+			if len(ips) == 0 {
+				return nil, fmt.Errorf("cimd: %q did not resolve", host)
+			}
+			// Reject the host outright if ANY of its addresses is special-use,
+			// rather than picking a routable one. A name that resolves to both
+			// a public and an internal address is the shape of a rebinding
+			// attack, and a legitimate client metadata host has no reason to.
+			for _, ip := range ips {
+				if isSpecialUseIP(ip) {
+					return nil, fmt.Errorf("cimd: %q resolves to the special-use address %s", host, ip)
+				}
+			}
+			// Dial the address that was actually validated, never the hostname:
+			// re-resolving here would reopen the DNS-rebinding window between
+			// the check above and the connection.
+			return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].String(), port))
+		},
+	}
+
+	return &cimdResolver{
+		client: &http.Client{
+			Transport: transport,
+			Timeout:   cimdFetchTimeout,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				// The draft requires the AS to treat a redirect as a fetch
+				// failure, not follow it.
+				return http.ErrUseLastResponse
+			},
+		},
+		cache: make(map[string]cimdCacheEntry),
+	}
+}
+
+// blockedIPNets are the RFC 6890 special-use ranges that Go's own IP
+// predicates do not already cover. They matter here because a Client ID
+// Metadata Document URL is supplied by the caller: without this filter, a
+// client_id is a primitive for reaching infrastructure that is only
+// addressable from the server.
+//
+// 64:ff9b::/96 is the significant one — NAT64 embeds an arbitrary IPv4
+// address in the low 32 bits, so without it a v6 literal can still reach
+// 127.0.0.1 or a private range.
+var blockedIPNets = func() []*net.IPNet {
+	cidrs := []string{
+		"100.64.0.0/10",   // RFC 6598 shared address space (CGNAT, some cluster networks)
+		"192.0.0.0/24",    // RFC 6890 IETF protocol assignments
+		"192.0.2.0/24",    // TEST-NET-1
+		"198.18.0.0/15",   // RFC 2544 benchmarking
+		"198.51.100.0/24", // TEST-NET-2
+		"203.0.113.0/24",  // TEST-NET-3
+		"240.0.0.0/4",     // reserved for future use
+		"64:ff9b::/96",    // RFC 6052 NAT64 — embeds an arbitrary IPv4 address
+		"2002::/16",       // 6to4 — likewise wraps an IPv4 address
+		"100::/64",        // RFC 6666 discard-only
+	}
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		if _, n, err := net.ParseCIDR(cidr); err == nil {
+			nets = append(nets, n)
+		}
+	}
+	return nets
+}()
+
+// isSpecialUseIP reports whether ip falls in an RFC 6890 special-use range
+// that the draft requires an authorization server to refuse to fetch from.
+// IPv4-mapped IPv6 addresses are normalized first, so ::ffff:127.0.0.1 is
+// rejected for the same reason 127.0.0.1 is.
+func isSpecialUseIP(ip net.IP) bool {
+	if ip == nil {
+		return true // unparseable: fail closed
+	}
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() || ip.IsInterfaceLocalMulticast() ||
+		ip.IsMulticast() || ip.IsUnspecified() {
+		return true
+	}
+	if ip.Equal(net.IPv4bcast) {
+		return true
+	}
+	for _, n := range blockedIPNets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *cimdResolver) IsClientIDURL(clientID string) bool {
+	_, err := parseClientIDURL(clientID)
+	return err == nil
+}
+
+// parseClientIDURL validates clientID against the draft's §2 requirements
+// for a Client Identifier URL.
+func parseClientIDURL(clientID string) (*url.URL, error) {
+	if !strings.HasPrefix(clientID, "https://") {
+		return nil, fmt.Errorf("not an https URL")
+	}
+	u, err := url.Parse(clientID)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme != "https" {
+		return nil, fmt.Errorf("scheme must be https")
+	}
+	if u.User != nil {
+		return nil, fmt.Errorf("must not contain a userinfo component")
+	}
+	if u.Path == "" {
+		return nil, fmt.Errorf("must contain a path component")
+	}
+	if u.Fragment != "" {
+		return nil, fmt.Errorf("must not contain a fragment component")
+	}
+	for seg := range strings.SplitSeq(u.Path, "/") {
+		if seg == "." || seg == ".." {
+			return nil, fmt.Errorf("must not contain dot path segments")
+		}
+	}
+	return u, nil
+}
+
+func (r *cimdResolver) Resolve(ctx context.Context, clientID string) (*ClientMetadata, error) {
+	if _, err := parseClientIDURL(clientID); err != nil {
+		return nil, fmt.Errorf("cimd: invalid client_id URL: %w", err)
+	}
+
+	r.mu.Lock()
+	if entry, ok := r.cache[clientID]; ok && time.Now().Before(entry.expiresAt) {
+		r.mu.Unlock()
+		return entry.metadata, nil
+	}
+	r.mu.Unlock()
+
+	metadata, ttl, err := r.fetch(ctx, clientID)
+	if err != nil {
+		// The draft forbids caching error/invalid responses.
+		return nil, err
+	}
+
+	r.mu.Lock()
+	r.cache[clientID] = cimdCacheEntry{metadata: metadata, expiresAt: time.Now().Add(ttl)}
+	r.mu.Unlock()
+
+	return metadata, nil
+}
+
+func (r *cimdResolver) fetch(ctx context.Context, clientID string) (*ClientMetadata, time.Duration, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, clientID, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	// CodeQL: go/request-forgery ("Uncontrolled data used in network request").
+	// Dismissed as "won't fix — risk is mitigated". Rationale, so the decision
+	// is reviewable rather than folklore:
+	//
+	// 1. The finding is accurate. clientID is caller-supplied and does reach
+	//    this request's URL. It cannot be otherwise: under
+	//    draft-ietf-oauth-client-id-metadata-document the client_id *is* the
+	//    URL the authorization server fetches. There is no variant of this
+	//    feature where the URL is not attacker-influenced, so the taint path
+	//    cannot be broken — only bounded.
+	//
+	// 2. What bounds it is this client's transport, not this call site, which
+	//    is why dataflow analysis cannot see it. NewCIMDResolver's dialer
+	//    resolves DNS itself and refuses the host outright if ANY resolved
+	//    address is special-use (isSpecialUseIP + blockedIPNets, covering
+	//    loopback, private, link-local, CGNAT, and the NAT64/6to4 ranges that
+	//    smuggle an IPv4 address inside an IPv6 one). It then dials the address
+	//    it validated rather than the hostname, leaving no window to
+	//    re-resolve, and never follows redirects. parseClientIDURL has already
+	//    constrained the URL to https with no userinfo, fragment or
+	//    dot-segments, and the response is capped at 5KB.
+	//
+	// 3. Residual risk accepted: the server will still make an outbound GET to
+	//    an arbitrary *public* host. That is the documented behaviour of the
+	//    spec, is rate-bounded by the 5s timeout and the success cache, and is
+	//    equivalent to any OIDC/webhook discovery fetch.
+	//
+	// Do not weaken NewCIMDResolver's transport without revisiting this
+	// dismissal — the justification above is the only thing standing between
+	// this call and a genuine SSRF primitive.
+	//
+	// The directive below records the same decision in the SARIF. Note it does
+	// not by itself clear the code-scanning gate: GitHub does not act on SARIF
+	// suppressions unless a workflow step consumes them, so the alert is also
+	// dismissed in the Security tab.
+	// codeql[go/request-forgery]
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("cimd: fetch failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// The draft requires exactly 200 OK; redirects (blocked above) and any
+	// other status MUST be treated as an error.
+	if resp.StatusCode != http.StatusOK {
+		return nil, 0, fmt.Errorf("cimd: unexpected status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, cimdMaxBodyBytes))
+	if err != nil {
+		return nil, 0, fmt.Errorf("cimd: reading body: %w", err)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, 0, fmt.Errorf("cimd: invalid JSON: %w", err)
+	}
+
+	// These fields are explicitly forbidden by the draft: a CIMD client is
+	// never a confidential client authenticated by a shared secret.
+	if _, has := doc["client_secret"]; has {
+		return nil, 0, fmt.Errorf("cimd: client_secret is not permitted in a client metadata document")
+	}
+	if _, has := doc["client_secret_expires_at"]; has {
+		return nil, 0, fmt.Errorf("cimd: client_secret_expires_at is not permitted in a client metadata document")
+	}
+
+	docClientID, _ := doc["client_id"].(string)
+	if docClientID != clientID {
+		return nil, 0, fmt.Errorf("cimd: document client_id %q does not match fetch URL %q", docClientID, clientID)
+	}
+
+	metadata := &ClientMetadata{ClientID: docClientID}
+	if authMethod, ok := doc["token_endpoint_auth_method"].(string); ok {
+		switch authMethod {
+		case "client_secret_post", "client_secret_basic", "client_secret_jwt":
+			return nil, 0, fmt.Errorf("cimd: token_endpoint_auth_method %q is not permitted in a client metadata document", authMethod)
+		}
+		metadata.TokenEndpointAuthMethod = authMethod
+	}
+	if rawURIs, ok := doc["redirect_uris"].([]any); ok {
+		for _, item := range rawURIs {
+			if s, ok := item.(string); ok && s != "" {
+				metadata.RedirectURIs = append(metadata.RedirectURIs, s)
+			}
+		}
+	}
+
+	return metadata, cacheTTLFromResponse(resp), nil
+}
+
+// cacheTTLFromResponse honors the document's Cache-Control: max-age when
+// present, clamped to a sane range, and otherwise falls back to a default.
+func cacheTTLFromResponse(resp *http.Response) time.Duration {
+	cc := resp.Header.Get("Cache-Control")
+	for directive := range strings.SplitSeq(cc, ",") {
+		directive = strings.TrimSpace(directive)
+		after, ok := strings.CutPrefix(directive, "max-age=")
+		if !ok {
+			continue
+		}
+		seconds, err := strconv.Atoi(after)
+		if err != nil {
+			continue
+		}
+		ttl := time.Duration(seconds) * time.Second
+		if ttl < cimdMinTTL {
+			return cimdMinTTL
+		}
+		if ttl > cimdMaxTTL {
+			return cimdMaxTTL
+		}
+		return ttl
+	}
+	return cimdDefaultTTL
+}

--- a/backend/internal/service/auth/cimd_test.go
+++ b/backend/internal/service/auth/cimd_test.go
@@ -1,0 +1,305 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newTestResolver builds a resolver pointed at an httptest TLS server. It
+// deliberately reuses the server's own client (which trusts the test cert and
+// dials loopback) instead of NewCIMDResolver's SSRF-hardened transport, which
+// would — correctly — refuse to connect to 127.0.0.1. The SSRF policy itself
+// is covered separately by TestIsSpecialUseIP.
+func newTestResolver(ts *httptest.Server) *cimdResolver {
+	client := ts.Client()
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return &cimdResolver{client: client, cache: make(map[string]cimdCacheEntry)}
+}
+
+func TestIsClientIDURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		clientID string
+		want     bool
+	}{
+		{"valid https URL with path", "https://client.example.com/app", true},
+		{"valid with port", "https://client.example.com:8443/app", true},
+		{"http scheme rejected", "http://client.example.com/app", false},
+		{"custom scheme rejected", "cursor://callback", false},
+		{"opaque DCR client id rejected", "dynamic-abc123", false},
+		{"no path rejected", "https://client.example.com", false},
+		{"userinfo rejected", "https://user:pass@client.example.com/app", false},
+		{"fragment rejected", "https://client.example.com/app#frag", false},
+		{"single-dot path segment rejected", "https://client.example.com/./app", false},
+		{"double-dot path segment rejected", "https://client.example.com/../app", false},
+		{"empty rejected", "", false},
+	}
+
+	r := &cimdResolver{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := r.IsClientIDURL(tt.clientID); got != tt.want {
+				t.Errorf("IsClientIDURL(%q) = %v, want %v", tt.clientID, got, tt.want)
+			}
+		})
+	}
+}
+
+// isSpecialUseIP is what keeps an attacker from pointing a client_id at
+// internal infrastructure (SSRF), so its ranges are worth pinning down.
+func TestIsSpecialUseIP(t *testing.T) {
+	tests := []struct {
+		ip   string
+		want bool
+	}{
+		{"127.0.0.1", true},       // loopback
+		{"::1", true},             // loopback v6
+		{"10.0.0.1", true},        // private
+		{"192.168.1.1", true},     // private
+		{"172.16.0.1", true},      // private
+		{"169.254.169.254", true}, // link-local (cloud metadata endpoint)
+		{"0.0.0.0", true},         // unspecified
+		{"224.0.0.1", true},       // multicast
+		{"255.255.255.255", true}, // broadcast
+		{"fd00::1", true},         // IPv6 unique-local
+		{"fe80::1", true},         // IPv6 link-local
+
+		// An IPv4-mapped v6 literal must be rejected for the same reason its
+		// bare v4 form is, or it becomes a trivial bypass.
+		{"::ffff:127.0.0.1", true},
+		{"::ffff:169.254.169.254", true},
+
+		// NAT64 and 6to4 wrap an arbitrary IPv4 address inside a v6 one.
+		{"64:ff9b::7f00:1", true},    // -> 127.0.0.1
+		{"64:ff9b::a9fe:a9fe", true}, // -> 169.254.169.254
+
+		{"100.64.0.1", true}, // RFC 6598 shared address space
+		{"198.18.0.1", true}, // benchmarking
+		{"240.0.0.1", true},  // reserved for future use
+		{"192.0.0.1", true},  // IETF protocol assignments
+
+		{"93.184.216.34", false},
+		{"8.8.8.8", false},
+		{"2606:4700:4700::1111", false}, // public v6 resolver
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ip, func(t *testing.T) {
+			if got := isSpecialUseIP(net.ParseIP(tt.ip)); got != tt.want {
+				t.Errorf("isSpecialUseIP(%s) = %v, want %v", tt.ip, got, tt.want)
+			}
+		})
+	}
+}
+
+// The production resolver must refuse to connect to internal targets even
+// though the client_id URL is entirely attacker-supplied. This exercises the
+// real NewCIMDResolver transport, not the loopback-permitting test one.
+func TestNewCIMDResolver_RefusesInternalTargets(t *testing.T) {
+	// A real local listener, so a failure here means the guard let it through
+	// rather than the address simply being unreachable.
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"client_id":"pwned"}`))
+	}))
+	defer ts.Close()
+
+	resolver := NewCIMDResolver()
+	for _, clientID := range []string{
+		ts.URL + "/client",                  // 127.0.0.1:port — a live server
+		"https://127.0.0.1/client",          // loopback
+		"https://[::1]/client",              // loopback v6
+		"https://169.254.169.254/latest",    // cloud metadata
+		"https://10.0.0.1/client",           // private
+		"https://[::ffff:127.0.0.1]/client", // v4-mapped bypass attempt
+	} {
+		t.Run(clientID, func(t *testing.T) {
+			if _, err := resolver.Resolve(context.Background(), clientID); err == nil {
+				t.Errorf("expected %q to be refused, but the fetch succeeded", clientID)
+			}
+		})
+	}
+}
+
+func TestResolve_ValidDocument(t *testing.T) {
+	var clientIDURL string
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"client_id": "` + clientIDURL + `",
+			"client_name": "Test Client",
+			"redirect_uris": ["https://client.example.com/callback", "cursor://callback"],
+			"token_endpoint_auth_method": "none"
+		}`))
+	}))
+	defer ts.Close()
+	clientIDURL = ts.URL + "/client"
+
+	metadata, err := newTestResolver(ts).Resolve(context.Background(), clientIDURL)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if metadata.ClientID != clientIDURL {
+		t.Errorf("ClientID = %q, want %q", metadata.ClientID, clientIDURL)
+	}
+	if len(metadata.RedirectURIs) != 2 {
+		t.Fatalf("expected 2 redirect_uris, got %v", metadata.RedirectURIs)
+	}
+	// A custom-scheme redirect is legitimate here precisely because the
+	// client published it in its own metadata document.
+	if metadata.RedirectURIs[1] != "cursor://callback" {
+		t.Errorf("unexpected redirect_uris: %v", metadata.RedirectURIs)
+	}
+	if metadata.TokenEndpointAuthMethod != "none" {
+		t.Errorf("TokenEndpointAuthMethod = %q, want none", metadata.TokenEndpointAuthMethod)
+	}
+}
+
+// The draft requires the document's client_id to match the URL it was
+// fetched from; without this a client could host a document claiming to be
+// someone else.
+func TestResolve_ClientIDMismatchRejected(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"client_id": "https://someone-else.example.com/client"}`))
+	}))
+	defer ts.Close()
+
+	_, err := newTestResolver(ts).Resolve(context.Background(), ts.URL+"/client")
+	if err == nil {
+		t.Fatal("expected a client_id mismatch to be rejected")
+	}
+}
+
+func TestResolve_ForbiddenFieldsRejected(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"client_secret", `{"client_id": "%s", "client_secret": "shhh"}`},
+		{"client_secret_expires_at", `{"client_id": "%s", "client_secret_expires_at": 0}`},
+		{"client_secret_basic auth", `{"client_id": "%s", "token_endpoint_auth_method": "client_secret_basic"}`},
+		{"client_secret_post auth", `{"client_id": "%s", "token_endpoint_auth_method": "client_secret_post"}`},
+		{"client_secret_jwt auth", `{"client_id": "%s", "token_endpoint_auth_method": "client_secret_jwt"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var clientIDURL string
+			ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintf(w, tt.body, clientIDURL)
+			}))
+			defer ts.Close()
+			clientIDURL = ts.URL + "/client"
+
+			if _, err := newTestResolver(ts).Resolve(context.Background(), clientIDURL); err == nil {
+				t.Errorf("expected %s to be rejected", tt.name)
+			}
+		})
+	}
+}
+
+func TestResolve_NonOKStatusRejected(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	if _, err := newTestResolver(ts).Resolve(context.Background(), ts.URL+"/client"); err == nil {
+		t.Fatal("expected a non-200 response to be rejected")
+	}
+}
+
+// The draft forbids following redirects when fetching the document.
+func TestResolve_RedirectNotFollowed(t *testing.T) {
+	var clientIDURL string
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/client" {
+			http.Redirect(w, r, "/elsewhere", http.StatusFound)
+			return
+		}
+		w.Write([]byte(`{"client_id": "` + clientIDURL + `"}`))
+	}))
+	defer ts.Close()
+	clientIDURL = ts.URL + "/client"
+
+	if _, err := newTestResolver(ts).Resolve(context.Background(), clientIDURL); err == nil {
+		t.Fatal("expected a redirect to be treated as a fetch failure")
+	}
+}
+
+func TestResolve_InvalidJSONRejected(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`not json at all`))
+	}))
+	defer ts.Close()
+
+	if _, err := newTestResolver(ts).Resolve(context.Background(), ts.URL+"/client"); err == nil {
+		t.Fatal("expected a malformed document to be rejected")
+	}
+}
+
+func TestResolve_NonURLClientIDRejectedWithoutFetch(t *testing.T) {
+	fetched := false
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetched = true
+	}))
+	defer ts.Close()
+
+	if _, err := newTestResolver(ts).Resolve(context.Background(), "dynamic-abc123"); err == nil {
+		t.Fatal("expected a non-URL client_id to be rejected")
+	}
+	if fetched {
+		t.Error("a non-URL client_id must not trigger an outbound fetch")
+	}
+}
+
+func TestResolve_CachesSuccessfulFetch(t *testing.T) {
+	var clientIDURL string
+	fetches := 0
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetches++
+		w.Write([]byte(`{"client_id": "` + clientIDURL + `"}`))
+	}))
+	defer ts.Close()
+	clientIDURL = ts.URL + "/client"
+
+	r := newTestResolver(ts)
+	for range 3 {
+		if _, err := r.Resolve(context.Background(), clientIDURL); err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+	}
+	if fetches != 1 {
+		t.Errorf("expected the document to be fetched once and cached, got %d fetches", fetches)
+	}
+}
+
+// Errors must never be cached, so a client that fixes its document isn't
+// locked out for the cache lifetime.
+func TestResolve_DoesNotCacheErrors(t *testing.T) {
+	var clientIDURL string
+	fetches := 0
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetches++
+		if fetches == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Write([]byte(`{"client_id": "` + clientIDURL + `"}`))
+	}))
+	defer ts.Close()
+	clientIDURL = ts.URL + "/client"
+
+	r := newTestResolver(ts)
+	if _, err := r.Resolve(context.Background(), clientIDURL); err == nil {
+		t.Fatal("expected the first fetch to fail")
+	}
+	if _, err := r.Resolve(context.Background(), clientIDURL); err != nil {
+		t.Fatalf("expected a retry after an error to re-fetch and succeed, got %v", err)
+	}
+}

--- a/backend/internal/service/auth/jwt.go
+++ b/backend/internal/service/auth/jwt.go
@@ -32,13 +32,27 @@ type StateClaims struct {
 	RedirectURL string `json:"rurl,omitempty"`
 }
 
+// DynamicClientAudience marks a token minted by the RFC 7591 dynamic client
+// registration endpoint. The token itself IS the client_id: it carries the
+// client's registered redirect_uris so /oauth2/authorize can validate a
+// redirect_uri against the specific client that requested it, without
+// needing a database to persist registrations.
+const DynamicClientAudience = "dynamic_client"
+
+type ClientRegistrationClaims struct {
+	jwt.RegisteredClaims
+	RedirectURIs []string `json:"redirect_uris,omitempty"`
+}
+
 type TokenService interface {
 	CreateToken(userID, email, name, picture string) (string, error)
 	CreateMCPToken(userID, workspaceID, tokenType string) (string, error)
 	CreateOAuthCodeToken(userID, workspaceID string) (string, error)
 	CreateOAuthStateToken(redirectURL, provider string) (string, error)
+	CreateClientRegistrationToken(redirectURIs []string) (string, error)
 	ValidateToken(tokenStr string) (*Claims, error)
 	ValidateOAuthStateToken(tokenStr, provider string) (redirectURL string, err error)
+	ValidateClientRegistrationToken(tokenStr string) (*ClientRegistrationClaims, error)
 }
 
 type tokenService struct {
@@ -109,6 +123,49 @@ func ContextHasAudience(ctx context.Context, audience string) bool {
 	}
 	claims, _ := ctx.Value(CtxKeyMCPClaims).(*Claims)
 	return HasAudience(claims, audience)
+}
+
+// CreateClientRegistrationToken mints the client_id returned by the RFC 7591
+// dynamic client registration endpoint. The client_id IS the token: it's a
+// signed, stateless credential carrying the client's registered
+// redirect_uris, so /oauth2/authorize can later validate a redirect_uri
+// against the specific client that registered it without persisting
+// anything server-side.
+func (s *tokenService) CreateClientRegistrationToken(redirectURIs []string) (string, error) {
+	claims := ClientRegistrationClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "dynamic_client",
+			Audience:  jwt.ClaimStrings{DynamicClientAudience},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(10 * 365 * 24 * time.Hour)), // effectively long-lived
+		},
+		RedirectURIs: redirectURIs,
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(s.secret)
+}
+
+// ValidateClientRegistrationToken parses a client_id minted by
+// CreateClientRegistrationToken. It returns an error for any client_id that
+// wasn't issued by this server's DCR endpoint (e.g. a legacy or third-party
+// client_id), which callers should treat as "not a recognized dynamic
+// client" rather than a hard authentication failure.
+func (s *tokenService) ValidateClientRegistrationToken(tokenStr string) (*ClientRegistrationClaims, error) {
+	token, err := jwt.ParseWithClaims(tokenStr, &ClientRegistrationClaims{}, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method")
+		}
+		return s.secret, nil
+	}, jwt.WithAudience(DynamicClientAudience))
+	if err != nil {
+		return nil, err
+	}
+
+	claims, ok := token.Claims.(*ClientRegistrationClaims)
+	if !ok || !token.Valid {
+		return nil, errors.New("invalid client registration token")
+	}
+	return claims, nil
 }
 
 func (s *tokenService) CreateOAuthCodeToken(userID, workspaceID string) (string, error) {

--- a/backend/internal/service/auth/redirect_scheme.go
+++ b/backend/internal/service/auth/redirect_scheme.go
@@ -1,0 +1,38 @@
+package auth
+
+import "strings"
+
+// allowedNativeRedirectSchemes are the private-use URI schemes belonging to
+// native MCP clients that may be used as an OAuth redirect_uri without the
+// client having registered it first.
+//
+// Custom schemes cannot be validated the way an https redirect can — there is
+// no origin to compare against — so the only options are an allowlist or
+// accepting anything. Accepting anything makes redirect_uri validation
+// meaningless: a caller can simply present an unrecognized client_id and send
+// the authorization code to a scheme of their choosing. This list keeps the
+// editors that actually integrate working while denying that.
+//
+// A client that registers its redirect_uris (RFC 7591) or publishes them in a
+// Client ID Metadata Document is matched exactly against those instead and
+// never consults this list, so a new client can always onboard without a code
+// change here.
+var allowedNativeRedirectSchemes = map[string]bool{
+	"cursor":          true,
+	"vscode":          true,
+	"vscode-insiders": true,
+	"vscodium":        true,
+	"code-oss":        true,
+	"windsurf":        true,
+	"zed":             true,
+	"jetbrains":       true,
+	"claude":          true,
+	"claude-code":     true,
+}
+
+// IsAllowedNativeRedirectScheme reports whether scheme is a known native-client
+// scheme acceptable as an unregistered redirect_uri. Comparison is
+// case-insensitive because URI schemes are (RFC 3986 §3.1).
+func IsAllowedNativeRedirectScheme(scheme string) bool {
+	return allowedNativeRedirectSchemes[strings.ToLower(scheme)]
+}


### PR DESCRIPTION
The authorize endpoint ignored client_id entirely (`_ = r.URL.Query() .Get("client_id")`), and /oauth2/register echoed back a generated client_id while storing nothing. Registration was therefore decorative: no redirect_uri was ever bound to the client that requested it. The only guard was a same-origin heuristic that explicitly skips custom schemes, so any caller could pass "attacker://callback" and receive a live authorization code. Both handlers carried the same duplicated logic.

Separately, both metadata handlers advertised
client_id_metadata_document_supported: true while nothing in the codebase ever fetched or parsed a client_id URL.

Client ID Metadata Documents (draft-ietf-oauth-client-id-metadata-document):
- New auth.CIMDResolver treats an https client_id as a metadata document URL: validates URL shape, caps the read at 5KB, requires exactly 200, refuses to follow redirects, requires the document's client_id to equal the fetch URL, and rejects client_secret* fields and shared-secret auth methods.
- Caches successes honoring Cache-Control max-age (clamped 60s-24h); never caches errors.
- SSRF hardening: the dialer resolves DNS itself and refuses loopback, private, link-local, unspecified and multicast addresses, so a client_id cannot be aimed at cloud metadata or internal hosts.
- Both authorize handlers resolve https client_ids and enforce the published redirect_uris; a resolution failure aborts the request.

RFC 7591 (dynamic client registration):
- Registration now actually retains redirect_uris: the returned client_id is a signed token carrying them, so authorize can bind against it without persisting server-side state.
- Adds invalid_client_metadata / invalid_redirect_uri error responses, token_endpoint_auth_method "none", and Cache-Control: no-store.

RFC 8414 (authorization server metadata):
- issuer was https://host for every workspace in the path-based case, so all workspaces claimed the same identity; it is now https://host/mcp/{workspaceID}.
- Adds the spec-correct well-known route (the suffix belongs between the host and the issuer path, not appended after it), keeping the existing route for compatibility, and points the protected-resource document at it.
- Advertises token_endpoint_auth_methods_supported: ["none"].
- Token responses now send Cache-Control: no-store and Pragma: no-cache (RFC 6749 5.1).

Task: 0hUTBpaErQn