### PR TITLE
chore: bump patch version to v0.4.4

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.4.3"
+	_appVersion   = "v0.4.4"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.4.3" {
-			t.Errorf("Expected version v0.4.3, got %s", s.Version())
+		if s.Version() != "v0.4.4" {
+			t.Errorf("Expected version v0.4.4, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
AgentRQ: 0hWRMI2MOxd

Patch bump `v0.4.3` → `v0.4.4`, via the `bump-version` skill.

## What's shipping

Single-change release, cut so production can pick up the login fix — **v0.4.3 shipped without it, so native MCP clients currently cannot complete the OAuth flow against `mcp.agentrq.com`.**

### fix
- **#338** `fix(oauth)`: allow any port for loopback redirect_uris (RFC 8252 §7.3). Claude Code — and any native client using loopback callbacks — could not log in at all, failing with `invalid redirect_uri: not registered for this client_id`. Such clients publish *portless* loopback `redirect_uris` and then listen on an OS-assigned ephemeral port, which the string-equality binding from #333 could never match. The relaxation covers the port only, and only when both URIs are loopback, so scheme, host, path, query and userinfo still bind. Affected both the core and per-workspace MCP authorize handlers.

## Version references updated

| file | change |
|---|---|
| `frontend/package.json` | `"version": "0.4.4"` |
| `frontend/package-lock.json` | regenerated via `npm install --package-lock-only` |
| `backend/internal/service/config/config.go` | `_appVersion = "v0.4.4"` |
| `backend/internal/service/config/config_test.go` | assertion updated to `v0.4.4` |

The `0.4.3` remaining in `backend/go.mod` is the `github.com/google/jsonschema-go v0.4.3` dependency and is deliberately untouched.

## Notes

There is **no `v0.4.3` git tag** — the latest tag is `v0.4.2`, so #337 was merged without tagging. The changelog above is therefore based on the previous bump commit (`ce00f28`) rather than a tag range, per the skill's documented fallback. Worth tagging `v0.4.3` and `v0.4.4` retroactively if the tags are meant to track releases.

## Verification

`go build ./...` clean; `go test ./internal/service/config/...` passes (that package asserts the version string, so a missed reference fails loudly). Repo-wide grep confirms no stale `0.4.3` outside `go.mod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)