### PR TITLE
chore: bump patch version to v0.4.5

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.4.4"
+	_appVersion   = "v0.4.5"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.4.4" {
-			t.Errorf("Expected version v0.4.4, got %s", s.Version())
+		if s.Version() != "v0.4.5" {
+			t.Errorf("Expected version v0.4.5, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.4.4",
+  "version": "0.4.5",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
## What changed
Bumped the app's patch version to v0.4.5 across the frontend package and backend config, including the workspace-to-workspace task move menu and an MCP test hardening merged since the last release.

## Why changed
Routine patch release to ship the accumulated changes since v0.4.4.

## Test coverage report
- New lines introduced: version string constants only, 100% covered (no new logic added).
- Total coverage impact: negligible; existing config test suite passes (`go test ./internal/service/config/...`).

## Other reports
Changelog since v0.4.4:
- feat: allow moving tasks between workspaces via right-click menu (#341)
- test(mcp): pin the duplicate-initialize refusal as correct behavior (#340)

## TaskID
AgentRQ: 0hauMXQva53