### PR TITLE
Use Tailwind radio group for Message Send Delay selector

### DIFF
--- a/frontend/src/views/WorkspaceSettingsView.vue
+++ b/frontend/src/views/WorkspaceSettingsView.vue
@@ -69,9 +69,23 @@
 
                   <div class="space-y-2 pt-4 border-t border-gray-100 dark:border-zinc-800/50">
                     <label class="block text-[10px] font-bold text-gray-400 dark:text-zinc-500 uppercase tracking-widest ml-1">Message Send Delay</label>
-                    <select v-model.number="form.inputSendDelaySeconds" class="bg-gray-50 dark:bg-zinc-800/50 border border-gray-200 dark:border-zinc-800 rounded-sm px-3 py-2 text-xs font-semibold text-gray-900 dark:text-zinc-100 outline-none focus:border-gray-900 dark:focus:border-white focus:ring-0 transition-all shadow-sm w-full max-w-xs">
-                      <option v-for="opt in INPUT_SEND_DELAY_OPTIONS" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
-                    </select>
+                    <div class="flex flex-wrap gap-1.5 mt-1">
+                      <label v-for="opt in INPUT_SEND_DELAY_OPTIONS" :key="opt.value"
+                             class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-sm border cursor-pointer transition-colors text-[11px] font-semibold"
+                             :class="form.inputSendDelaySeconds === opt.value
+                               ? 'border-gray-900 dark:border-white bg-gray-50 dark:bg-zinc-800 text-gray-900 dark:text-white'
+                               : 'border-gray-200 dark:border-zinc-700 text-gray-600 dark:text-zinc-400 hover:border-gray-300 dark:hover:border-zinc-600'">
+                        <input type="radio" name="inputSendDelaySeconds" :value="opt.value"
+                               :checked="form.inputSendDelaySeconds === opt.value"
+                               @change="form.inputSendDelaySeconds = opt.value"
+                               class="sr-only" />
+                        <span class="w-3 h-3 rounded-full border flex items-center justify-center shrink-0"
+                              :class="form.inputSendDelaySeconds === opt.value ? 'border-gray-900 dark:border-white' : 'border-gray-300 dark:border-zinc-600'">
+                          <span v-if="form.inputSendDelaySeconds === opt.value" class="w-1.5 h-1.5 rounded-full bg-gray-900 dark:bg-white"></span>
+                        </span>
+                        {{ opt.label }}
+                      </label>
+                    </div>
                     <p class="text-[9px] text-gray-500 dark:text-zinc-500 font-bold uppercase tracking-wider ml-1 mt-1">Hold sent messages for a countdown before delivery, with a chance to cancel.</p>
                   </div>
                 </div>
@@ -610,13 +624,13 @@ const slackError = ref('');
 const showManualForm = ref(false);
 const voiceLanguage = ref('auto');
 const INPUT_SEND_DELAY_OPTIONS = [
-  { value: 0, label: 'Off (send immediately)' },
-  { value: 3, label: '3 seconds' },
-  { value: 5, label: '5 seconds' },
-  { value: 10, label: '10 seconds' },
-  { value: 15, label: '15 seconds' },
-  { value: 30, label: '30 seconds' },
-  { value: 60, label: '60 seconds' }
+  { value: 0, label: 'Off' },
+  { value: 3, label: '3s' },
+  { value: 5, label: '5s' },
+  { value: 10, label: '10s' },
+  { value: 15, label: '15s' },
+  { value: 30, label: '30s' },
+  { value: 60, label: '60s' }
 ];
 
 const { checkWorkspaceSubscription, subscribeWorkspace, unsubscribeWorkspace } = usePushNotifications();


### PR DESCRIPTION
**What changed**: Replaces the plain dropdown for the workspace's message send delay setting with a row of Tailwind-styled radio pills, matching the look already used for the elicit tool's multiple-choice fields.

**Why changed**: Requested for visual consistency — native `<select>` boxes look out of place next to the rest of the app's custom controls.

**Test coverage report**: Pure frontend markup/styling change, no new logic; frontend build passes cleanly. No backend changes.

**Other reports**: None.

TaskID: 0htrYlIEzoX