### PR TITLE
Switch Codex setup instructions to acp-gateway

### DIFF
--- a/frontend/src/views/WorkspaceSettingsView.vue
+++ b/frontend/src/views/WorkspaceSettingsView.vue
@@ -209,9 +209,9 @@
                         <p class="text-[11px] text-gray-600 dark:text-zinc-400 font-medium">Start the bridge — npx fetches the latest version each run, so there's nothing to install or upgrade separately:</p>
                         <div class="bg-white dark:bg-zinc-900 p-3 rounded-sm border border-gray-200 dark:border-zinc-700 flex items-center justify-between group shadow-sm overflow-hidden">
                           <div class="flex-1 min-w-0 overflow-x-auto no-scrollbar">
-                            <code class="text-[10px] text-gray-900 dark:text-white font-bold whitespace-nowrap">npx @agentrq/codex-gateway@latest -- codex app-server</code>
+                            <code class="text-[10px] text-gray-900 dark:text-white font-bold whitespace-nowrap">npx @agentrq/acp-gateway@latest --max-concurrency 1 -- npx @agentclientprotocol/codex-acp</code>
                           </div>
-                          <button type="button" @click="copyToClipboard('npx @agentrq/codex-gateway@latest -- codex app-server', 'codexStart')" class="text-[9px] font-bold uppercase tracking-widest pl-4 shrink-0 transition-colors" :class="copiedState.codexStart ? 'text-green-500' : 'text-gray-400 hover:text-black dark:hover:text-white'">
+                          <button type="button" @click="copyToClipboard('npx @agentrq/acp-gateway@latest --max-concurrency 1 -- npx @agentclientprotocol/codex-acp', 'codexStart')" class="text-[9px] font-bold uppercase tracking-widest pl-4 shrink-0 transition-colors" :class="copiedState.codexStart ? 'text-green-500' : 'text-gray-400 hover:text-black dark:hover:text-white'">
                             {{ copiedState.codexStart ? 'Copied!' : 'Copy' }}
                           </button>
                         </div>


### PR DESCRIPTION
**What changed**: The Codex setup screen's start command now uses the general-purpose ACP gateway bridging to Codex's own ACP adapter, instead of the dedicated Codex gateway package.

**Why changed**: Requested switch to the ACP-based bridge, matching the same pattern already used for the Gemini/ACP setup tab.

**Test coverage report**: Single command-string swap (display + clipboard copy), no logic change; frontend build passes cleanly.

**Other reports**: The project README still documents the older `@agentrq/codex-gateway` package/workflow separately — left untouched since this task was scoped to the in-app setup screen; flagging in case that doc should be updated too.

TaskID: 0huCY1bZUC9