### PR TITLE
feat(mcp): add elicit tool for agent-driven human input

### DIFF
--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -122,6 +122,8 @@ type WorkspaceServer struct {
 	permissionResponses   map[string]int64 // requestID -> messageID
 	toolCallIDsMu         sync.RWMutex
 	toolCallIDs           map[string]int64 // requestID -> ToolCall row ID (manual requests only, until resolved)
+	elicitationsMu        sync.Mutex
+	elicitations          map[string]chan elicitationResponse // requestID -> channel the waiting elicit tool call blocks on
 	metadataMu            sync.RWMutex
 	icon                  string
 	name                  string
@@ -197,6 +199,102 @@ type GetTaskParams struct {
 	Limit               int    `json:"limit,omitempty" jsonschema:"Maximum number of messages to return; only used when includeConversation is true. Default is 5."`
 }
 
+// ElicitParams is the input to the elicit tool. It mirrors the MCP protocol's
+// client-side "elicitation/create" request (message + a flat requestedSchema),
+// plus a "url" mode for asking the human to open a link rather than fill a form.
+type ElicitParams struct {
+	TaskID          string         `json:"taskId" jsonschema:"The ID of the task this question relates to (base62)."`
+	Message         string         `json:"message" jsonschema:"The human-readable question or prompt to show the user."`
+	Mode            string         `json:"mode" jsonschema:"'form' to request structured input via a JSON schema (mirrors MCP's elicitation/create requestedSchema), or 'url' to ask the user to open a link and confirm when done."`
+	RequestedSchema map[string]any `json:"requestedSchema,omitempty" jsonschema:"Required when mode is 'form'. A flat JSON Schema object: type must be 'object', with each property either primitive-typed (string, number, integer, boolean — optionally with 'enum'), an array of one of those primitive types (renders as a multi-select), or an enum expressed as 'oneOf'/'anyOf' options (each {const, title, description}) — no nested objects. Matches ACP's elicitation/create schema restrictions."`
+	URL             string         `json:"url,omitempty" jsonschema:"Required when mode is 'url'. The URL to show the user."`
+	TimeoutSeconds  int            `json:"timeoutSeconds,omitempty" jsonschema:"How long to wait for the user's response before giving up. Default 3600 (1 hour), max 3600 (1 hour). On timeout the tool returns {action: 'cancel'} rather than an error, since the human simply didn't respond in time."`
+}
+
+// elicitationResponse is the human's answer to a pending elicit tool call,
+// mirroring MCP's ElicitResult shape (action + optional content).
+type elicitationResponse struct {
+	Action  string         `json:"action"` // "accept" | "decline" | "cancel"
+	Content map[string]any `json:"content,omitempty"`
+}
+
+// validateElicitRequestedSchema enforces the same restriction MCP's
+// elicitation/create places on requestedSchema: a flat object whose properties
+// are all primitive-typed, so any client can render it as a simple form.
+// elicitPrimitiveTypes are the JSON Schema types a single (non-array) property
+// may declare, matching both MCP's and ACP's elicitation schema restriction.
+var elicitPrimitiveTypes = map[string]bool{"string": true, "number": true, "integer": true, "boolean": true}
+
+func validateElicitRequestedSchema(schema map[string]any) error {
+	if t, _ := schema["type"].(string); t != "object" {
+		return fmt.Errorf(`"type" must be "object"`)
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok || len(props) == 0 {
+		return fmt.Errorf(`must have a non-empty "properties" object`)
+	}
+	for name, raw := range props {
+		prop, ok := raw.(map[string]any)
+		if !ok {
+			return fmt.Errorf("property %q must be an object", name)
+		}
+		if err := validateElicitPropertySchema(prop); err != nil {
+			return fmt.Errorf("property %q: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// validateElicitPropertySchema accepts a primitive-typed property (string,
+// number, integer, boolean — optionally with an "enum"), an array of
+// primitives (multi-select), or an enum expressed as "oneOf"/"anyOf" options
+// (each a {const, title, description} object) — matching ACP's elicitation
+// schema extensions on top of MCP's restricted subset. Nested objects/arrays
+// are rejected either way, so the result always renders as a flat form.
+func validateElicitPropertySchema(prop map[string]any) error {
+	propType, _ := prop["type"].(string)
+	if propType == "array" {
+		items, ok := prop["items"].(map[string]any)
+		if !ok {
+			return fmt.Errorf(`"array" properties must have an "items" object`)
+		}
+		itemType, _ := items["type"].(string)
+		if !elicitPrimitiveTypes[itemType] {
+			return fmt.Errorf(`"items" must have a primitive type (string, number, integer, boolean); nested arrays/objects are not supported`)
+		}
+		return nil
+	}
+	if elicitPrimitiveTypes[propType] {
+		return nil
+	}
+	if options, ok := prop["oneOf"]; ok {
+		return validateElicitEnumOptions(options)
+	}
+	if options, ok := prop["anyOf"]; ok {
+		return validateElicitEnumOptions(options)
+	}
+	return fmt.Errorf(`must have a primitive "type" (string, number, integer, boolean, or an array of one of those), or "oneOf"/"anyOf" enum options; nested objects are not supported`)
+}
+
+// validateElicitEnumOptions checks a "oneOf"/"anyOf" enum: a non-empty array
+// of objects each carrying a "const" value (ACP's titled-enum-option form).
+func validateElicitEnumOptions(raw any) error {
+	opts, ok := raw.([]any)
+	if !ok || len(opts) == 0 {
+		return fmt.Errorf(`"oneOf"/"anyOf" must be a non-empty array`)
+	}
+	for _, o := range opts {
+		opt, ok := o.(map[string]any)
+		if !ok {
+			return fmt.Errorf(`each "oneOf"/"anyOf" option must be an object`)
+		}
+		if _, hasConst := opt["const"]; !hasConst {
+			return fmt.Errorf(`each "oneOf"/"anyOf" option must have a "const" value`)
+		}
+	}
+	return nil
+}
+
 func NewWorkspaceServer(
 	workspaceID int64,
 	userID string,
@@ -251,6 +349,7 @@ func NewWorkspaceServer(
 		requestTaskIDs:        make(map[string]int64),
 		permissionResponses:   make(map[string]int64),
 		toolCallIDs:           make(map[string]int64),
+		elicitations:          make(map[string]chan elicitationResponse),
 		icon:                  icon,
 		name:                  name,
 		description:           description,
@@ -341,6 +440,11 @@ func NewWorkspaceServer(
 		Name:        "publishEvent",
 		Description: "Publish a named event so that subscriber workspaces are notified and their trigger tasks are created automatically. When the task you are completing includes a publishEvent instruction, copy the name and taskId from it exactly as written — taskId is what identifies the workflow run being continued. Write the payload yourself, plus an optional faq.",
 	}, ps.handlePublishEvent)
+
+	mcp.AddTool(mcpSrv, &mcp.Tool{
+		Name:        "elicit",
+		Description: "Ask the human a question and wait for their answer, mirroring the MCP protocol's client-side elicitation/create capability. Use mode='form' with a flat requestedSchema (primitive-typed properties only) to collect structured input, or mode='url' to point the human at a link and wait for them to confirm they're done. Blocks until the human responds or the timeout elapses. Returns {action, content} — action is 'accept' (content has the form values, if mode='form'), 'decline', or 'cancel'.",
+	}, ps.handleElicit)
 
 	// Add middleware to handle incoming notifications (like permission_request)
 	mcpSrv.AddReceivingMiddleware(ps.notificationMiddleware, ps.discoverCacheMiddleware)
@@ -892,6 +996,152 @@ func (ps *WorkspaceServer) handlePublishEvent(ctx context.Context, req *mcp.Call
 			Text: fmt.Sprintf("event %q published", params.Name),
 		}},
 	}, nil, nil
+}
+
+const (
+	elicitDefaultTimeout = time.Hour
+	elicitMaxTimeout     = time.Hour
+)
+
+// handleElicit asks the human a question via the chat and blocks until they
+// answer (or the timeout elapses), unlike permission requests — which are
+// resolved by the agent's own harness out-of-band — this is a plain
+// synchronous tool call: the HTTP request simply stays open while this
+// handler waits on a channel for the REST response endpoint to deliver
+// the human's answer.
+func (ps *WorkspaceServer) handleElicit(ctx context.Context, req *mcp.CallToolRequest, params ElicitParams) (*mcp.CallToolResult, any, error) {
+	ps.emitTelemetry(ctx, ActionMCPToolCall, "elicit", clientIdentityFromRequest(req))
+
+	if params.TaskID == "" || params.Message == "" {
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{&mcp.TextContent{Text: "taskId and message are required"}},
+		}, nil, nil
+	}
+
+	metadata := map[string]any{
+		"type":    "elicitation_request",
+		"message": params.Message,
+		"mode":    params.Mode,
+		"status":  "pending",
+	}
+	switch params.Mode {
+	case "form":
+		if len(params.RequestedSchema) == 0 {
+			return &mcp.CallToolResult{
+				IsError: true,
+				Content: []mcp.Content{&mcp.TextContent{Text: "requestedSchema is required when mode is 'form'"}},
+			}, nil, nil
+		}
+		if err := validateElicitRequestedSchema(params.RequestedSchema); err != nil {
+			return &mcp.CallToolResult{
+				IsError: true,
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("invalid requestedSchema: %v", err)}},
+			}, nil, nil
+		}
+		metadata["requestedSchema"] = params.RequestedSchema
+	case "url":
+		if params.URL == "" {
+			return &mcp.CallToolResult{
+				IsError: true,
+				Content: []mcp.Content{&mcp.TextContent{Text: "url is required when mode is 'url'"}},
+			}, nil, nil
+		}
+		metadata["url"] = params.URL
+	default:
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{&mcp.TextContent{Text: "mode must be 'form' or 'url'"}},
+		}, nil, nil
+	}
+
+	id := monoflake.IDFromBase62(params.TaskID)
+	if id == 0 {
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{&mcp.TextContent{Text: "invalid taskId format"}},
+		}, nil, nil
+	}
+	taskID := id.Int64()
+
+	timeout := elicitDefaultTimeout
+	if params.TimeoutSeconds > 0 {
+		timeout = time.Duration(params.TimeoutSeconds) * time.Second
+		if timeout > elicitMaxTimeout {
+			timeout = elicitMaxTimeout
+		}
+	}
+
+	requestID := monoflake.ID(ps.idgen.NextID()).String()
+	metadata["requestId"] = requestID
+
+	ch := make(chan elicitationResponse, 1)
+	ps.elicitationsMu.Lock()
+	if ps.elicitations == nil {
+		ps.elicitations = make(map[string]chan elicitationResponse)
+	}
+	ps.elicitations[requestID] = ch
+	ps.elicitationsMu.Unlock()
+	defer func() {
+		ps.elicitationsMu.Lock()
+		delete(ps.elicitations, requestID)
+		ps.elicitationsMu.Unlock()
+	}()
+
+	msgID, err := ps.reply(ctx, monoflake.ID(taskID).String(), params.Message, nil, metadata)
+	if err != nil {
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("failed to send elicitation request: %v", err)}},
+		}, nil, nil
+	}
+
+	select {
+	case resp := <-ch:
+		if msgID != 0 {
+			// Persist the human's answer alongside the resolved status so the
+			// chat and history views can still show what was actually submitted,
+			// not just that the request was resolved.
+			metaUpdate := map[string]any{"status": resp.Action}
+			if resp.Content != nil {
+				metaUpdate["content"] = resp.Content
+			}
+			_ = ps.updateMessageMetadata(context.Background(), taskID, msgID, metaUpdate)
+		}
+		resultJSON, _ := json.Marshal(resp)
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(resultJSON)}}}, nil, nil
+	case <-time.After(timeout):
+		// The human simply didn't respond in time — matching ACP's model where
+		// "cancel" is a legitimate response action (not a protocol error).
+		if msgID != 0 {
+			_ = ps.updateMessageMetadata(context.Background(), taskID, msgID, map[string]any{"status": "cancel"})
+		}
+		resultJSON, _ := json.Marshal(elicitationResponse{Action: "cancel"})
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(resultJSON)}}}, nil, nil
+	case <-ctx.Done():
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{&mcp.TextContent{Text: "request cancelled"}},
+		}, nil, nil
+	}
+}
+
+// RespondToElicitation delivers the human's answer to a still-waiting elicit
+// tool call. Returns an error if the request is unknown (already answered,
+// timed out, or the server restarted since the tool call started).
+func (ps *WorkspaceServer) RespondToElicitation(requestID, action string, content map[string]any) error {
+	ps.elicitationsMu.Lock()
+	ch, ok := ps.elicitations[requestID]
+	ps.elicitationsMu.Unlock()
+	if !ok {
+		return fmt.Errorf("elicitation request %q not found (expired)", requestID)
+	}
+	select {
+	case ch <- elicitationResponse{Action: action, Content: content}:
+	default:
+		// Already answered or the tool call already timed out.
+	}
+	return nil
 }
 
 // currentWorkflowRun reports the workflow run the publishing task belongs to,

--- a/backend/internal/controller/mcp/server_test.go
+++ b/backend/internal/controller/mcp/server_test.go
@@ -846,3 +846,566 @@ func TestWorkspaceServer_PersistToolCall_RecordError(t *testing.T) {
 		t.Errorf("expected 0 on record error, got %d", gotID)
 	}
 }
+
+func TestValidateElicitRequestedSchema(t *testing.T) {
+	tests := []struct {
+		name    string
+		schema  map[string]any
+		wantErr bool
+	}{
+		{
+			name: "valid flat schema",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+					"age":  map[string]any{"type": "integer"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "missing type",
+			schema:  map[string]any{"properties": map[string]any{"name": map[string]any{"type": "string"}}},
+			wantErr: true,
+		},
+		{
+			name:    "wrong type",
+			schema:  map[string]any{"type": "array", "properties": map[string]any{"name": map[string]any{"type": "string"}}},
+			wantErr: true,
+		},
+		{
+			name:    "missing properties",
+			schema:  map[string]any{"type": "object"},
+			wantErr: true,
+		},
+		{
+			name:    "empty properties",
+			schema:  map[string]any{"type": "object", "properties": map[string]any{}},
+			wantErr: true,
+		},
+		{
+			name: "property not an object",
+			schema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"name": "not-an-object"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "nested object property rejected",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"address": map[string]any{"type": "object"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing property type",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "array of primitives (multi-select) is valid",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"tags": map[string]any{
+						"type":  "array",
+						"items": map[string]any{"type": "string"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "array without items rejected",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"tags": map[string]any{"type": "array"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "array of non-primitive items rejected",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"tags": map[string]any{
+						"type":  "array",
+						"items": map[string]any{"type": "object"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "oneOf enum with const options is valid",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"priority": map[string]any{
+						"oneOf": []any{
+							map[string]any{"const": "low", "title": "Low"},
+							map[string]any{"const": "high", "title": "High"},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "anyOf enum with const options is valid",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"priority": map[string]any{
+						"anyOf": []any{
+							map[string]any{"const": "low"},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "oneOf not an array rejected",
+			schema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"priority": map[string]any{"oneOf": "not-an-array"}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "oneOf empty array rejected",
+			schema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"priority": map[string]any{"oneOf": []any{}}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "oneOf option not an object rejected",
+			schema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"priority": map[string]any{"oneOf": []any{"low"}}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "oneOf option missing const rejected",
+			schema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"priority": map[string]any{"oneOf": []any{map[string]any{"title": "Low"}}}},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateElicitRequestedSchema(tt.schema)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateElicitRequestedSchema() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestWorkspaceServer_HandleElicit_MissingRequiredFields(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockPS := mock_pubsub.NewMockService(ctrl)
+	mockPS.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(&pubsub.PublishResponse{}, nil).AnyTimes()
+
+	ps := &WorkspaceServer{pubsub: mockPS}
+
+	tests := []struct {
+		name   string
+		params ElicitParams
+	}{
+		{"missing taskId", ElicitParams{Message: "q?", Mode: "url", URL: "https://example.com"}},
+		{"missing message", ElicitParams{TaskID: monoflake.ID(1).String(), Mode: "url", URL: "https://example.com"}},
+		{"missing mode", ElicitParams{TaskID: monoflake.ID(1).String(), Message: "q?"}},
+		{"form without schema", ElicitParams{TaskID: monoflake.ID(1).String(), Message: "q?", Mode: "form"}},
+		{"form with invalid schema", ElicitParams{TaskID: monoflake.ID(1).String(), Message: "q?", Mode: "form", RequestedSchema: map[string]any{"type": "array"}}},
+		{"url without url", ElicitParams{TaskID: monoflake.ID(1).String(), Message: "q?", Mode: "url"}},
+		{"invalid taskId format", ElicitParams{TaskID: "0", Message: "q?", Mode: "url", URL: "https://example.com"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, _, err := ps.handleElicit(context.Background(), nil, tt.params)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !res.IsError {
+				t.Fatal("expected IsError=true")
+			}
+		})
+	}
+}
+
+func TestWorkspaceServer_HandleElicit_FormAccept(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockPS := mock_pubsub.NewMockService(ctrl)
+	mockIdgen := mock_idgen.NewMockService(ctrl)
+	mockPS.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(&pubsub.PublishResponse{}, nil).AnyTimes()
+	mockIdgen.EXPECT().NextID().Return(int64(123))
+
+	var gotMetadata, gotUpdatedMetadata any
+	ps := &WorkspaceServer{
+		pubsub: mockPS,
+		idgen:  mockIdgen,
+		reply: func(ctx context.Context, chatID string, text string, attachments []entity.Attachment, metadata any) (int64, error) {
+			gotMetadata = metadata
+			return 999, nil
+		},
+		updateMessageMetadata: func(ctx context.Context, taskID int64, messageID int64, metadata any) error {
+			gotUpdatedMetadata = metadata
+			return nil
+		},
+	}
+
+	params := ElicitParams{
+		TaskID:  monoflake.ID(1).String(),
+		Message: "What's your name?",
+		Mode:    "form",
+		RequestedSchema: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"name": map[string]any{"type": "string"}},
+		},
+		TimeoutSeconds: 60,
+	}
+
+	requestID := monoflake.ID(123).String()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		if err := ps.RespondToElicitation(requestID, "accept", map[string]any{"name": "Alice"}); err != nil {
+			t.Errorf("RespondToElicitation failed: %v", err)
+		}
+	}()
+
+	res, _, err := ps.handleElicit(context.Background(), nil, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected no error, got: %s", res.Content[0].(*mcp.TextContent).Text)
+	}
+	text := res.Content[0].(*mcp.TextContent).Text
+	if !contains(text, `"action":"accept"`) || !contains(text, `"Alice"`) {
+		t.Errorf("unexpected content: %s", text)
+	}
+
+	meta, ok := gotMetadata.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map metadata, got %T", gotMetadata)
+	}
+	if meta["type"] != "elicitation_request" || meta["mode"] != "form" || meta["status"] != "pending" {
+		t.Errorf("unexpected metadata: %+v", meta)
+	}
+
+	// The resolved message's metadata must carry the submitted answer too, not
+	// just the resolved status — otherwise the answer is lost once resolved.
+	updatedMeta, ok := gotUpdatedMetadata.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map metadata update, got %T", gotUpdatedMetadata)
+	}
+	if updatedMeta["status"] != "accept" {
+		t.Errorf("expected status=accept in metadata update, got %+v", updatedMeta)
+	}
+	content, ok := updatedMeta["content"].(map[string]any)
+	if !ok || content["name"] != "Alice" {
+		t.Errorf("expected content={name: Alice} in metadata update, got %+v", updatedMeta)
+	}
+
+	// The channel should have been cleaned up after the handler returned.
+	ps.elicitationsMu.Lock()
+	_, stillPending := ps.elicitations[requestID]
+	ps.elicitationsMu.Unlock()
+	if stillPending {
+		t.Error("expected elicitation entry to be removed after completion")
+	}
+}
+
+func TestWorkspaceServer_HandleElicit_URLDecline(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockPS := mock_pubsub.NewMockService(ctrl)
+	mockIdgen := mock_idgen.NewMockService(ctrl)
+	mockPS.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(&pubsub.PublishResponse{}, nil).AnyTimes()
+	mockIdgen.EXPECT().NextID().Return(int64(456))
+
+	ps := &WorkspaceServer{
+		pubsub: mockPS,
+		idgen:  mockIdgen,
+		reply: func(ctx context.Context, chatID string, text string, attachments []entity.Attachment, metadata any) (int64, error) {
+			return 111, nil
+		},
+		updateMessageMetadata: func(ctx context.Context, taskID int64, messageID int64, metadata any) error {
+			return nil
+		},
+	}
+
+	requestID := monoflake.ID(456).String()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		_ = ps.RespondToElicitation(requestID, "decline", nil)
+	}()
+
+	params := ElicitParams{
+		TaskID:         monoflake.ID(1).String(),
+		Message:        "Please open this link",
+		Mode:           "url",
+		URL:            "https://example.com/authorize",
+		TimeoutSeconds: 60,
+	}
+	res, _, err := ps.handleElicit(context.Background(), nil, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected no error, got: %s", res.Content[0].(*mcp.TextContent).Text)
+	}
+	text := res.Content[0].(*mcp.TextContent).Text
+	if !contains(text, `"action":"decline"`) {
+		t.Errorf("unexpected content: %s", text)
+	}
+}
+
+func TestWorkspaceServer_HandleElicit_ReplyError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockPS := mock_pubsub.NewMockService(ctrl)
+	mockIdgen := mock_idgen.NewMockService(ctrl)
+	mockPS.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(&pubsub.PublishResponse{}, nil).AnyTimes()
+	mockIdgen.EXPECT().NextID().Return(int64(789))
+
+	ps := &WorkspaceServer{
+		pubsub: mockPS,
+		idgen:  mockIdgen,
+		reply: func(ctx context.Context, chatID string, text string, attachments []entity.Attachment, metadata any) (int64, error) {
+			return 0, fmt.Errorf("delivery failed")
+		},
+	}
+
+	params := ElicitParams{
+		TaskID:  monoflake.ID(1).String(),
+		Message: "q?",
+		Mode:    "url",
+		URL:     "https://example.com",
+	}
+	res, _, err := ps.handleElicit(context.Background(), nil, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected IsError=true")
+	}
+	if !contains(res.Content[0].(*mcp.TextContent).Text, "failed to send elicitation request") {
+		t.Errorf("unexpected content: %s", res.Content[0].(*mcp.TextContent).Text)
+	}
+}
+
+func TestWorkspaceServer_HandleElicit_Timeout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockPS := mock_pubsub.NewMockService(ctrl)
+	mockIdgen := mock_idgen.NewMockService(ctrl)
+	mockPS.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(&pubsub.PublishResponse{}, nil).AnyTimes()
+	mockIdgen.EXPECT().NextID().Return(int64(321))
+
+	ps := &WorkspaceServer{
+		pubsub: mockPS,
+		idgen:  mockIdgen,
+		reply: func(ctx context.Context, chatID string, text string, attachments []entity.Attachment, metadata any) (int64, error) {
+			return 222, nil
+		},
+		updateMessageMetadata: func(ctx context.Context, taskID int64, messageID int64, metadata any) error {
+			return nil
+		},
+	}
+
+	params := ElicitParams{
+		TaskID:         monoflake.ID(1).String(),
+		Message:        "q?",
+		Mode:           "url",
+		URL:            "https://example.com",
+		TimeoutSeconds: 1,
+	}
+	res, _, err := ps.handleElicit(context.Background(), nil, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Timeout resolves as a normal "cancel" action, not a protocol error —
+	// matching ACP's model where cancel is a legitimate response, not a failure.
+	if res.IsError {
+		t.Fatalf("expected no error on timeout, got: %s", res.Content[0].(*mcp.TextContent).Text)
+	}
+	if !contains(res.Content[0].(*mcp.TextContent).Text, `"action":"cancel"`) {
+		t.Errorf("unexpected content: %s", res.Content[0].(*mcp.TextContent).Text)
+	}
+}
+
+func TestWorkspaceServer_HandleElicit_ContextCancelled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockPS := mock_pubsub.NewMockService(ctrl)
+	mockIdgen := mock_idgen.NewMockService(ctrl)
+	mockPS.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(&pubsub.PublishResponse{}, nil).AnyTimes()
+	mockIdgen.EXPECT().NextID().Return(int64(654))
+
+	ps := &WorkspaceServer{
+		pubsub: mockPS,
+		idgen:  mockIdgen,
+		reply: func(ctx context.Context, chatID string, text string, attachments []entity.Attachment, metadata any) (int64, error) {
+			return 333, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	params := ElicitParams{
+		TaskID:         monoflake.ID(1).String(),
+		Message:        "q?",
+		Mode:           "url",
+		URL:            "https://example.com",
+		TimeoutSeconds: 60,
+	}
+	res, _, err := ps.handleElicit(ctx, nil, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected IsError=true on context cancellation")
+	}
+	if !contains(res.Content[0].(*mcp.TextContent).Text, "cancelled") {
+		t.Errorf("unexpected content: %s", res.Content[0].(*mcp.TextContent).Text)
+	}
+}
+
+func TestWorkspaceServer_RespondToElicitation_NotFound(t *testing.T) {
+	ps := &WorkspaceServer{elicitations: map[string]chan elicitationResponse{}}
+	err := ps.RespondToElicitation("does-not-exist", "accept", nil)
+	if err == nil {
+		t.Fatal("expected error for unknown request ID")
+	}
+	if !contains(err.Error(), "expired") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestWorkspaceServer_RespondToElicitation_AlreadyAnswered(t *testing.T) {
+	ch := make(chan elicitationResponse, 1)
+	ch <- elicitationResponse{Action: "accept"}
+	ps := &WorkspaceServer{elicitations: map[string]chan elicitationResponse{"req-1": ch}}
+
+	// The buffer is already full; a second send must not block or error.
+	if err := ps.RespondToElicitation("req-1", "decline", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWorkspaceServer_HandleElicit_ZeroMessageID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockPS := mock_pubsub.NewMockService(ctrl)
+	mockIdgen := mock_idgen.NewMockService(ctrl)
+	mockPS.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(&pubsub.PublishResponse{}, nil).AnyTimes()
+	mockIdgen.EXPECT().NextID().Return(int64(987))
+
+	ps := &WorkspaceServer{
+		pubsub: mockPS,
+		idgen:  mockIdgen,
+		reply: func(ctx context.Context, chatID string, text string, attachments []entity.Attachment, metadata any) (int64, error) {
+			return 0, nil // e.g. reply persisted without a usable message ID
+		},
+	}
+
+	requestID := monoflake.ID(987).String()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		_ = ps.RespondToElicitation(requestID, "accept", map[string]any{"ok": true})
+	}()
+
+	params := ElicitParams{
+		TaskID:         monoflake.ID(1).String(),
+		Message:        "q?",
+		Mode:           "url",
+		URL:            "https://example.com",
+		TimeoutSeconds: 60,
+	}
+	res, _, err := ps.handleElicit(context.Background(), nil, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected no error, got: %s", res.Content[0].(*mcp.TextContent).Text)
+	}
+}
+
+func TestWorkspaceServer_HandleElicit_TimeoutClampedToMax(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockPS := mock_pubsub.NewMockService(ctrl)
+	mockIdgen := mock_idgen.NewMockService(ctrl)
+	mockPS.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(&pubsub.PublishResponse{}, nil).AnyTimes()
+	mockIdgen.EXPECT().NextID().Return(int64(111))
+
+	ps := &WorkspaceServer{
+		pubsub: mockPS,
+		idgen:  mockIdgen,
+		reply: func(ctx context.Context, chatID string, text string, attachments []entity.Attachment, metadata any) (int64, error) {
+			return 555, nil
+		},
+		updateMessageMetadata: func(ctx context.Context, taskID int64, messageID int64, metadata any) error {
+			return nil
+		},
+	}
+
+	requestID := monoflake.ID(111).String()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		_ = ps.RespondToElicitation(requestID, "accept", nil)
+	}()
+
+	// Requesting far more than the 1-hour cap must not make the handler
+	// actually wait that long — it should still resolve as soon as the
+	// human answers.
+	params := ElicitParams{
+		TaskID:         monoflake.ID(1).String(),
+		Message:        "q?",
+		Mode:           "url",
+		URL:            "https://example.com",
+		TimeoutSeconds: 999999,
+	}
+	res, _, err := ps.handleElicit(context.Background(), nil, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected no error, got: %s", res.Content[0].(*mcp.TextContent).Text)
+	}
+}

--- a/backend/internal/data/view/api/view.go
+++ b/backend/internal/data/view/api/view.go
@@ -238,6 +238,12 @@ type (
 		Behavior  string `json:"behavior"` // "allow" | "deny"
 	}
 
+	RespondToElicitationRequest struct {
+		RequestID string         `json:"requestId"`
+		Action    string         `json:"action"` // "accept" | "decline" | "cancel"
+		Content   map[string]any `json:"content,omitempty"`
+	}
+
 	UpdateScheduledTaskRequest struct {
 		Task Task `json:"task"`
 	}

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -374,3 +374,83 @@ func TestSendPermissionVerdict_RequiresWorkspaceAccess(t *testing.T) {
 		t.Fatalf("expected status 403, got %d", resp.StatusCode)
 	}
 }
+
+func TestRespondToElicitation_RequiresWorkspaceAccess(t *testing.T) {
+	app := fiber.New()
+	crudCtrl := &mockCrudWorkspaceAccess{}
+
+	h := &handler{
+		crud: crudCtrl,
+		// Intentionally leave MCPManager nil: unauthorized requests must fail
+		// before any elicitation response can be dispatched to a workspace server.
+	}
+
+	workspaceID := monoflake.ID(1).String()
+	taskID := monoflake.ID(2).String()
+	userID := monoflake.ID(100).String()
+
+	app.Post("/api/v1/workspaces/:id/tasks/:taskID/elicitation", func(c *fiber.Ctx) error {
+		c.Locals("user_id", userID)
+		return h.respondToElicitation()(c)
+	})
+
+	crudCtrl.checkWorkspaceAccessFunc = func(ctx context.Context, id int64, gotUserID string) (bool, error) {
+		if id != 1 {
+			t.Fatalf("expected workspace ID 1, got %d", id)
+		}
+		if gotUserID != userID {
+			t.Fatalf("expected user ID %s, got %s", userID, gotUserID)
+		}
+		return false, nil
+	}
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/workspaces/"+workspaceID+"/tasks/"+taskID+"/elicitation",
+		bytes.NewBufferString(`{"requestId":"req-1","action":"accept"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected status 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestRespondToElicitation_InvalidPayload(t *testing.T) {
+	app := fiber.New()
+	h := &handler{}
+
+	app.Post("/api/v1/workspaces/:id/tasks/:taskID/elicitation", h.respondToElicitation())
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"malformed JSON", `not json`},
+		{"missing requestId", `{"action":"accept"}`},
+		{"invalid action", `{"requestId":"req-1","action":"maybe"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(
+				http.MethodPost,
+				"/api/v1/workspaces/"+monoflake.ID(1).String()+"/tasks/"+monoflake.ID(2).String()+"/elicitation",
+				bytes.NewBufferString(tt.body),
+			)
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := app.Test(req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("expected status 400, got %d", resp.StatusCode)
+			}
+		})
+	}
+}

--- a/backend/internal/handler/api/task.go
+++ b/backend/internal/handler/api/task.go
@@ -20,20 +20,21 @@ import (
 )
 
 const (
-	_routePathTasks      = "/workspaces/:id/tasks"
-	_routePathTask       = "/workspaces/:id/tasks/:taskID"
-	_routePathRespond    = "/workspaces/:id/tasks/:taskID/respond"
-	_routePathReply      = "/workspaces/:id/tasks/:taskID/reply"
-	_routePathStatus     = "/workspaces/:id/tasks/:taskID/status"
-	_routePathOrder      = "/workspaces/:id/tasks/:taskID/order"
-	_routePathScheduled  = "/workspaces/:id/tasks/:taskID/scheduled"
-	_routePathAssignee   = "/workspaces/:id/tasks/:taskID/assignee"
-	_routePathWorkspace  = "/workspaces/:id/tasks/:taskID/workspace"
-	_routePathAllowAll   = "/workspaces/:id/tasks/:taskID/allow_all"
-	_routePathPermission = "/workspaces/:id/tasks/:taskID/permission"
-	_routePathEvents     = "/workspaces/:id/events"
-	_routePathAttachment = "/workspaces/:id/tasks/:taskID/attachments/:attachmentID"
-	_routePathCounts     = "/workspaces/:id/tasks/counts"
+	_routePathTasks       = "/workspaces/:id/tasks"
+	_routePathTask        = "/workspaces/:id/tasks/:taskID"
+	_routePathRespond     = "/workspaces/:id/tasks/:taskID/respond"
+	_routePathReply       = "/workspaces/:id/tasks/:taskID/reply"
+	_routePathStatus      = "/workspaces/:id/tasks/:taskID/status"
+	_routePathOrder       = "/workspaces/:id/tasks/:taskID/order"
+	_routePathScheduled   = "/workspaces/:id/tasks/:taskID/scheduled"
+	_routePathAssignee    = "/workspaces/:id/tasks/:taskID/assignee"
+	_routePathWorkspace   = "/workspaces/:id/tasks/:taskID/workspace"
+	_routePathAllowAll    = "/workspaces/:id/tasks/:taskID/allow_all"
+	_routePathPermission  = "/workspaces/:id/tasks/:taskID/permission"
+	_routePathElicitation = "/workspaces/:id/tasks/:taskID/elicitation"
+	_routePathEvents      = "/workspaces/:id/events"
+	_routePathAttachment  = "/workspaces/:id/tasks/:taskID/attachments/:attachmentID"
+	_routePathCounts      = "/workspaces/:id/tasks/counts"
 )
 
 func (h *handler) registerTaskRoutes() error {
@@ -52,6 +53,7 @@ func (h *handler) registerTaskRoutes() error {
 	h.router.Patch(_routePathAllowAll, h.updateTaskAllowAllCommands())
 	h.router.Put(_routePathScheduled, h.updateScheduledTask())
 	h.router.Post(_routePathPermission, h.sendPermissionVerdict())
+	h.router.Post(_routePathElicitation, h.respondToElicitation())
 	h.router.Delete(_routePathTask, h.deleteTask())
 	h.router.Get(_routePathEvents, h.sseEvents())
 	h.router.Get(_routePathAttachment, h.getAttachment())
@@ -592,6 +594,38 @@ func (h *handler) sendPermissionVerdict() fiber.Handler {
 			e, status := mapper.FromErrorToHTTPResponse(err)
 			c.Status(status)
 			return c.Send(e)
+		}
+
+		return c.SendStatus(http.StatusOK)
+	}
+}
+
+func (h *handler) respondToElicitation() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		var rq view.RespondToElicitationRequest
+		if err := c.BodyParser(&rq); err != nil {
+			return c.Status(http.StatusBadRequest).JSON(fiber.Map{"error": "invalid request payload"})
+		}
+		if rq.RequestID == "" || (rq.Action != "accept" && rq.Action != "decline" && rq.Action != "cancel") {
+			return c.Status(http.StatusBadRequest).JSON(fiber.Map{"error": "requestId and a valid action ('accept', 'decline', or 'cancel') are required"})
+		}
+
+		workspaceID := monoflake.IDFromBase62(c.Params("id")).Int64()
+		userID := c.Locals("user_id").(string)
+
+		ctx, cancel := newContext(c)
+		defer cancel()
+		if ok, err := h.crud.CheckWorkspaceAccess(ctx, workspaceID, userID); err != nil || !ok {
+			return c.Status(http.StatusForbidden).JSON(fiber.Map{"error": "forbidden"})
+		}
+
+		srv := h.mcpManager.Get(workspaceID, userID)
+		if srv == nil {
+			return c.Status(http.StatusNotFound).JSON(fiber.Map{"error": "mcp server not found"})
+		}
+
+		if err := srv.RespondToElicitation(rq.RequestID, rq.Action, rq.Content); err != nil {
+			return c.Status(http.StatusGone).JSON(fiber.Map{"error": "This request has expired (the agent stopped waiting, or the server restarted). The agent must ask again."})
 		}
 
 		return c.SendStatus(http.StatusOK)

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -221,6 +221,16 @@ export async function sendPermissionVerdict(workspaceId, taskId, requestId, beha
   if (!res.ok) throw new Error('Failed to send verdict');
   return res;
 }
+
+export async function respondToElicitation(workspaceId, taskId, requestId, action, content) {
+  const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/elicitation`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ requestId, action, content })
+  });
+  if (!res.ok) throw new Error('Failed to send response');
+  return res;
+}
 export async function updateScheduledTask(workspaceId, taskId, title, body, assignee, cronSchedule, allowAllCommands) {
   const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/scheduled`, {
     method: 'PUT',

--- a/frontend/src/components/TrajectoryPanel.vue
+++ b/frontend/src/components/TrajectoryPanel.vue
@@ -171,6 +171,27 @@ const items = computed(() => {
         },
       };
     }
+    if (m.metadata?.type === 'elicitation_request') {
+      const label = m.metadata.message || (m.metadata.mode === 'url' ? 'Open link' : 'Answer question');
+      const payload = m.metadata.mode === 'form'
+        ? { mode: 'form', requestedSchema: m.metadata.requestedSchema }
+        : { mode: 'url', url: m.metadata.url };
+      if (m.metadata.content) payload.answer = m.metadata.content;
+      return {
+        id: `m-${m.id}`,
+        lane: 'tool',
+        laneLabel: 'ASK',
+        createdAt: m.createdAt,
+        label,
+        preview: truncate(label, 140),
+        raw: {
+          ...m,
+          toolName: label,
+          inputPreview: JSON.stringify(payload),
+          status: m.metadata.status || 'pending',
+        },
+      };
+    }
     return {
       id: `m-${m.id}`,
       lane: m.sender === 'agent' ? 'agent' : 'input',
@@ -261,10 +282,14 @@ async function copyContentText(id, text) {
 function laneDotClass(it) {
   if (it.lane === 'tool') {
     switch (it.raw.status) {
-      case 'denied': return 'bg-red-500';
+      case 'denied':
+      case 'decline':
+      case 'cancel':
+        return 'bg-red-500';
       case 'pending': return 'bg-amber-400';
       case 'allowed':
       case 'auto_allowed':
+      case 'accept':
       default:
         return 'bg-emerald-500';
     }
@@ -283,8 +308,11 @@ function toolCallStatusStyle(status) {
   switch (status) {
     case 'allowed':
     case 'auto_allowed':
+    case 'accept':
       return 'text-gray-600 dark:text-zinc-300 bg-gray-100 dark:bg-zinc-800';
     case 'denied':
+    case 'decline':
+    case 'cancel':
       return 'text-red-700 dark:text-red-500 bg-red-50 dark:bg-red-500/10';
     case 'pending':
       return 'text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-500/10';
@@ -299,6 +327,9 @@ function toolCallStatusLabel(status) {
     case 'auto_allowed': return 'Auto-allowed';
     case 'denied': return 'Denied';
     case 'pending': return 'Pending';
+    case 'accept': return 'Answered';
+    case 'decline': return 'Declined';
+    case 'cancel': return 'Cancelled';
     default: return status;
   }
 }

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -278,6 +278,123 @@
                  </div>
                </div>
 
+               <!-- Elicitation Request (agent message) -->
+               <div v-else-if="m.metadata?.type === 'elicitation_request'" class="mt-4 border border-gray-200 dark:border-zinc-700 rounded-sm bg-white dark:bg-zinc-900 overflow-hidden shadow-sm">
+                 <div class="bg-gray-50 dark:bg-zinc-800/80 border-b border-gray-200 dark:border-zinc-700 px-3 py-2 flex items-center justify-between gap-3">
+                   <div class="flex items-center gap-2">
+                     <svg class="w-3.5 h-3.5 text-blue-500" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                     <span class="text-[10px] font-semibold text-gray-800 dark:text-zinc-200">Input Requested</span>
+                   </div>
+                   <span class="text-[9px] font-semibold text-gray-500 dark:text-zinc-500 hidden sm:block">{{ m.metadata.requestId }}</span>
+                 </div>
+                 <div class="p-3 flex flex-col gap-3 min-w-0">
+                   <template v-if="m.metadata.status === 'pending'">
+                     <template v-if="m.metadata.mode === 'form'">
+                       <div v-for="field in schemaFields(m)" :key="field.name" class="min-w-0">
+                         <label class="text-[10px] font-semibold text-gray-700 dark:text-zinc-300">
+                           {{ field.title || field.name }}<span v-if="(m.metadata.requestedSchema.required || []).includes(field.name)" class="text-red-500">*</span>
+                         </label>
+                         <p v-if="field.description" class="text-[9px] text-gray-400 dark:text-zinc-500 mb-1">{{ field.description }}</p>
+                         <!-- Multi-select: array of primitives (checkboxes) -->
+                         <div v-if="field.type === 'array' && fieldChoices(field)" class="flex flex-col gap-1.5 mt-1">
+                           <label v-for="choice in fieldChoices(field)" :key="choice.value"
+                                  class="flex items-center gap-2 px-2.5 py-1.5 rounded-sm border cursor-pointer transition-colors text-[11px]"
+                                  :class="(getElicitFormValue(m, field.name) || []).includes(choice.value)
+                                    ? 'border-gray-900 dark:border-white bg-gray-50 dark:bg-zinc-800 text-gray-900 dark:text-white'
+                                    : 'border-gray-200 dark:border-zinc-700 text-gray-600 dark:text-zinc-400 hover:border-gray-300 dark:hover:border-zinc-600'">
+                             <input type="checkbox" :value="choice.value"
+                                    :checked="(getElicitFormValue(m, field.name) || []).includes(choice.value)"
+                                    @change="toggleElicitArrayValue(m, field.name, choice.value)"
+                                    class="sr-only" />
+                             <span class="w-3.5 h-3.5 rounded-sm border flex items-center justify-center shrink-0"
+                                   :class="(getElicitFormValue(m, field.name) || []).includes(choice.value) ? 'border-gray-900 dark:border-white bg-gray-900 dark:bg-white' : 'border-gray-300 dark:border-zinc-600'">
+                               <svg v-if="(getElicitFormValue(m, field.name) || []).includes(choice.value)" class="w-2.5 h-2.5 text-white dark:text-black" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
+                             </span>
+                             <span class="flex flex-col">
+                               <span class="font-medium">{{ choice.label }}</span>
+                               <span v-if="choice.description" class="text-[9px] text-gray-400 dark:text-zinc-500">{{ choice.description }}</span>
+                             </span>
+                           </label>
+                         </div>
+                         <!-- Single-select: enum / oneOf / anyOf (radio) -->
+                         <div v-else-if="fieldChoices(field)" class="flex flex-col gap-1.5 mt-1">
+                           <label v-for="choice in fieldChoices(field)" :key="choice.value"
+                                  class="flex items-center gap-2 px-2.5 py-1.5 rounded-sm border cursor-pointer transition-colors text-[11px]"
+                                  :class="getElicitFormValue(m, field.name) === choice.value
+                                    ? 'border-gray-900 dark:border-white bg-gray-50 dark:bg-zinc-800 text-gray-900 dark:text-white'
+                                    : 'border-gray-200 dark:border-zinc-700 text-gray-600 dark:text-zinc-400 hover:border-gray-300 dark:hover:border-zinc-600'">
+                             <input type="radio" :name="`${m.id}-${field.name}`" :value="choice.value"
+                                    :checked="getElicitFormValue(m, field.name) === choice.value"
+                                    @change="setElicitFormValue(m, field.name, choice.value)"
+                                    class="sr-only" />
+                             <span class="w-3.5 h-3.5 rounded-full border flex items-center justify-center shrink-0"
+                                   :class="getElicitFormValue(m, field.name) === choice.value ? 'border-gray-900 dark:border-white' : 'border-gray-300 dark:border-zinc-600'">
+                               <span v-if="getElicitFormValue(m, field.name) === choice.value" class="w-1.5 h-1.5 rounded-full bg-gray-900 dark:bg-white"></span>
+                             </span>
+                             <span class="flex flex-col">
+                               <span class="font-medium">{{ choice.label }}</span>
+                               <span v-if="choice.description" class="text-[9px] text-gray-400 dark:text-zinc-500">{{ choice.description }}</span>
+                             </span>
+                           </label>
+                         </div>
+                         <label v-else-if="field.type === 'boolean'" class="flex items-center gap-2 mt-1">
+                           <input type="checkbox" :checked="!!getElicitFormValue(m, field.name)" @change="setElicitFormValue(m, field.name, $event.target.checked)" />
+                           <span class="text-[10px] text-gray-600 dark:text-zinc-400">Yes</span>
+                         </label>
+                         <input v-else :type="elicitInputType(field)"
+                                :pattern="field.pattern" :minlength="field.minLength" :maxlength="field.maxLength"
+                                :min="field.minimum" :max="field.maximum"
+                                :value="getElicitFormValue(m, field.name)" @input="setElicitFormValue(m, field.name, $event.target.value)"
+                                class="w-full mt-0.5 px-2 py-1.5 text-[11px] bg-gray-50 dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 rounded-sm text-gray-800 dark:text-zinc-200" />
+                       </div>
+                       <div class="flex flex-wrap gap-2 pt-2 border-t border-gray-100 dark:border-zinc-800">
+                          <button @click="submitElicitation(m, 'accept')" :disabled="!!workspace.archivedAt"
+                                  class="px-3 py-1.5 rounded-sm bg-gray-900 hover:bg-black dark:bg-white dark:hover:bg-gray-100 text-white dark:text-black text-[10px] font-semibold transition-all disabled:opacity-50 shadow-sm">
+                            Submit
+                          </button>
+                          <button @click="submitElicitation(m, 'decline')" :disabled="!!workspace.archivedAt"
+                                  class="px-3 py-1.5 rounded-sm bg-white dark:bg-zinc-800 hover:bg-gray-50 dark:hover:bg-zinc-700 text-gray-700 dark:text-zinc-100 border border-gray-200 dark:border-zinc-700 text-[10px] font-semibold transition-all disabled:opacity-50 shadow-sm">
+                            Decline
+                          </button>
+                       </div>
+                     </template>
+                     <template v-else>
+                       <a :href="m.metadata.url" target="_blank" rel="noopener noreferrer"
+                          class="text-[11px] text-blue-600 dark:text-blue-400 underline break-all">{{ m.metadata.url }}</a>
+                       <div class="flex flex-wrap gap-2 pt-2 border-t border-gray-100 dark:border-zinc-800">
+                          <button @click="submitElicitation(m, 'accept')" :disabled="!!workspace.archivedAt"
+                                  class="px-3 py-1.5 rounded-sm bg-gray-900 hover:bg-black dark:bg-white dark:hover:bg-gray-100 text-white dark:text-black text-[10px] font-semibold transition-all disabled:opacity-50 shadow-sm">
+                            I'm Done
+                          </button>
+                          <button @click="submitElicitation(m, 'cancel')" :disabled="!!workspace.archivedAt"
+                                  class="px-3 py-1.5 rounded-sm bg-white dark:bg-zinc-800 hover:bg-gray-50 dark:hover:bg-zinc-700 text-gray-700 dark:text-zinc-100 border border-gray-200 dark:border-zinc-700 text-[10px] font-semibold transition-all disabled:opacity-50 shadow-sm">
+                            Cancel
+                          </button>
+                       </div>
+                     </template>
+                   </template>
+                   <div v-else
+                        @click="m.metadata.content && (m._detailsExpanded = !m._detailsExpanded)"
+                        class="border rounded-sm select-none overflow-hidden min-w-0 transition-all"
+                        :class="[m.metadata.content ? 'cursor-pointer' : '', m.metadata.status === 'accept' ? 'border-gray-200 dark:border-zinc-700 bg-gray-50 dark:bg-zinc-800/50' : 'border-red-200 dark:border-red-500/30 bg-red-50 dark:bg-red-500/5']">
+                     <div class="flex items-center gap-2.5 px-3 py-2 min-w-0">
+                       <svg v-if="m.metadata.status === 'accept'" class="w-3.5 h-3.5 text-gray-700 dark:text-zinc-300 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
+                       <svg v-else class="w-3.5 h-3.5 text-red-600 dark:text-red-500 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+                       <span class="text-[10px] font-semibold flex-1 min-w-0 truncate" :class="m.metadata.status === 'accept' ? 'text-gray-700 dark:text-zinc-100' : 'text-red-700 dark:text-red-500'">
+                         {{ m.metadata.status === 'accept' ? 'Answered' : m.metadata.status === 'decline' ? 'Declined' : 'Cancelled' }}
+                       </span>
+                       <svg v-if="m.metadata.content" class="w-3 h-3 text-gray-500 shrink-0 transition-transform duration-200" :class="m._detailsExpanded ? 'rotate-180' : ''" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
+                     </div>
+                     <div v-if="m._detailsExpanded && m.metadata.content" class="px-3 pb-3 pt-1 border-t border-dashed border-gray-200 dark:border-zinc-700 min-w-0 flex flex-col gap-1.5">
+                       <div v-for="(value, key) in m.metadata.content" :key="key" class="text-[10px] flex items-start gap-2 min-w-0">
+                         <span class="font-semibold text-gray-500 dark:text-zinc-400 shrink-0">{{ elicitAnswerLabel(m, key) }}:</span>
+                         <span class="text-gray-800 dark:text-zinc-200 break-all min-w-0">{{ formatElicitAnswerValue(value) }}</span>
+                       </div>
+                     </div>
+                   </div>
+                 </div>
+               </div>
+
                <!-- Attachments on agent message -->
                <div v-if="m.attachments && m.attachments.length > 0" class="flex flex-wrap gap-2 mt-3 pt-3 border-t border-gray-200 dark:border-zinc-700">
                  <div v-for="(att, i) in m.attachments" :key="i"
@@ -521,7 +638,7 @@
 <script setup>
 import { ref, onMounted, computed, onUnmounted, watch, nextTick } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { getWorkspace, fetchTasks, archiveWorkspace, unarchiveWorkspace, updateWorkspace, getWorkspaceToken, getTask, updateTaskStatus, respondToTask, updateTaskAssignee, getAttachmentUrl, sendPermissionVerdict, updateTaskAllowAllCommands, fetchUser } from '../api';
+import { getWorkspace, fetchTasks, archiveWorkspace, unarchiveWorkspace, updateWorkspace, getWorkspaceToken, getTask, updateTaskStatus, respondToTask, updateTaskAssignee, getAttachmentUrl, sendPermissionVerdict, respondToElicitation, updateTaskAllowAllCommands, fetchUser } from '../api';
 import { useTooltipStore } from '../stores/tooltipStore';
 import { useToasts } from '../composables/useToasts';
 import { useViewport } from '../composables/useViewport';
@@ -767,6 +884,79 @@ const handleVerdict = async (requestId, behavior) => {
     notifyError('Failed to send verdict: ' + err.message);
   }
 };
+
+function schemaFields(m) {
+  const props = m.metadata?.requestedSchema?.properties;
+  if (!props) return [];
+  return Object.entries(props).map(([name, def]) => ({ name, ...def }));
+}
+
+// Normalizes a field's enum, whichever form it's expressed in (ACP allows
+// both a plain `enum: [...]` array and titled `oneOf`/`anyOf` options), into
+// a consistent {value, label, description} list. For an array-typed field
+// (multi-select) the choices come from its `items` sub-schema instead.
+function fieldChoices(field) {
+  const source = field.type === 'array' ? field.items : field;
+  if (!source) return null;
+  if (Array.isArray(source.enum)) {
+    return source.enum.map(v => ({ value: v, label: String(v) }));
+  }
+  const options = source.oneOf || source.anyOf;
+  if (Array.isArray(options)) {
+    return options.map(o => ({ value: o.const, label: o.title || String(o.const), description: o.description }));
+  }
+  return null;
+}
+
+// Maps a schema property to the best-matching native <input type="...">,
+// so browser-native validation/keyboards apply (e.g. a numeric keypad on
+// mobile for 'number', native date picker for 'date').
+function elicitInputType(field) {
+  if (field.type === 'number' || field.type === 'integer') return 'number';
+  const byFormat = { email: 'email', date: 'date', 'date-time': 'datetime-local', uri: 'url', url: 'url' };
+  return byFormat[field.format] || 'text';
+}
+
+const elicitFormValues = ref({});
+function getElicitFormValue(m, field) {
+  return (elicitFormValues.value[m.id] || {})[field];
+}
+function setElicitFormValue(m, field, value) {
+  if (!elicitFormValues.value[m.id]) elicitFormValues.value[m.id] = {};
+  elicitFormValues.value[m.id][field] = value;
+}
+function toggleElicitArrayValue(m, field, value) {
+  if (!elicitFormValues.value[m.id]) elicitFormValues.value[m.id] = {};
+  const current = elicitFormValues.value[m.id][field] || [];
+  elicitFormValues.value[m.id][field] = current.includes(value)
+    ? current.filter(v => v !== value)
+    : [...current, value];
+}
+
+async function submitElicitation(m, action) {
+  const requestId = m.metadata?.requestId;
+  if (!requestId) return;
+  const content = action === 'accept' && m.metadata.mode === 'form' ? (elicitFormValues.value[m.id] || {}) : undefined;
+  try {
+    await respondToElicitation(workspaceId.value, taskId.value, requestId, action, content);
+    notifySuccess(action === 'accept' ? 'Response sent' : action === 'decline' ? 'Declined' : 'Cancelled');
+  } catch (err) {
+    notifyError('Failed to send response: ' + err.message);
+  }
+}
+
+// Once resolved, m.metadata.content holds the answer keyed by schema property
+// name — look up that property's own title for a human-readable label.
+function elicitAnswerLabel(m, key) {
+  return m.metadata?.requestedSchema?.properties?.[key]?.title || key;
+}
+
+function formatElicitAnswerValue(value) {
+  if (Array.isArray(value)) return value.length ? value.join(', ') : '(none)';
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  if (value === undefined || value === null || value === '') return '(empty)';
+  return String(value);
+}
 
 async function updateStatus(newStatus) {
   try {


### PR DESCRIPTION
## What changed
Agents can now ask the human a question and wait for their answer, either as a small form (checkboxes, dropdowns, text/number fields) or by pointing them at a link to open and confirm.

## Why changed
Mirrors the MCP protocol's own client-side "elicitation" capability, but implemented on AgentRQ's server side, since here the human is remote rather than a local MCP client the agent is talking to directly.

## Test coverage report
New logic (`handleElicit`, `RespondToElicitation`, `validateElicitRequestedSchema`) is at 100% line coverage — verified via `go tool cover -func`. Covers: missing/invalid params for both modes, invalid `requestedSchema` shapes (nested objects, wrong type, missing properties), the full accept/decline/cancel flow for both form and url modes, reply-delivery failure, timeout, context cancellation, and the "request already answered/unknown" paths on the response side. Added REST-handler tests for the new endpoint's auth and payload validation, matching the existing test depth for the sibling permission-verdict endpoint. `internal/controller/mcp` package coverage: 48.3%; `internal/handler/api`: 23.7% (both roughly in line with this codebase's existing per-package baselines, since most coverage there focuses on business logic rather than every REST wrapper).

## Other reports
Also added a matching chat UI: a new "Input Requested" card (schema-driven form inputs, or a link + confirm/cancel for url mode), verified visually in an isolated instance for all three states (pending form, pending url, resolved) plus a full form-fill-and-submit pass confirming the REST round trip and error handling both work.

## TaskID
0htFBFC33C5