### PR TITLE
test(mcp): pin the version-less server/discover refusal as correct behavior

### DIFF
--- a/backend/internal/controller/mcp/protocol_version_test.go
+++ b/backend/internal/controller/mcp/protocol_version_test.go
@@ -254,6 +254,67 @@ func TestEveryAdvertisedVersionCompletesHandshake(t *testing.T) {
 	}
 }
 
+// Refusing a version-less server/discover is correct, not a spec deviation,
+// and this test exists to stop someone "fixing" it.
+//
+// A third-party conformance suite reported:
+//
+//	a version-less server/discover must be served, not refused:
+//	{"code":-32601,"message":"method not found: \"server/discover\""}
+//
+// server/discover is itself a >= 2026-07-28 addition, and that revision made
+// every request self-describing: protocol version and capabilities travel in
+// the JSON-RPC `_meta` field on each call rather than in a negotiated
+// session, precisely so a server can be stateless. A request with no
+// version anywhere — no MCP-Protocol-Version header, no `_meta` — carries no
+// signal that the caller knows about `_meta`-based negotiation at all, so
+// the server has no way to distinguish it from a pre-2026-07-28 client
+// blindly calling a method name it doesn't recognize. Pre-2026-07-28,
+// server/discover does not exist, so "method not found" is the only
+// consistent answer.
+//
+// The official SDK's own conformance fixture
+// (mcp/testdata/conformance/server/discover.txtar) agrees: its sole
+// server/discover case always carries the >= 2026-07-28 `_meta` envelope
+// (protocolVersion, clientInfo, clientCapabilities) — there is no
+// version-less fixture. TestServerDiscover_ReportsIdentityAndVersions above
+// already proves discover works with no session and no initialize
+// handshake, using exactly that envelope; the only thing this server
+// declines to do is guess at a version nobody asked for. Serving a bare
+// call would mean inventing behavior the reference implementation itself
+// does not define, to satisfy a third-party suite.
+func TestVersionlessDiscoverIsRefused(t *testing.T) {
+	srv := newProtocolTestServer(t)
+
+	status, out, _ := mcpPost(t, srv.URL, nil, `{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{}}`)
+	if status != http.StatusOK {
+		t.Fatalf("expected a JSON-RPC error carried over HTTP 200, got %d: %s", status, out)
+	}
+
+	var env struct {
+		Error *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(out, &env); err != nil {
+		t.Fatalf("decode %s: %v", out, err)
+	}
+	if env.Error == nil {
+		t.Fatal("expected a version-less server/discover call to be refused")
+	}
+	if !strings.Contains(env.Error.Message, "method not found") {
+		t.Errorf("unexpected refusal reason: %q", env.Error.Message)
+	}
+
+	// The remedy is on the client: carry the >= 2026-07-28 `_meta` envelope,
+	// which always succeeds — see TestServerDiscover_ReportsIdentityAndVersions.
+	versions, _ := discoverResult(t, srv)
+	if len(versions) == 0 {
+		t.Error("expected the properly-tagged discover call to still succeed")
+	}
+}
+
 // tools/call must return a schema-conformant CallToolResult: "content" is
 // required by the spec, so it must be present and non-empty.
 func TestToolsCall_ReturnsSchemaConformantResult(t *testing.T) {

--- a/backend/internal/controller/mcp/protocol_version_test.go
+++ b/backend/internal/controller/mcp/protocol_version_test.go
@@ -262,31 +262,51 @@ func TestEveryAdvertisedVersionCompletesHandshake(t *testing.T) {
 //	a version-less server/discover must be served, not refused:
 //	{"code":-32601,"message":"method not found: \"server/discover\""}
 //
-// server/discover is itself a >= 2026-07-28 addition, and that revision made
-// every request self-describing: protocol version and capabilities travel in
-// the JSON-RPC `_meta` field on each call rather than in a negotiated
-// session, precisely so a server can be stateless. A request with no
-// version anywhere — no MCP-Protocol-Version header, no `_meta` — carries no
-// signal that the caller knows about `_meta`-based negotiation at all, so
-// the server has no way to distinguish it from a pre-2026-07-28 client
-// blindly calling a method name it doesn't recognize. Pre-2026-07-28,
-// server/discover does not exist, so "method not found" is the only
-// consistent answer.
+// Checked directly against the prescriptive spec text (not just the SDK),
+// at https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http#protocol-version-header:
 //
-// The official SDK's own conformance fixture
-// (mcp/testdata/conformance/server/discover.txtar) agrees: its sole
-// server/discover case always carries the >= 2026-07-28 `_meta` envelope
-// (protocolVersion, clientInfo, clientCapabilities) — there is no
-// version-less fixture. TestServerDiscover_ReportsIdentityAndVersions above
-// already proves discover works with no session and no initialize
-// handshake, using exactly that envelope; the only thing this server
-// declines to do is guess at a version nobody asked for. Serving a bare
-// call would mean inventing behavior the reference implementation itself
-// does not define, to satisfy a third-party suite.
+//	"A server that supports clients implementing protocol versions earlier
+//	than 2025-06-18 (which did not define the MCP-Protocol-Version header)
+//	MAY treat a request that omits the header as protocol version
+//	2025-03-26."
+//
+// This server does support those earlier clients (it advertises
+// 2024-11-05 through 2025-11-25 — see TestEveryAdvertisedVersionCompletesHandshake)
+// and takes exactly that option: a header-less request is treated as
+// speaking protocol 2025-03-26. server/discover is itself a >= 2026-07-28
+// addition (https://modelcontextprotocol.io/specification/2026-07-28/server/discover),
+// so under the assumed 2025-03-26 dialect the method plainly does not
+// exist — "method not found" is the only spec-consistent answer, exactly
+// as it would be for any other unknown method name.
+//
+// That also explains the HTTP status: SEP-2575 mandates 404 for
+// MethodNotFound, but only ">= 2026-07-28" — see extractErrorStatus in the
+// SDK (mcp/streamable.go). A request assumed to be 2025-03-26 predates that
+// rule, so the error rides back on a plain 200, the pre-2026-07-28
+// convention. This isn't the SDK improvising: it's the two spec rules
+// (header-omission fallback, and the version-gated 404) composing
+// correctly, and this test asserts both halves so neither regresses
+// silently.
+//
+// The spec's own example request for server/discover
+// (https://modelcontextprotocol.io/specification/2026-07-28/server/discover#request)
+// always carries the full `_meta` envelope (protocolVersion, clientInfo,
+// clientCapabilities) — there is no version-less example, and the SDK's
+// conformance fixture (mcp/testdata/conformance/server/discover.txtar)
+// agrees. TestServerDiscover_ReportsIdentityAndVersions above already
+// proves discover works with no session and no initialize handshake, using
+// exactly that envelope; the only thing this server declines to do is
+// guess at a version nobody asked for. Serving a bare call would mean
+// inventing behavior neither the spec nor the reference implementation
+// defines, to satisfy a third-party suite.
 func TestVersionlessDiscoverIsRefused(t *testing.T) {
 	srv := newProtocolTestServer(t)
 
 	status, out, _ := mcpPost(t, srv.URL, nil, `{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{}}`)
+	// 200, not 404: a header-less request is assumed to speak the pre-2026-07-28
+	// dialect (see the fallback rule cited above), whose error convention embeds
+	// the JSON-RPC error in a 200 response rather than using SEP-2575's
+	// version-gated 404-for-MethodNotFound.
 	if status != http.StatusOK {
 		t.Fatalf("expected a JSON-RPC error carried over HTTP 200, got %d: %s", status, out)
 	}


### PR DESCRIPTION
## Summary
- The MCP spec-test report (`@hasmcp/mcp-spec-test`) flagged that a version-less `server/discover` call returns `-32601 method not found` instead of being served, calling it a spec deviation.
- Investigated and reproduced the exact error against the real workspace server, then verified this is a **false positive**, not a real deviation — no production behavior changed.

## Why no code fix
`server/discover` is itself a >= 2026-07-28 addition. That revision made every request self-describing: protocol version and capabilities travel per-request in the JSON-RPC `_meta` field rather than a negotiated session, so the server can stay stateless. A request with literally no version signal anywhere (no header, no `_meta`) is indistinguishable from a pre-2026-07-28 client calling a method name it has never heard of — and pre-2026-07-28, `server/discover` doesn't exist, so `method not found` is the only consistent answer.

The reference SDK we depend on (`github.com/modelcontextprotocol/go-sdk`, pinned at its latest release `v1.7.0`) agrees: its own conformance fixture for discover (`mcp/testdata/conformance/server/discover.txtar`) always carries the full `_meta` envelope — there's no version-less fixture in the reference implementation either.

This mirrors two existing pinning tests already in this file (pre-handshake `tools/list`, duplicate `initialize`), where the same third-party suite's complaints were checked against the reference implementation and found incorrect (see `e31d458`).

## What changed
Added `TestVersionlessDiscoverIsRefused` to `protocol_version_test.go`, documenting the reasoning so this isn't accidentally "fixed" later, and asserting the actual remedy (carrying the `_meta` envelope succeeds, per the existing `TestServerDiscover_ReportsIdentityAndVersions`).

## Test coverage report
- New lines: 100% covered (the added test exercises every new line).
- Total coverage impact: negligible increase; no production code paths changed.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/controller/mcp/...` — all pass
- [x] `go test ./internal/...` — full backend suite passes
- [x] `gofmt`/`go vet` clean

AgentRQ: 0hgr62MnlZp

🤖 Generated with [Claude Code](https://claude.com/claude-code)