### PR TITLE
feat(desktop): server connection screen, OAuth sign-in, and app menu

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -10,8 +10,8 @@ frontend appears here with no change on this side. `platform` is recorded in the
 frontend's platform store, which is how a component offers a desktop-only
 affordance without either build growing its own copy of the view.
 
-Plan and phase breakdown: `docs/DESKTOP_APP_PLAN.md`. This package covers phase 1
-(TaskID `0hua6QI7nXN`) and phase 2 (`0hua7LpaQID`).
+Plan and phase breakdown: `docs/DESKTOP_APP_PLAN.md`. This package covers
+phase 1 (`0hua6QI7nXN`), phase 2 (`0hua7LpaQID`) and phase 3 (`0hua8EL8awL`).
 
 ## Running it
 
@@ -25,15 +25,25 @@ npm start                       # build, then run the packaged entry
 npm run test:coverage           # unit tests, gated at 100% on main-process modules
 ```
 
-By default the app talks to `http://localhost:3000`. Point it elsewhere with
-`AGENTRQ_SERVER_URL`:
+On first run the app asks which AgentRQ server to connect to, defaulting to
+`http://localhost:3000`. The URL is probed before it is stored, so a typo is
+caught there rather than surfacing later as a mysterious failure to sign in. The
+choice lives in `agentrq-desktop.json` under Electron's userData directory, and
+**Switch Server** in the application menu returns to that screen.
+
+`AGENTRQ_SERVER_URL` pins the server for a launch and skips the connection
+screen entirely — handy for pointing at a scratch backend without disturbing
+stored settings:
 
 ```bash
 AGENTRQ_SERVER_URL=http://localhost:3999 npm run dev
 ```
 
-The first-run connection screen that replaces this environment variable is
-phase 3 (`0hua8EL8awL`).
+Google and GitHub sign-in work unchanged. `LoginView.vue` renders those as
+ordinary links, which cannot work from the app:// origin, so the shell
+intercepts the navigation and runs the flow in its own window against the real
+server. That window shares the session, so the cookie it earns is the one the
+proxy sends.
 
 ## How it works
 
@@ -71,9 +81,15 @@ AGENTRQ_SERVER_URL=http://localhost:3999 \
 AGENTRQ_ROOT_TOKEN=... npx electron scripts/verify-e2e.mjs
 ```
 
-`verify-e2e.mjs` runs the real protocol handler against a real backend and
-checks that the renderer mounts, an unauthenticated call is refused, root-token
-login succeeds, the cookie is replayed, and the SSE stream connects.
+`verify:e2e` runs the real protocol handler against a real backend and checks
+that the renderer mounts, the stylesheet is applied, an unauthenticated call is
+refused, root-token login succeeds, the cookie is replayed, and the SSE stream
+connects. `verify:connection` starts from nothing stored and drives the
+first-run screen: a bad URL is refused with a reason and nothing is saved; a
+good one is probed, stored, and reachable through the proxy.
+
+Both assert a *computed* style rather than DOM presence alone — see the Tailwind
+note below for why that check earns its place.
 
 ### Spike result: EventSource works over `app://`
 
@@ -89,29 +105,51 @@ EventSource connects and streams normally:
 **No preload SSE bridge is needed and `useEventBus.js` needs no platform
 branch.**
 
-### Known backend issue found while verifying
+### Tailwind scans from the build root, which is not frontend/
+
+Tailwind v4 decides which files to scan by walking out from the build's root.
+The desktop build's Vite root is `src/renderer`, so the scan found only the body
+classes in that `index.html` and dropped every utility the actual views use — a
+13 KB stylesheet where the web build produces 102 KB. The DOM looked correct
+throughout; the app simply rendered unstyled.
+
+`frontend/src/style.css` now declares `@source './'`, which resolves to
+`frontend/src` in both builds and needs no knowledge of either. It also holds in
+the production Docker image, which copies only `./frontend` — an `@source`
+pointing at `desktop/` would not exist there.
+
+The end-to-end checks assert a computed `border-radius`, so this cannot regress
+silently again.
+
+### Backend issue found while verifying (since fixed)
 
 `eventsHandler` in `backend/internal/app/app.go` sets the SSE headers but never
 flushes them, so Go buffers the response until the first real event or the 30s
 keepalive tick. `EventSource.onopen` therefore fires up to 30 seconds late.
 
-This is **not** desktop-specific — the web app's connection indicator has the
-same delay today. Confirmed with plain `curl` against the backend, with no
-Electron involved. Tracked separately as `0huclLMe3BB`; a single `flusher.Flush()`
-after the headers fixes it.
+This was **not** desktop-specific — the web app's connection indicator had the
+same delay. Confirmed with plain `curl` against the backend, with no Electron
+involved. Fixed in #361 (task `0huclLMe3BB`) by flushing the headers on connect;
+the end-to-end check now sees the stream open immediately rather than after 30
+seconds.
 
 ## Layout
 
 ```
-src/renderer/main.js        bootstrap — calls the frontend's createAgentRQApp
+src/renderer/main.js        bootstrap — connection screen, or createAgentRQApp
 src/main/protocol.js        app:// handler and API proxy — the core of the design
-src/main/server-config.js   which server to talk to, and URL normalisation
-src/main/index.js           app lifecycle, window creation, scheme registration
+src/main/server-config.js   which server to talk to: normalisation, storage, probing
+src/main/auth.js            OAuth sign-in taken over from the login view's links
+src/main/menu.js            application menu (switch server, log out)
+src/main/index.js           lifecycle, window creation, scheme registration, IPC
 src/preload/index.js        the narrow contextBridge surface
-src/renderer/               entry point and the vite-plugin-pwa stub
 scripts/                    dev launcher, build, spike, e2e verification
 test/                       unit tests (plain Node — no Electron binary needed)
 ```
+
+The connection screen itself lives at `frontend/src/desktop/ConnectionView.vue`,
+not here — see the note at the top of that file for why moving it into this
+package would silently strip its styling.
 
 Electron APIs are injected into the main-process modules rather than imported,
 which is what lets the routing rules be tested without launching Electron.

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,7 +11,9 @@
     "start": "npm run build && electron .",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "spike:eventsource": "npm run build && electron scripts/spike-eventsource.mjs"
+    "spike:eventsource": "npm run build && electron scripts/spike-eventsource.mjs",
+    "verify:e2e": "npm run build && electron scripts/verify-e2e.mjs",
+    "verify:connection": "npm run build && electron scripts/verify-connection.mjs"
   },
   "dependencies": {
     "electron-updater": "^6.6.2"

--- a/desktop/scripts/verify-connection.mjs
+++ b/desktop/scripts/verify-connection.mjs
@@ -1,0 +1,168 @@
+/**
+ * End-to-end check of the first-run connection screen.
+ *
+ * Complements verify-e2e.mjs, which covers the already-configured case. This
+ * one starts with nothing stored and drives the screen the way a new user
+ * would: a bad URL must be refused with a readable reason, and a good one must
+ * be probed, stored and then honoured by the proxy.
+ *
+ * The two IPC handlers below mirror the ones in src/main/index.js. They are
+ * repeated rather than imported because index.js takes over the Electron app
+ * lifecycle at import time; the logic they exercise — validateServerUrl and the
+ * config store — is the real thing.
+ *
+ *   AGENTRQ_TEST_SERVER=http://localhost:3999 npx electron scripts/verify-connection.mjs
+ */
+import { app, BrowserWindow, ipcMain, net, protocol, session } from 'electron'
+import { readFile, writeFile, access, mkdtemp } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { createAppProtocolHandler } from '../src/main/protocol.js'
+import { CONFIG_FILENAME, createServerConfigStore, validateServerUrl } from '../src/main/server-config.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const RENDERER_ROOT = join(__dirname, '../dist/renderer')
+const PRELOAD = join(__dirname, '../dist/preload/index.cjs')
+const testServer = process.env.AGENTRQ_TEST_SERVER ?? 'http://localhost:3999'
+
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: 'app',
+    privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true, corsEnabled: true },
+  },
+])
+
+let serverUrl = ''
+let configStore
+
+async function fileExists(pathname) {
+  try {
+    await access(join(RENDERER_ROOT, pathname), constants.R_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const CHECKS = `(async () => {
+  const out = [];
+  const record = (name, pass, detail) => out.push({ name, pass, detail });
+
+  const heading = document.querySelector('h2')?.textContent?.trim();
+  const subtitle = document.querySelector('p')?.textContent?.trim();
+  record('connection screen is showing', subtitle === 'Connect to your workspace server',
+    heading + ' / ' + subtitle);
+
+  const input = document.querySelector('input');
+  const button = document.querySelector('button[type=submit]');
+  record('URL field is focused and prefilled', document.activeElement === input && !!input?.value,
+    'value ' + JSON.stringify(input?.value));
+
+  // The screen is styled, not just present. Tailwind's source detection is
+  // rooted at the build, and a misconfigured root silently drops every
+  // utility — which looks fine in the DOM and broken on screen.
+  const card = document.querySelector('[role=dialog] > div');
+  const radius = getComputedStyle(card).borderRadius;
+  record('styles are applied', parseFloat(radius) > 0, 'card border-radius ' + radius);
+
+  const setValue = (el, v) => {
+    el.value = v;
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  };
+  const settled = () => new Promise((r) => setTimeout(r, 400));
+
+  // A URL that parses but is not a server: the screen must say so rather than
+  // storing it and failing mysteriously later.
+  setValue(input, 'http://localhost:1');
+  await settled();
+  button.click();
+  await new Promise((r) => setTimeout(r, 1500));
+  const error = document.querySelector('[role=dialog] p.text-red-600, [role=dialog] .text-red-600');
+  record('bad server is refused with a reason', !!error?.textContent?.trim(),
+    (error?.textContent ?? 'no error shown').trim());
+
+  record('nothing was stored for the bad server', (await window.agentrq.connection.get()).configured === false,
+    'configured ' + (await window.agentrq.connection.get()).configured);
+
+  // The real one.
+  setValue(input, ${JSON.stringify(testServer)});
+  await settled();
+  const saved = await window.agentrq.connection.save(${JSON.stringify(testServer)});
+  record('good server is accepted and stored', saved.ok === true, JSON.stringify(saved));
+
+  const after = await window.agentrq.connection.get();
+  record('connection is now configured', after.configured === true && after.serverUrl === ${JSON.stringify(testServer)},
+    JSON.stringify(after));
+
+  // And the proxy now has somewhere to forward to.
+  const res = await fetch('/api/v1/auth/config');
+  record('proxy reaches the newly configured server', res.status === 200, 'status ' + res.status);
+
+  return out;
+})()`
+
+app.whenReady().then(async () => {
+  await session.defaultSession.clearStorageData({ storages: ['cookies'] })
+
+  // A throwaway userData directory, so the run always starts unconfigured and
+  // never disturbs a real installation's settings.
+  const configPath = join(await mkdtemp(join(tmpdir(), 'agentrq-conn-')), CONFIG_FILENAME)
+  configStore = createServerConfigStore({
+    readFile: () => readFile(configPath, 'utf-8'),
+    writeFile: (contents) => writeFile(configPath, contents, 'utf-8'),
+  })
+  serverUrl = (await configStore.load()).serverUrl
+
+  ipcMain.handle('agentrq:connection:get', () => ({
+    configured: Boolean(serverUrl),
+    serverUrl,
+    locked: false,
+  }))
+  ipcMain.handle('agentrq:connection:validate', async (_e, url) => {
+    const result = await validateServerUrl(url, net.fetch)
+    return result.ok ? { ok: true, url: result.url } : result
+  })
+  ipcMain.handle('agentrq:connection:save', async (_e, url) => {
+    const validated = await validateServerUrl(url, net.fetch)
+    if (!validated.ok) return validated
+    const saved = await configStore.save(validated.url)
+    if (!saved.ok) return saved
+    serverUrl = saved.url
+    return { ok: true, url: saved.url }
+  })
+
+  protocol.handle(
+    'app',
+    createAppProtocolHandler({
+      serverUrl: () => serverUrl,
+      netFetch: net.fetch,
+      fileExists,
+      readFile: (pathname) => readFile(join(RENDERER_ROOT, pathname)),
+    })
+  )
+
+  const win = new BrowserWindow({
+    show: false,
+    webPreferences: { preload: PRELOAD, contextIsolation: true, nodeIntegration: false, sandbox: true },
+  })
+  await win.loadURL('app://agentrq/')
+  await new Promise((r) => setTimeout(r, 1200))
+
+  let results
+  try {
+    results = await win.webContents.executeJavaScript(CHECKS)
+  } catch (err) {
+    console.error('✗ checks threw:', err)
+    app.exit(1)
+    return
+  }
+
+  console.log('\n─── first-run connection screen ───')
+  for (const r of results) console.log(`${r.pass ? '✓' : '✗'} ${r.name} — ${r.detail}`)
+  const failed = results.filter((r) => !r.pass)
+  console.log(failed.length === 0 ? '\n✓ all checks passed' : `\n✗ ${failed.length} check(s) failed`)
+  app.exit(failed.length === 0 ? 0 : 1)
+})

--- a/desktop/scripts/verify-e2e.mjs
+++ b/desktop/scripts/verify-e2e.mjs
@@ -11,7 +11,7 @@
  *   AGENTRQ_SERVER_URL=http://localhost:3999 \
  *   AGENTRQ_ROOT_TOKEN=... npx electron scripts/verify-e2e.mjs
  */
-import { app, BrowserWindow, net, protocol, session } from 'electron'
+import { app, BrowserWindow, ipcMain, net, protocol, session } from 'electron'
 import { readFile, access } from 'node:fs/promises'
 import { constants } from 'node:fs'
 import { join, dirname } from 'node:path'
@@ -55,6 +55,18 @@ const CHECKS = `(async () => {
   // createWebHistory on the app:// origin.
   record('shared auth guard routed to /login', location.pathname === '/login', 'at ' + location.pathname);
 
+  // Tailwind's source detection is rooted at the build, and a wrong root
+  // silently drops every utility — the DOM looks correct and the app renders
+  // unstyled. Assert a computed style, not just presence.
+  const styled = getComputedStyle(document.body).fontFamily.includes('Inter')
+    || document.styleSheets.length > 0;
+  const probe = document.createElement('div');
+  probe.className = 'rounded-3xl';
+  document.body.appendChild(probe);
+  const radius = getComputedStyle(probe).borderRadius;
+  probe.remove();
+  record('stylesheet is applied', parseFloat(radius) > 0, 'rounded-3xl -> ' + radius);
+
   // The desktop bridge is visible to the renderer.
   record('desktop bridge exposed', window.agentrq?.isDesktop === true, 'platform ' + window.agentrq?.platform);
 
@@ -96,6 +108,14 @@ app.whenReady().then(async () => {
   // after a successful login — the check would be measuring leftover state
   // rather than the proxy.
   await session.defaultSession.clearStorageData({ storages: ['cookies'] })
+
+  // Mirrors the handler in src/main/index.js: the renderer asks which server it
+  // is pointed at before deciding what to mount.
+  ipcMain.handle('agentrq:connection:get', () => ({
+    configured: true,
+    serverUrl,
+    locked: true,
+  }))
 
   protocol.handle(
     'app',

--- a/desktop/src/main/auth.js
+++ b/desktop/src/main/auth.js
@@ -1,0 +1,116 @@
+/**
+ * OAuth sign-in for the desktop app.
+ *
+ * `LoginView.vue` renders its Google and GitHub buttons as ordinary links to
+ * `/api/v1/auth/<provider>/login`. In the browser that just works. Here it
+ * cannot: the link resolves against the app:// origin, and the provider's
+ * redirect chain has to run against the *real* https origin for the callback to
+ * come back to a server that can set a cookie.
+ *
+ * So the shell intercepts the navigation and runs the flow in a dedicated
+ * window pointed at the real server. That window shares the default session, so
+ * the `at` cookie the callback sets lands in the same jar `net.fetch` reads —
+ * which is what makes the main window authenticated the moment it reloads.
+ *
+ * The login view itself is untouched, and the browser build is unaffected.
+ *
+ * Electron is injected rather than imported, so the rules below are testable in
+ * plain Node.
+ */
+
+/** Providers whose sign-in the shell has to take over. */
+export const OAUTH_PROVIDERS = ['google', 'github']
+
+const OAUTH_LOGIN_PATTERN = new RegExp(`^/api/v1/auth/(${OAUTH_PROVIDERS.join('|')})/login/?$`)
+
+/** Name of the session cookie the backend sets on a successful login. */
+export const AUTH_COOKIE = 'at'
+
+/**
+ * Is this the start of an OAuth sign-in?
+ *
+ * @returns {string|null} the provider name, or null.
+ */
+export function matchOAuthLogin(pathname) {
+  const match = OAUTH_LOGIN_PATTERN.exec(pathname)
+  return match ? match[1] : null
+}
+
+/**
+ * Has the OAuth window come back to the application?
+ *
+ * The provider redirects to the backend's callback, which sets the cookie and
+ * then redirects on to the app. Landing anywhere on the server that is not
+ * still inside the auth endpoints means the round trip finished — success or
+ * failure is then decided by whether a cookie actually exists.
+ */
+export function isOAuthReturn(url, serverUrl) {
+  let target
+  let server
+  try {
+    target = new URL(url)
+    server = new URL(serverUrl)
+  } catch {
+    return false
+  }
+
+  if (target.origin !== server.origin) return false
+  return !target.pathname.startsWith('/api/v1/auth/')
+}
+
+/**
+ * Where the OAuth window should start: the same path the link pointed at, but
+ * on the real server rather than the app:// origin.
+ */
+export function oauthStartUrl(serverUrl, pathname, search = '') {
+  return new URL(pathname + search, `${serverUrl}/`).toString()
+}
+
+/**
+ * Run an OAuth sign-in.
+ *
+ * @param {object} deps
+ * @param {string} deps.serverUrl
+ * @param {string} deps.startUrl          where the flow begins, from `oauthStartUrl`
+ * @param {() => object} deps.createWindow  builds the OAuth BrowserWindow
+ * @param {() => Promise<boolean>} deps.hasAuthCookie
+ * @returns {Promise<{ ok: boolean, reason?: string }>} resolves once the window
+ *          closes, however it closed.
+ */
+export function runOAuthFlow({ serverUrl, startUrl, createWindow, hasAuthCookie }) {
+  return new Promise((resolve) => {
+    const win = createWindow()
+    let settled = false
+
+    // Whatever happens, the window closing is what ends the flow — including
+    // the user giving up and closing it by hand.
+    const finish = (result) => {
+      if (settled) return
+      settled = true
+      resolve(result)
+      if (!win.isDestroyed()) win.close()
+    }
+
+    const checkNavigation = async (url) => {
+      if (settled || !isOAuthReturn(url, serverUrl)) return
+      finish(
+        (await hasAuthCookie())
+          ? { ok: true }
+          : { ok: false, reason: 'Sign-in did not complete' }
+      )
+    }
+
+    win.webContents.on('did-navigate', (_event, url) => checkNavigation(url))
+    // The callback usually arrives as a redirect rather than a fresh
+    // navigation, so both have to be watched.
+    win.webContents.on('did-redirect-navigation', (_event, url) => checkNavigation(url))
+
+    win.on('closed', () => {
+      if (settled) return
+      settled = true
+      resolve({ ok: false, reason: 'Sign-in window was closed' })
+    })
+
+    win.loadURL(startUrl)
+  })
+}

--- a/desktop/src/main/index.js
+++ b/desktop/src/main/index.js
@@ -1,12 +1,18 @@
-import { app, BrowserWindow, net, protocol, shell } from 'electron'
-import { readFile } from 'node:fs/promises'
-import { access } from 'node:fs/promises'
+import { app, BrowserWindow, Menu, ipcMain, net, protocol, session, shell } from 'electron'
+import { readFile, writeFile, access } from 'node:fs/promises'
 import { constants } from 'node:fs'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { createAppProtocolHandler } from './protocol.js'
-import { resolveServerUrl } from './server-config.js'
+import {
+  CONFIG_FILENAME,
+  createServerConfigStore,
+  normalizeServerUrl,
+  validateServerUrl,
+} from './server-config.js'
+import { AUTH_COOKIE, matchOAuthLogin, oauthStartUrl, runOAuthFlow } from './auth.js'
+import { buildMenuTemplate } from './menu.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -30,7 +36,17 @@ protocol.registerSchemesAsPrivileged([
   },
 ])
 
-let serverUrl = resolveServerUrl({ env: process.env })
+/**
+ * The environment override exists so a developer can point at a scratch backend
+ * without disturbing stored settings. When it is set the connection is locked:
+ * the connection screen is skipped and "Switch Server" is a no-op, because the
+ * stored value would not be what the app is using anyway.
+ */
+const envServerUrl = normalizeServerUrl(process.env.AGENTRQ_SERVER_URL ?? '')
+const isConnectionLocked = envServerUrl.ok
+
+let serverUrl = isConnectionLocked ? envServerUrl.url : ''
+let configStore
 
 async function fileExists(pathname) {
   try {
@@ -39,6 +55,46 @@ async function fileExists(pathname) {
   } catch {
     return false
   }
+}
+
+function connectionState() {
+  return { configured: Boolean(serverUrl), serverUrl, locked: isConnectionLocked }
+}
+
+/** Send the window back to the app root, picking up whatever the state now is. */
+function reloadToRoot(win) {
+  if (win && !win.isDestroyed()) win.loadURL(`${APP_ORIGIN}/`)
+}
+
+async function startOAuth(win, pathname, search) {
+  const result = await runOAuthFlow({
+    serverUrl,
+    startUrl: oauthStartUrl(serverUrl, pathname, search),
+    createWindow: () =>
+      new BrowserWindow({
+        parent: win,
+        width: 520,
+        height: 720,
+        title: 'Sign in to AgentRQ',
+        autoHideMenuBar: true,
+        webPreferences: {
+          // No preload and no partition: this window is showing a third-party
+          // sign-in page, so it gets no bridge, and it must stay on the default
+          // session so the cookie it earns is the one net.fetch will send.
+          contextIsolation: true,
+          nodeIntegration: false,
+          sandbox: true,
+        },
+      }),
+    hasAuthCookie: async () => {
+      const cookies = await session.defaultSession.cookies.get({ name: AUTH_COOKIE })
+      return cookies.length > 0
+    },
+  })
+
+  // On success the cookie is already in the jar, so simply reloading lands the
+  // user inside the app. On failure the login view is still there to try again.
+  if (result.ok) reloadToRoot(win)
 }
 
 function createWindow() {
@@ -60,21 +116,80 @@ function createWindow() {
 
   win.once('ready-to-show', () => win.show())
 
-  // Anything that is not the app itself belongs in the user's real browser —
-  // OAuth included, which phase 3 (0hua8EL8awL) replaces with a proper flow.
+  // Anything that is not the app itself belongs in the user's real browser.
   win.webContents.setWindowOpenHandler(({ url }) => {
     shell.openExternal(url)
     return { action: 'deny' }
   })
+
   win.webContents.on('will-navigate', (event, url) => {
     if (!url.startsWith(APP_ORIGIN)) {
       event.preventDefault()
       shell.openExternal(url)
+      return
+    }
+
+    // LoginView renders its Google and GitHub buttons as plain links. Following
+    // one here would run the provider's redirect chain against the app:// origin
+    // and lose the callback, so the shell takes the flow over instead — leaving
+    // the login view itself untouched.
+    const { pathname, search } = new URL(url)
+    if (matchOAuthLogin(pathname)) {
+      event.preventDefault()
+      startOAuth(win, pathname, search)
     }
   })
 
   win.loadURL(`${APP_ORIGIN}/`)
   return win
+}
+
+function installMenu(getWindow) {
+  const template = buildMenuTemplate({
+    platform: process.platform,
+    appName: app.getName(),
+    actions: {
+      switchServer: async () => {
+        if (isConnectionLocked) return
+        await configStore.clear()
+        serverUrl = ''
+        reloadToRoot(getWindow())
+      },
+      logOut: async () => {
+        await session.defaultSession.clearStorageData({ storages: ['cookies'] })
+        reloadToRoot(getWindow())
+      },
+    },
+  })
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template))
+}
+
+function registerIpc(getWindow) {
+  ipcMain.handle('agentrq:connection:get', () => connectionState())
+
+  ipcMain.handle('agentrq:connection:validate', async (_event, url) => {
+    const result = await validateServerUrl(url, net.fetch)
+    // The probe response carries auth flags that are of no use to the
+    // connection screen and would be a needless leak across the bridge.
+    return result.ok ? { ok: true, url: result.url } : result
+  })
+
+  ipcMain.handle('agentrq:connection:save', async (_event, url) => {
+    if (isConnectionLocked) {
+      return { ok: false, reason: 'Server is pinned by AGENTRQ_SERVER_URL' }
+    }
+
+    const validated = await validateServerUrl(url, net.fetch)
+    if (!validated.ok) return validated
+
+    const saved = await configStore.save(validated.url)
+    if (!saved.ok) return saved
+
+    serverUrl = saved.url
+    reloadToRoot(getWindow())
+    return { ok: true, url: saved.url }
+  })
 }
 
 // A second launch should surface the running app, not start a rival instance
@@ -90,7 +205,17 @@ if (!app.requestSingleInstanceLock()) {
     }
   })
 
-  app.whenReady().then(() => {
+  app.whenReady().then(async () => {
+    const configPath = join(app.getPath('userData'), CONFIG_FILENAME)
+    configStore = createServerConfigStore({
+      readFile: () => readFile(configPath, 'utf-8'),
+      writeFile: (contents) => writeFile(configPath, contents, 'utf-8'),
+    })
+
+    if (!isConnectionLocked) {
+      serverUrl = (await configStore.load()).serverUrl
+    }
+
     protocol.handle(
       'app',
       createAppProtocolHandler({
@@ -102,6 +227,12 @@ if (!app.requestSingleInstanceLock()) {
       })
     )
 
+    // The main window is looked up lazily: on macOS it can be closed and
+    // recreated while the app keeps running, so a captured reference goes stale.
+    const getWindow = () => BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())
+
+    registerIpc(getWindow)
+    installMenu(getWindow)
     createWindow()
 
     app.on('activate', () => {

--- a/desktop/src/main/menu.js
+++ b/desktop/src/main/menu.js
@@ -1,0 +1,87 @@
+/**
+ * Application menu.
+ *
+ * Only the entries phase 3 needs live here — switching server and signing out,
+ * both of which are shell concerns the web app has no equivalent for. The full
+ * menu, tray and shortcuts arrive with phase 5 (task 0huaA6sKHoX).
+ *
+ * The template is built as plain data so it can be asserted on without
+ * launching Electron.
+ */
+
+/**
+ * @param {object} options
+ * @param {string} options.platform  `process.platform`
+ * @param {string} options.appName
+ * @param {object} options.actions   handlers, keyed by menu item id
+ */
+export function buildMenuTemplate({ platform, appName = 'AgentRQ', actions = {} }) {
+  const isMac = platform === 'darwin'
+
+  const accountItems = [
+    { id: 'switch-server', label: 'Switch Server…', click: actions.switchServer },
+    { id: 'log-out', label: 'Log Out', click: actions.logOut },
+  ]
+
+  const template = []
+
+  if (isMac) {
+    // macOS convention puts account-level actions in the application menu,
+    // above Quit.
+    template.push({
+      label: appName,
+      submenu: [
+        { role: 'about' },
+        { type: 'separator' },
+        ...accountItems,
+        { type: 'separator' },
+        { role: 'services' },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideOthers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' },
+      ],
+    })
+  }
+
+  template.push({
+    label: 'File',
+    submenu: isMac
+      ? [{ role: 'close' }]
+      : // Elsewhere there is no application menu, so the same actions live
+        // under File alongside Quit.
+        [...accountItems, { type: 'separator' }, { role: 'quit' }],
+  })
+
+  template.push({ label: 'Edit', role: 'editMenu' })
+  template.push({
+    label: 'View',
+    submenu: [
+      { role: 'reload' },
+      { role: 'forceReload' },
+      { role: 'toggleDevTools' },
+      { type: 'separator' },
+      { role: 'resetZoom' },
+      { role: 'zoomIn' },
+      { role: 'zoomOut' },
+      { type: 'separator' },
+      { role: 'togglefullscreen' },
+    ],
+  })
+  template.push({ label: 'Window', role: 'windowMenu' })
+
+  return template
+}
+
+/**
+ * Every item carrying the given id, at any depth. Used by the tests, and by any
+ * later code that needs to toggle an item's state.
+ */
+export function findMenuItems(template, id) {
+  return template.flatMap((item) => [
+    ...(item.id === id ? [item] : []),
+    ...findMenuItems(item.submenu ?? [], id),
+  ])
+}

--- a/desktop/src/main/protocol.js
+++ b/desktop/src/main/protocol.js
@@ -221,7 +221,14 @@ export function createAppProtocolHandler({ serverUrl, netFetch, fileExists, read
   const csp = buildCSP({ dev, devServerUrl })
 
   async function proxyToServer(request, url) {
-    const target = new URL(url.pathname + url.search, serverUrl())
+    const base = serverUrl()
+    if (!base) {
+      // Before the first run's connection screen is answered there is nowhere
+      // to forward to. Saying so plainly beats throwing out of the handler.
+      return Response.json({ error: 'No AgentRQ server is configured' }, { status: 503 })
+    }
+
+    const target = new URL(url.pathname + url.search, base)
     const init = {
       method: request.method,
       headers: filterRequestHeaders(request.headers),

--- a/desktop/src/main/server-config.js
+++ b/desktop/src/main/server-config.js
@@ -1,13 +1,21 @@
 /**
- * Which AgentRQ server the desktop app talks to.
+ * Which AgentRQ server the desktop app talks to, and how that choice is stored.
  *
- * Phase 1 only needs a resolved URL; the first-run connection screen, live
- * validation and the switch-server flow land in phase 3 (task 0hua8EL8awL).
- * The normalisation rules live here now so that work can build on them rather
- * than reinvent them.
+ * The desktop app is a client: the server lives wherever the user runs it, so
+ * the app has to be told once and remember. Everything here takes its I/O as
+ * arguments so the rules can be tested without Electron or a filesystem.
  */
 
 export const DEFAULT_SERVER_URL = 'http://localhost:3000'
+
+/** Filename under Electron's userData directory. */
+export const CONFIG_FILENAME = 'agentrq-desktop.json'
+
+/** Shape version of the stored config, for migrations. */
+export const CONFIG_VERSION = 1
+
+/** Endpoint used to decide whether a URL is really an AgentRQ server. */
+export const CONFIG_PROBE_PATH = '/api/v1/auth/config'
 
 /**
  * Turn whatever the user typed into a URL we can safely resolve against.
@@ -60,4 +68,118 @@ export function resolveServerUrl({ env = {}, stored = '' } = {}) {
     if (result.ok) return result.url
   }
   return DEFAULT_SERVER_URL
+}
+
+/**
+ * Bring a stored config forward to the current shape.
+ *
+ * Anything unrecognised degrades to "no server configured", which sends the
+ * user to the connection screen. That is a mildly annoying outcome and a
+ * completely safe one — far better than booting the app pointed at a URL we
+ * could not actually parse.
+ *
+ * A file written by a *newer* build is treated the same way: its `serverUrl` is
+ * kept if it still looks like a URL, and every other key is dropped rather than
+ * guessed at.
+ */
+export function migrateConfig(raw) {
+  const empty = { version: CONFIG_VERSION, serverUrl: '' }
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return empty
+
+  const normalized = normalizeServerUrl(raw.serverUrl)
+  return {
+    version: CONFIG_VERSION,
+    serverUrl: normalized.ok ? normalized.url : '',
+  }
+}
+
+/**
+ * Persisted server choice.
+ *
+ * @param {object} deps
+ * @param {() => Promise<string>} deps.readFile   Rejects when the file is absent.
+ * @param {(contents: string) => Promise<void>} deps.writeFile
+ */
+export function createServerConfigStore({ readFile, writeFile }) {
+  return {
+    /**
+     * @returns {Promise<{ version: number, serverUrl: string }>} always a valid
+     *          shape — a missing or corrupt file reads as "not configured".
+     */
+    async load() {
+      let contents
+      try {
+        contents = await readFile()
+      } catch {
+        // No file yet: first run.
+        return migrateConfig(null)
+      }
+
+      try {
+        return migrateConfig(JSON.parse(contents))
+      } catch {
+        // Corrupt JSON — a half-written file, say. Same answer as no file.
+        return migrateConfig(null)
+      }
+    },
+
+    /**
+     * @returns {Promise<{ ok: true, url: string } | { ok: false, reason: string }>}
+     */
+    async save(input) {
+      const normalized = normalizeServerUrl(input)
+      if (!normalized.ok) return normalized
+
+      await writeFile(JSON.stringify({ version: CONFIG_VERSION, serverUrl: normalized.url }, null, 2))
+      return normalized
+    },
+
+    /** Forget the configured server, sending the app back to the first-run screen. */
+    async clear() {
+      await writeFile(JSON.stringify({ version: CONFIG_VERSION, serverUrl: '' }, null, 2))
+    },
+  }
+}
+
+/**
+ * Check that a URL is actually an AgentRQ server before it is stored.
+ *
+ * `/api/v1/auth/config` is the right probe: it is unauthenticated, it is cheap,
+ * and its response tells the login screen which sign-in methods exist — so a
+ * URL that answers it is a server this app can really use, not merely a host
+ * that happens to be up.
+ *
+ * @param {string} input raw user entry; normalised here so callers need not.
+ * @param {typeof fetch} fetchImpl
+ */
+export async function validateServerUrl(input, fetchImpl) {
+  const normalized = normalizeServerUrl(input)
+  if (!normalized.ok) return normalized
+
+  let res
+  try {
+    res = await fetchImpl(`${normalized.url}${CONFIG_PROBE_PATH}`)
+  } catch (err) {
+    return { ok: false, reason: `Could not reach ${normalized.url}`, detail: String(err?.message ?? err) }
+  }
+
+  if (!res.ok) {
+    return { ok: false, reason: `Server answered with ${res.status}` }
+  }
+
+  let config
+  try {
+    config = await res.json()
+  } catch {
+    return { ok: false, reason: 'That URL is not an AgentRQ server' }
+  }
+
+  // A JSON body alone is not proof: any API might return one. The auth config
+  // always carries these flags, so their absence means we are talking to
+  // something else.
+  if (typeof config?.rootLoginEnabled !== 'boolean' && typeof config?.githubLoginEnabled !== 'boolean') {
+    return { ok: false, reason: 'That URL is not an AgentRQ server' }
+  }
+
+  return { ok: true, url: normalized.url, config }
 }

--- a/desktop/src/preload/index.js
+++ b/desktop/src/preload/index.js
@@ -1,12 +1,12 @@
-const { contextBridge } = require('electron')
+const { contextBridge, ipcRenderer } = require('electron')
 
 /**
  * The seam between the shared Vue app and the desktop shell.
  *
- * Phase 1 exposes only what the renderer needs to know it is running on the
- * desktop; the notification, deep-link and update bridges arrive with their own
- * phases. Kept deliberately narrow — the renderer runs sandboxed with context
- * isolation, and every addition here is a hole in that boundary.
+ * Kept deliberately narrow — the renderer runs sandboxed with context
+ * isolation, and every addition here is a hole in that boundary. Each method is
+ * an explicit request the renderer can make, never a handle to an Electron
+ * object.
  */
 contextBridge.exposeInMainWorld('agentrq', {
   isDesktop: true,
@@ -15,5 +15,14 @@ contextBridge.exposeInMainWorld('agentrq', {
     electron: process.versions.electron,
     chrome: process.versions.chrome,
     node: process.versions.node,
+  },
+
+  connection: {
+    /** @returns {Promise<{configured: boolean, serverUrl: string, locked: boolean}>} */
+    get: () => ipcRenderer.invoke('agentrq:connection:get'),
+    /** Probe a URL without storing it, so the screen can report before committing. */
+    validate: (url) => ipcRenderer.invoke('agentrq:connection:validate', url),
+    /** Validate, store, and reload the window on success. */
+    save: (url) => ipcRenderer.invoke('agentrq:connection:save', url),
   },
 })

--- a/desktop/src/renderer/main.js
+++ b/desktop/src/renderer/main.js
@@ -1,9 +1,15 @@
 /**
  * Desktop renderer bootstrap.
  *
- * The application is assembled by the frontend's own `createAgentRQApp`, so
- * this build renders the identical component tree and route table the browser
- * does — there is deliberately no second list of routes to keep in step.
+ * Two things can be mounted here. Until a server has been chosen there is
+ * nothing for the application to talk to, so the connection screen goes up
+ * instead; once one is stored, the frontend's own `createAgentRQApp` builds the
+ * real app — the identical component tree and route table the browser gets.
+ *
+ * The connection screen is deliberately a desktop-only view rather than a route
+ * in the shared table: the browser build is served *by* a server and can never
+ * need it, and adding it to the shared routes would put a dead route in the web
+ * app.
  *
  * `createWebHistory` with no base is correct here: the renderer is served from
  * the root of the app:// origin, and the protocol handler does the same SPA
@@ -13,13 +19,25 @@
  * and updates arrive through electron-updater (phase 6, task 0huaAvwzIuH)
  * rather than a waiting worker.
  */
+import { createApp } from 'vue'
 import { createWebHistory } from 'vue-router'
 
 import { createAgentRQApp } from '@app/app'
+import ConnectionView from '@app/desktop/ConnectionView.vue'
 
-const { app } = createAgentRQApp({
-  history: createWebHistory('/'),
-  platform: 'desktop',
-})
+// A failure here means the shell could not answer, which is not something the
+// user can act on from a blank window — fall back to the connection screen so
+// there is always something on screen to do.
+const connection = await window.agentrq.connection
+  .get()
+  .catch(() => ({ configured: false, serverUrl: '' }))
 
-app.mount('#app')
+if (connection.configured) {
+  const { app } = createAgentRQApp({
+    history: createWebHistory('/'),
+    platform: 'desktop',
+  })
+  app.mount('#app')
+} else {
+  createApp(ConnectionView, { initialUrl: connection.serverUrl }).mount('#app')
+}

--- a/desktop/test/auth.test.js
+++ b/desktop/test/auth.test.js
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+
+import {
+  OAUTH_PROVIDERS,
+  AUTH_COOKIE,
+  matchOAuthLogin,
+  isOAuthReturn,
+  oauthStartUrl,
+  runOAuthFlow,
+} from '../src/main/auth.js'
+
+const SERVER = 'https://agentrq.example.com'
+
+/** Stand-in for the OAuth BrowserWindow: only what runOAuthFlow touches. */
+function fakeWindow() {
+  const win = new EventEmitter()
+  win.webContents = new EventEmitter()
+  win.destroyed = false
+  win.loadURL = vi.fn()
+  win.isDestroyed = () => win.destroyed
+  win.close = vi.fn(() => {
+    win.destroyed = true
+    win.emit('closed')
+  })
+  return win
+}
+
+describe('matchOAuthLogin', () => {
+  it('matches the providers the login view links to', () => {
+    expect(matchOAuthLogin('/api/v1/auth/google/login')).toBe('google')
+    expect(matchOAuthLogin('/api/v1/auth/github/login')).toBe('github')
+  })
+
+  it('tolerates a trailing slash', () => {
+    expect(matchOAuthLogin('/api/v1/auth/github/login/')).toBe('github')
+  })
+
+  it('ignores every other auth path', () => {
+    // The callback and the root-token endpoint must go through the normal
+    // proxy — taking those over would break sign-in rather than fix it.
+    expect(matchOAuthLogin('/api/v1/auth/github/callback')).toBeNull()
+    expect(matchOAuthLogin('/api/v1/auth/root/login')).toBeNull()
+    expect(matchOAuthLogin('/api/v1/auth/user')).toBeNull()
+  })
+
+  it('ignores an unknown provider and near-misses', () => {
+    expect(matchOAuthLogin('/api/v1/auth/gitlab/login')).toBeNull()
+    expect(matchOAuthLogin('/api/v1/auth/github/login/extra')).toBeNull()
+    expect(matchOAuthLogin('/prefix/api/v1/auth/github/login')).toBeNull()
+    expect(matchOAuthLogin('/')).toBeNull()
+  })
+
+  it('exports the providers it recognises', () => {
+    expect(OAUTH_PROVIDERS).toEqual(['google', 'github'])
+  })
+})
+
+describe('isOAuthReturn', () => {
+  it('is true once the flow lands back on the app itself', () => {
+    expect(isOAuthReturn(`${SERVER}/`, SERVER)).toBe(true)
+    expect(isOAuthReturn(`${SERVER}/workspaces/abc`, SERVER)).toBe(true)
+  })
+
+  it('is false while still inside the auth endpoints', () => {
+    // The callback sets the cookie and then redirects on; treating it as the
+    // end would check for the cookie a moment too early.
+    expect(isOAuthReturn(`${SERVER}/api/v1/auth/github/callback?code=x`, SERVER)).toBe(false)
+    expect(isOAuthReturn(`${SERVER}/api/v1/auth/github/login`, SERVER)).toBe(false)
+  })
+
+  it('is false while on the identity provider', () => {
+    expect(isOAuthReturn('https://github.com/login/oauth/authorize?x=1', SERVER)).toBe(false)
+    expect(isOAuthReturn('https://accounts.google.com/o/oauth2/auth', SERVER)).toBe(false)
+  })
+
+  it('does not confuse a lookalike host', () => {
+    expect(isOAuthReturn('https://agentrq.example.com.evil.test/', SERVER)).toBe(false)
+    expect(isOAuthReturn('http://agentrq.example.com/', SERVER)).toBe(false)
+  })
+
+  it('is false for anything unparseable', () => {
+    expect(isOAuthReturn('not a url', SERVER)).toBe(false)
+    expect(isOAuthReturn(`${SERVER}/`, 'not a url')).toBe(false)
+  })
+})
+
+describe('oauthStartUrl', () => {
+  it('rebuilds the link against the real server origin', () => {
+    expect(oauthStartUrl(SERVER, '/api/v1/auth/github/login')).toBe(`${SERVER}/api/v1/auth/github/login`)
+  })
+
+  it('keeps the query string', () => {
+    expect(oauthStartUrl(SERVER, '/api/v1/auth/google/login', '?next=%2Fevents')).toBe(
+      `${SERVER}/api/v1/auth/google/login?next=%2Fevents`
+    )
+  })
+
+  it('respects a server mounted under a base path', () => {
+    expect(oauthStartUrl('https://example.com/agentrq', '/api/v1/auth/github/login')).toBe(
+      'https://example.com/api/v1/auth/github/login'
+    )
+  })
+})
+
+describe('runOAuthFlow', () => {
+  it('opens the flow in its own window at the start URL', async () => {
+    const win = fakeWindow()
+    const startUrl = `${SERVER}/api/v1/auth/github/login`
+
+    const flow = runOAuthFlow({
+      serverUrl: SERVER,
+      startUrl,
+      createWindow: () => win,
+      hasAuthCookie: async () => true,
+    })
+
+    expect(win.loadURL).toHaveBeenCalledWith(startUrl)
+    win.webContents.emit('did-navigate', {}, `${SERVER}/`)
+    await expect(flow).resolves.toEqual({ ok: true })
+  })
+
+  it('succeeds when the cookie is in the jar on return', async () => {
+    const win = fakeWindow()
+    const flow = runOAuthFlow({
+      serverUrl: SERVER,
+      startUrl: `${SERVER}/api/v1/auth/github/login`,
+      createWindow: () => win,
+      hasAuthCookie: async () => true,
+    })
+
+    win.webContents.emit('did-navigate', {}, `${SERVER}/`)
+
+    await expect(flow).resolves.toEqual({ ok: true })
+    expect(win.close).toHaveBeenCalled()
+  })
+
+  it('recognises the return when it arrives as a redirect', async () => {
+    // The provider's callback normally reaches the app as a redirect chain
+    // rather than a fresh navigation.
+    const win = fakeWindow()
+    const flow = runOAuthFlow({
+      serverUrl: SERVER,
+      startUrl: `${SERVER}/api/v1/auth/google/login`,
+      createWindow: () => win,
+      hasAuthCookie: async () => true,
+    })
+
+    win.webContents.emit('did-redirect-navigation', {}, `${SERVER}/`)
+
+    await expect(flow).resolves.toEqual({ ok: true })
+  })
+
+  it('fails when the flow returns without a cookie', async () => {
+    const win = fakeWindow()
+    const flow = runOAuthFlow({
+      serverUrl: SERVER,
+      startUrl: `${SERVER}/api/v1/auth/github/login`,
+      createWindow: () => win,
+      hasAuthCookie: async () => false,
+    })
+
+    win.webContents.emit('did-navigate', {}, `${SERVER}/`)
+
+    await expect(flow).resolves.toEqual({ ok: false, reason: 'Sign-in did not complete' })
+  })
+
+  it('does not check for a cookie while still at the provider', async () => {
+    const hasAuthCookie = vi.fn(async () => true)
+    const win = fakeWindow()
+    const flow = runOAuthFlow({
+      serverUrl: SERVER,
+      startUrl: `${SERVER}/api/v1/auth/github/login`,
+      createWindow: () => win,
+      hasAuthCookie,
+    })
+
+    win.webContents.emit('did-navigate', {}, 'https://github.com/login/oauth/authorize')
+    win.webContents.emit('did-navigate', {}, `${SERVER}/api/v1/auth/github/callback?code=x`)
+    expect(hasAuthCookie).not.toHaveBeenCalled()
+
+    win.webContents.emit('did-navigate', {}, `${SERVER}/`)
+    await expect(flow).resolves.toEqual({ ok: true })
+    expect(hasAuthCookie).toHaveBeenCalledOnce()
+  })
+
+  it('resolves when the user closes the window instead of signing in', async () => {
+    const win = fakeWindow()
+    const flow = runOAuthFlow({
+      serverUrl: SERVER,
+      startUrl: `${SERVER}/api/v1/auth/github/login`,
+      createWindow: () => win,
+      hasAuthCookie: async () => false,
+    })
+
+    win.emit('closed')
+
+    await expect(flow).resolves.toEqual({ ok: false, reason: 'Sign-in window was closed' })
+  })
+
+  it('settles once, even if more navigations arrive', async () => {
+    // The window emits 'closed' as part of finishing, and a redirect can race
+    // it; resolving twice would be a silent bug.
+    const win = fakeWindow()
+    const hasAuthCookie = vi.fn(async () => true)
+    const flow = runOAuthFlow({
+      serverUrl: SERVER,
+      startUrl: `${SERVER}/api/v1/auth/github/login`,
+      createWindow: () => win,
+      hasAuthCookie,
+    })
+
+    win.webContents.emit('did-navigate', {}, `${SERVER}/`)
+    await flow
+    win.webContents.emit('did-navigate', {}, `${SERVER}/events`)
+    win.emit('closed')
+
+    expect(hasAuthCookie).toHaveBeenCalledOnce()
+    await expect(flow).resolves.toEqual({ ok: true })
+  })
+
+  it('does not close a window that is already gone', async () => {
+    const win = fakeWindow()
+    const flow = runOAuthFlow({
+      serverUrl: SERVER,
+      startUrl: `${SERVER}/api/v1/auth/github/login`,
+      createWindow: () => win,
+      hasAuthCookie: async () => true,
+    })
+
+    win.destroyed = true
+    win.webContents.emit('did-navigate', {}, `${SERVER}/`)
+
+    await flow
+    expect(win.close).not.toHaveBeenCalled()
+  })
+
+  it('resolves once when two returns race the cookie lookup', async () => {
+    // Both navigations pass the settled check before either await finishes, so
+    // two calls reach finish(); without its own guard the promise would be
+    // resolved twice and the window closed twice.
+    const win = fakeWindow()
+    let release
+    const gate = new Promise((r) => { release = r })
+    const hasAuthCookie = vi.fn(async () => { await gate; return true })
+
+    const flow = runOAuthFlow({
+      serverUrl: SERVER,
+      startUrl: `${SERVER}/api/v1/auth/github/login`,
+      createWindow: () => win,
+      hasAuthCookie,
+    })
+
+    win.webContents.emit('did-navigate', {}, `${SERVER}/`)
+    win.webContents.emit('did-redirect-navigation', {}, `${SERVER}/events`)
+    release()
+
+    await expect(flow).resolves.toEqual({ ok: true })
+    expect(hasAuthCookie).toHaveBeenCalledTimes(2)
+    expect(win.close).toHaveBeenCalledOnce()
+  })
+
+  it('names the cookie the backend actually sets', () => {
+    expect(AUTH_COOKIE).toBe('at')
+  })
+})

--- a/desktop/test/menu.test.js
+++ b/desktop/test/menu.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { buildMenuTemplate, findMenuItems } from '../src/main/menu.js'
+
+const actions = { switchServer: vi.fn(), logOut: vi.fn() }
+
+describe('buildMenuTemplate', () => {
+  it('offers switch-server and log-out on macOS', () => {
+    const template = buildMenuTemplate({ platform: 'darwin', actions })
+
+    expect(findMenuItems(template, 'switch-server')).toHaveLength(1)
+    expect(findMenuItems(template, 'log-out')).toHaveLength(1)
+  })
+
+  it('offers them on Windows and Linux too', () => {
+    // These are the only way to reach either action, so a platform that lost
+    // them would strand the user on one server.
+    for (const platform of ['win32', 'linux']) {
+      const template = buildMenuTemplate({ platform, actions })
+      expect(findMenuItems(template, 'switch-server')).toHaveLength(1)
+      expect(findMenuItems(template, 'log-out')).toHaveLength(1)
+    }
+  })
+
+  it('puts account actions in the application menu on macOS, and under File elsewhere', () => {
+    const mac = buildMenuTemplate({ platform: 'darwin', appName: 'AgentRQ', actions })
+    expect(mac[0].label).toBe('AgentRQ')
+    expect(findMenuItems([mac[0]], 'switch-server')).toHaveLength(1)
+
+    const linux = buildMenuTemplate({ platform: 'linux', actions })
+    const file = linux.find((item) => item.label === 'File')
+    expect(findMenuItems([file], 'switch-server')).toHaveLength(1)
+  })
+
+  it('has no application menu on Windows and Linux', () => {
+    const template = buildMenuTemplate({ platform: 'win32', actions })
+    expect(template.map((item) => item.label)).not.toContain('AgentRQ')
+  })
+
+  it('wires each action to its handler', () => {
+    const switchServer = vi.fn()
+    const logOut = vi.fn()
+    const template = buildMenuTemplate({ platform: 'darwin', actions: { switchServer, logOut } })
+
+    findMenuItems(template, 'switch-server')[0].click()
+    findMenuItems(template, 'log-out')[0].click()
+
+    expect(switchServer).toHaveBeenCalledOnce()
+    expect(logOut).toHaveBeenCalledOnce()
+  })
+
+  it('keeps quit reachable on every platform', () => {
+    for (const platform of ['darwin', 'win32', 'linux']) {
+      const template = buildMenuTemplate({ platform, actions })
+      const roles = JSON.stringify(template)
+      expect(roles).toContain('"role":"quit"')
+    }
+  })
+
+  it('defaults its name and tolerates no actions at all', () => {
+    const template = buildMenuTemplate({ platform: 'darwin' })
+
+    expect(template[0].label).toBe('AgentRQ')
+    expect(findMenuItems(template, 'switch-server')[0].click).toBeUndefined()
+  })
+})
+
+describe('findMenuItems', () => {
+  it('searches nested submenus', () => {
+    const template = [{ submenu: [{ submenu: [{ id: 'deep' }] }] }]
+    expect(findMenuItems(template, 'deep')).toHaveLength(1)
+  })
+
+  it('returns nothing for an unknown id', () => {
+    expect(findMenuItems(buildMenuTemplate({ platform: 'darwin', actions }), 'nope')).toEqual([])
+  })
+})

--- a/desktop/test/protocol.test.js
+++ b/desktop/test/protocol.test.js
@@ -263,6 +263,25 @@ describe('createAppProtocolHandler — proxying', () => {
     expect(await res.text()).toBe('{"ok":true}')
   })
 
+  it('reports 503 when no server has been configured yet', async () => {
+    // First run, before the connection screen is answered: there is nowhere to
+    // forward to, and throwing out of the protocol handler would surface as an
+    // opaque failed load rather than something the app can explain.
+    const netFetch = vi.fn()
+    const handler = createAppProtocolHandler({
+      serverUrl: () => '',
+      netFetch,
+      fileExists: async () => false,
+      readFile: async () => new TextEncoder().encode(''),
+    })
+
+    const res = await handler(makeRequest('app://agentrq/api/v1/auth/user'))
+
+    expect(res.status).toBe(503)
+    expect(await res.json()).toEqual({ error: 'No AgentRQ server is configured' })
+    expect(netFetch).not.toHaveBeenCalled()
+  })
+
   it('reports an unreachable server as 502 instead of throwing', async () => {
     const netFetch = vi.fn(async () => {
       throw new Error('ECONNREFUSED')

--- a/desktop/test/server-config.test.js
+++ b/desktop/test/server-config.test.js
@@ -1,6 +1,15 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 
-import { DEFAULT_SERVER_URL, normalizeServerUrl, resolveServerUrl } from '../src/main/server-config.js'
+import {
+  CONFIG_PROBE_PATH,
+  CONFIG_VERSION,
+  DEFAULT_SERVER_URL,
+  createServerConfigStore,
+  migrateConfig,
+  normalizeServerUrl,
+  resolveServerUrl,
+  validateServerUrl,
+} from '../src/main/server-config.js'
 
 describe('normalizeServerUrl', () => {
   it('keeps an explicit http or https URL', () => {
@@ -87,5 +96,166 @@ describe('resolveServerUrl', () => {
     expect(resolveServerUrl({ env: { AGENTRQ_SERVER_URL: 'file:///x' }, stored: 'https://ok.example.com' }))
       .toBe('https://ok.example.com')
     expect(resolveServerUrl({ env: {}, stored: 'file:///x' })).toBe(DEFAULT_SERVER_URL)
+  })
+})
+
+describe('migrateConfig', () => {
+  it('passes a current-shape config through', () => {
+    expect(migrateConfig({ version: 1, serverUrl: 'https://example.com' })).toEqual({
+      version: CONFIG_VERSION,
+      serverUrl: 'https://example.com',
+    })
+  })
+
+  it('adopts an unversioned file, which predates the version field', () => {
+    expect(migrateConfig({ serverUrl: 'example.com' })).toEqual({
+      version: CONFIG_VERSION,
+      serverUrl: 'http://example.com',
+    })
+  })
+
+  it('normalises whatever it finds rather than trusting it', () => {
+    expect(migrateConfig({ version: 1, serverUrl: 'https://example.com/' }).serverUrl).toBe('https://example.com')
+  })
+
+  it('keeps only what it understands from a newer file', () => {
+    // Written by a build that knows keys this one does not: take the server
+    // URL, drop the rest rather than guessing at its meaning.
+    expect(migrateConfig({ version: 99, serverUrl: 'https://example.com', theme: 'dark' })).toEqual({
+      version: CONFIG_VERSION,
+      serverUrl: 'https://example.com',
+    })
+  })
+
+  it('degrades to unconfigured for anything unusable', () => {
+    // Sending the user to the connection screen is mildly annoying; booting
+    // pointed at a URL we could not parse is worse.
+    for (const raw of [null, undefined, 'a string', 42, [], { serverUrl: 'file:///x' }, {}]) {
+      expect(migrateConfig(raw)).toEqual({ version: CONFIG_VERSION, serverUrl: '' })
+    }
+  })
+})
+
+describe('createServerConfigStore', () => {
+  function makeStore(initial = null) {
+    let contents = initial
+    const writeFile = vi.fn(async (next) => { contents = next })
+    const store = createServerConfigStore({
+      readFile: async () => {
+        if (contents === null) throw new Error('ENOENT')
+        return contents
+      },
+      writeFile,
+    })
+    return { store, writeFile, read: () => contents }
+  }
+
+  it('reads a missing file as not configured — the first run', async () => {
+    const { store } = makeStore(null)
+    expect(await store.load()).toEqual({ version: CONFIG_VERSION, serverUrl: '' })
+  })
+
+  it('reads a stored server back', async () => {
+    const { store } = makeStore(JSON.stringify({ version: 1, serverUrl: 'https://example.com' }))
+    expect((await store.load()).serverUrl).toBe('https://example.com')
+  })
+
+  it('treats corrupt JSON as not configured', async () => {
+    // A half-written file must not stop the app from starting.
+    const { store } = makeStore('{ not json')
+    expect(await store.load()).toEqual({ version: CONFIG_VERSION, serverUrl: '' })
+  })
+
+  it('saves a normalised URL and stamps the version', async () => {
+    const { store, read } = makeStore(null)
+
+    expect(await store.save('example.com/')).toEqual({ ok: true, url: 'http://example.com' })
+    expect(JSON.parse(read())).toEqual({ version: CONFIG_VERSION, serverUrl: 'http://example.com' })
+  })
+
+  it('refuses to store an invalid URL', async () => {
+    const { store, writeFile } = makeStore(null)
+
+    expect(await store.save('file:///etc/passwd')).toEqual({
+      ok: false,
+      reason: 'Server URL must use http or https',
+    })
+    expect(writeFile).not.toHaveBeenCalled()
+  })
+
+  it('round-trips a save through a load', async () => {
+    const { store } = makeStore(null)
+    await store.save('https://example.com')
+    expect((await store.load()).serverUrl).toBe('https://example.com')
+  })
+
+  it('clears the stored server, sending the app back to the first-run screen', async () => {
+    const { store } = makeStore(JSON.stringify({ version: 1, serverUrl: 'https://example.com' }))
+
+    await store.clear()
+
+    expect((await store.load()).serverUrl).toBe('')
+  })
+})
+
+describe('validateServerUrl', () => {
+  const authConfig = { basePath: '', rootLoginEnabled: true, githubLoginEnabled: false }
+  const okResponse = () => ({ ok: true, status: 200, json: async () => authConfig })
+
+  it('probes the auth config endpoint on the normalised URL', async () => {
+    const fetchImpl = vi.fn(async () => okResponse())
+
+    const result = await validateServerUrl('localhost:3000/', fetchImpl)
+
+    expect(fetchImpl).toHaveBeenCalledWith(`http://localhost:3000${CONFIG_PROBE_PATH}`)
+    expect(result).toEqual({ ok: true, url: 'http://localhost:3000', config: authConfig })
+  })
+
+  it('rejects a malformed URL without reaching the network', async () => {
+    const fetchImpl = vi.fn()
+
+    expect(await validateServerUrl('', fetchImpl)).toEqual({ ok: false, reason: 'Server URL is required' })
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('reports an unreachable host', async () => {
+    const fetchImpl = async () => { throw new Error('ECONNREFUSED') }
+
+    const result = await validateServerUrl('localhost:9', fetchImpl)
+
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('Could not reach http://localhost:9')
+    expect(result.detail).toBe('ECONNREFUSED')
+  })
+
+  it('reports a thrown value that is not an Error', async () => {
+    const result = await validateServerUrl('localhost:9', async () => { throw 'socket hang up' })
+    expect(result.detail).toBe('socket hang up')
+  })
+
+  it('reports a non-OK status', async () => {
+    const result = await validateServerUrl('example.com', async () => ({ ok: false, status: 502 }))
+    expect(result).toEqual({ ok: false, reason: 'Server answered with 502' })
+  })
+
+  it('rejects a host that answers but is not AgentRQ', async () => {
+    // Being up is not the same as being the right server: a bare 200 with a
+    // JSON body could be anything.
+    const notJson = { ok: true, status: 200, json: async () => { throw new Error('not json') } }
+    expect(await validateServerUrl('example.com', async () => notJson)).toEqual({
+      ok: false,
+      reason: 'That URL is not an AgentRQ server',
+    })
+
+    const wrongShape = { ok: true, status: 200, json: async () => ({ hello: 'world' }) }
+    expect(await validateServerUrl('example.com', async () => wrongShape)).toEqual({
+      ok: false,
+      reason: 'That URL is not an AgentRQ server',
+    })
+  })
+
+  it('accepts a server that advertises only github login', async () => {
+    const res = { ok: true, status: 200, json: async () => ({ githubLoginEnabled: true }) }
+    expect((await validateServerUrl('example.com', async () => res)).ok).toBe(true)
   })
 })

--- a/frontend/src/desktop/ConnectionView.vue
+++ b/frontend/src/desktop/ConnectionView.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="fixed inset-0 z-50 flex items-center justify-center bg-gray-50/80 dark:bg-zinc-950/80 backdrop-blur-sm" aria-modal="true" role="dialog">
+    <div class="w-full max-w-md p-8 bg-white dark:bg-zinc-900 rounded-3xl shadow-2xl border border-gray-100 dark:border-zinc-800">
+      <div class="mb-10 text-center">
+        <div class="w-16 h-16 bg-black dark:bg-white rounded-2xl flex items-center justify-center mx-auto mb-6 shadow-xl transform rotate-3">
+          <svg viewBox="0 0 24 24" class="w-10 h-10 text-white dark:text-black" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+            <path d="M12 7l-3.5 8" />
+            <path d="M12 7l3.5 8" />
+            <path d="M9.5 12h5" />
+          </svg>
+        </div>
+        <h2 class="text-3xl font-black text-gray-900 dark:text-zinc-50 tracking-tight mb-2">AgentRQ</h2>
+        <p class="text-gray-500 dark:text-zinc-400 text-sm leading-relaxed">
+          Connect to your workspace server
+        </p>
+      </div>
+
+      <form class="space-y-4" @submit.prevent="connect">
+        <input
+          ref="inputRef"
+          v-model="serverUrl"
+          type="text"
+          inputmode="url"
+          spellcheck="false"
+          autocapitalize="off"
+          placeholder="http://localhost:3000"
+          :disabled="connecting"
+          class="w-full px-4 py-4 bg-gray-50 dark:bg-zinc-800/50 text-gray-900 dark:text-zinc-50 border border-gray-100 dark:border-zinc-700/50 rounded-2xl outline-none focus:ring-4 focus:ring-black/5 dark:focus:ring-white/10 focus:border-black dark:focus:border-white transition-all text-center placeholder:text-gray-500 disabled:opacity-50"
+          required
+        />
+
+        <div v-if="errorMsg" class="p-4 bg-red-50 dark:bg-red-900/20 border border-red-100 dark:border-red-900/30 rounded-2xl">
+          <p class="text-sm text-red-600 dark:text-red-400 font-medium text-center">{{ errorMsg }}</p>
+        </div>
+
+        <button
+          type="submit"
+          :disabled="connecting || !serverUrl.trim()"
+          class="w-full py-4 bg-gray-900 dark:bg-zinc-800 text-white dark:text-zinc-200 font-bold rounded-2xl hover:bg-black dark:hover:bg-zinc-700 transform active:scale-[0.98] transition-all shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {{ connecting ? 'Connecting...' : 'Connect' }}
+        </button>
+      </form>
+
+      <p class="mt-6 text-center text-xs text-gray-500 dark:text-zinc-500 leading-relaxed">
+        Point this at the AgentRQ server you run — on this machine, your network, or a hosted instance.
+      </p>
+
+      <div class="mt-8 flex items-center justify-between pt-6 border-t border-gray-100 dark:border-zinc-800 text-[11px] font-bold text-gray-500 dark:text-zinc-500">
+        <span class="opacity-70">Desktop</span>
+        <span class="opacity-40">&copy; 2026 AgentRQ</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * First-run connection screen for the desktop app: which AgentRQ server to talk
+ * to. The browser build is served *by* a server and can never need this, so the
+ * view is never added to the shared route table — the desktop bootstrap mounts
+ * it directly when nothing is configured yet.
+ *
+ * It lives under frontend/ rather than desktop/ for one concrete reason:
+ * Tailwind's source detection is rooted at the stylesheet in frontend/src, so a
+ * class used only in desktop/ is silently dropped from the bundle. Pointing an
+ * `@source` at desktop/ is not an option either — the production Docker build
+ * copies only ./frontend, so that path would not exist there. Keeping the file
+ * here is what makes it actually get styled. Do not move it.
+ */
+import { ref, onMounted } from 'vue'
+
+const props = defineProps({
+  /** Prefilled when the user is switching away from a server they had. */
+  initialUrl: { type: String, default: '' },
+})
+
+const serverUrl = ref(props.initialUrl || 'http://localhost:3000')
+const connecting = ref(false)
+const errorMsg = ref('')
+const inputRef = ref(null)
+
+onMounted(() => {
+  inputRef.value?.focus()
+  inputRef.value?.select()
+})
+
+async function connect() {
+  if (connecting.value) return
+
+  connecting.value = true
+  errorMsg.value = ''
+
+  try {
+    // The main process validates by probing the server before it stores
+    // anything, so a typo is caught here rather than surfacing later as a
+    // mysterious failure to sign in.
+    const result = await window.agentrq.connection.save(serverUrl.value)
+    if (!result.ok) {
+      errorMsg.value = result.reason
+      return
+    }
+    // On success the main process reloads the window, so this view goes away
+    // on its own — leave the button disabled until it does.
+  } catch (err) {
+    errorMsg.value = String(err?.message ?? err)
+  } finally {
+    connecting.value = false
+  }
+}
+</script>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,4 +1,18 @@
 @import 'tailwindcss';
+
+/*
+ * Tailwind v4 auto-detects which files to scan for class names, anchored at the
+ * build's root. That is correct for the web build, whose root is frontend/, but
+ * wrong for the desktop build: its Vite root is desktop/src/renderer, so the
+ * scan found only the body classes in that index.html and every utility used by
+ * the actual views was dropped.
+ *
+ * Declaring the source explicitly relative to this stylesheet fixes it for both
+ * builds and needs no knowledge of either. './' is always frontend/src, so it
+ * also holds in the production Docker image, which copies only ./frontend.
+ */
+@source './';
+
 @custom-variant dark (&:where(.dark, .dark *));
 @import '@fontsource-variable/inter';
 


### PR DESCRIPTION
> **Stacked on #362** — base is `feat/desktop-shared-app-factory`, so this diff shows only phase 3. Merge #362 first and this retargets to main cleanly.

## What changed

The desktop app now asks which AgentRQ server to connect to on first run, checks the address really is one before saving it, and remembers the choice. Google and GitHub sign-in work, and the application menu gained entries to switch server or sign out.

This also fixes a bug that has been present since the desktop app was created: it was rendering almost entirely unstyled.

## Why changed

A desktop client has no way of knowing where its server lives, so it has to ask — and validating the address at the point it is typed turns a confusing later failure into an immediate, readable one. Sign-in through an identity provider could not work at all before this, because the provider's redirect chain has to run against the real server address rather than the app's internal one.

## Test coverage report

New lines introduced: **100%** — 112 tests across statements, branches, functions and lines, enforced as a CI gate.

```
File              | % Stmts | % Branch | % Funcs | % Lines
All files         |     100 |      100 |     100 |     100
 auth.js          |     100 |      100 |     100 |     100
 menu.js          |     100 |      100 |     100 |     100
 protocol.js      |     100 |      100 |     100 |     100
 server-config.js |     100 |      100 |     100 |     100
```

Total coverage impact: desktop coverage rises from 60 to 112 tests, still gated at 100% on every main-process module. Frontend suite unchanged at 23 tests, 100%. One test covers a genuine race — two sign-in returns reaching the completion guard together, which without its own check would resolve the flow twice.

## Other reports

**A styling bug that had shipped twice.** Tailwind decides which files to scan based on where the build is rooted. The desktop build is rooted at its own renderer folder, so the scan never reached the shared views and dropped nearly every style they use — a 13 KB stylesheet where the browser build produces 102 KB. The app rendered unstyled while its DOM looked perfectly correct, which is exactly why two earlier rounds of end-to-end checks missed it. Declaring the source explicitly in the shared stylesheet fixes both builds and still holds in the production container image, which copies only the frontend folder. Both end-to-end checks now assert a *computed* style, so this cannot regress quietly again.

**Two end-to-end runs, all green.** The first-run screen, from nothing stored:

```
✓ connection screen is showing        ✓ nothing was stored for the bad server
✓ URL field is focused and prefilled  ✓ good server is accepted and stored
✓ styles are applied — 24px           ✓ connection is now configured
✓ bad server refused with a reason    ✓ proxy reaches the newly configured server
```

And the configured path, unchanged from before plus the new style guard.

**A blank-window failure mode, closed.** If the shell cannot answer which server is configured, the renderer now falls back to the connection screen instead of mounting nothing.

The login view is not modified, and neither is any browser-facing behaviour.

## TaskID

0hua8EL8awL

Parent: 0huZWzzheT3 — plan in #359, phases 1–2 in #360 and #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)