### PR TITLE
chore: bump patch version to v0.4.3

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.4.2"
+	_appVersion   = "v0.4.3"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.4.2" {
-			t.Errorf("Expected version v0.4.2, got %s", s.Version())
+		if s.Version() != "v0.4.3" {
+			t.Errorf("Expected version v0.4.3, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
AgentRQ: 0hWMsH3iKhN

Patch bump `v0.4.2` → `v0.4.3`, via the `bump-version` skill.

## What's shipping

Everything merged since `v0.4.2` is MCP/OAuth protocol-correctness work or docs. No user-facing feature changes, no migrations.

### fix
- **#336** `fix(mcp)`: advertise the AS issuer per RFC 9728, not a metadata URL. Protected-resource metadata emitted a non-standard singular `authorization_server` whose value was a metadata document URL; RFC 9728 §2 requires `authorization_servers`, an array of *issuer identifiers*, so strict clients derived a doubled `.well-known` path. Also adds the `WWW-Authenticate` challenge on 401s required by RFC 9728 §5.1.
- **#335** `fix(mcp)`: give `server/discover` a usable cache hint. The SDK hardcodes `ttlMs: 0` — "immediately stale" by its own docs — so clients re-fetched static config on every connection. Now 1h/`public`, safe because the tool set is fixed at construction time.
- **#333** `fix(oauth)`: bind `redirect_uri` to the registered client (CIMD + DCR).
- **#334** `fix(mcp)`: support protocol revision 2026-07-28 discovery via go-sdk v1.7.0.

### docs
- **#332** Features section in README with animated feature captures.

### chore
- **#331** `chore(frontend)`: use `npx @latest` for gateway setup, drop the install step.

## Version references updated

| file | change |
|---|---|
| `frontend/package.json` | `"version": "0.4.3"` |
| `frontend/package-lock.json` | regenerated via `npm install --package-lock-only` |
| `backend/internal/service/config/config.go` | `_appVersion = "v0.4.3"` |
| `backend/internal/service/config/config_test.go` | assertion updated to `v0.4.3` |

The `0.4.2` remaining in `backend/go.sum` is the `golang.org/x/mod v0.4.2` dependency and is deliberately untouched.

## Verification

`go build ./...` clean; `go test ./internal/service/config/...` passes (that package asserts the version string, so it fails loudly if a reference is missed). A repo-wide grep confirms no stale `0.4.2` outside `go.sum`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)