### PR TITLE
Point send button icons up instead of right

### DIFF
--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -573,7 +573,7 @@
                     class="h-6 w-6 rounded-full bg-black dark:bg-white text-white dark:text-zinc-900 hover:opacity-90 disabled:opacity-30 transition-all flex items-center justify-center shrink-0 shadow-sm"
                     title="Send Message">
               <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M14 5l7 7m0 0l-7 7m7-7H3" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M5 10l7-7m0 0l7 7m-7-7v18" />
               </svg>
             </button>
           </div>

--- a/frontend/src/views/TaskFormView.vue
+++ b/frontend/src/views/TaskFormView.vue
@@ -263,7 +263,7 @@
                      :disabled="sending || !newTask.title || !newTask.body"
                      class="h-8 w-8 sm:h-9 sm:w-9 rounded-full bg-black dark:bg-white text-white dark:text-zinc-900 hover:opacity-90 disabled:opacity-30 transition-all flex items-center justify-center shrink-0 shadow-md border border-transparent">
                 <svg v-if="sending" class="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 12a8 8 0 018-8v8H4z" /></svg>
-                <svg v-else class="w-4 h-4 translate-x-px" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path d="M14 5l7 7m0 0l-7 7m7-7H3" /></svg>
+                <svg v-else class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path d="M5 10l7-7m0 0l7 7m-7-7v18" /></svg>
              </button>
           </div>
         </form>


### PR DESCRIPTION
**What changed**: Both the chat composer's send button and the new-task creation form's submit button now show an upward-pointing arrow instead of a rightward-pointing one.

**Why changed**: Requested icon direction change to match the more common "send" convention, applied consistently across both places that use the same submit-arrow button.

**Test coverage report**: Icon-path swap only, no logic change; frontend build passes cleanly.

**Other reports**: Verified visually in an isolated instance for both the chat composer and the new-task form.

TaskID: 0htrr0tZ1er