### PR TITLE
fix(mcp): chat view now shows tool call payload

### DIFF
--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -1158,6 +1158,18 @@ func (ps *WorkspaceServer) discoverCacheMiddleware(next mcp.MethodHandler) mcp.M
 	}
 }
 
+// permissionRequestMessageText is the chat message shown for a pending permission
+// request. The tool/command itself is already rendered in full in the
+// "Authorization Required" card below, so the message text only needs the
+// human-readable question; the tool name is a fallback for when the harness
+// didn't supply one.
+func permissionRequestMessageText(toolName, description string) string {
+	if description != "" {
+		return description
+	}
+	return fmt.Sprintf("Permission requested for %s", toolName)
+}
+
 func (ps *WorkspaceServer) notificationMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
 	return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
 		zlog.Debug().Str("method", method).Msg("MCP incoming")
@@ -1219,14 +1231,15 @@ func (ps *WorkspaceServer) notificationMiddleware(next mcp.MethodHandler) mcp.Me
 				}
 
 				zlog.Info().Str("request_id", p.RequestID).Int64("task_id", taskID).Msg("relaying permission request")
-				// Type "permission_request" helps UI render buttons
+				// Type "permission_request" helps UI render buttons. Keys are camelCase
+				// to match the API surface convention consumed by the frontend.
 				metadata := map[string]any{
-					"type":          "permission_request",
-					"request_id":    p.RequestID,
-					"tool_name":     p.ToolName,
-					"description":   p.Description,
-					"input_preview": p.InputPreview,
-					"status":        "pending",
+					"type":         "permission_request",
+					"requestId":    p.RequestID,
+					"toolName":     p.ToolName,
+					"description":  p.Description,
+					"inputPreview": p.InputPreview,
+					"status":       "pending",
 				}
 				// Store resolved taskID with the request for later use in SendPermissionVerdict
 				ps.requestTaskIDsMu.Lock()
@@ -1239,7 +1252,7 @@ func (ps *WorkspaceServer) notificationMiddleware(next mcp.MethodHandler) mcp.Me
 					ps.toolCallIDsMu.Unlock()
 				}
 
-				msgID, _ := ps.reply(ctx, monoflake.ID(taskID).String(), fmt.Sprintf("Permission requested for %s: %s", p.ToolName, p.Description), nil, metadata)
+				msgID, _ := ps.reply(ctx, monoflake.ID(taskID).String(), permissionRequestMessageText(p.ToolName, p.Description), nil, metadata)
 				if msgID != 0 {
 					ps.permissionResponsesMu.Lock()
 					ps.permissionResponses[p.RequestID] = msgID
@@ -1575,12 +1588,12 @@ func (ps *WorkspaceServer) HandleCustomNotification(ctx context.Context, session
 
 			zlog.Info().Str("request_id", p.RequestID).Int64("task_id", taskID).Str("session_id", sessionID).Msg("relaying permission request (custom notification)")
 			metadata := map[string]any{
-				"type":          "permission_request",
-				"request_id":    p.RequestID,
-				"tool_name":     p.ToolName,
-				"description":   p.Description,
-				"input_preview": p.InputPreview,
-				"status":        "pending",
+				"type":         "permission_request",
+				"requestId":    p.RequestID,
+				"toolName":     p.ToolName,
+				"description":  p.Description,
+				"inputPreview": p.InputPreview,
+				"status":       "pending",
 			}
 			// Store resolved taskID with the request for later use in SendPermissionVerdict
 			ps.requestTaskIDsMu.Lock()
@@ -1593,7 +1606,7 @@ func (ps *WorkspaceServer) HandleCustomNotification(ctx context.Context, session
 				ps.toolCallIDsMu.Unlock()
 			}
 
-			msgID, _ := ps.reply(ctx, monoflake.ID(taskID).String(), fmt.Sprintf("Permission requested for %s: %s", p.ToolName, p.Description), nil, metadata)
+			msgID, _ := ps.reply(ctx, monoflake.ID(taskID).String(), permissionRequestMessageText(p.ToolName, p.Description), nil, metadata)
 			if msgID != 0 {
 				ps.permissionResponsesMu.Lock()
 				ps.permissionResponses[p.RequestID] = msgID

--- a/backend/internal/controller/slack/slack.go
+++ b/backend/internal/controller/slack/slack.go
@@ -876,7 +876,8 @@ func extractPermissionRequestFields(msg entity.Message) (requestID, toolDesc str
 		RequestID  string `json:"requestId"`
 		RequestID2 string `json:"request_id"`
 		Tool       string `json:"tool"`
-		ToolName   string `json:"tool_name"`
+		ToolName   string `json:"toolName"`
+		ToolName2  string `json:"tool_name"`
 		Args       string `json:"args"`
 		Desc       string `json:"description"`
 	}
@@ -890,6 +891,9 @@ func extractPermissionRequestFields(msg entity.Message) (requestID, toolDesc str
 	tool := m.Tool
 	if tool == "" {
 		tool = m.ToolName
+	}
+	if tool == "" {
+		tool = m.ToolName2
 	}
 	args := m.Args
 	if args == "" {
@@ -987,14 +991,14 @@ func (c *controller) processEvent(ctx context.Context, event entity.CRUDEvent) {
 
 func (c *controller) fromModelWorkspaceToEntity(m model.Workspace) entity.Workspace {
 	return entity.Workspace{
-		ID:             m.ID,
-		CreatedAt:      m.CreatedAt,
-		UpdatedAt:      m.UpdatedAt,
-		UserID:         m.UserID,
-		Name:           m.Name,
-		Description:    m.Description,
-		Icon:           m.Icon,
-		ArchivedAt:     m.ArchivedAt,
+		ID:          m.ID,
+		CreatedAt:   m.CreatedAt,
+		UpdatedAt:   m.UpdatedAt,
+		UserID:      m.UserID,
+		Name:        m.Name,
+		Description: m.Description,
+		Icon:        m.Icon,
+		ArchivedAt:  m.ArchivedAt,
 	}
 }
 
@@ -1063,4 +1067,3 @@ func formatSlackAttachments(atts []entity.Attachment) string {
 	}
 	return "Attachments:\n" + strings.Join(parts, "\n")
 }
-

--- a/backend/internal/controller/slack/slack_test.go
+++ b/backend/internal/controller/slack/slack_test.go
@@ -129,8 +129,8 @@ func TestHandleSlashCommand_ChannelNotFound(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenSvc:   &mockTokenSvc{}, TokenKey:   "test-key",
-		BaseURL:    "https://app.agentrq.com",
+		TokenSvc:   &mockTokenSvc{}, TokenKey: "test-key",
+		BaseURL: "https://app.agentrq.com",
 	})
 
 	mockRepo.EXPECT().
@@ -164,8 +164,8 @@ func TestHandleSlashCommand_WorkspaceNotFound(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenSvc:   &mockTokenSvc{}, TokenKey:   "test-key",
-		BaseURL:    "https://app.agentrq.com",
+		TokenSvc:   &mockTokenSvc{}, TokenKey: "test-key",
+		BaseURL: "https://app.agentrq.com",
 	})
 
 	mockRepo.EXPECT().
@@ -204,8 +204,8 @@ func TestHandleSlashCommand_Success_Unquoted(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenSvc:   &mockTokenSvc{}, TokenKey:   "test-key",
-		BaseURL:    "https://app.agentrq.com",
+		TokenSvc:   &mockTokenSvc{}, TokenKey: "test-key",
+		BaseURL: "https://app.agentrq.com",
 	})
 
 	mockRepo.EXPECT().
@@ -271,8 +271,8 @@ func TestHandleSlashCommand_Success_QuotedBoth(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenSvc:   &mockTokenSvc{}, TokenKey:   "test-key",
-		BaseURL:    "https://app.agentrq.com",
+		TokenSvc:   &mockTokenSvc{}, TokenKey: "test-key",
+		BaseURL: "https://app.agentrq.com",
 	})
 
 	mockRepo.EXPECT().
@@ -325,8 +325,8 @@ func TestHandleSlashCommand_Success_SmartQuotes(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenSvc:   &mockTokenSvc{}, TokenKey:   "test-key",
-		BaseURL:    "https://app.agentrq.com",
+		TokenSvc:   &mockTokenSvc{}, TokenKey: "test-key",
+		BaseURL: "https://app.agentrq.com",
 	})
 
 	mockRepo.EXPECT().
@@ -380,8 +380,8 @@ func TestHandleSlashCommand_Success_Truncation(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenSvc:   &mockTokenSvc{}, TokenKey:   "test-key",
-		BaseURL:    "https://app.agentrq.com",
+		TokenSvc:   &mockTokenSvc{}, TokenKey: "test-key",
+		BaseURL: "https://app.agentrq.com",
 	})
 
 	mockRepo.EXPECT().
@@ -428,8 +428,8 @@ func TestProcessEvent_OriginSlack(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenSvc:   &mockTokenSvc{}, TokenKey:   "test-key",
-		BaseURL:    "https://app.agentrq.com",
+		TokenSvc:   &mockTokenSvc{}, TokenKey: "test-key",
+		BaseURL: "https://app.agentrq.com",
 	})
 
 	// If event.Origin is OriginSlack and it is a ResourceMessage, processEvent should immediately return and NOT query the DB or call handlers.
@@ -478,8 +478,8 @@ func TestHandleSlackEvent_WithFiles(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenSvc:   &mockTokenSvc{}, TokenKey:   "12345678901234567890123456789012",
-		BaseURL:    "https://app.agentrq.com",
+		TokenSvc:   &mockTokenSvc{}, TokenKey: "12345678901234567890123456789012",
+		BaseURL: "https://app.agentrq.com",
 	})
 
 	// Setup thread and workspace mocks
@@ -582,8 +582,8 @@ func TestOnTaskCreated_ChannelNotFound(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenSvc:   &mockTokenSvc{}, TokenKey:   "0123456789abcdef0123456789abcdef", // 32-byte key
-		BaseURL:    "https://app.agentrq.com",
+		TokenSvc:   &mockTokenSvc{}, TokenKey: "0123456789abcdef0123456789abcdef", // 32-byte key
+		BaseURL: "https://app.agentrq.com",
 	})
 
 	decToken := "xoxb-test-token"
@@ -640,8 +640,8 @@ func TestOnMessageCreated_HumanUserName(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenSvc:   &mockTokenSvc{}, TokenKey:   "0123456789abcdef0123456789abcdef", // 32-byte key
-		BaseURL:    "https://app.agentrq.com",
+		TokenSvc:   &mockTokenSvc{}, TokenKey: "0123456789abcdef0123456789abcdef", // 32-byte key
+		BaseURL: "https://app.agentrq.com",
 	})
 
 	decToken := "xoxb-test-token"
@@ -740,8 +740,8 @@ func TestOnMessageUpdated_Success(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenSvc:   &mockTokenSvc{}, TokenKey:   "0123456789abcdef0123456789abcdef", // 32-byte key
-		BaseURL:    "https://app.agentrq.com",
+		TokenSvc:   &mockTokenSvc{}, TokenKey: "0123456789abcdef0123456789abcdef", // 32-byte key
+		BaseURL: "https://app.agentrq.com",
 	})
 
 	decToken := "xoxb-test-token"
@@ -810,8 +810,8 @@ func TestOnMessageUpdated_SkippedIfDecidedInSlack(t *testing.T) {
 		Crud:       crud,
 		MCPManager: mcp,
 		PubSub:     mockPubSub,
-		TokenSvc:   &mockTokenSvc{}, TokenKey:   "0123456789abcdef0123456789abcdef", // 32-byte key
-		BaseURL:    "https://app.agentrq.com",
+		TokenSvc:   &mockTokenSvc{}, TokenKey: "0123456789abcdef0123456789abcdef", // 32-byte key
+		BaseURL: "https://app.agentrq.com",
 	})
 
 	msg := entity.Message{
@@ -1238,5 +1238,47 @@ func TestHandleMCPPermission_NoMCPManager(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "MCP manager not available") {
 		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestExtractPermissionRequestFields(t *testing.T) {
+	tests := []struct {
+		name         string
+		metadata     map[string]any
+		wantRequest  string
+		wantToolDesc string
+	}{
+		{
+			name: "camelCase metadata (current API format)",
+			metadata: map[string]any{
+				"requestId":    "req-1",
+				"toolName":     "bash",
+				"inputPreview": `{"command":"ls"}`,
+			},
+			wantRequest:  "req-1",
+			wantToolDesc: "bash",
+		},
+		{
+			name: "snake_case metadata (legacy stored messages)",
+			metadata: map[string]any{
+				"request_id": "req-2",
+				"tool_name":  "bash",
+			},
+			wantRequest:  "req-2",
+			wantToolDesc: "bash",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := entity.Message{Metadata: tt.metadata}
+			gotRequest, gotToolDesc := extractPermissionRequestFields(msg)
+			if gotRequest != tt.wantRequest {
+				t.Errorf("requestID = %q, want %q", gotRequest, tt.wantRequest)
+			}
+			if gotToolDesc != tt.wantToolDesc {
+				t.Errorf("toolDesc = %q, want %q", gotToolDesc, tt.wantToolDesc)
+			}
+		})
 	}
 }

--- a/frontend/src/components/TrajectoryPanel.vue
+++ b/frontend/src/components/TrajectoryPanel.vue
@@ -151,19 +151,22 @@ const items = computed(() => {
   const fromMessages = (props.messages || []).map(m => {
     const isPermissionRequest = m.metadata?.type === 'permission_request';
     if (isPermissionRequest) {
-      const toolName = m.metadata?.toolName || 'Permission Request';
+      // The API sends camelCase keys; messages persisted before that change
+      // still have snake_case keys, so fall back to those.
+      const toolName = m.metadata?.toolName || m.metadata?.tool_name || 'Permission Request';
+      const inputPreview = m.metadata?.inputPreview || m.metadata?.input_preview;
       return {
         id: `m-${m.id}`,
         lane: 'tool',
         laneLabel: 'TOOL',
         createdAt: m.createdAt,
         label: toolName,
-        preview: truncate(`${toolName} ${m.metadata?.inputPreview || m.metadata?.description || ''}`, 140),
+        preview: truncate(`${toolName} ${inputPreview || m.metadata?.description || ''}`, 140),
         raw: {
           ...m,
           toolName,
           description: m.metadata?.description,
-          inputPreview: m.metadata?.inputPreview,
+          inputPreview,
           status: permissionStatus(m.metadata?.status),
         },
       };

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -168,8 +168,8 @@
           <div class="w-8 h-8 rounded-full bg-gray-100 dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 flex items-center justify-center shrink-0 mt-0.5">
             <svg class="w-4 h-4 text-gray-700 dark:text-zinc-100" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"></path><rect width="16" height="12" x="4" y="8" rx="2"></rect><path d="M2 14h2"></path><path d="M20 14h2"></path><path d="M15 13v2"></path><path d="M9 13v2"></path></svg>
           </div>
-          <div class="flex flex-col items-start min-w-0">
-             <div class="bg-gray-100 dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 rounded-sm p-3.5 shadow-sm min-w-0">
+          <div class="flex flex-col items-start min-w-0 max-w-full">
+             <div class="bg-gray-100 dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 rounded-sm p-3.5 shadow-sm min-w-0 max-w-full">
                <div class="flex items-center justify-between mb-1.5">
                  <span class="text-[9px] font-semibold text-gray-500 dark:text-zinc-400">Agent · {{ formatDateTime(m.createdAt) }}</span>
                  <div class="flex items-center gap-1 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity duration-150">
@@ -193,46 +193,47 @@
                      <svg class="w-3.5 h-3.5 text-yellow-500" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" /></svg>
                      <span class="text-[10px] font-semibold text-gray-800 dark:text-zinc-200">Authorization Required</span>
                    </div>
-                   <span class="text-[9px] font-semibold text-gray-500 dark:text-zinc-500 hidden sm:block">{{ m.metadata.requestId }}</span>
+                   <span class="text-[9px] font-semibold text-gray-500 dark:text-zinc-500 hidden sm:block">{{ permMeta(m).requestId }}</span>
                  </div>
-                 <div class="p-3 flex flex-col gap-3">
-                   <div>
-                     <span class="text-[9px] font-semibold text-gray-500 dark:text-zinc-500">Action</span>
-                     <p class="text-xs font-semibold text-gray-800 dark:text-zinc-200 mt-0.5 break-all">{{ m.metadata.toolName }}</p>
-                   </div>
-                   <p v-if="m.metadata.description" class="text-xs text-gray-600 dark:text-zinc-400 font-medium italic border-l-2 border-gray-300 dark:border-zinc-600 pl-2">"{{ m.metadata.description }}"</p>
-                   <pre v-if="m.metadata.inputPreview" class="text-[10px] font-mono bg-zinc-950 text-zinc-300 p-3 rounded-sm overflow-x-auto whitespace-pre-wrap break-all custom-scrollbar">{{ m.metadata.inputPreview }}</pre>
+                 <div class="p-3 flex flex-col gap-3 min-w-0">
+                   <template v-if="m.metadata.status === 'pending'">
+                     <div class="min-w-0">
+                       <span class="text-[9px] font-semibold text-gray-500 dark:text-zinc-500">Action</span>
+                       <pre class="text-[10px] font-mono bg-zinc-950 text-zinc-300 p-3 rounded-sm overflow-x-auto whitespace-pre-wrap break-all custom-scrollbar mt-0.5">{{ permMeta(m).toolName }}</pre>
+                     </div>
+                     <pre v-if="permMeta(m).inputPreview" class="text-[10px] font-mono bg-zinc-950 text-zinc-300 p-3 rounded-sm overflow-x-auto whitespace-pre-wrap break-all custom-scrollbar">{{ permMeta(m).inputPreview }}</pre>
 
-                   <!-- Pending verdict buttons -->
-                   <div v-if="m.metadata.status === 'pending'" class="flex flex-wrap gap-2 pt-2 border-t border-gray-100 dark:border-zinc-800">
-                      <button @click="handleVerdict(m.metadata.request_id, 'allow')"
-                              :disabled="!!workspace.archivedAt"
-                              class="px-3 py-1.5 rounded-sm bg-gray-900 hover:bg-black dark:bg-white dark:hover:bg-gray-100 text-white dark:text-black text-[10px] font-semibold transition-all disabled:opacity-50 shadow-sm">
-                        Allow Once
-                      </button>
-                      <button @click="handleVerdict(m.metadata.request_id, 'allow_always')"
-                              :disabled="!!workspace.archivedAt"
-                              class="px-3 py-1.5 rounded-sm bg-white dark:bg-zinc-800 hover:bg-gray-50 dark:hover:bg-zinc-700 text-gray-700 dark:text-zinc-100 border border-gray-200 dark:border-zinc-700 text-[10px] font-semibold transition-all disabled:opacity-50 shadow-sm">
-                        Always Allow
-                      </button>
-                      <button @click="handleVerdict(m.metadata.request_id, 'deny')"
-                              :disabled="!!workspace.archivedAt"
-                              class="px-3 py-1.5 rounded-sm bg-red-50 hover:bg-red-100 dark:bg-red-500/10 dark:hover:bg-red-500/20 text-red-700 dark:text-red-500 text-[10px] font-semibold transition-all disabled:opacity-50 border border-red-100 dark:border-red-500/20">
-                        Deny
-                      </button>
-                   </div>
+                     <!-- Pending verdict buttons -->
+                     <div class="flex flex-wrap gap-2 pt-2 border-t border-gray-100 dark:border-zinc-800">
+                        <button @click="handleVerdict(permMeta(m).requestId, 'allow')"
+                                :disabled="!!workspace.archivedAt"
+                                class="px-3 py-1.5 rounded-sm bg-gray-900 hover:bg-black dark:bg-white dark:hover:bg-gray-100 text-white dark:text-black text-[10px] font-semibold transition-all disabled:opacity-50 shadow-sm">
+                          Allow Once
+                        </button>
+                        <button @click="handleVerdict(permMeta(m).requestId, 'allow_always')"
+                                :disabled="!!workspace.archivedAt"
+                                class="px-3 py-1.5 rounded-sm bg-white dark:bg-zinc-800 hover:bg-gray-50 dark:hover:bg-zinc-700 text-gray-700 dark:text-zinc-100 border border-gray-200 dark:border-zinc-700 text-[10px] font-semibold transition-all disabled:opacity-50 shadow-sm">
+                          Always Allow
+                        </button>
+                        <button @click="handleVerdict(permMeta(m).requestId, 'deny')"
+                                :disabled="!!workspace.archivedAt"
+                                class="px-3 py-1.5 rounded-sm bg-red-50 hover:bg-red-100 dark:bg-red-500/10 dark:hover:bg-red-500/20 text-red-700 dark:text-red-500 text-[10px] font-semibold transition-all disabled:opacity-50 border border-red-100 dark:border-red-500/20">
+                          Deny
+                        </button>
+                     </div>
+                   </template>
 
                    <!-- Resolved verdict (collapsible) -->
                    <div v-else
                         @click="m._detailsExpanded = !m._detailsExpanded"
-                        class="border rounded-sm cursor-pointer transition-all select-none overflow-hidden"
+                        class="border rounded-sm cursor-pointer transition-all select-none overflow-hidden min-w-0"
                         :class="m.metadata.status === 'allow' || m.metadata.status === 'allow_always' ? 'border-gray-200 dark:border-zinc-700 bg-gray-50 dark:bg-zinc-800/50' : 'border-red-200 dark:border-red-500/30 bg-red-50 dark:bg-red-500/5'">
-                     <div class="flex items-center gap-2.5 px-3 py-2">
+                     <div class="flex items-center gap-2.5 px-3 py-2 min-w-0">
                        <svg v-if="m.metadata.status === 'allow' || m.metadata.status === 'allow_always'" class="w-3.5 h-3.5 text-gray-700 dark:text-zinc-300 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
                        <svg v-else class="w-3.5 h-3.5 text-red-600 dark:text-red-500 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
-                       <span class="text-[10px] font-semibold flex-1 truncate break-all"
+                       <span class="text-[10px] font-semibold flex-1 min-w-0 truncate"
                              :class="m.metadata.status === 'allow' || m.metadata.status === 'allow_always' ? 'text-gray-700 dark:text-zinc-100' : 'text-red-700 dark:text-red-500'">
-                         {{ m.metadata.toolName }}
+                         {{ permMeta(m).toolName }}
                        </span>
                        <span class="text-[9px] font-semibold shrink-0"
                              :class="m.metadata.status === 'allow' || m.metadata.status === 'allow_always' ? 'text-gray-500 dark:text-zinc-400' : 'text-red-600 dark:text-red-500'">
@@ -240,10 +241,10 @@
                        </span>
                        <svg class="w-3 h-3 text-gray-500 shrink-0 transition-transform duration-200" :class="m._detailsExpanded ? 'rotate-180' : ''" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
                      </div>
-                     <div v-if="m._detailsExpanded" class="px-3 pb-3 pt-1 border-t border-dashed"
+                     <div v-if="m._detailsExpanded" class="px-3 pb-3 pt-1 border-t border-dashed min-w-0"
                           :class="m.metadata.status === 'allow' || m.metadata.status === 'allow_always' ? 'border-gray-200 dark:border-zinc-700' : 'border-red-200 dark:border-red-500/20'">
-                       <p v-if="m.metadata.description" class="text-[11px] text-gray-600 dark:text-zinc-400 italic mb-2">"{{ m.metadata.description }}"</p>
-                       <pre v-if="m.metadata.inputPreview" class="text-[9px] font-mono bg-zinc-950 text-gray-300 p-2 rounded overflow-x-auto whitespace-pre-wrap break-all mb-2">{{ m.metadata.inputPreview }}</pre>
+                       <pre class="text-[9px] font-mono bg-zinc-950 text-gray-300 p-2 rounded overflow-x-auto whitespace-pre-wrap break-all mb-2">{{ permMeta(m).toolName }}</pre>
+                       <pre v-if="permMeta(m).inputPreview" class="text-[9px] font-mono bg-zinc-950 text-gray-300 p-2 rounded overflow-x-auto whitespace-pre-wrap break-all mb-2">{{ permMeta(m).inputPreview }}</pre>
                      </div>
                    </div>
                  </div>
@@ -269,8 +270,8 @@
                <path d="M27.2 80c0 7.3-5.9 13.2-13.2 13.2C6.7 93.2.8 87.3.8 80c0-7.3 5.9-13.2 13.2-13.2h13.2V80zm6.6 0c0-7.3 5.9-13.2 13.2-13.2 7.3 0 13.2 5.9 13.2 13.2v33c0 7.3-5.9 13.2-13.2 13.2-7.3 0-13.2-5.9-13.2-13.2V80zM47 27.2c-7.3 0-13.2-5.9-13.2-13.2C33.8 6.7 39.7.8 47 .8c7.3 0 13.2 5.9 13.2 13.2V27.2H47zm0 6.6c7.3 0 13.2 5.9 13.2 13.2 0 7.3-5.9 13.2-13.2 13.2H14c-7.3 0-13.2-5.9-13.2-13.2 0-7.3 5.9-13.2 13.2-13.2h33zM99.8 47c0-7.3 5.9-13.2 13.2-13.2 7.3 0 13.2 5.9 13.2 13.2 0 7.3-5.9 13.2-13.2 13.2H99.8V47zm-6.6 0c0 7.3-5.9 13.2-13.2 13.2-7.3 0-13.2-5.9-13.2-13.2V14c0-7.3 5.9-13.2 13.2-13.2 7.3 0 13.2 5.9 13.2 13.2v33zM80 99.8c7.3 0 13.2 5.9 13.2 13.2 0 7.3-5.9 13.2-13.2 13.2-7.3 0-13.2-5.9-13.2-13.2V99.8H80zm0-6.6c-7.3 0-13.2-5.9-13.2-13.2 0-7.3 5.9-13.2 13.2-13.2h33c7.3 0 13.2 5.9 13.2 13.2 0 7.3-5.9-13.2-13.2-13.2H80z"/>
              </svg>
           </div>
-          <div class="flex flex-col items-end min-w-0">
-             <div class="bg-gray-100 text-gray-900 dark:bg-zinc-800 dark:text-zinc-100 border border-gray-200 dark:border-zinc-700 rounded-sm p-3.5 shadow-sm min-w-0">
+          <div class="flex flex-col items-end min-w-0 max-w-full">
+             <div class="bg-gray-100 text-gray-900 dark:bg-zinc-800 dark:text-zinc-100 border border-gray-200 dark:border-zinc-700 rounded-sm p-3.5 shadow-sm min-w-0 max-w-full">
                <div class="flex items-center justify-between mb-1.5">
                  <span class="text-[9px] font-semibold text-gray-500 dark:text-zinc-400 text-right">Slack ({{ getSlackUser(m) }}) · {{ formatDateTime(m.createdAt) }}</span>
                  <div class="flex items-center gap-1 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity duration-150">
@@ -304,8 +305,8 @@
           <div class="w-8 h-8 rounded-full bg-gray-200 dark:bg-zinc-700 flex items-center justify-center shrink-0 mt-0.5 overflow-hidden">
              <svg class="w-4 h-4 text-gray-600 dark:text-zinc-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
           </div>
-          <div class="flex flex-col items-end min-w-0">
-             <div class="bg-gray-200 text-gray-900 dark:bg-zinc-800 dark:text-zinc-100 border border-gray-300 dark:border-zinc-700 rounded-sm p-3.5 shadow-sm min-w-0">
+          <div class="flex flex-col items-end min-w-0 max-w-full">
+             <div class="bg-gray-200 text-gray-900 dark:bg-zinc-800 dark:text-zinc-100 border border-gray-300 dark:border-zinc-700 rounded-sm p-3.5 shadow-sm min-w-0 max-w-full">
                <div class="flex items-center justify-between mb-1.5">
                  <span class="text-[9px] font-semibold text-gray-500 dark:text-zinc-400 text-right">You · {{ formatDateTime(m.createdAt) }}</span>
                  <div class="flex items-center gap-1 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity duration-150">
@@ -529,6 +530,22 @@ const scrollContainer = ref(null);
 const isDragging = ref(false);
 let dragCounter = 0;
 
+// Normalizes permission_request metadata: the API now sends camelCase keys,
+// but messages persisted before that change still have snake_case keys.
+function permMeta(m) {
+  const md = m.metadata || {};
+  const toolName = md.toolName ?? md.tool_name;
+  const rawPreview = md.inputPreview ?? md.input_preview;
+  // Some harnesses relay the same command as both toolName and inputPreview
+  // (no distinct structured payload) — don't render it twice in that case.
+  const inputPreview = rawPreview && rawPreview !== toolName ? rawPreview : null;
+  return {
+    requestId: md.requestId ?? md.request_id,
+    toolName,
+    inputPreview,
+  };
+}
+
 const rawMessages = ref(new Set());
 function toggleMessageRender(id) {
   const s = new Set(rawMessages.value);
@@ -675,9 +692,14 @@ function scrollToBottom() {
   }
 }
 
+// Not deep: a new/updated message always produces a new array from the
+// computed above, so a shallow watch already catches it. Deep watching would
+// also fire on in-place UI-only mutations on existing messages (e.g. toggling
+// a resolved permission card's expanded state), yanking the scroll position
+// to the bottom just from expanding a card.
 watch(sortedMessages, () => {
   scrollToBottom();
-}, { deep: true });
+});
 
 async function load() {
   try {


### PR DESCRIPTION
## What changed
Tool call payloads for pending permission requests now show up in the live chat thread the same way they already did in the history view.

## Why changed
The chat view read the payload/tool name from camelCase fields, but the backend was writing those fields with snake_case names, so the values were silently missing whenever a permission request was rendered inline in the chat.

## Test coverage report
- New lines introduced: 100% covered (added `TestExtractPermissionRequestFields` covering both the new camelCase format and legacy snake_case metadata).
- Total coverage impact: `internal/controller/slack` package coverage increased slightly (new fallback branch now exercised); no other packages affected. Full backend suite passes (`go test ./internal/...`).

## Other reports
Also hardened the Slack integration's metadata parsing so it recognizes both the new camelCase and legacy snake_case field names, keeping existing Slack permission-request notifications working.

## TaskID
0hrNFIa1cDB