### PR TITLE
fix: send-delay countdown not visually ticking down

### DIFF
--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -1030,16 +1030,17 @@ async function submitReply() {
     return;
   }
 
-  const pending = { text, atts, secondsLeft: delaySeconds };
-  pending.intervalId = setInterval(() => {
-    pending.secondsLeft -= 1;
-    if (pending.secondsLeft <= 0) {
-      clearInterval(pending.intervalId);
+  pendingSend.value = { text, atts, secondsLeft: delaySeconds };
+  pendingSend.value.intervalId = setInterval(() => {
+    if (!pendingSend.value) return;
+    pendingSend.value.secondsLeft -= 1;
+    if (pendingSend.value.secondsLeft <= 0) {
+      clearInterval(pendingSend.value.intervalId);
+      const { text: pendingText, atts: pendingAtts } = pendingSend.value;
       pendingSend.value = null;
-      deliverReply(pending.text, pending.atts);
+      deliverReply(pendingText, pendingAtts);
     }
   }, 1000);
-  pendingSend.value = pending;
 }
 
 function sendPendingNow() {


### PR DESCRIPTION
**What changed**: Fixes the message send-delay countdown so the "Sending in Ns..." display actually counts down instead of staying frozen at the initial value.

**Why changed**: The pending-send state was built as a plain object and mutated directly inside the interval timer, then assigned to a Vue ref — but Vue only reactively tracks mutations made through the ref's `.value`, not through the original object reference captured in the closure, so the UI never re-rendered on each tick (the timer itself still fired correctly and delivered the message on schedule, just the visible countdown never moved).

**Test coverage report**: Pure frontend reactivity fix, no new logic paths; frontend build passes cleanly. No backend changes.

**Other reports**: Manually verified in an isolated instance — screenshots ~2.5s apart show the countdown moving from "Sending in 5s..." to "Sending in 3s...".

TaskID: N/A (reported directly, not via an AgentRQ task)