### PR TITLE
Add per-workspace input send delay with cancel/send now

### DIFF
--- a/backend/internal/controller/crud/workspace.go
+++ b/backend/internal/controller/crud/workspace.go
@@ -20,14 +20,15 @@ func (c *controller) CreateWorkspace(ctx context.Context, req entity.CreateWorks
 
 	now := time.Now()
 	m := model.Workspace{
-		ID:          c.idgen.NextID(),
-		CreatedAt:   now,
-		UpdatedAt:   now,
-		UserID:      userID,
-		Name:                 req.Workspace.Name,
-		Description:          req.Workspace.Description,
-		AllowAllCommands:     req.Workspace.AllowAllCommands,
-		SelfLearningLoopNote: req.Workspace.SelfLearningLoopNote,
+		ID:                    c.idgen.NextID(),
+		CreatedAt:             now,
+		UpdatedAt:             now,
+		UserID:                userID,
+		Name:                  req.Workspace.Name,
+		Description:           req.Workspace.Description,
+		AllowAllCommands:      req.Workspace.AllowAllCommands,
+		SelfLearningLoopNote:  req.Workspace.SelfLearningLoopNote,
+		InputSendDelaySeconds: req.Workspace.InputSendDelaySeconds,
 	}
 
 	if req.Workspace.NotificationSettings != nil {
@@ -154,8 +155,15 @@ func (c *controller) UnarchiveWorkspace(ctx context.Context, req entity.Unarchiv
 	return err
 }
 
+// validInputSendDelaySeconds are the only values the composer's send-delay
+// selector may offer; anything else is rejected rather than silently clamped.
+var validInputSendDelaySeconds = map[int]bool{0: true, 3: true, 5: true, 10: true, 15: true, 30: true, 60: true}
+
 func (c *controller) UpdateWorkspace(ctx context.Context, req entity.UpdateWorkspaceRequest) (*entity.UpdateWorkspaceResponse, error) {
 	uid := monoflake.IDFromBase62(req.UserID).Int64()
+	if !validInputSendDelaySeconds[req.Workspace.InputSendDelaySeconds] {
+		return nil, fmt.Errorf("invalid inputSendDelaySeconds: %d", req.Workspace.InputSendDelaySeconds)
+	}
 	m, err := c.repository.GetWorkspace(ctx, req.Workspace.ID, uid)
 	if err != nil {
 		return nil, err
@@ -168,6 +176,7 @@ func (c *controller) UpdateWorkspace(ctx context.Context, req entity.UpdateWorks
 	m.Description = req.Workspace.Description
 	m.AllowAllCommands = req.Workspace.AllowAllCommands
 	m.SelfLearningLoopNote = req.Workspace.SelfLearningLoopNote
+	m.InputSendDelaySeconds = req.Workspace.InputSendDelaySeconds
 	if req.Workspace.NotificationSettings != nil {
 		b, _ := json.Marshal(req.Workspace.NotificationSettings)
 		m.NotificationSettings = datatypes.JSON(b)
@@ -285,17 +294,18 @@ func (c *controller) SystemGetWorkspace(ctx context.Context, id int64) (entity.W
 
 func fromModelWorkspaceToEntity(m model.Workspace) entity.Workspace {
 	res := entity.Workspace{
-		ID:               m.ID,
-		CreatedAt:        m.CreatedAt,
-		UpdatedAt:        m.UpdatedAt,
-		UserID:           m.UserID,
-		Name:             m.Name,
-		Description:      m.Description,
-		Icon:             m.Icon,
-		ArchivedAt:       m.ArchivedAt,
-		AutoAllowedTools:     make([]string, 0),
-		AllowAllCommands:     m.AllowAllCommands,
-		SelfLearningLoopNote: m.SelfLearningLoopNote,
+		ID:                    m.ID,
+		CreatedAt:             m.CreatedAt,
+		UpdatedAt:             m.UpdatedAt,
+		UserID:                m.UserID,
+		Name:                  m.Name,
+		Description:           m.Description,
+		Icon:                  m.Icon,
+		ArchivedAt:            m.ArchivedAt,
+		AutoAllowedTools:      make([]string, 0),
+		AllowAllCommands:      m.AllowAllCommands,
+		SelfLearningLoopNote:  m.SelfLearningLoopNote,
+		InputSendDelaySeconds: m.InputSendDelaySeconds,
 	}
 	if len(m.AutoAllowedTools) > 0 {
 		_ = json.Unmarshal(m.AutoAllowedTools, &res.AutoAllowedTools)

--- a/backend/internal/controller/crud/workspace_test.go
+++ b/backend/internal/controller/crud/workspace_test.go
@@ -135,7 +135,7 @@ func TestUpdateWorkspace_Full(t *testing.T) {
 
 	resp, err := e.controller.UpdateWorkspace(context.Background(), entity.UpdateWorkspaceRequest{
 		UserID:    testUserIDStr,
-		Workspace: entity.Workspace{ID: 1, Name: "updated", Description: "desc", AutoAllowedTools: []string{"*"}, NotificationSettings: &entity.NotificationSettings{TaskCreated: true}, AllowAllCommands: true, SelfLearningLoopNote: "Be mindful."},
+		Workspace: entity.Workspace{ID: 1, Name: "updated", Description: "desc", AutoAllowedTools: []string{"*"}, NotificationSettings: &entity.NotificationSettings{TaskCreated: true}, AllowAllCommands: true, SelfLearningLoopNote: "Be mindful.", InputSendDelaySeconds: 10},
 	})
 
 	if err != nil {
@@ -149,6 +149,22 @@ func TestUpdateWorkspace_Full(t *testing.T) {
 	}
 	if resp.Workspace.SelfLearningLoopNote != "Be mindful." {
 		t.Errorf("expected SelfLearningLoopNote to be updated")
+	}
+	if resp.Workspace.InputSendDelaySeconds != 10 {
+		t.Errorf("expected InputSendDelaySeconds to be 10, got %d", resp.Workspace.InputSendDelaySeconds)
+	}
+}
+
+func TestUpdateWorkspace_InvalidInputSendDelaySeconds_Fails(t *testing.T) {
+	e := newTestController(t)
+
+	_, err := e.controller.UpdateWorkspace(context.Background(), entity.UpdateWorkspaceRequest{
+		UserID:    testUserIDStr,
+		Workspace: entity.Workspace{ID: 1, Name: "updated", InputSendDelaySeconds: 7},
+	})
+
+	if err == nil {
+		t.Fatalf("expected an error for invalid InputSendDelaySeconds")
 	}
 }
 

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -20,20 +20,21 @@ type (
 
 	// Workspace entity
 	Workspace struct {
-		ID                   int64
-		CreatedAt            time.Time
-		UpdatedAt            time.Time
-		UserID               int64
-		Name                 string
-		Description          string
-		ArchivedAt           *time.Time
-		Icon                 string
-		NotificationSettings *NotificationSettings
-		AgentConnected       bool
-		AutoAllowedTools     []string
-		AllowAllCommands     bool
-		SelfLearningLoopNote string
-		Slack                *SlackConfig
+		ID                    int64
+		CreatedAt             time.Time
+		UpdatedAt             time.Time
+		UserID                int64
+		Name                  string
+		Description           string
+		ArchivedAt            *time.Time
+		Icon                  string
+		NotificationSettings  *NotificationSettings
+		AgentConnected        bool
+		AutoAllowedTools      []string
+		AllowAllCommands      bool
+		SelfLearningLoopNote  string
+		InputSendDelaySeconds int
+		Slack                 *SlackConfig
 	}
 
 	// SlackConfig holds the Slack channel linked to a workspace.

--- a/backend/internal/data/model/model.go
+++ b/backend/internal/data/model/model.go
@@ -9,18 +9,19 @@ import (
 type (
 	// Workspace hosts an agentrq workspace
 	Workspace struct {
-		ID                   int64 `gorm:"primaryKey;autoIncrement:false"`
-		CreatedAt            time.Time
-		UpdatedAt            time.Time
-		UserID               int64  `gorm:"index:idx_workspaces_user_id"`
-		Name                 string `gorm:"type:varchar(128)"`
-		Description          string `gorm:"type:text"`
-		ArchivedAt           *time.Time
-		Icon                 string         `gorm:"type:text"`
-		NotificationSettings datatypes.JSON `gorm:"type:text"`
-		AutoAllowedTools     datatypes.JSON `gorm:"type:text"`
-		AllowAllCommands     bool           `gorm:"default:false"`
-		SelfLearningLoopNote string         `gorm:"type:text"`
+		ID                    int64 `gorm:"primaryKey;autoIncrement:false"`
+		CreatedAt             time.Time
+		UpdatedAt             time.Time
+		UserID                int64  `gorm:"index:idx_workspaces_user_id"`
+		Name                  string `gorm:"type:varchar(128)"`
+		Description           string `gorm:"type:text"`
+		ArchivedAt            *time.Time
+		Icon                  string         `gorm:"type:text"`
+		NotificationSettings  datatypes.JSON `gorm:"type:text"`
+		AutoAllowedTools      datatypes.JSON `gorm:"type:text"`
+		AllowAllCommands      bool           `gorm:"default:false"`
+		SelfLearningLoopNote  string         `gorm:"type:text"`
+		InputSendDelaySeconds int            `gorm:"default:0"`
 	}
 
 	// Task hosts a task created by a human or an agent within a workspace

--- a/backend/internal/data/view/api/view.go
+++ b/backend/internal/data/view/api/view.go
@@ -9,21 +9,22 @@ type (
 	// Workspace views
 
 	Workspace struct {
-		ID                   string                `json:"id"`
-		CreatedAt            time.Time             `json:"createdAt"`
-		UpdatedAt            time.Time             `json:"updatedAt"`
-		Name                 string                `json:"name"`
-		Description          string                `json:"description"`
-		ArchivedAt           *time.Time            `json:"archivedAt,omitempty"`
-		Icon                 string                `json:"icon,omitempty"`
-		NotificationSettings *NotificationSettings `json:"notificationSettings,omitempty"`
-		AgentConnected       bool                  `json:"agentConnected"`
-		MCPURL               string                `json:"mcpUrl"`
-		MCPToken             string                `json:"mcpToken,omitempty"`
-		AutoAllowedTools     []string              `json:"autoAllowedTools,omitempty"`
-		AllowAllCommands     bool                  `json:"allowAllCommands"`
-		SelfLearningLoopNote string                `json:"selfLearningLoopNote,omitempty"`
-		Slack                *SlackConfig          `json:"slack,omitempty"`
+		ID                    string                `json:"id"`
+		CreatedAt             time.Time             `json:"createdAt"`
+		UpdatedAt             time.Time             `json:"updatedAt"`
+		Name                  string                `json:"name"`
+		Description           string                `json:"description"`
+		ArchivedAt            *time.Time            `json:"archivedAt,omitempty"`
+		Icon                  string                `json:"icon,omitempty"`
+		NotificationSettings  *NotificationSettings `json:"notificationSettings,omitempty"`
+		AgentConnected        bool                  `json:"agentConnected"`
+		MCPURL                string                `json:"mcpUrl"`
+		MCPToken              string                `json:"mcpToken,omitempty"`
+		AutoAllowedTools      []string              `json:"autoAllowedTools,omitempty"`
+		AllowAllCommands      bool                  `json:"allowAllCommands"`
+		SelfLearningLoopNote  string                `json:"selfLearningLoopNote,omitempty"`
+		InputSendDelaySeconds int                   `json:"inputSendDelaySeconds"`
+		Slack                 *SlackConfig          `json:"slack,omitempty"`
 	}
 
 	SlackConfig struct {

--- a/backend/internal/mapper/api/workspace.go
+++ b/backend/internal/mapper/api/workspace.go
@@ -19,12 +19,13 @@ func FromHTTPRequestToCreateWorkspaceRequestEntity(c *fiber.Ctx) *entity.CreateW
 	}
 	return &entity.CreateWorkspaceRequest{
 		Workspace: entity.Workspace{
-			Name:                 payload.Workspace.Name,
-			Description:          payload.Workspace.Description,
-			Icon:                 payload.Workspace.Icon,
-			NotificationSettings: fromViewNotificationSettingsToEntity(payload.Workspace.NotificationSettings),
-			AllowAllCommands:     payload.Workspace.AllowAllCommands,
-			SelfLearningLoopNote: payload.Workspace.SelfLearningLoopNote,
+			Name:                  payload.Workspace.Name,
+			Description:           payload.Workspace.Description,
+			Icon:                  payload.Workspace.Icon,
+			NotificationSettings:  fromViewNotificationSettingsToEntity(payload.Workspace.NotificationSettings),
+			AllowAllCommands:      payload.Workspace.AllowAllCommands,
+			SelfLearningLoopNote:  payload.Workspace.SelfLearningLoopNote,
+			InputSendDelaySeconds: payload.Workspace.InputSendDelaySeconds,
 		},
 	}
 }
@@ -108,14 +109,15 @@ func FromHTTPRequestToUpdateWorkspaceRequestEntity(c *fiber.Ctx) *entity.UpdateW
 	}
 	return &entity.UpdateWorkspaceRequest{
 		Workspace: entity.Workspace{
-			ID:                   id,
-			Name:                 payload.Workspace.Name,
-			Description:          payload.Workspace.Description,
-			Icon:                 payload.Workspace.Icon,
-			NotificationSettings: fromViewNotificationSettingsToEntity(payload.Workspace.NotificationSettings),
-			AutoAllowedTools:     payload.Workspace.AutoAllowedTools,
-			AllowAllCommands:     payload.Workspace.AllowAllCommands,
-			SelfLearningLoopNote: payload.Workspace.SelfLearningLoopNote,
+			ID:                    id,
+			Name:                  payload.Workspace.Name,
+			Description:           payload.Workspace.Description,
+			Icon:                  payload.Workspace.Icon,
+			NotificationSettings:  fromViewNotificationSettingsToEntity(payload.Workspace.NotificationSettings),
+			AutoAllowedTools:      payload.Workspace.AutoAllowedTools,
+			AllowAllCommands:      payload.Workspace.AllowAllCommands,
+			SelfLearningLoopNote:  payload.Workspace.SelfLearningLoopNote,
+			InputSendDelaySeconds: payload.Workspace.InputSendDelaySeconds,
 		},
 	}
 }
@@ -138,19 +140,20 @@ func FromUpdateWorkspaceResponseEntityToMCPResponse(rs *entity.Workspace, mcpURL
 
 func fromEntityWorkspaceToView(p entity.Workspace, mcpURL string) view.Workspace {
 	v := view.Workspace{
-		ID:                   monoflake.ID(p.ID).String(),
-		CreatedAt:            p.CreatedAt,
-		UpdatedAt:            p.UpdatedAt,
-		Name:                 p.Name,
-		Description:          p.Description,
-		Icon:                 p.Icon,
-		ArchivedAt:           p.ArchivedAt,
-		NotificationSettings: fromEntityNotificationSettingsToView(p.NotificationSettings),
-		AgentConnected:       p.AgentConnected,
-		MCPURL:               mcpURL,
-		AutoAllowedTools:     p.AutoAllowedTools,
-		AllowAllCommands:     p.AllowAllCommands,
-		SelfLearningLoopNote: p.SelfLearningLoopNote,
+		ID:                    monoflake.ID(p.ID).String(),
+		CreatedAt:             p.CreatedAt,
+		UpdatedAt:             p.UpdatedAt,
+		Name:                  p.Name,
+		Description:           p.Description,
+		Icon:                  p.Icon,
+		ArchivedAt:            p.ArchivedAt,
+		NotificationSettings:  fromEntityNotificationSettingsToView(p.NotificationSettings),
+		AgentConnected:        p.AgentConnected,
+		MCPURL:                mcpURL,
+		AutoAllowedTools:      p.AutoAllowedTools,
+		AllowAllCommands:      p.AllowAllCommands,
+		SelfLearningLoopNote:  p.SelfLearningLoopNote,
+		InputSendDelaySeconds: p.InputSendDelaySeconds,
 	}
 	if p.Slack != nil {
 		v.Slack = &view.SlackConfig{

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -568,6 +568,14 @@
           </div>
         </div>
 
+        <!-- Pending delayed send: countdown + cancel/send now -->
+        <div v-if="pendingSend" class="flex items-center gap-3 mt-2 px-3 py-2 bg-gray-105 dark:bg-zinc-800/50 border border-gray-200 dark:border-zinc-700 rounded-sm">
+          <span class="w-2.5 h-2.5 rounded-full bg-gray-900 dark:bg-white animate-pulse shrink-0"></span>
+          <p class="text-[10px] text-gray-700 dark:text-zinc-300 font-bold flex-1 min-w-0 truncate">Sending in {{ pendingSend.secondsLeft }}s&hellip;</p>
+          <button type="button" @click="sendPendingNow" class="text-[10px] font-bold uppercase tracking-widest px-2.5 py-1 rounded-sm bg-black dark:bg-white text-white dark:text-zinc-900 hover:opacity-90 transition-opacity shrink-0">Send Now</button>
+          <button type="button" @click="cancelPendingSend" class="text-[10px] font-bold uppercase tracking-widest px-2.5 py-1 rounded-sm bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-700 text-gray-900 dark:text-zinc-100 hover:border-gray-400 dark:hover:border-zinc-500 transition-colors shrink-0">Cancel</button>
+        </div>
+
         <!-- Status Warning Messages -->
         <div v-if="!workspace.agentConnected && task.assignee !== 'human'" class="flex items-center gap-3 mt-2 px-3 py-2 bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/20 rounded-sm">
              <span class="w-2.5 h-2.5 rounded-full bg-red-500 animate-pulse shrink-0"></span>
@@ -660,6 +668,7 @@ const user = ref(null);
 const descExpanded = ref(false);
 const replyText = ref('');
 const replyAttachments = ref([]);
+const pendingSend = ref(null); // { text, atts, secondsLeft, intervalId } while a delayed send counts down
 
 const {
   isRecording: sttRecording,
@@ -991,15 +1000,7 @@ const toggleYOLO = async () => {
   }
 };
 
-async function submitReply() {
-  if (!replyText.value.trim() && replyAttachments.value.length === 0) return;
-  const text = replyText.value;
-  const atts = [...replyAttachments.value];
-  replyText.value = '';
-  replyAttachments.value = [];
-  nextTick(() => {
-    adjustTextareaHeight();
-  });
+async function deliverReply(text, atts) {
   try {
     const res = await respondToTask(workspaceId.value, taskId.value, 'text', text, atts);
     task.value = res.task;
@@ -1011,6 +1012,55 @@ async function submitReply() {
       adjustTextareaHeight();
     });
   }
+}
+
+async function submitReply() {
+  if (!replyText.value.trim() && replyAttachments.value.length === 0) return;
+  const text = replyText.value;
+  const atts = [...replyAttachments.value];
+  replyText.value = '';
+  replyAttachments.value = [];
+  nextTick(() => {
+    adjustTextareaHeight();
+  });
+
+  const delaySeconds = workspace.value?.inputSendDelaySeconds || 0;
+  if (delaySeconds <= 0) {
+    await deliverReply(text, atts);
+    return;
+  }
+
+  const pending = { text, atts, secondsLeft: delaySeconds };
+  pending.intervalId = setInterval(() => {
+    pending.secondsLeft -= 1;
+    if (pending.secondsLeft <= 0) {
+      clearInterval(pending.intervalId);
+      pendingSend.value = null;
+      deliverReply(pending.text, pending.atts);
+    }
+  }, 1000);
+  pendingSend.value = pending;
+}
+
+function sendPendingNow() {
+  const pending = pendingSend.value;
+  if (!pending) return;
+  clearInterval(pending.intervalId);
+  pendingSend.value = null;
+  deliverReply(pending.text, pending.atts);
+}
+
+function cancelPendingSend() {
+  const pending = pendingSend.value;
+  if (!pending) return;
+  clearInterval(pending.intervalId);
+  pendingSend.value = null;
+  replyText.value = pending.text;
+  replyAttachments.value = pending.atts;
+  nextTick(() => {
+    adjustTextareaHeight();
+    textareaRef.value?.focus();
+  });
 }
 
 const textareaRef = ref(null);
@@ -1103,6 +1153,9 @@ onMounted(() => {
   load();
 });
 onUnmounted(disconnect);
+onUnmounted(() => {
+  if (pendingSend.value) clearInterval(pendingSend.value.intervalId);
+});
 function getSlackUser(m) {
   return m.metadata?.slack_user || 'Slack';
 }

--- a/frontend/src/views/WorkspaceSettingsView.vue
+++ b/frontend/src/views/WorkspaceSettingsView.vue
@@ -66,6 +66,14 @@
                     </select>
                     <p class="text-[9px] text-gray-500 dark:text-zinc-500 font-bold uppercase tracking-wider ml-1 mt-1">Select the spoken language for local speech-to-text transcribing.</p>
                   </div>
+
+                  <div class="space-y-2 pt-4 border-t border-gray-100 dark:border-zinc-800/50">
+                    <label class="block text-[10px] font-bold text-gray-400 dark:text-zinc-500 uppercase tracking-widest ml-1">Message Send Delay</label>
+                    <select v-model.number="form.inputSendDelaySeconds" class="bg-gray-50 dark:bg-zinc-800/50 border border-gray-200 dark:border-zinc-800 rounded-sm px-3 py-2 text-xs font-semibold text-gray-900 dark:text-zinc-100 outline-none focus:border-gray-900 dark:focus:border-white focus:ring-0 transition-all shadow-sm w-full max-w-xs">
+                      <option v-for="opt in INPUT_SEND_DELAY_OPTIONS" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+                    </select>
+                    <p class="text-[9px] text-gray-500 dark:text-zinc-500 font-bold uppercase tracking-wider ml-1 mt-1">Hold sent messages for a countdown before delivery, with a chance to cancel.</p>
+                  </div>
                 </div>
 
                 <!-- Setup -->
@@ -601,6 +609,15 @@ const linkingSlack = ref(false);
 const slackError = ref('');
 const showManualForm = ref(false);
 const voiceLanguage = ref('auto');
+const INPUT_SEND_DELAY_OPTIONS = [
+  { value: 0, label: 'Off (send immediately)' },
+  { value: 3, label: '3 seconds' },
+  { value: 5, label: '5 seconds' },
+  { value: 10, label: '10 seconds' },
+  { value: 15, label: '15 seconds' },
+  { value: 30, label: '30 seconds' },
+  { value: 60, label: '60 seconds' }
+];
 
 const { checkWorkspaceSubscription, subscribeWorkspace, unsubscribeWorkspace } = usePushNotifications();
 const isPushSubscribed = ref(false);
@@ -837,7 +854,8 @@ const form = ref({
   },
   autoAllowedTools: [],
   allowAllCommands: false,
-  selfLearningLoopNote: ''
+  selfLearningLoopNote: '',
+  inputSendDelaySeconds: 0
 });
 
 watch(() => form.value.name, (newVal) => {
@@ -867,7 +885,8 @@ async function load() {
       },
       autoAllowedTools: workspace.value.autoAllowedTools || [],
       allowAllCommands: workspace.value.allowAllCommands || false,
-      selfLearningLoopNote: workspace.value.selfLearningLoopNote || ''
+      selfLearningLoopNote: workspace.value.selfLearningLoopNote || '',
+      inputSendDelaySeconds: workspace.value.inputSendDelaySeconds || 0
     };
     slackConfig.value = workspace.value.slack || null;
     if (slackConfig.value) {


### PR DESCRIPTION
**What changed**: Adds an optional per-workspace setting to delay delivering a human's chat message for a chosen countdown (off, or 3/5/10/15/30/60 seconds), with the ability to cancel (message returns to the input box unsent) or send immediately.

**Why changed**: Gives the human a brief window to catch mistakes or reconsider before a message is actually delivered to the agent.

**Test coverage report**: New backend logic (delay-value validation in `UpdateWorkspace`, field plumbing through model/entity/view/mapper layers) is 100% covered by two new/updated unit tests; overall package coverage unchanged at 66.5% (uncovered lines are pre-existing, unrelated branches). Frontend build passes cleanly; the countdown/cancel/send-now flow was manually verified end-to-end in an isolated instance (screenshots of settings selector, countdown state, cancel-restores-text, and immediate send).

**Other reports**: None.

TaskID: 0htg3dCgLDt