### PR TITLE
fix(mcp): give server/discover a usable cache hint

### DIFF
--- a/backend/internal/controller/mcp/protocol_version_test.go
+++ b/backend/internal/controller/mcp/protocol_version_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/agentrq/agentrq/backend/internal/data/model"
@@ -107,8 +108,80 @@ func TestServerDiscover_ReportsIdentityAndVersions(t *testing.T) {
 	if result["capabilities"] == nil {
 		t.Error("expected server/discover to report capabilities")
 	}
-	if _, ok := result["ttlMs"]; !ok {
-		t.Error("expected server/discover to carry a ttlMs cache hint")
+
+	// Server identity travels in _meta for this revision, per the SDK's own
+	// discover conformance fixture — not as a top-level serverInfo field.
+	meta, _ := result["_meta"].(map[string]any)
+	if meta == nil || meta["io.modelcontextprotocol/serverInfo"] == nil {
+		t.Errorf("expected server identity in _meta, got %v", result["_meta"])
+	}
+}
+
+// server/discover is a CacheableResult, and it is the cheap probe clients make
+// before negotiating. The SDK defaults ttlMs to 0, which its own docs define as
+// "immediately stale" — a hint that tells a client nothing. Everything in the
+// result is fixed at construction, so it should advertise a real lifetime.
+func TestServerDiscover_CarriesUsableCacheHint(t *testing.T) {
+	srv := newProtocolTestServer(t)
+	_, result := discoverResult(t, srv)
+
+	ttl, ok := result["ttlMs"].(float64)
+	if !ok {
+		t.Fatalf("expected a numeric ttlMs, got %v", result["ttlMs"])
+	}
+	if ttl <= 0 {
+		t.Errorf("ttlMs = %v; a zero TTL means immediately stale, which is not a usable cache hint", ttl)
+	}
+	if scope := result["cacheScope"]; scope != "public" {
+		t.Errorf("cacheScope = %v, want public (the result carries no per-user state)", scope)
+	}
+}
+
+// The result is derived entirely from construction-time configuration, so
+// repeated calls within the TTL must not drift.
+func TestServerDiscover_StableAcrossCalls(t *testing.T) {
+	srv := newProtocolTestServer(t)
+
+	_, first := discoverResult(t, srv)
+	_, second := discoverResult(t, srv)
+
+	a, _ := json.Marshal(first)
+	b, _ := json.Marshal(second)
+	if string(a) != string(b) {
+		t.Errorf("server/discover drifted between calls:\n  %s\n  %s", a, b)
+	}
+}
+
+// Refusing a pre-handshake tools/list is correct, not a spec deviation, and
+// this test exists to stop someone "fixing" it.
+//
+// A third-party conformance suite reported that a version-less tools/list
+// "must be served, not refused". The official SDK's own conformance fixture
+// (mcp/testdata/conformance/server/lifecycle.txtar, "rejects non-ping requests
+// until 'initialized' is received") asserts the exact opposite, expecting
+// precisely the error below. Serving such a request would mean failing the
+// reference suite to satisfy a third-party one.
+func TestPreHandshakeRequestIsRefused(t *testing.T) {
+	srv := newProtocolTestServer(t)
+
+	status, out, _ := mcpPost(t, srv.URL, nil, `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`)
+	if status != http.StatusOK {
+		t.Fatalf("expected a JSON-RPC error carried over HTTP 200, got %d: %s", status, out)
+	}
+
+	var env struct {
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(out, &env); err != nil {
+		t.Fatalf("decode %s: %v", out, err)
+	}
+	if env.Error == nil {
+		t.Fatal("expected tools/list before initialize to be refused")
+	}
+	if !strings.Contains(env.Error.Message, "invalid during session initialization") {
+		t.Errorf("unexpected refusal reason: %q", env.Error.Message)
 	}
 }
 

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -343,7 +343,7 @@ func NewWorkspaceServer(
 	}, ps.handlePublishEvent)
 
 	// Add middleware to handle incoming notifications (like permission_request)
-	mcpSrv.AddReceivingMiddleware(ps.notificationMiddleware)
+	mcpSrv.AddReceivingMiddleware(ps.notificationMiddleware, ps.discoverCacheMiddleware)
 
 	cp := http.NewCrossOriginProtection()
 	// Allow all origins for the MCP server in development (same syntax as ServeMux)
@@ -1119,6 +1119,43 @@ func buildConversationJSON(task model.Task, cursor, limit int) string {
 		"cursor":   end,
 	})
 	return string(b)
+}
+
+// methodServerDiscover is the SDK's discovery method. The SDK keeps its own
+// constant unexported, so the literal is repeated here.
+const methodServerDiscover = "server/discover"
+
+// discoverCacheTTL is how long a client may cache a server/discover result.
+//
+// Everything the result carries — the advertised protocol revisions, the
+// capabilities, the tool set and the instructions — is fixed when the server is
+// constructed and never mutated afterwards (every AddTool call happens in
+// NewWorkspaceServer). The SDK defaults the hint to 0, which its own docs
+// define as "immediately stale", so without this a client re-fetches static
+// configuration on every connection.
+//
+// An hour is comfortable precisely because the tool set cannot change while
+// the process runs: a client would have to reconnect to a restarted server to
+// see a different answer, and reconnecting re-probes anyway.
+const discoverCacheTTL = time.Hour
+
+// discoverCacheMiddleware supplies the cache hint the SDK leaves at zero.
+// server/discover is a CacheableResult, and answering it is the cheap probe
+// clients use before negotiating, so telling them how long the answer is good
+// for is the difference between a usable hint and a no-op.
+func (ps *WorkspaceServer) discoverCacheMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
+	return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+		res, err := next(ctx, method, req)
+		if err != nil || method != methodServerDiscover {
+			return res, err
+		}
+		// CacheScope is left as the SDK set it ("public"): the result is
+		// identical for every caller, carrying no per-user state.
+		if discoverRes, ok := res.(*mcp.DiscoverResult); ok {
+			discoverRes.TTLMs = int(discoverCacheTTL.Milliseconds())
+		}
+		return res, err
+	}
 }
 
 func (ps *WorkspaceServer) notificationMiddleware(next mcp.MethodHandler) mcp.MethodHandler {


### PR DESCRIPTION
Rework of the original discovery/version-negotiation report, now that go-sdk v1.7.0 is merged. Most of what was reported is already resolved by that upgrade, and re-testing against current main narrowed it to one real gap plus one finding that should not be "fixed" at all.

The real gap: server/discover is a CacheableResult, but the SDK sets ttlMs to 0, which its own documentation defines as "immediately stale". Discovery is the cheap probe a client makes before negotiating, and everything the result carries — advertised revisions, capabilities, the tool set, instructions — is fixed when the server is constructed (every AddTool call happens in NewWorkspaceServer, none at runtime). A zero TTL therefore made clients re-fetch static configuration on every connection. A receiving middleware now sets a one-hour TTL; cacheScope stays "public" since the result carries no per-user state.

The finding that is not a bug: the report said a version-less tools/list "must be served, not refused". It must not. The official SDK's own conformance fixture, mcp/testdata/conformance/server/lifecycle.txtar ("rejects non-ping requests until 'initialized' is received"), asserts exactly the error we return. Serving that request would mean failing the reference implementation's suite in order to satisfy a third-party one, and would also bypass the lifecycle the spec mandates. Locked in with a test that documents the reasoning so it is not "fixed" later.

Also asserts server identity travels in _meta (matching the SDK's discover fixture) and that repeated calls do not drift.

Task: 0hUOFFI5YVV