### PR TITLE
chore: bump patch version to v0.4.7

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.4.6"
+	_appVersion   = "v0.4.7"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.4.6" {
-			t.Errorf("Expected version v0.4.6, got %s", s.Version())
+		if s.Version() != "v0.4.7" {
+			t.Errorf("Expected version v0.4.7, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
**What changed**: Bumps the project's patch version from 0.4.6 to 0.4.7 across the frontend and backend version references.

**Why changed**: Routine release bump to ship the elicit tool, the chat send-delay feature, and recent chat-payload fixes merged since v0.4.6.

**Test coverage report**: No new logic added; existing config test updated to assert the new version string, all tests pass.

**Other reports**: Changelog since v0.4.6 included in the commit body (feat: elicit tool, per-workspace send delay; fix: tool call payload chat overflow/duplication; chore: copy buttons on permission-request blocks).

TaskID: 0htqwUlBrzF