### PR TITLE
fix(mcp): advertise the AS issuer per RFC 9728, not a metadata URL

### DIFF
--- a/backend/internal/handler/coremcp/coremcp.go
+++ b/backend/internal/handler/coremcp/coremcp.go
@@ -119,6 +119,52 @@ func getTokenVal(r *http.Request) string {
 	return ""
 }
 
+// oauthIdentity holds the URLs identifying the core MCP resource and its
+// authorization server. Both metadata handlers derive them here so the issuer
+// one publishes can never drift from the one the other points clients at.
+type oauthIdentity struct {
+	baseURL string
+	// issuer is the authorization server's issuer identifier (RFC 8414 §2).
+	issuer string
+	// resource is the protected resource identifier (RFC 9728 §2).
+	resource string
+	// prmURL is the RFC 9728 §3.1 metadata URL for resource.
+	prmURL string
+}
+
+func oauthIdentityFor(r *http.Request) oauthIdentity {
+	proto := "https://"
+	if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" && !strings.Contains(r.Host, "mcp.") {
+		proto = "http://"
+	}
+	baseURL := proto + r.Host
+
+	// On a workspace subdomain the resource is the origin root; otherwise the
+	// core MCP endpoint lives under /mcp. The authorization server is the
+	// origin either way, so its RFC 8414 well-known URL needs no path segment.
+	id := oauthIdentity{
+		baseURL:  baseURL,
+		issuer:   baseURL,
+		resource: baseURL + "/mcp",
+		prmURL:   baseURL + "/.well-known/oauth-protected-resource/mcp",
+	}
+	if strings.Contains(r.Host, ".mcp.") {
+		id.resource = baseURL
+		id.prmURL = baseURL + "/.well-known/oauth-protected-resource"
+	}
+	return id
+}
+
+// challengeUnauthorized writes the RFC 9728 §5.1 challenge that tells an
+// unauthenticated client exactly where to find our metadata, instead of making
+// it guess well-known paths.
+func challengeUnauthorized(w http.ResponseWriter, r *http.Request, message string) {
+	id := oauthIdentityFor(r)
+	w.Header().Set("WWW-Authenticate", fmt.Sprintf(
+		`Bearer realm=%q, resource_metadata=%q`, id.resource, id.prmURL))
+	sendJSONRPCError(w, message, -32000, http.StatusUnauthorized)
+}
+
 func sendJSONRPCError(w http.ResponseWriter, message string, code int, httpStatus int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(httpStatus)
@@ -232,13 +278,13 @@ func (h *handler) streamableHandler() http.Handler {
 
 		queryToken := getTokenVal(r)
 		if queryToken == "" {
-			sendJSONRPCError(w, "unauthorized", -32000, http.StatusUnauthorized)
+			challengeUnauthorized(w, r, "unauthorized")
 			return
 		}
 
 		claims, err := h.tokenSvc.ValidateToken(queryToken)
 		if err != nil || claims == nil {
-			sendJSONRPCError(w, "unauthorized", -32000, http.StatusUnauthorized)
+			challengeUnauthorized(w, r, "unauthorized")
 			return
 		}
 
@@ -255,7 +301,7 @@ func (h *handler) streamableHandler() http.Handler {
 		}
 
 		if !hasCoreMCP || hasRestricted || claims.Subject == "" {
-			sendJSONRPCError(w, "unauthorized", -32000, http.StatusUnauthorized)
+			challengeUnauthorized(w, r, "unauthorized")
 			return
 		}
 
@@ -272,12 +318,8 @@ func (h *handler) streamableHandler() http.Handler {
 func (h *handler) oauthMetadataHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		proto := "https://"
-		if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" && !strings.Contains(r.Host, "mcp.") {
-			proto = "http://"
-		}
-
-		baseURL := proto + r.Host
+		id := oauthIdentityFor(r)
+		baseURL := id.baseURL
 
 		pathPrefix := ""
 		if !strings.Contains(r.Host, "mcp.") {
@@ -292,12 +334,18 @@ func (h *handler) oauthMetadataHandler() http.Handler {
 		regEndpoint := baseURL + pathPrefix + "/oauth2/register"
 
 		metadata := map[string]interface{}{
-			"issuer":                   baseURL,
+			"issuer":                   id.issuer,
 			"authorization_endpoint":   authEndpoint,
 			"token_endpoint":           tokenEndpoint,
 			"registration_endpoint":    regEndpoint,
 			"response_types_supported": []string{"code"},
-			"grant_types_supported":    []string{"authorization_code", "refresh_token"},
+			// Deliberately no client_credentials: every token here is bound to
+			// a specific user's workspace access, and that grant has no user to
+			// bind one to. Clients are also all public (see below), so there
+			// would be no secret to authenticate with either — any self-
+			// registered client could mint workspace tokens. Headless callers
+			// reuse a refresh token obtained once via authorization_code.
+			"grant_types_supported": []string{"authorization_code", "refresh_token"},
 			// Registered clients are always public (DCR never issues a
 			// client_secret); advertise "none" rather than letting clients
 			// assume the RFC 8414 default of client_secret_basic.
@@ -316,24 +364,17 @@ func (h *handler) oauthMetadataHandler() http.Handler {
 func (h *handler) oauthProtectedResourceHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		proto := "https://"
-		if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" && !strings.Contains(r.Host, "mcp.") {
-			proto = "http://"
-		}
-
-		baseURL := proto + r.Host
-
-		resource := baseURL + "/mcp"
-		if strings.Contains(r.Host, ".mcp.") {
-			// If it's a workspace subdomain, the resource is the root
-			resource = baseURL
-		}
-
-		authServer := baseURL + "/.well-known/oauth-authorization-server"
+		id := oauthIdentityFor(r)
 
 		json.NewEncoder(w).Encode(map[string]interface{}{
-			"resource":             resource,
-			"authorization_server": authServer,
+			"resource": id.resource,
+			// RFC 9728 §2: "authorization_servers" is an ARRAY of issuer
+			// identifiers — not metadata document URLs. The client derives the
+			// RFC 8414 well-known URL from the issuer itself; handing it the
+			// metadata URL made strict clients resolve
+			// .../.well-known/oauth-authorization-server/.well-known/oauth-authorization-server.
+			"authorization_servers":    []string{id.issuer},
+			"bearer_methods_supported": []string{"header"},
 		})
 	})
 }

--- a/backend/internal/handler/coremcp/oauth_metadata_test.go
+++ b/backend/internal/handler/coremcp/oauth_metadata_test.go
@@ -1,0 +1,106 @@
+package coremcp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// RFC 9728 §2: the protected-resource document advertises
+// "authorization_servers" — an ARRAY of issuer IDENTIFIERS, not a singular
+// metadata document URL.
+func TestProtectedResource_AdvertisesIssuerPerRFC9728(t *testing.T) {
+	h := &handler{}
+
+	req := httptest.NewRequest("GET", "/.well-known/oauth-protected-resource/mcp", nil)
+	req.Host = "mcp.agentrq.com"
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	w := httptest.NewRecorder()
+	h.oauthProtectedResourceHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if _, legacy := doc["authorization_server"]; legacy {
+		t.Error(`non-standard singular "authorization_server" must not be emitted`)
+	}
+
+	servers, _ := doc["authorization_servers"].([]any)
+	if len(servers) != 1 {
+		t.Fatalf("authorization_servers = %v, want a single-entry array", doc["authorization_servers"])
+	}
+	// The issuer identifier, not the .well-known metadata URL derived from it.
+	if servers[0] != "https://mcp.agentrq.com" {
+		t.Errorf("authorization_servers[0] = %v, want the issuer %q", servers[0], "https://mcp.agentrq.com")
+	}
+	if doc["resource"] != "https://mcp.agentrq.com/mcp" {
+		t.Errorf("resource = %v, want %q", doc["resource"], "https://mcp.agentrq.com/mcp")
+	}
+}
+
+// The issuer in the protected-resource document must match the one the
+// authorization server metadata publishes for itself (RFC 8414 §3.3).
+func TestProtectedResourceIssuerMatchesMetadataIssuer(t *testing.T) {
+	h := &handler{}
+
+	newReq := func(path string) *http.Request {
+		r := httptest.NewRequest("GET", path, nil)
+		r.Host = "mcp.agentrq.com"
+		r.Header.Set("X-Forwarded-Proto", "https")
+		return r
+	}
+
+	prmW := httptest.NewRecorder()
+	h.oauthProtectedResourceHandler().ServeHTTP(prmW, newReq("/.well-known/oauth-protected-resource/mcp"))
+	var prm map[string]any
+	if err := json.Unmarshal(prmW.Body.Bytes(), &prm); err != nil {
+		t.Fatalf("decode protected resource metadata: %v", err)
+	}
+
+	asW := httptest.NewRecorder()
+	h.oauthMetadataHandler().ServeHTTP(asW, newReq("/.well-known/oauth-authorization-server"))
+	var as map[string]any
+	if err := json.Unmarshal(asW.Body.Bytes(), &as); err != nil {
+		t.Fatalf("decode authorization server metadata: %v", err)
+	}
+
+	servers, _ := prm["authorization_servers"].([]any)
+	if len(servers) != 1 || servers[0] != as["issuer"] {
+		t.Errorf("authorization_servers = %v, want it to name the AS issuer %v", prm["authorization_servers"], as["issuer"])
+	}
+}
+
+// RFC 9728 §5.1 / MCP auth spec: a 401 MUST carry a WWW-Authenticate challenge
+// naming the resource metadata URL, so clients need not guess well-known paths.
+func TestUnauthorized_AdvertisesResourceMetadataChallenge(t *testing.T) {
+	h := &handler{}
+
+	req := httptest.NewRequest("POST", "/mcp", nil)
+	req.Host = "mcp.agentrq.com"
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	w := httptest.NewRecorder()
+	h.streamableHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without a token, got %d", w.Code)
+	}
+
+	challenge := w.Header().Get("WWW-Authenticate")
+	want := `resource_metadata="https://mcp.agentrq.com/.well-known/oauth-protected-resource/mcp"`
+	if !strings.Contains(challenge, want) {
+		t.Errorf("WWW-Authenticate = %q, want it to contain %s", challenge, want)
+	}
+	if !strings.HasPrefix(challenge, "Bearer ") {
+		t.Errorf("WWW-Authenticate = %q, want a Bearer challenge", challenge)
+	}
+}

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -129,6 +129,62 @@ func getTokenVal(r *http.Request) string {
 	return ""
 }
 
+// oauthIdentity holds the URLs that identify this workspace's OAuth resource
+// and authorization server. Every handler derives them here so the issuer that
+// oauthMetadataHandler publishes can never drift from the one
+// oauthProtectedResourceHandler points clients at.
+type oauthIdentity struct {
+	baseURL string
+	// issuer is the authorization server's issuer identifier (RFC 8414 §2).
+	issuer string
+	// resource is the protected resource identifier (RFC 9728 §2).
+	resource string
+	// prmURL is the RFC 9728 §3.1 metadata URL for resource.
+	prmURL string
+}
+
+func oauthIdentityFor(r *http.Request, workspaceID int64) oauthIdentity {
+	proto := "https://"
+	if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" && !strings.Contains(r.Host, "mcp.") {
+		proto = "http://"
+	}
+	baseURL := proto + r.Host
+
+	// On a workspace subdomain the workspace *is* the origin, so both the
+	// issuer and the resource sit at the root and the well-known suffixes
+	// need no path component.
+	if strings.Contains(r.Host, ".mcp.") {
+		return oauthIdentity{
+			baseURL:  baseURL,
+			issuer:   baseURL,
+			resource: baseURL,
+			prmURL:   baseURL + "/.well-known/oauth-protected-resource",
+		}
+	}
+
+	// Path-based routing: every workspace shares one host, so the workspace
+	// path segment has to be part of both identifiers or all workspaces would
+	// claim the same identity. RFC 8414 §3.1 and RFC 9728 §3.1 both insert the
+	// well-known suffix between the host and that path component.
+	wsPath := "/mcp/" + monoflake.ID(workspaceID).String()
+	return oauthIdentity{
+		baseURL:  baseURL,
+		issuer:   baseURL + wsPath,
+		resource: baseURL + wsPath,
+		prmURL:   baseURL + "/.well-known/oauth-protected-resource" + wsPath,
+	}
+}
+
+// challengeUnauthorized writes the RFC 9728 §5.1 challenge that tells an
+// unauthenticated client exactly where to find our metadata, instead of making
+// it guess well-known paths.
+func challengeUnauthorized(w http.ResponseWriter, r *http.Request, workspaceID int64, message string) {
+	id := oauthIdentityFor(r, workspaceID)
+	w.Header().Set("WWW-Authenticate", fmt.Sprintf(
+		`Bearer realm=%q, resource_metadata=%q`, id.resource, id.prmURL))
+	sendJSONRPCError(w, message, jsonrpc.CodeInvalidRequest, http.StatusUnauthorized)
+}
+
 func sendJSONRPCError(w http.ResponseWriter, message string, code int, httpStatus int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(httpStatus)
@@ -252,7 +308,7 @@ func (h *handler) streamableHandler() http.Handler {
 		queryToken := getTokenVal(r)
 		userID := ""
 		if queryToken == "" {
-			sendJSONRPCError(w, "situational security: mission token required", jsonrpc.CodeInvalidRequest, http.StatusUnauthorized)
+			challengeUnauthorized(w, r, workspaceID, "situational security: mission token required")
 			return
 		}
 
@@ -274,7 +330,7 @@ func (h *handler) streamableHandler() http.Handler {
 
 		// Final check: userID must be set
 		if userID == "" {
-			sendJSONRPCError(w, "situational security: unauthorized", jsonrpc.CodeInvalidRequest, http.StatusUnauthorized)
+			challengeUnauthorized(w, r, workspaceID, "situational security: unauthorized")
 			return
 		}
 
@@ -364,31 +420,17 @@ func (h *handler) oauthProtectedResourceHandler() http.Handler {
 			return
 		}
 
-		workspaceIDBase62 := monoflake.ID(workspaceID).String()
-
-		proto := "https://"
-		if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" && !strings.Contains(r.Host, "mcp.") {
-			proto = "http://"
-		}
-
-		baseURL := proto + r.Host
-
-		resource := baseURL + "/mcp/" + workspaceIDBase62
-		if strings.Contains(r.Host, ".mcp.") {
-			resource = baseURL
-		}
-
-		// Per RFC 8414 §3.1, the well-known suffix belongs between the host
-		// and the issuer's path component, not after it — this is the URL a
-		// strictly-compliant client computes directly from the issuer.
-		authServer := baseURL + "/.well-known/oauth-authorization-server"
-		if !strings.Contains(r.Host, ".mcp.") {
-			authServer = baseURL + "/.well-known/oauth-authorization-server/mcp/" + workspaceIDBase62
-		}
+		id := oauthIdentityFor(r, workspaceID)
 
 		json.NewEncoder(w).Encode(map[string]interface{}{
-			"resource":             resource,
-			"authorization_server": authServer,
+			"resource": id.resource,
+			// RFC 9728 §2: "authorization_servers" is an ARRAY of issuer
+			// identifiers — not metadata document URLs. The client derives the
+			// RFC 8414 well-known URL from the issuer itself; handing it the
+			// metadata URL made strict clients resolve
+			// .../.well-known/oauth-authorization-server/.well-known/oauth-authorization-server.
+			"authorization_servers":    []string{id.issuer},
+			"bearer_methods_supported": []string{"header"},
 		})
 	})
 }
@@ -402,40 +444,29 @@ func (h *handler) oauthMetadataHandler() http.Handler {
 			return
 		}
 
-		proto := "https://"
-		if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" && !strings.Contains(r.Host, "mcp.") {
-			proto = "http://"
-		}
-
-		baseURL := proto + r.Host
-
 		// issuer MUST identify this specific workspace's authorization
 		// server (RFC 8414 §3.3: "the issuer value returned MUST be
 		// identical to the issuer value... used to construct the URL").
 		// Every workspace shares the same baseURL/host in the path-based
 		// (non-subdomain) case, so the workspace path segment has to be part
 		// of the issuer or every workspace would claim the same identity.
-		issuer := baseURL
-		authEndpoint := baseURL + "/oauth2/authorize"
-		tokenEndpoint := baseURL + "/oauth2/token"
-		regEndpoint := baseURL + "/oauth2/register"
+		id := oauthIdentityFor(r, workspaceID)
 
-		// If accessed without a subdomain (e.g. localhost or a custom domain root), append the workspace route
-		if !strings.Contains(r.Host, ".mcp.") {
-			workspaceIDBase62 := monoflake.ID(workspaceID).String()
-			issuer = baseURL + "/mcp/" + workspaceIDBase62
-			authEndpoint = baseURL + "/mcp/" + workspaceIDBase62 + "/oauth2/authorize"
-			tokenEndpoint = baseURL + "/mcp/" + workspaceIDBase62 + "/oauth2/token"
-			regEndpoint = baseURL + "/mcp/" + workspaceIDBase62 + "/oauth2/register"
-		}
-
+		// The OAuth endpoints hang off the issuer, which already carries the
+		// workspace path segment (or is the subdomain root).
 		metadata := map[string]interface{}{
-			"issuer":                   issuer,
-			"authorization_endpoint":   authEndpoint,
-			"token_endpoint":           tokenEndpoint,
-			"registration_endpoint":    regEndpoint,
+			"issuer":                   id.issuer,
+			"authorization_endpoint":   id.issuer + "/oauth2/authorize",
+			"token_endpoint":           id.issuer + "/oauth2/token",
+			"registration_endpoint":    id.issuer + "/oauth2/register",
 			"response_types_supported": []string{"code"},
-			"grant_types_supported":    []string{"authorization_code", "refresh_token"},
+			// Deliberately no client_credentials: every token here is bound to
+			// a specific user's workspace access, and that grant has no user to
+			// bind one to. Clients are also all public (see below), so there
+			// would be no secret to authenticate with either — any self-
+			// registered client could mint workspace tokens. Headless callers
+			// reuse a refresh token obtained once via authorization_code.
+			"grant_types_supported": []string{"authorization_code", "refresh_token"},
 			// Registered clients are always public (DCR never issues a
 			// client_secret); advertise "none" rather than letting clients
 			// assume the RFC 8414 default of client_secret_basic.

--- a/backend/internal/handler/mcp/oauth_client_binding_test.go
+++ b/backend/internal/handler/mcp/oauth_client_binding_test.go
@@ -323,9 +323,11 @@ func TestMetadata_RFC8414IssuerAndWellKnownPath(t *testing.T) {
 	}
 }
 
-// The protected-resource document must point at the same RFC 8414 URL the
-// metadata handler is actually mounted on.
-func TestProtectedResource_PointsAtRFC8414AuthServerURL(t *testing.T) {
+// RFC 9728 §2: the protected-resource document advertises
+// "authorization_servers" — an ARRAY of issuer IDENTIFIERS, not a singular
+// metadata document URL — and the RFC 8414 URL a client derives from that
+// issuer must resolve to the metadata handler.
+func TestProtectedResource_AdvertisesIssuerPerRFC9728(t *testing.T) {
 	mux := setupBindingRouter(&bindingTokenSvc{}, &fakeCIMD{})
 
 	req := httptest.NewRequest("GET", "/.well-known/oauth-protected-resource/mcp/12345", nil)
@@ -345,18 +347,73 @@ func TestProtectedResource_PointsAtRFC8414AuthServerURL(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 
-	authServer, _ := doc["authorization_server"].(string)
-	want := "https://agentrq.com/.well-known/oauth-authorization-server/mcp/" + monoflake.IDFromBase62("12345").String()
-	if authServer != want {
-		t.Errorf("authorization_server = %q, want %q", authServer, want)
+	if _, legacy := doc["authorization_server"]; legacy {
+		t.Error(`non-standard singular "authorization_server" must not be emitted`)
 	}
 
-	// Following that URL must actually resolve.
-	followReq := httptest.NewRequest("GET", strings.TrimPrefix(authServer, "https://agentrq.com"), nil)
+	servers, _ := doc["authorization_servers"].([]any)
+	if len(servers) != 1 {
+		t.Fatalf("authorization_servers = %v, want a single-entry array", doc["authorization_servers"])
+	}
+	issuer, _ := servers[0].(string)
+	wantIssuer := "https://agentrq.com/mcp/" + monoflake.IDFromBase62("12345").String()
+	if issuer != wantIssuer {
+		t.Errorf("authorization_servers[0] = %q, want issuer %q", issuer, wantIssuer)
+	}
+
+	wantResource := wantIssuer
+	if doc["resource"] != wantResource {
+		t.Errorf("resource = %v, want %q", doc["resource"], wantResource)
+	}
+
+	// A client derives the metadata URL from the issuer itself (RFC 8414 §3.1:
+	// the well-known suffix goes between host and the issuer's path). That
+	// derived URL must resolve.
+	derived := strings.Replace(issuer, "https://agentrq.com",
+		"/.well-known/oauth-authorization-server", 1)
+	followReq := httptest.NewRequest("GET", derived, nil)
 	followReq.Host = "agentrq.com"
 	followW := httptest.NewRecorder()
 	mux.ServeHTTP(followW, followReq)
 	if followW.Code != http.StatusOK {
-		t.Errorf("advertised authorization_server URL returned %d, expected it to resolve", followW.Code)
+		t.Errorf("metadata URL %q derived from the advertised issuer returned %d, expected it to resolve", derived, followW.Code)
+	}
+}
+
+// RFC 9728 §5.1 / MCP auth spec: a 401 from the MCP endpoint MUST carry a
+// WWW-Authenticate challenge naming the resource metadata URL, so clients do
+// not have to guess well-known paths.
+func TestUnauthorized_AdvertisesResourceMetadataChallenge(t *testing.T) {
+	mux := setupBindingRouter(&bindingTokenSvc{}, &fakeCIMD{})
+
+	req := httptest.NewRequest("POST", "/mcp/12345", nil)
+	req.SetPathValue("workspaceID", "12345")
+	req.Host = "agentrq.com"
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without a token, got %d", w.Code)
+	}
+
+	challenge := w.Header().Get("WWW-Authenticate")
+	wsPath := "/mcp/" + monoflake.IDFromBase62("12345").String()
+	wantMetadata := `resource_metadata="https://agentrq.com/.well-known/oauth-protected-resource` + wsPath + `"`
+	if !strings.Contains(challenge, wantMetadata) {
+		t.Errorf("WWW-Authenticate = %q, want it to contain %s", challenge, wantMetadata)
+	}
+	if !strings.HasPrefix(challenge, "Bearer ") {
+		t.Errorf("WWW-Authenticate = %q, want a Bearer challenge", challenge)
+	}
+
+	// The advertised metadata URL must resolve.
+	followReq := httptest.NewRequest("GET", "/.well-known/oauth-protected-resource"+wsPath, nil)
+	followReq.Host = "agentrq.com"
+	followW := httptest.NewRecorder()
+	mux.ServeHTTP(followW, followReq)
+	if followW.Code != http.StatusOK {
+		t.Errorf("advertised resource_metadata URL returned %d, expected it to resolve", followW.Code)
 	}
 }


### PR DESCRIPTION
AgentRQ: 0hWKKJ1vtPl

Validates a report from `@hasmcp/mcp-spec-test` against `https://mcp.agentrq.com/mcp`. Two of the three claims were real bugs; the third is intentional and is now documented in code.

## Claim 1 & 2 — confirmed, fixed

The protected-resource metadata document emitted a non-standard **singular** `authorization_server` key whose value was the RFC 8414 *metadata document URL*:

```json
{"authorization_server":"https://mcp.agentrq.com/.well-known/oauth-authorization-server",
 "resource":"https://mcp.agentrq.com/mcp"}
```

RFC 9728 §2 defines `authorization_servers` as an **array of issuer identifiers**, from which the client derives the metadata URL itself. So a strict client resolved `…/.well-known/oauth-authorization-server/.well-known/oauth-authorization-server`.

Both the core MCP endpoint (`coremcp`) and the **per-workspace** endpoints (`mcp`) were affected. Workspace MCPs were the worse case, since their issuer carries a `/mcp/{id}` path segment — the doubled derivation there 404s outright.

After (workspace MCP):

```json
{"resource":"https://mcp.agentrq.com/mcp/0ZzhYQG2qtl",
 "authorization_servers":["https://mcp.agentrq.com/mcp/0ZzhYQG2qtl"],
 "bearer_methods_supported":["header"]}
```

Deriving from that issuer yields `/.well-known/oauth-authorization-server/mcp/0ZzhYQG2qtl` — a route already served, and it matches the `issuer` our own AS metadata publishes for itself.

The legacy singular key is **dropped** rather than kept as an alias: nothing in the repo (backend, frontend, plugins, docs) reads it, and no conformant client ever did, since it appears in no specification.

## Root cause

Each handler derived the issuer independently, in two places per package — which is how the protected-resource document and the AS metadata drifted apart to begin with. Collapsed into one `oauthIdentityFor()` helper per package returning `{issuer, resource, prmURL}`, so the two documents can no longer disagree.

## Bonus gap found while verifying

We never sent a `WWW-Authenticate` header on a 401 — required by both RFC 9728 §5.1 and the MCP authorization spec. Its absence is why the spec-test had to *guess* well-known paths ("endpoint returned 401; discovering OAuth configuration"). Now every MCP 401 carries:

```
WWW-Authenticate: Bearer realm="<resource>", resource_metadata="<prm-url>"
```

## Claim 3 — accurate, but working as designed

`grant_types_supported` really is `["authorization_code","refresh_token"]` with no `client_credentials`. That stays: every token here is bound to a specific user's workspace access and that grant has no user to bind one to, and our clients are all public (`token_endpoint_auth_methods_supported: ["none"]` — DCR never issues a secret), so there would be no secret to authenticate with either. Adding it would let any self-registered client mint workspace tokens. Headless callers reuse a refresh token obtained once via `authorization_code`. Rationale is now a code comment next to the field so it isn't re-litigated.

## Tests

- Rewrote `TestProtectedResource_PointsAtRFC8414AuthServerURL` → `TestProtectedResource_AdvertisesIssuerPerRFC9728`: asserts the array shape, asserts the singular key is *absent*, and follows the URL derived from the advertised issuer to prove it resolves.
- New `coremcp/oauth_metadata_test.go` — **that package had no test files at all**. Includes a test cross-checking the protected-resource issuer against the AS metadata `issuer`, so this class of drift fails loudly.
- A 401-challenge test in each package, each verifying the advertised `resource_metadata` URL actually resolves.

`go test ./internal/...` — all packages pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)