### PR TITLE
feat(frontend): add copy buttons for permission-request tool/payload

### DIFF
--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -199,9 +199,23 @@
                    <template v-if="m.metadata.status === 'pending'">
                      <div class="min-w-0">
                        <span class="text-[9px] font-semibold text-gray-500 dark:text-zinc-500">Action</span>
-                       <pre class="text-[10px] font-mono bg-zinc-950 text-zinc-300 p-3 rounded-sm overflow-x-auto whitespace-pre-wrap break-all custom-scrollbar mt-0.5">{{ permMeta(m).toolName }}</pre>
+                       <div class="relative mt-0.5">
+                         <pre class="text-[10px] font-mono bg-zinc-950 text-zinc-300 p-3 pr-8 rounded-sm overflow-x-auto whitespace-pre-wrap break-all custom-scrollbar">{{ permMeta(m).toolName }}</pre>
+                         <button type="button" @click.stop="copyMessageText(m.id + '-action', permMeta(m).toolName)"
+                                 class="absolute top-1.5 right-1.5 p-1 rounded bg-black/40 hover:bg-black/60 text-zinc-400 hover:text-white transition-colors" title="Copy">
+                           <svg v-if="!copiedMessages.has(m.id + '-action')" class="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                           <svg v-else class="w-2.5 h-2.5 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                         </button>
+                       </div>
                      </div>
-                     <pre v-if="permMeta(m).inputPreview" class="text-[10px] font-mono bg-zinc-950 text-zinc-300 p-3 rounded-sm overflow-x-auto whitespace-pre-wrap break-all custom-scrollbar">{{ permMeta(m).inputPreview }}</pre>
+                     <div v-if="permMeta(m).inputPreview" class="relative">
+                       <pre class="text-[10px] font-mono bg-zinc-950 text-zinc-300 p-3 pr-8 rounded-sm overflow-x-auto whitespace-pre-wrap break-all custom-scrollbar">{{ permMeta(m).inputPreview }}</pre>
+                       <button type="button" @click.stop="copyMessageText(m.id + '-payload', permMeta(m).inputPreview)"
+                               class="absolute top-1.5 right-1.5 p-1 rounded bg-black/40 hover:bg-black/60 text-zinc-400 hover:text-white transition-colors" title="Copy">
+                         <svg v-if="!copiedMessages.has(m.id + '-payload')" class="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                         <svg v-else class="w-2.5 h-2.5 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                       </button>
+                     </div>
 
                      <!-- Pending verdict buttons -->
                      <div class="flex flex-wrap gap-2 pt-2 border-t border-gray-100 dark:border-zinc-800">
@@ -243,8 +257,22 @@
                      </div>
                      <div v-if="m._detailsExpanded" class="px-3 pb-3 pt-1 border-t border-dashed min-w-0"
                           :class="m.metadata.status === 'allow' || m.metadata.status === 'allow_always' ? 'border-gray-200 dark:border-zinc-700' : 'border-red-200 dark:border-red-500/20'">
-                       <pre class="text-[9px] font-mono bg-zinc-950 text-gray-300 p-2 rounded overflow-x-auto whitespace-pre-wrap break-all mb-2">{{ permMeta(m).toolName }}</pre>
-                       <pre v-if="permMeta(m).inputPreview" class="text-[9px] font-mono bg-zinc-950 text-gray-300 p-2 rounded overflow-x-auto whitespace-pre-wrap break-all mb-2">{{ permMeta(m).inputPreview }}</pre>
+                       <div class="relative mb-2">
+                         <pre class="text-[9px] font-mono bg-zinc-950 text-gray-300 p-2 pr-8 rounded overflow-x-auto whitespace-pre-wrap break-all">{{ permMeta(m).toolName }}</pre>
+                         <button type="button" @click.stop="copyMessageText(m.id + '-action', permMeta(m).toolName)"
+                                 class="absolute top-1.5 right-1.5 p-1 rounded bg-black/40 hover:bg-black/60 text-zinc-400 hover:text-white transition-colors" title="Copy">
+                           <svg v-if="!copiedMessages.has(m.id + '-action')" class="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                           <svg v-else class="w-2.5 h-2.5 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                         </button>
+                       </div>
+                       <div v-if="permMeta(m).inputPreview" class="relative mb-2">
+                         <pre class="text-[9px] font-mono bg-zinc-950 text-gray-300 p-2 pr-8 rounded overflow-x-auto whitespace-pre-wrap break-all">{{ permMeta(m).inputPreview }}</pre>
+                         <button type="button" @click.stop="copyMessageText(m.id + '-payload', permMeta(m).inputPreview)"
+                                 class="absolute top-1.5 right-1.5 p-1 rounded bg-black/40 hover:bg-black/60 text-zinc-400 hover:text-white transition-colors" title="Copy">
+                           <svg v-if="!copiedMessages.has(m.id + '-payload')" class="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                           <svg v-else class="w-2.5 h-2.5 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                         </button>
+                       </div>
                      </div>
                    </div>
                  </div>


### PR DESCRIPTION
## What changed
Adds a copy button on the tool command and structured payload code blocks shown in a permission request's "Authorization Required" card (both pending and resolved/expanded states).

## Why changed
There was no way to copy the command or payload shown there other than manually selecting the text, which is awkward for long, wrapped, or truncated commands.

## Test coverage report
Frontend-only UI change (button + click handler reusing the existing copy-to-clipboard composable already used for message text on this same view). No backend logic touched, so no new backend test coverage applies. Verified manually: button renders in the correct position for both pending and resolved states, doesn't trigger the card's own expand/collapse toggle (click event is stopped), and the frontend builds clean.

## TaskID
0hrNFIa1cDB