### PR TITLE
Append --name <workspace-name> to Claude start command

### DIFF
--- a/frontend/src/views/WorkspaceSettingsView.vue
+++ b/frontend/src/views/WorkspaceSettingsView.vue
@@ -734,7 +734,7 @@ const authenticatedUrl = computed(() => {
 });
 
 const serverName = computed(() => `agentrq-${workspaceId.value}`);
-const startCommand = computed(() => `claude --dangerously-load-development-channels server:${serverName.value}`);
+const startCommand = computed(() => `claude --dangerously-load-development-channels server:${serverName.value} --name ${workspace.value?.name}`);
 
 const mcpConfig = computed(() => ({
   mcpServers: {


### PR DESCRIPTION
**What changed**: The Claude setup screen's terminal start command now includes `--name <workspace-name>` at the end.

**Why changed**: Requested so the workspace's name is passed along when starting the MCP server, making it easier to identify which workspace a running session belongs to.

**Test coverage report**: Single-expression template literal change, no new logic; frontend build passes cleanly.

**Other reports**: Verified visually in an isolated instance — the Setup tab's Start Command now reads `claude --dangerously-load-development-channels server:<id> --name <workspace-name>`.

TaskID: 0htzGVg7bxR