### PR TITLE
feat(desktop): native notifications from the event stream

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -11,7 +11,7 @@ frontend's platform store, which is how a component offers a desktop-only
 affordance without either build growing its own copy of the view.
 
 Plan and phase breakdown: `docs/DESKTOP_APP_PLAN.md`. This package covers
-phase 1 (`0hua6QI7nXN`), phase 2 (`0hua7LpaQID`) and phase 3 (`0hua8EL8awL`).
+phases 1-4: `0hua6QI7nXN`, `0hua7LpaQID`, `0hua8EL8awL`, `0hua8txMLIn`.
 
 ## Running it
 
@@ -105,6 +105,41 @@ EventSource connects and streams normally:
 **No preload SSE bridge is needed and `useEventBus.js` needs no platform
 branch.**
 
+## Notifications
+
+Web Push cannot work in Electron - there is no push service behind it - so the
+desktop app produces the same user-facing behaviour from the event stream it
+already has. The main process holds its own SSE connection (separate from the
+renderer's, because notifications must keep arriving while the window is in the
+background), maps events to native notifications, and drives the dock badge or
+Windows taskbar overlay. Clicking one focuses the window and routes to the task.
+
+Wording, trigger rules and click destinations mirror
+`backend/internal/controller/push/push.go`, so a user moving between the browser
+and the desktop app sees the same notifications for the same events. Only agent
+activity notifies - being told about your own click is noise. Reconnect and
+backoff match `useEventBus.js`: one second, doubling to thirty, and a hard stop
+on 401.
+
+`frontend/src/composables/usePushNotifications.js` is untouched and still serves
+the browser build; the desktop renderer simply never calls it.
+
+Per-workspace muting lives in the workspace settings, beside the browser's push
+toggle, and is stored locally in the same config file as the server URL.
+
+### The backend publishes each task event twice
+
+One task creation reaches the stream twice: the REST handler publishes
+`task.created` directly, and the CRUD-event consumer publishes it again from the
+same write. The renderer never noticed - it just re-renders - but two identical
+native notifications for one event is plainly wrong. Confirmed against a live
+backend: two events in, one notification out.
+
+Notifications are therefore collapsed by `tag` within a short window. That is the
+same field, carrying the same value, that the browser uses to collapse duplicate
+web-push notifications; this applies the mechanism on our side rather than
+changing the backend's publishing.
+
 ### Tailwind scans from the build root, which is not frontend/
 
 Tailwind v4 decides which files to scan by walking out from the build's root.
@@ -141,6 +176,8 @@ src/main/protocol.js        app:// handler and API proxy — the core of the des
 src/main/server-config.js   which server to talk to: normalisation, storage, probing
 src/main/auth.js            OAuth sign-in taken over from the login view's links
 src/main/menu.js            application menu (switch server, log out)
+src/main/sse.js             event-stream client for the main process
+src/main/notifications.js   events -> native notifications, mute rules, badge
 src/main/index.js           lifecycle, window creation, scheme registration, IPC
 src/preload/index.js        the narrow contextBridge surface
 scripts/                    dev launcher, build, spike, e2e verification

--- a/desktop/src/main/index.js
+++ b/desktop/src/main/index.js
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Menu, ipcMain, net, protocol, session, shell } from 'electron'
+import { app, BrowserWindow, Menu, Notification, ipcMain, nativeImage, net, protocol, session, shell } from 'electron'
 import { readFile, writeFile, access } from 'node:fs/promises'
 import { constants } from 'node:fs'
 import { join, dirname } from 'node:path'
@@ -13,6 +13,8 @@ import {
 } from './server-config.js'
 import { AUTH_COOKIE, matchOAuthLogin, oauthStartUrl, runOAuthFlow } from './auth.js'
 import { buildMenuTemplate } from './menu.js'
+import { badgeFor, createNotificationGate, createUnreadCounter, mapEventToNotification } from './notifications.js'
+import { createEventStreamClient } from './sse.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -57,6 +59,43 @@ async function fileExists(pathname) {
   }
 }
 
+/** Workspace id -> display name, for notification bodies. */
+const workspaceNames = new Map()
+let mutedWorkspaces = []
+let eventStream = null
+let unread = null
+
+// One task creation is published twice by the backend — once by the REST
+// handler and once by the CRUD-event consumer — so identical notifications
+// have to be collapsed before they reach the user.
+const notificationGate = createNotificationGate()
+
+async function refreshWorkspaceNames() {
+  if (!serverUrl) return
+  try {
+    const res = await net.fetch(`${serverUrl}/api/v1/workspaces`)
+    if (!res.ok) return
+    const body = await res.json()
+    for (const ws of Array.isArray(body) ? body : (body?.workspaces ?? [])) {
+      if (ws?.id) workspaceNames.set(ws.id, ws.name ?? '')
+    }
+  } catch {
+    // A name is a nicety; a notification without one is still useful.
+  }
+}
+
+function applyBadge(count) {
+  const { badge, overlay } = badgeFor(count, process.platform)
+
+  if (app.dock) app.dock.setBadge(badge)
+  else if (typeof app.setBadgeCount === 'function') app.setBadgeCount(count)
+
+  const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())
+  if (win && process.platform === 'win32') {
+    win.setOverlayIcon(overlay ? nativeImage.createEmpty() : null, overlay?.description ?? '')
+  }
+}
+
 function connectionState() {
   return { configured: Boolean(serverUrl), serverUrl, locked: isConnectionLocked }
 }
@@ -94,7 +133,62 @@ async function startOAuth(win, pathname, search) {
 
   // On success the cookie is already in the jar, so simply reloading lands the
   // user inside the app. On failure the login view is still there to try again.
-  if (result.ok) reloadToRoot(win)
+  if (result.ok) {
+    startEventStream()
+    reloadToRoot(win)
+  }
+}
+
+function focusMainWindow() {
+  const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())
+  if (!win) return null
+  if (win.isMinimized()) win.restore()
+  win.show()
+  win.focus()
+  return win
+}
+
+function handleStreamEvent(event) {
+  const notification = mapEventToNotification(event, {
+    mutedWorkspaces,
+    workspaceName: (id) => workspaceNames.get(id) ?? '',
+  })
+  if (!notification) return
+
+  // An unknown workspace means the list is stale — refresh for next time
+  // rather than blocking this notification on a round trip.
+  if (!workspaceNames.has(event.payload.workspaceId)) refreshWorkspaceNames()
+
+  if (!notificationGate.allow(notification.tag)) return
+  if (!Notification.isSupported()) return
+
+  const native = new Notification({ title: notification.title, body: notification.body })
+  native.on('click', () => {
+    const win = focusMainWindow()
+    unread?.clear()
+    // The renderer owns routing: it has the router the shared factory built.
+    win?.webContents.send('agentrq:notification:activate', notification.route)
+  })
+  native.show()
+  unread?.increment()
+}
+
+function startEventStream() {
+  eventStream?.stop()
+  if (!serverUrl) return
+
+  eventStream = createEventStreamClient({
+    streamUrl: () => `${serverUrl}/api/v1/events/stream`,
+    netFetch: net.fetch,
+    onEvent: handleStreamEvent,
+    delay: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    onUnauthorized: () => {
+      // Signed out. The renderer's own stream sends the user to the login
+      // screen; this one waits to be restarted after a successful sign-in.
+    },
+  })
+  eventStream.start()
+  refreshWorkspaceNames()
 }
 
 function createWindow() {
@@ -115,6 +209,9 @@ function createWindow() {
   })
 
   win.once('ready-to-show', () => win.show())
+
+  // A badge answers "is there anything new"; looking at the app answers it.
+  win.on('focus', () => unread?.clear())
 
   // Anything that is not the app itself belongs in the user's real browser.
   win.webContents.setWindowOpenHandler(({ url }) => {
@@ -153,10 +250,13 @@ function installMenu(getWindow) {
         if (isConnectionLocked) return
         await configStore.clear()
         serverUrl = ''
+        eventStream?.stop()
         reloadToRoot(getWindow())
       },
       logOut: async () => {
         await session.defaultSession.clearStorageData({ storages: ['cookies'] })
+        eventStream?.stop()
+        unread?.clear()
         reloadToRoot(getWindow())
       },
     },
@@ -175,6 +275,16 @@ function registerIpc(getWindow) {
     return result.ok ? { ok: true, url: result.url } : result
   })
 
+  ipcMain.handle('agentrq:notifications:get', async () => ({
+    supported: Notification.isSupported(),
+    mutedWorkspaces,
+  }))
+
+  ipcMain.handle('agentrq:notifications:setMuted', async (_event, workspaceId, muted) => {
+    mutedWorkspaces = await configStore.setWorkspaceMuted(workspaceId, muted)
+    return { mutedWorkspaces }
+  })
+
   ipcMain.handle('agentrq:connection:save', async (_event, url) => {
     if (isConnectionLocked) {
       return { ok: false, reason: 'Server is pinned by AGENTRQ_SERVER_URL' }
@@ -187,6 +297,7 @@ function registerIpc(getWindow) {
     if (!saved.ok) return saved
 
     serverUrl = saved.url
+    startEventStream()
     reloadToRoot(getWindow())
     return { ok: true, url: saved.url }
   })
@@ -212,9 +323,13 @@ if (!app.requestSingleInstanceLock()) {
       writeFile: (contents) => writeFile(configPath, contents, 'utf-8'),
     })
 
+    const stored = await configStore.load()
+    mutedWorkspaces = stored.mutedWorkspaces
     if (!isConnectionLocked) {
-      serverUrl = (await configStore.load()).serverUrl
+      serverUrl = stored.serverUrl
     }
+
+    unread = createUnreadCounter({ setBadge: applyBadge })
 
     protocol.handle(
       'app',
@@ -234,6 +349,7 @@ if (!app.requestSingleInstanceLock()) {
     registerIpc(getWindow)
     installMenu(getWindow)
     createWindow()
+    startEventStream()
 
     app.on('activate', () => {
       if (BrowserWindow.getAllWindows().length === 0) createWindow()
@@ -243,4 +359,6 @@ if (!app.requestSingleInstanceLock()) {
   app.on('window-all-closed', () => {
     if (process.platform !== 'darwin') app.quit()
   })
+
+  app.on('before-quit', () => eventStream?.stop())
 }

--- a/desktop/src/main/notifications.js
+++ b/desktop/src/main/notifications.js
@@ -1,0 +1,176 @@
+/**
+ * Turning event-stream traffic into native notifications.
+ *
+ * Web Push cannot work in Electron — there is no push service behind it — so
+ * the desktop app produces the same user-facing behaviour from the SSE stream
+ * it already has. The wording, the trigger rules and the click destinations
+ * deliberately mirror the backend's push controller
+ * (`backend/internal/controller/push/push.go`) so a user who moves between the
+ * browser and the desktop app sees the same notifications for the same events.
+ *
+ * `frontend/src/composables/usePushNotifications.js` is untouched and still
+ * serves the browser; the desktop renderer simply never calls it.
+ *
+ * Pure functions, so the mapping and mute rules are testable without Electron.
+ */
+
+/** Event types that can produce a notification. Others are UI-only signals. */
+export const NOTIFIABLE_TYPES = ['task.created', 'status.updated', 'task.updated', 'reply.received']
+
+/** Matches the backend's truncation lengths so titles read identically. */
+export function truncate(text, max) {
+  const value = String(text ?? '')
+  return value.length > max ? `${value.slice(0, max)}…` : value
+}
+
+/**
+ * Should this event notify at all?
+ *
+ * Two rules, both inherited from the push controller. Only the agent's actions
+ * are worth interrupting someone for — being told about your own click is
+ * noise, not news. And a muted workspace stays silent.
+ */
+export function shouldNotify(event, { mutedWorkspaces = [] } = {}) {
+  if (!event || !NOTIFIABLE_TYPES.includes(event.type)) return false
+
+  const task = event.payload
+  if (!task || typeof task !== 'object') return false
+  if (!task.workspaceId || !task.id) return false
+
+  // `createdBy` is the actor on the task view. The push controller gates on
+  // `ev.Actor != ActorAgent`; this is the same rule expressed in what the SSE
+  // payload actually carries.
+  const actor = event.type === 'reply.received' ? 'agent' : task.createdBy
+  if (actor !== 'agent') return false
+
+  return !mutedWorkspaces.includes(task.workspaceId)
+}
+
+/**
+ * Build the notification for an event, or null when it should not fire.
+ *
+ * @param {object} event                 `{ type, payload }` from the stream
+ * @param {object} [options]
+ * @param {string[]} [options.mutedWorkspaces]
+ * @param {(id: string) => string} [options.workspaceName] resolves a display
+ *        name; falls back to nothing rather than showing a raw id
+ */
+export function mapEventToNotification(event, { mutedWorkspaces = [], workspaceName = () => '' } = {}) {
+  if (!shouldNotify(event, { mutedWorkspaces })) return null
+
+  const task = event.payload
+  const workspace = workspaceName(task.workspaceId) || 'AgentRQ'
+  const workspaceRoute = `/workspaces/${task.workspaceId}`
+
+  switch (event.type) {
+    case 'task.created':
+      return {
+        title: `New task: ${truncate(task.title, 60)}`,
+        body: workspace,
+        route: workspaceRoute,
+        tag: `task-create-${task.id}`,
+      }
+
+    case 'status.updated':
+    case 'task.updated':
+      return {
+        title: `Task ${String(task.status ?? '').toUpperCase()}: ${truncate(task.title, 50)}`,
+        body: workspace,
+        route: workspaceRoute,
+        tag: `task-status-${task.id}`,
+      }
+
+    default:
+      // reply.received. The stream carries the task, not the message, so the
+      // reply text the browser notification shows is not available here; the
+      // workspace name is the honest stand-in.
+      return {
+        title: `Reply on: ${truncate(task.title, 55)}`,
+        body: workspace,
+        route: `${workspaceRoute}/tasks/${task.id}`,
+        tag: `reply-${task.id}`,
+      }
+  }
+}
+
+/** How long a tag suppresses a repeat. */
+export const DEDUPE_WINDOW_MS = 10000
+
+/**
+ * Suppress duplicate notifications by tag.
+ *
+ * A single task creation reaches the stream twice: the REST handler publishes
+ * `task.created` directly, and the CRUD-event consumer publishes it again from
+ * the same write. The renderer does not care — it just re-renders — but firing
+ * two identical native notifications for one event is plainly wrong.
+ *
+ * The `tag` field carries the same value in both copies, which is exactly what
+ * the browser uses to collapse duplicate web-push notifications; this is that
+ * mechanism, applied on our side.
+ *
+ * A time window rather than an unbounded set: a genuine second event with the
+ * same tag much later (a task edited twice, say) should still notify, and the
+ * map must not grow forever.
+ */
+export function createNotificationGate({ windowMs = DEDUPE_WINDOW_MS, now = () => Date.now() } = {}) {
+  const seen = new Map()
+
+  return {
+    /** @returns {boolean} true when this notification should be shown. */
+    allow(tag) {
+      const at = now()
+
+      for (const [key, timestamp] of seen) {
+        if (at - timestamp >= windowMs) seen.delete(key)
+      }
+
+      if (seen.has(tag)) return false
+      seen.set(tag, at)
+      return true
+    },
+  }
+}
+
+/**
+ * Unread count behind the dock badge and taskbar overlay.
+ *
+ * Counting is per notification raised and cleared when the user looks at the
+ * app, which is the behaviour a badge is understood to have — it answers "is
+ * there anything new", not "how many events have ever occurred".
+ */
+export function createUnreadCounter({ setBadge }) {
+  let count = 0
+
+  const publish = () => setBadge(count)
+
+  return {
+    increment() {
+      count += 1
+      publish()
+      return count
+    },
+    clear() {
+      if (count === 0) return 0
+      count = 0
+      publish()
+      return count
+    },
+    get value() {
+      return count
+    },
+  }
+}
+
+/**
+ * Windows has no numeric dock badge, so the count is rendered as a taskbar
+ * overlay description instead; macOS and Linux take the number directly.
+ *
+ * Returns what should be shown, so the choice is testable without a window.
+ */
+export function badgeFor(count, platform) {
+  if (count <= 0) return { badge: '', overlay: null }
+  if (platform === 'win32') {
+    return { badge: '', overlay: { count, description: `${count} unread notification${count === 1 ? '' : 's'}` } }
+  }
+  return { badge: String(count), overlay: null }
+}

--- a/desktop/src/main/server-config.js
+++ b/desktop/src/main/server-config.js
@@ -11,8 +11,15 @@ export const DEFAULT_SERVER_URL = 'http://localhost:3000'
 /** Filename under Electron's userData directory. */
 export const CONFIG_FILENAME = 'agentrq-desktop.json'
 
-/** Shape version of the stored config, for migrations. */
-export const CONFIG_VERSION = 1
+/**
+ * Shape version of the stored config.
+ *
+ * v1: { serverUrl }
+ * v2: adds { mutedWorkspaces } — workspaces the desktop app must not raise
+ *     notifications for. A v1 file migrates forward by defaulting it to empty,
+ *     which is the same behaviour it had.
+ */
+export const CONFIG_VERSION = 2
 
 /** Endpoint used to decide whether a URL is really an AgentRQ server. */
 export const CONFIG_PROBE_PATH = '/api/v1/auth/config'
@@ -83,13 +90,18 @@ export function resolveServerUrl({ env = {}, stored = '' } = {}) {
  * guessed at.
  */
 export function migrateConfig(raw) {
-  const empty = { version: CONFIG_VERSION, serverUrl: '' }
+  const empty = { version: CONFIG_VERSION, serverUrl: '', mutedWorkspaces: [] }
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return empty
 
   const normalized = normalizeServerUrl(raw.serverUrl)
   return {
     version: CONFIG_VERSION,
     serverUrl: normalized.ok ? normalized.url : '',
+    // Absent in v1, and anything that is not a list of ids is not something to
+    // guess at. Empty means "notify for everything", which is what v1 did.
+    mutedWorkspaces: Array.isArray(raw.mutedWorkspaces)
+      ? raw.mutedWorkspaces.filter((id) => typeof id === 'string' && id !== '')
+      : [],
   }
 }
 
@@ -101,6 +113,9 @@ export function migrateConfig(raw) {
  * @param {(contents: string) => Promise<void>} deps.writeFile
  */
 export function createServerConfigStore({ readFile, writeFile }) {
+  const write = (config) =>
+    writeFile(JSON.stringify({ ...config, version: CONFIG_VERSION }, null, 2))
+
   return {
     /**
      * @returns {Promise<{ version: number, serverUrl: string }>} always a valid
@@ -130,13 +145,34 @@ export function createServerConfigStore({ readFile, writeFile }) {
       const normalized = normalizeServerUrl(input)
       if (!normalized.ok) return normalized
 
-      await writeFile(JSON.stringify({ version: CONFIG_VERSION, serverUrl: normalized.url }, null, 2))
+      // Read-modify-write: switching server must not silently discard the
+      // user's mute choices.
+      const current = await this.load()
+      await write({ ...current, serverUrl: normalized.url })
       return normalized
     },
 
     /** Forget the configured server, sending the app back to the first-run screen. */
     async clear() {
-      await writeFile(JSON.stringify({ version: CONFIG_VERSION, serverUrl: '' }, null, 2))
+      const current = await this.load()
+      await write({ ...current, serverUrl: '' })
+    },
+
+    /** Replace the muted-workspace list. */
+    async setMutedWorkspaces(ids) {
+      const current = await this.load()
+      const mutedWorkspaces = [...new Set((ids ?? []).filter((id) => typeof id === 'string' && id !== ''))]
+      await write({ ...current, mutedWorkspaces })
+      return mutedWorkspaces
+    },
+
+    /** Turn notifications for one workspace on or off. */
+    async setWorkspaceMuted(workspaceId, muted) {
+      const { mutedWorkspaces } = await this.load()
+      const next = muted
+        ? [...mutedWorkspaces, workspaceId]
+        : mutedWorkspaces.filter((id) => id !== workspaceId)
+      return this.setMutedWorkspaces(next)
     },
   }
 }

--- a/desktop/src/main/sse.js
+++ b/desktop/src/main/sse.js
@@ -1,0 +1,171 @@
+/**
+ * Server-sent events client for the main process.
+ *
+ * The renderer already consumes this stream through `useEventBus.js` for live
+ * UI updates. The main process needs its own connection for a different reason:
+ * notifications have to keep arriving when the window is in the background, and
+ * on some platforms a backgrounded renderer is throttled. This client is
+ * deliberately separate from the renderer's and does not replace it.
+ *
+ * Reconnect behaviour matches `useEventBus.js` exactly — one second, doubling to
+ * a thirty second ceiling, and a hard stop on 401 rather than a reconnect loop
+ * against a server that has already said no.
+ *
+ * Everything is injected, so the parsing and backoff rules are testable in plain
+ * Node with no Electron and no network.
+ */
+
+export const INITIAL_RECONNECT_DELAY = 1000
+export const MAX_RECONNECT_DELAY = 30000
+
+/** The delay after a failure at `current`. Mirrors useEventBus.js. */
+export function nextReconnectDelay(current) {
+  return Math.min(current * 2, MAX_RECONNECT_DELAY)
+}
+
+/**
+ * Incremental parser for the SSE wire format.
+ *
+ * Chunks arrive on arbitrary boundaries, so a frame can be split anywhere —
+ * including mid-line. State is kept in the closure and only complete frames are
+ * emitted.
+ */
+export function createSSEParser() {
+  let buffer = ''
+
+  return {
+    /**
+     * @returns {string[]} the `data` payload of each complete frame in this
+     *          chunk. Keepalive comments and frames with no data yield nothing.
+     */
+    feed(chunk) {
+      buffer += chunk
+      const out = []
+
+      // Frames are separated by a blank line. Anything after the last separator
+      // is an incomplete frame and stays buffered.
+      let separator
+      while ((separator = buffer.indexOf('\n\n')) !== -1) {
+        const frame = buffer.slice(0, separator)
+        buffer = buffer.slice(separator + 2)
+
+        const data = frame
+          .split('\n')
+          // A line starting with ':' is a comment — the backend sends
+          // ': agentrq' as its keepalive.
+          .filter((line) => line.startsWith('data:'))
+          .map((line) => line.slice('data:'.length).trimStart())
+          .join('\n')
+
+        if (data) out.push(data)
+      }
+
+      return out
+    },
+  }
+}
+
+/**
+ * Hold a connection to the event stream, reconnecting until stopped.
+ *
+ * @param {object} deps
+ * @param {() => string} deps.streamUrl     resolved per attempt, so a server
+ *                                          switch is picked up on reconnect
+ * @param {typeof fetch} deps.netFetch
+ * @param {(event: object) => void} deps.onEvent
+ * @param {(connected: boolean) => void} [deps.onStatus]
+ * @param {(ms: number) => Promise<void>} deps.delay
+ * @param {() => void} [deps.onUnauthorized] called instead of reconnecting when
+ *                                           the server rejects the credentials
+ * @returns {{ start: () => void, stop: () => void, isRunning: () => boolean }}
+ */
+export function createEventStreamClient({
+  streamUrl,
+  netFetch,
+  onEvent,
+  onStatus = () => {},
+  delay,
+  onUnauthorized = () => {},
+}) {
+  let running = false
+  let controller = null
+
+  async function readStream(response) {
+    const parser = createSSEParser()
+    const decoder = new TextDecoder()
+    const reader = response.body.getReader()
+
+    while (running) {
+      const { done, value } = await reader.read()
+      if (done) return
+
+      for (const data of parser.feed(decoder.decode(value, { stream: true }))) {
+        try {
+          onEvent(JSON.parse(data))
+        } catch {
+          // A frame we cannot parse is not a reason to drop the connection;
+          // the next one is probably fine.
+        }
+      }
+    }
+  }
+
+  async function loop() {
+    let reconnectDelay = INITIAL_RECONNECT_DELAY
+
+    while (running) {
+      controller = new AbortController()
+      try {
+        const response = await netFetch(streamUrl(), {
+          headers: { Accept: 'text/event-stream' },
+          signal: controller.signal,
+        })
+
+        if (response.status === 401) {
+          // Reconnecting would just be rejected again. The renderer's own
+          // stream handles sending the user to the login screen.
+          //
+          // `running` is cleared before returning so the client is genuinely
+          // stopped rather than merely idle: leaving it set would make a later
+          // start() — after a successful sign-in — a silent no-op.
+          running = false
+          onStatus(false)
+          onUnauthorized()
+          return
+        }
+
+        if (!response.ok || !response.body) {
+          throw new Error(`stream responded ${response.status}`)
+        }
+
+        onStatus(true)
+        // A connection that lasted is not suspect, so the next failure starts
+        // its backoff from the bottom again.
+        reconnectDelay = INITIAL_RECONNECT_DELAY
+        await readStream(response)
+      } catch {
+        // Network error, or stop() aborting the in-flight request.
+      }
+
+      onStatus(false)
+      if (!running) return
+
+      await delay(reconnectDelay)
+      reconnectDelay = nextReconnectDelay(reconnectDelay)
+    }
+  }
+
+  return {
+    start() {
+      if (running) return
+      running = true
+      loop()
+    },
+    stop() {
+      running = false
+      controller?.abort()
+      controller = null
+    },
+    isRunning: () => running,
+  }
+}

--- a/desktop/src/preload/index.js
+++ b/desktop/src/preload/index.js
@@ -25,4 +25,24 @@ contextBridge.exposeInMainWorld('agentrq', {
     /** Validate, store, and reload the window on success. */
     save: (url) => ipcRenderer.invoke('agentrq:connection:save', url),
   },
+
+  notifications: {
+    /** @returns {Promise<{supported: boolean, mutedWorkspaces: string[]}>} */
+    get: () => ipcRenderer.invoke('agentrq:notifications:get'),
+    setMuted: (workspaceId, muted) =>
+      ipcRenderer.invoke('agentrq:notifications:setMuted', workspaceId, muted),
+
+    /**
+     * Called with the in-app route when the user clicks a notification.
+     * Only the callback crosses the bridge — never the IPC event object, which
+     * would hand the renderer a handle back into the main process.
+     *
+     * @returns {() => void} unsubscribe
+     */
+    onActivate: (callback) => {
+      const listener = (_event, route) => callback(route)
+      ipcRenderer.on('agentrq:notification:activate', listener)
+      return () => ipcRenderer.off('agentrq:notification:activate', listener)
+    },
+  },
 })

--- a/desktop/src/renderer/main.js
+++ b/desktop/src/renderer/main.js
@@ -33,10 +33,20 @@ const connection = await window.agentrq.connection
   .catch(() => ({ configured: false, serverUrl: '' }))
 
 if (connection.configured) {
-  const { app } = createAgentRQApp({
+  const { app, router } = createAgentRQApp({
     history: createWebHistory('/'),
     platform: 'desktop',
   })
+
+  // Clicking a native notification lands here: the shell has already focused
+  // the window, and the router the shared factory built does the navigating.
+  window.agentrq.notifications?.onActivate((route) => {
+    router.push(route).catch(() => {
+      // An unknown or unchanged route is not worth surfacing — the window is
+      // focused either way, which is most of what the click asked for.
+    })
+  })
+
   app.mount('#app')
 } else {
   createApp(ConnectionView, { initialUrl: connection.serverUrl }).mount('#app')

--- a/desktop/test/notifications.test.js
+++ b/desktop/test/notifications.test.js
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import {
+  DEDUPE_WINDOW_MS,
+  NOTIFIABLE_TYPES,
+  createNotificationGate,
+  badgeFor,
+  createUnreadCounter,
+  mapEventToNotification,
+  shouldNotify,
+  truncate,
+} from '../src/main/notifications.js'
+
+/** A task view as the event stream delivers it. */
+const task = (over = {}) => ({
+  id: '0hua6QI7nXN',
+  workspaceId: '0ZzhYQG2qtl',
+  title: 'Ship the desktop app',
+  status: 'ongoing',
+  createdBy: 'agent',
+  ...over,
+})
+
+const event = (type, over = {}) => ({ type, payload: task(over) })
+const names = { workspaceName: () => 'agentrq-code' }
+
+describe('truncate', () => {
+  it('leaves short text alone', () => {
+    expect(truncate('short', 60)).toBe('short')
+  })
+
+  it('cuts long text and marks it', () => {
+    expect(truncate('x'.repeat(70), 60)).toBe(`${'x'.repeat(60)}…`)
+  })
+
+  it('handles missing text', () => {
+    expect(truncate(undefined, 10)).toBe('')
+    expect(truncate(null, 10)).toBe('')
+  })
+})
+
+describe('shouldNotify', () => {
+  it('accepts the event types worth interrupting someone for', () => {
+    for (const type of NOTIFIABLE_TYPES) {
+      expect(shouldNotify(event(type))).toBe(true)
+    }
+  })
+
+  it('ignores UI-only signals', () => {
+    // agent.connected drives a status dot; task.deleted has nothing to show.
+    expect(shouldNotify(event('agent.connected'))).toBe(false)
+    expect(shouldNotify(event('task.deleted'))).toBe(false)
+  })
+
+  it('ignores the user\'s own actions', () => {
+    // Mirrors the push controller, which notifies only on agent activity —
+    // being told about your own click is noise, not news.
+    expect(shouldNotify(event('task.created', { createdBy: 'human' }))).toBe(false)
+    expect(shouldNotify(event('status.updated', { createdBy: 'human' }))).toBe(false)
+  })
+
+  it('always notifies for a reply, which only an agent sends', () => {
+    expect(shouldNotify(event('reply.received', { createdBy: 'human' }))).toBe(true)
+  })
+
+  it('stays silent for a muted workspace', () => {
+    expect(shouldNotify(event('task.created'), { mutedWorkspaces: ['0ZzhYQG2qtl'] })).toBe(false)
+    expect(shouldNotify(event('task.created'), { mutedWorkspaces: ['other'] })).toBe(true)
+  })
+
+  it('rejects malformed events rather than raising an empty notification', () => {
+    expect(shouldNotify(null)).toBe(false)
+    expect(shouldNotify({})).toBe(false)
+    expect(shouldNotify({ type: 'task.created' })).toBe(false)
+    expect(shouldNotify({ type: 'task.created', payload: 'nope' })).toBe(false)
+    expect(shouldNotify(event('task.created', { workspaceId: undefined }))).toBe(false)
+    expect(shouldNotify(event('task.created', { id: undefined }))).toBe(false)
+  })
+})
+
+describe('mapEventToNotification', () => {
+  it('words a new task the way the browser notification does', () => {
+    expect(mapEventToNotification(event('task.created'), names)).toEqual({
+      title: 'New task: Ship the desktop app',
+      body: 'agentrq-code',
+      route: '/workspaces/0ZzhYQG2qtl',
+      tag: 'task-create-0hua6QI7nXN',
+    })
+  })
+
+  it('words a status change with the status in caps', () => {
+    expect(mapEventToNotification(event('status.updated', { status: 'completed' }), names)).toMatchObject({
+      title: 'Task COMPLETED: Ship the desktop app',
+      route: '/workspaces/0ZzhYQG2qtl',
+      tag: 'task-status-0hua6QI7nXN',
+    })
+  })
+
+  it('treats a plain task update the same as a status change', () => {
+    expect(mapEventToNotification(event('task.updated'), names).title).toBe('Task ONGOING: Ship the desktop app')
+  })
+
+  it('routes a reply to the task itself, not the workspace', () => {
+    expect(mapEventToNotification(event('reply.received'), names)).toEqual({
+      title: 'Reply on: Ship the desktop app',
+      body: 'agentrq-code',
+      route: '/workspaces/0ZzhYQG2qtl/tasks/0hua6QI7nXN',
+      tag: 'reply-0hua6QI7nXN',
+    })
+  })
+
+  it('truncates long titles at the same lengths the backend uses', () => {
+    const long = 'y'.repeat(100)
+    expect(mapEventToNotification(event('task.created', { title: long }), names).title)
+      .toBe(`New task: ${'y'.repeat(60)}…`)
+    expect(mapEventToNotification(event('status.updated', { title: long }), names).title)
+      .toBe(`Task ONGOING: ${'y'.repeat(50)}…`)
+    expect(mapEventToNotification(event('reply.received', { title: long }), names).title)
+      .toBe(`Reply on: ${'y'.repeat(55)}…`)
+  })
+
+  it('falls back to the product name rather than showing a raw workspace id', () => {
+    expect(mapEventToNotification(event('task.created')).body).toBe('AgentRQ')
+    expect(mapEventToNotification(event('task.created'), { workspaceName: () => '' }).body).toBe('AgentRQ')
+  })
+
+  it('returns nothing for an event that should not notify', () => {
+    expect(mapEventToNotification(event('agent.connected'), names)).toBeNull()
+    expect(mapEventToNotification(event('task.created'), { ...names, mutedWorkspaces: ['0ZzhYQG2qtl'] })).toBeNull()
+  })
+
+  it('copes with a status that is missing', () => {
+    expect(mapEventToNotification(event('status.updated', { status: undefined }), names).title)
+      .toBe('Task : Ship the desktop app')
+  })
+})
+
+describe('createNotificationGate', () => {
+  it('lets the first notification for a tag through', () => {
+    expect(createNotificationGate().allow('task-create-1')).toBe(true)
+  })
+
+  it('collapses the backend\'s duplicate publish of one event', () => {
+    // A single task creation is published twice — once by the REST handler and
+    // once by the CRUD-event consumer — carrying the same tag both times.
+    const gate = createNotificationGate()
+
+    expect(gate.allow('task-create-1')).toBe(true)
+    expect(gate.allow('task-create-1')).toBe(false)
+  })
+
+  it('does not collapse different tags', () => {
+    const gate = createNotificationGate()
+
+    expect(gate.allow('task-create-1')).toBe(true)
+    expect(gate.allow('task-create-2')).toBe(true)
+  })
+
+  it('allows the same tag again once the window has passed', () => {
+    // A task genuinely updated twice, minutes apart, is two pieces of news.
+    let clock = 0
+    const gate = createNotificationGate({ windowMs: 1000, now: () => clock })
+
+    expect(gate.allow('task-status-1')).toBe(true)
+    clock = 999
+    expect(gate.allow('task-status-1')).toBe(false)
+    clock = 1000
+    expect(gate.allow('task-status-1')).toBe(true)
+  })
+
+  it('forgets old tags rather than growing without bound', () => {
+    let clock = 0
+    const gate = createNotificationGate({ windowMs: 100, now: () => clock })
+
+    for (let i = 0; i < 50; i += 1) {
+      gate.allow(`tag-${i}`)
+      clock += 10
+    }
+    // Well past the window, so the early entries must have been pruned; the
+    // first tag being allowed again is the observable proof.
+    clock += 1000
+    expect(gate.allow('tag-0')).toBe(true)
+  })
+
+  it('has a sane default window', () => {
+    expect(DEDUPE_WINDOW_MS).toBe(10000)
+  })
+})
+
+describe('createUnreadCounter', () => {
+  it('counts up and publishes each change', () => {
+    const setBadge = vi.fn()
+    const counter = createUnreadCounter({ setBadge })
+
+    expect(counter.increment()).toBe(1)
+    expect(counter.increment()).toBe(2)
+    expect(counter.value).toBe(2)
+    expect(setBadge).toHaveBeenNthCalledWith(2, 2)
+  })
+
+  it('clears back to zero', () => {
+    const setBadge = vi.fn()
+    const counter = createUnreadCounter({ setBadge })
+
+    counter.increment()
+    expect(counter.clear()).toBe(0)
+    expect(setBadge).toHaveBeenLastCalledWith(0)
+  })
+
+  it('does not republish a clear when already at zero', () => {
+    // The window emits focus constantly; repainting an unchanged badge each
+    // time is pointless work.
+    const setBadge = vi.fn()
+    const counter = createUnreadCounter({ setBadge })
+
+    counter.clear()
+    counter.clear()
+
+    expect(setBadge).not.toHaveBeenCalled()
+  })
+})
+
+describe('badgeFor', () => {
+  it('shows nothing at zero', () => {
+    expect(badgeFor(0, 'darwin')).toEqual({ badge: '', overlay: null })
+    expect(badgeFor(-1, 'darwin')).toEqual({ badge: '', overlay: null })
+    expect(badgeFor(0, 'win32')).toEqual({ badge: '', overlay: null })
+  })
+
+  it('puts the number on the dock on macOS and Linux', () => {
+    expect(badgeFor(3, 'darwin')).toEqual({ badge: '3', overlay: null })
+    expect(badgeFor(3, 'linux')).toEqual({ badge: '3', overlay: null })
+  })
+
+  it('uses a taskbar overlay on Windows, which has no numeric badge', () => {
+    expect(badgeFor(3, 'win32')).toEqual({
+      badge: '',
+      overlay: { count: 3, description: '3 unread notifications' },
+    })
+  })
+
+  it('gets the singular right in the overlay description, which is read aloud', () => {
+    expect(badgeFor(1, 'win32').overlay.description).toBe('1 unread notification')
+  })
+})

--- a/desktop/test/server-config.test.js
+++ b/desktop/test/server-config.test.js
@@ -101,9 +101,10 @@ describe('resolveServerUrl', () => {
 
 describe('migrateConfig', () => {
   it('passes a current-shape config through', () => {
-    expect(migrateConfig({ version: 1, serverUrl: 'https://example.com' })).toEqual({
+    expect(migrateConfig({ version: 2, serverUrl: 'https://example.com', mutedWorkspaces: ['ws1'] })).toEqual({
       version: CONFIG_VERSION,
       serverUrl: 'https://example.com',
+      mutedWorkspaces: ['ws1'],
     })
   })
 
@@ -111,7 +112,26 @@ describe('migrateConfig', () => {
     expect(migrateConfig({ serverUrl: 'example.com' })).toEqual({
       version: CONFIG_VERSION,
       serverUrl: 'http://example.com',
+      mutedWorkspaces: [],
     })
+  })
+
+  it('migrates a v1 file forward by defaulting the new field', () => {
+    // v1 had no mute list, and notifying for everything is what it did.
+    expect(migrateConfig({ version: 1, serverUrl: 'https://example.com' })).toEqual({
+      version: CONFIG_VERSION,
+      serverUrl: 'https://example.com',
+      mutedWorkspaces: [],
+    })
+  })
+
+  it('discards a mute list that is not a list of ids', () => {
+    for (const bad of ['ws1', 42, { ws1: true }, null]) {
+      expect(migrateConfig({ version: 2, serverUrl: 'https://e.com', mutedWorkspaces: bad }).mutedWorkspaces)
+        .toEqual([])
+    }
+    expect(migrateConfig({ version: 2, serverUrl: 'https://e.com', mutedWorkspaces: ['ok', '', 7, null] })
+      .mutedWorkspaces).toEqual(['ok'])
   })
 
   it('normalises whatever it finds rather than trusting it', () => {
@@ -124,6 +144,7 @@ describe('migrateConfig', () => {
     expect(migrateConfig({ version: 99, serverUrl: 'https://example.com', theme: 'dark' })).toEqual({
       version: CONFIG_VERSION,
       serverUrl: 'https://example.com',
+      mutedWorkspaces: [],
     })
   })
 
@@ -131,7 +152,7 @@ describe('migrateConfig', () => {
     // Sending the user to the connection screen is mildly annoying; booting
     // pointed at a URL we could not parse is worse.
     for (const raw of [null, undefined, 'a string', 42, [], { serverUrl: 'file:///x' }, {}]) {
-      expect(migrateConfig(raw)).toEqual({ version: CONFIG_VERSION, serverUrl: '' })
+      expect(migrateConfig(raw)).toEqual({ version: CONFIG_VERSION, serverUrl: '', mutedWorkspaces: [] })
     }
   })
 })
@@ -152,7 +173,7 @@ describe('createServerConfigStore', () => {
 
   it('reads a missing file as not configured — the first run', async () => {
     const { store } = makeStore(null)
-    expect(await store.load()).toEqual({ version: CONFIG_VERSION, serverUrl: '' })
+    expect(await store.load()).toEqual({ version: CONFIG_VERSION, serverUrl: '', mutedWorkspaces: [] })
   })
 
   it('reads a stored server back', async () => {
@@ -163,14 +184,18 @@ describe('createServerConfigStore', () => {
   it('treats corrupt JSON as not configured', async () => {
     // A half-written file must not stop the app from starting.
     const { store } = makeStore('{ not json')
-    expect(await store.load()).toEqual({ version: CONFIG_VERSION, serverUrl: '' })
+    expect(await store.load()).toEqual({ version: CONFIG_VERSION, serverUrl: '', mutedWorkspaces: [] })
   })
 
   it('saves a normalised URL and stamps the version', async () => {
     const { store, read } = makeStore(null)
 
     expect(await store.save('example.com/')).toEqual({ ok: true, url: 'http://example.com' })
-    expect(JSON.parse(read())).toEqual({ version: CONFIG_VERSION, serverUrl: 'http://example.com' })
+    expect(JSON.parse(read())).toEqual({
+      version: CONFIG_VERSION,
+      serverUrl: 'http://example.com',
+      mutedWorkspaces: [],
+    })
   })
 
   it('refuses to store an invalid URL', async () => {
@@ -187,6 +212,44 @@ describe('createServerConfigStore', () => {
     const { store } = makeStore(null)
     await store.save('https://example.com')
     expect((await store.load()).serverUrl).toBe('https://example.com')
+  })
+
+  it('keeps mute choices when the server changes', async () => {
+    // Switching server is not a reason to start notifying about workspaces the
+    // user deliberately silenced.
+    const { store } = makeStore(
+      JSON.stringify({ version: 2, serverUrl: 'https://a.example.com', mutedWorkspaces: ['ws1'] })
+    )
+
+    await store.save('https://b.example.com')
+
+    expect(await store.load()).toEqual({
+      version: CONFIG_VERSION,
+      serverUrl: 'https://b.example.com',
+      mutedWorkspaces: ['ws1'],
+    })
+  })
+
+  it('mutes and unmutes a single workspace', async () => {
+    const { store } = makeStore(JSON.stringify({ version: 2, serverUrl: 'https://e.com', mutedWorkspaces: [] }))
+
+    expect(await store.setWorkspaceMuted('ws1', true)).toEqual(['ws1'])
+    expect(await store.setWorkspaceMuted('ws2', true)).toEqual(['ws1', 'ws2'])
+    expect(await store.setWorkspaceMuted('ws1', false)).toEqual(['ws2'])
+    expect((await store.load()).mutedWorkspaces).toEqual(['ws2'])
+  })
+
+  it('does not list a workspace twice when muted again', async () => {
+    const { store } = makeStore(JSON.stringify({ version: 2, serverUrl: 'https://e.com', mutedWorkspaces: ['ws1'] }))
+
+    expect(await store.setWorkspaceMuted('ws1', true)).toEqual(['ws1'])
+  })
+
+  it('replaces the whole mute list, dropping junk entries', async () => {
+    const { store } = makeStore(null)
+
+    expect(await store.setMutedWorkspaces(['ws1', 'ws1', '', null, 'ws2'])).toEqual(['ws1', 'ws2'])
+    expect(await store.setMutedWorkspaces()).toEqual([])
   })
 
   it('clears the stored server, sending the app back to the first-run screen', async () => {

--- a/desktop/test/sse.test.js
+++ b/desktop/test/sse.test.js
@@ -1,0 +1,324 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import {
+  INITIAL_RECONNECT_DELAY,
+  MAX_RECONNECT_DELAY,
+  createEventStreamClient,
+  createSSEParser,
+  nextReconnectDelay,
+} from '../src/main/sse.js'
+
+/** A response whose body streams the given chunks, then ends. */
+function streamingResponse(chunks, { status = 200 } = {}) {
+  const encoder = new TextEncoder()
+  let i = 0
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    body: {
+      getReader: () => ({
+        read: async () =>
+          i < chunks.length ? { done: false, value: encoder.encode(chunks[i++]) } : { done: true, value: undefined },
+      }),
+    },
+  }
+}
+
+describe('nextReconnectDelay', () => {
+  it('doubles, matching useEventBus.js', () => {
+    expect(nextReconnectDelay(1000)).toBe(2000)
+    expect(nextReconnectDelay(2000)).toBe(4000)
+    expect(nextReconnectDelay(8000)).toBe(16000)
+  })
+
+  it('caps at thirty seconds, as the renderer does', () => {
+    expect(nextReconnectDelay(16000)).toBe(MAX_RECONNECT_DELAY)
+    expect(nextReconnectDelay(MAX_RECONNECT_DELAY)).toBe(MAX_RECONNECT_DELAY)
+  })
+
+  it('starts from one second', () => {
+    expect(INITIAL_RECONNECT_DELAY).toBe(1000)
+  })
+})
+
+describe('createSSEParser', () => {
+  it('reads a complete frame', () => {
+    expect(createSSEParser().feed('data: {"a":1}\n\n')).toEqual(['{"a":1}'])
+  })
+
+  it('reads several frames from one chunk', () => {
+    expect(createSSEParser().feed('data: one\n\ndata: two\n\n')).toEqual(['one', 'two'])
+  })
+
+  it('reassembles a frame split across chunks', () => {
+    // Chunks arrive on arbitrary boundaries, including mid-line.
+    const parser = createSSEParser()
+    expect(parser.feed('data: {"a"')).toEqual([])
+    expect(parser.feed(':1}\n')).toEqual([])
+    expect(parser.feed('\n')).toEqual(['{"a":1}'])
+  })
+
+  it('holds an incomplete trailing frame until it is finished', () => {
+    const parser = createSSEParser()
+    expect(parser.feed('data: done\n\ndata: partial')).toEqual(['done'])
+    expect(parser.feed('\n\n')).toEqual(['partial'])
+  })
+
+  it('ignores the keepalive comment the backend sends', () => {
+    // ': agentrq' every 30s is what holds the connection open.
+    expect(createSSEParser().feed(': agentrq\n\n')).toEqual([])
+  })
+
+  it('ignores fields other than data', () => {
+    expect(createSSEParser().feed('event: ping\nid: 7\ndata: payload\n\n')).toEqual(['payload'])
+  })
+
+  it('joins a multi-line data field', () => {
+    expect(createSSEParser().feed('data: line1\ndata: line2\n\n')).toEqual(['line1\nline2'])
+  })
+
+  it('tolerates a data field with no space after the colon', () => {
+    expect(createSSEParser().feed('data:tight\n\n')).toEqual(['tight'])
+  })
+
+  it('emits nothing for an empty data field', () => {
+    expect(createSSEParser().feed('data:\n\n')).toEqual([])
+  })
+})
+
+describe('createEventStreamClient', () => {
+  const setup = ({ stopAfterDelays = 1, ...overrides } = {}) => {
+    const onEvent = vi.fn()
+    const onStatus = vi.fn()
+    const onUnauthorized = vi.fn()
+
+    // The reconnect loop is unbounded by design — it retries until stopped. A
+    // delay that resolves instantly would therefore spin the loop as fast as
+    // the event loop allows and exhaust memory before the test could assert,
+    // so this stands in for the passage of time *and* ends the run.
+    let handle
+    const delay = vi.fn(async () => {
+      if (delay.mock.calls.length >= stopAfterDelays) handle.stop()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    handle = createEventStreamClient({
+      streamUrl: () => 'https://example.com/api/v1/events/stream',
+      netFetch: overrides.netFetch ?? vi.fn(async () => streamingResponse([])),
+      onEvent,
+      onStatus,
+      onUnauthorized,
+      delay,
+      ...overrides,
+    })
+    return { client: handle, onEvent, onStatus, onUnauthorized, delay }
+  }
+
+  /** Let the client's async loop advance. */
+  const settle = () => new Promise((r) => setTimeout(r, 5))
+
+  it('asks for an event stream', async () => {
+    const netFetch = vi.fn(async () => streamingResponse([]))
+    const { client } = setup({ netFetch })
+
+    client.start()
+    await settle()
+    client.stop()
+
+    expect(netFetch.mock.calls[0][0]).toBe('https://example.com/api/v1/events/stream')
+    expect(netFetch.mock.calls[0][1].headers).toEqual({ Accept: 'text/event-stream' })
+  })
+
+  it('delivers parsed events', async () => {
+    const netFetch = vi.fn(async () => streamingResponse(['data: {"type":"task.created"}\n\n']))
+    const { client, onEvent } = setup({ netFetch })
+
+    client.start()
+    await settle()
+    client.stop()
+
+    expect(onEvent).toHaveBeenCalledWith({ type: 'task.created' })
+  })
+
+  it('survives a frame it cannot parse', async () => {
+    // One malformed frame is not a reason to drop a working connection.
+    const netFetch = vi.fn(async () => streamingResponse(['data: not json\n\ndata: {"type":"ok"}\n\n']))
+    const { client, onEvent } = setup({ netFetch })
+
+    client.start()
+    await settle()
+    client.stop()
+
+    expect(onEvent).toHaveBeenCalledOnce()
+    expect(onEvent).toHaveBeenCalledWith({ type: 'ok' })
+  })
+
+  it('reports connected and disconnected', async () => {
+    const { client, onStatus } = setup()
+
+    client.start()
+    await settle()
+    client.stop()
+
+    expect(onStatus).toHaveBeenCalledWith(true)
+    expect(onStatus).toHaveBeenCalledWith(false)
+  })
+
+  it('stops on 401 instead of hammering a server that said no', async () => {
+    const netFetch = vi.fn(async () => ({ ok: false, status: 401 }))
+    const { client, onUnauthorized, delay } = setup({ netFetch })
+
+    client.start()
+    await settle()
+
+    expect(onUnauthorized).toHaveBeenCalledOnce()
+    expect(netFetch).toHaveBeenCalledOnce()
+    expect(delay).not.toHaveBeenCalled()
+  })
+
+  it('backs off after a failure, doubling each time', async () => {
+    const netFetch = vi.fn(async () => {
+      throw new Error('ECONNREFUSED')
+    })
+    const { client, delay } = setup({ netFetch, stopAfterDelays: 3 })
+
+    client.start()
+    await settle()
+    client.stop()
+
+    expect(delay.mock.calls[0][0]).toBe(1000)
+    expect(delay.mock.calls[1][0]).toBe(2000)
+    expect(delay.mock.calls[2][0]).toBe(4000)
+  })
+
+  it('treats a non-OK, non-401 response as a failure and retries', async () => {
+    const netFetch = vi.fn(async () => ({ ok: false, status: 503 }))
+    const { client, delay } = setup({ netFetch })
+
+    client.start()
+    await settle()
+    client.stop()
+
+    expect(delay).toHaveBeenCalled()
+  })
+
+  it('resets the backoff after a connection that worked', async () => {
+    // A connection that lasted is not suspect: the next failure should retry
+    // promptly rather than inherit a long delay.
+    let attempt = 0
+    const netFetch = vi.fn(async () => {
+      attempt += 1
+      if (attempt === 1) throw new Error('down')
+      if (attempt === 2) return streamingResponse(['data: {"type":"ok"}\n\n'])
+      throw new Error('down again')
+    })
+    const { client, delay } = setup({ netFetch, stopAfterDelays: 2 })
+
+    client.start()
+    await settle()
+    client.stop()
+
+    expect(delay.mock.calls[0][0]).toBe(1000)
+    // Third attempt failed after a good connection, so back to the floor.
+    expect(delay.mock.calls[1][0]).toBe(1000)
+  })
+
+  it('re-resolves the URL each attempt, so a server switch is picked up', async () => {
+    let url = 'https://first.example.com/api/v1/events/stream'
+    const netFetch = vi.fn(async () => {
+      throw new Error('down')
+    })
+    const { client } = setup({ netFetch, streamUrl: () => url, stopAfterDelays: 1 })
+
+    client.start()
+    await settle()
+    url = 'https://second.example.com/api/v1/events/stream'
+    client.start()
+    await settle()
+    client.stop()
+
+    expect(netFetch.mock.calls.at(-1)[0]).toBe('https://second.example.com/api/v1/events/stream')
+  })
+
+  it('reports whether it is running, and starting twice is a no-op', async () => {
+    const netFetch = vi.fn(async () => streamingResponse([]))
+    const { client } = setup({ netFetch })
+
+    expect(client.isRunning()).toBe(false)
+    client.start()
+    client.start()
+    expect(client.isRunning()).toBe(true)
+
+    await settle()
+    client.stop()
+    expect(client.isRunning()).toBe(false)
+  })
+
+  it('does not schedule a retry when stopped mid-attempt', async () => {
+    // stop() during an in-flight request must end the loop then and there,
+    // rather than falling through into a reconnect delay.
+    let handle
+    const delay = vi.fn(async () => {})
+    handle = createEventStreamClient({
+      streamUrl: () => 'https://example.com/api/v1/events/stream',
+      netFetch: async () => {
+        handle.stop()
+        throw new Error('aborted')
+      },
+      onEvent: () => {},
+      delay,
+    })
+
+    handle.start()
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(delay).not.toHaveBeenCalled()
+    expect(handle.isRunning()).toBe(false)
+  })
+
+  it('treats a 200 with no body as a failure', async () => {
+    const netFetch = vi.fn(async () => ({ ok: true, status: 200, body: null }))
+    const { client, delay } = setup({ netFetch })
+
+    client.start()
+    await settle()
+    client.stop()
+
+    expect(delay).toHaveBeenCalled()
+  })
+
+  it('works without optional callbacks', async () => {
+    // onStatus and onUnauthorized are optional; omitting them must not throw
+    // on either the connected path or the 401 path.
+    let attempt = 0
+    const client = createEventStreamClient({
+      streamUrl: () => 'https://example.com/api/v1/events/stream',
+      netFetch: async () => {
+        attempt += 1
+        return attempt === 1 ? streamingResponse(['data: {"type":"ok"}\n\n']) : { ok: false, status: 401 }
+      },
+      onEvent: () => {},
+      delay: async () => {},
+    })
+
+    client.start()
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(client.isRunning()).toBe(false)
+  })
+
+  it('aborts the in-flight request when stopped', async () => {
+    let signal
+    const netFetch = vi.fn(async (_url, init) => {
+      signal = init.signal
+      return streamingResponse([])
+    })
+    const { client } = setup({ netFetch })
+
+    client.start()
+    await settle()
+    client.stop()
+
+    expect(signal.aborted).toBe(true)
+  })
+})

--- a/desktop/test/sse.test.js
+++ b/desktop/test/sse.test.js
@@ -114,15 +114,27 @@ describe('createEventStreamClient', () => {
     return { client: handle, onEvent, onStatus, onUnauthorized, delay }
   }
 
-  /** Let the client's async loop advance. */
-  const settle = () => new Promise((r) => setTimeout(r, 5))
+  /**
+   * Wait until a condition holds rather than for a fixed span.
+   *
+   * The reconnect loop is asynchronous, so "has it retried three times yet"
+   * depends on how fast the machine is. A fixed sleep passes locally and fails
+   * on a slower CI runner — which is exactly what it did.
+   */
+  const waitFor = async (predicate, label) => {
+    for (let i = 0; i < 2000; i += 1) {
+      if (predicate()) return
+      await new Promise((r) => setTimeout(r, 1))
+    }
+    throw new Error(`timed out waiting for ${label}`)
+  }
 
   it('asks for an event stream', async () => {
     const netFetch = vi.fn(async () => streamingResponse([]))
     const { client } = setup({ netFetch })
 
     client.start()
-    await settle()
+    await waitFor(() => netFetch.mock.calls.length >= 1, 'the first request')
     client.stop()
 
     expect(netFetch.mock.calls[0][0]).toBe('https://example.com/api/v1/events/stream')
@@ -134,7 +146,7 @@ describe('createEventStreamClient', () => {
     const { client, onEvent } = setup({ netFetch })
 
     client.start()
-    await settle()
+    await waitFor(() => onEvent.mock.calls.length >= 1, 'the first event')
     client.stop()
 
     expect(onEvent).toHaveBeenCalledWith({ type: 'task.created' })
@@ -146,7 +158,7 @@ describe('createEventStreamClient', () => {
     const { client, onEvent } = setup({ netFetch })
 
     client.start()
-    await settle()
+    await waitFor(() => onEvent.mock.calls.length >= 1, 'the parseable event')
     client.stop()
 
     expect(onEvent).toHaveBeenCalledOnce()
@@ -157,7 +169,7 @@ describe('createEventStreamClient', () => {
     const { client, onStatus } = setup()
 
     client.start()
-    await settle()
+    await waitFor(() => onStatus.mock.calls.length >= 2, 'connect and disconnect')
     client.stop()
 
     expect(onStatus).toHaveBeenCalledWith(true)
@@ -169,7 +181,7 @@ describe('createEventStreamClient', () => {
     const { client, onUnauthorized, delay } = setup({ netFetch })
 
     client.start()
-    await settle()
+    await waitFor(() => onUnauthorized.mock.calls.length >= 1, 'the 401 handler')
 
     expect(onUnauthorized).toHaveBeenCalledOnce()
     expect(netFetch).toHaveBeenCalledOnce()
@@ -183,7 +195,7 @@ describe('createEventStreamClient', () => {
     const { client, delay } = setup({ netFetch, stopAfterDelays: 3 })
 
     client.start()
-    await settle()
+    await waitFor(() => delay.mock.calls.length >= 3, 'three reconnect delays')
     client.stop()
 
     expect(delay.mock.calls[0][0]).toBe(1000)
@@ -196,7 +208,7 @@ describe('createEventStreamClient', () => {
     const { client, delay } = setup({ netFetch })
 
     client.start()
-    await settle()
+    await waitFor(() => delay.mock.calls.length >= 1, 'a retry delay')
     client.stop()
 
     expect(delay).toHaveBeenCalled()
@@ -215,7 +227,7 @@ describe('createEventStreamClient', () => {
     const { client, delay } = setup({ netFetch, stopAfterDelays: 2 })
 
     client.start()
-    await settle()
+    await waitFor(() => delay.mock.calls.length >= 2, 'two reconnect delays')
     client.stop()
 
     expect(delay.mock.calls[0][0]).toBe(1000)
@@ -231,10 +243,13 @@ describe('createEventStreamClient', () => {
     const { client } = setup({ netFetch, streamUrl: () => url, stopAfterDelays: 1 })
 
     client.start()
-    await settle()
+    await waitFor(() => netFetch.mock.calls.length >= 1, 'the first attempt')
     url = 'https://second.example.com/api/v1/events/stream'
     client.start()
-    await settle()
+    await waitFor(
+      () => netFetch.mock.calls.at(-1)[0].includes('second'),
+      'an attempt against the new URL'
+    )
     client.stop()
 
     expect(netFetch.mock.calls.at(-1)[0]).toBe('https://second.example.com/api/v1/events/stream')
@@ -249,7 +264,7 @@ describe('createEventStreamClient', () => {
     client.start()
     expect(client.isRunning()).toBe(true)
 
-    await settle()
+    await waitFor(() => netFetch.mock.calls.length >= 1, 'the first attempt')
     client.stop()
     expect(client.isRunning()).toBe(false)
   })
@@ -270,7 +285,7 @@ describe('createEventStreamClient', () => {
     })
 
     handle.start()
-    await new Promise((r) => setTimeout(r, 10))
+    await waitFor(() => !handle.isRunning(), 'the client to stop')
 
     expect(delay).not.toHaveBeenCalled()
     expect(handle.isRunning()).toBe(false)
@@ -281,7 +296,7 @@ describe('createEventStreamClient', () => {
     const { client, delay } = setup({ netFetch })
 
     client.start()
-    await settle()
+    await waitFor(() => delay.mock.calls.length >= 1, 'a retry delay')
     client.stop()
 
     expect(delay).toHaveBeenCalled()
@@ -302,7 +317,7 @@ describe('createEventStreamClient', () => {
     })
 
     client.start()
-    await new Promise((r) => setTimeout(r, 10))
+    await waitFor(() => !client.isRunning(), 'the 401 to stop the client')
 
     expect(client.isRunning()).toBe(false)
   })
@@ -316,7 +331,7 @@ describe('createEventStreamClient', () => {
     const { client } = setup({ netFetch })
 
     client.start()
-    await settle()
+    await waitFor(() => signal !== undefined, 'the request to start')
     client.stop()
 
     expect(signal.aborted).toBe(true)

--- a/frontend/src/views/WorkspaceSettingsView.vue
+++ b/frontend/src/views/WorkspaceSettingsView.vue
@@ -371,6 +371,21 @@
                             {{ isPushLoading ? '...' : isPushSubscribed ? 'Push Active' : 'Enable Push' }}
                           </span>
                         </button>
+                        <!--
+                          Desktop only. Web Push has no Electron equivalent, so the desktop app
+                          raises native notifications from the event stream instead; this is the
+                          switch for that, per workspace.
+                        -->
+                        <button v-if="isDesktopAlertsAvailable" type="button" @click="toggleDesktopAlerts" :disabled="isDesktopAlertsLoading"
+                                class="flex items-center gap-3 px-4 py-2.5 rounded-sm transition-all shadow-sm border text-left"
+                                :class="isDesktopAlertsEnabled ? 'bg-violet-50 dark:bg-violet-500/10 border-violet-100 dark:border-violet-500/20 hover:bg-violet-100' : 'bg-gray-50 dark:bg-zinc-800 border-gray-200 dark:border-zinc-700 hover:bg-gray-100'">
+                          <svg class="w-3.5 h-3.5 shrink-0" :class="isDesktopAlertsEnabled ? 'text-violet-600 dark:text-violet-400' : 'text-gray-400 dark:text-zinc-500'" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                          </svg>
+                          <span class="text-[10px] font-bold uppercase tracking-widest" :class="isDesktopAlertsEnabled ? 'text-violet-700 dark:text-violet-400' : 'text-gray-600 dark:text-zinc-400'">
+                            {{ isDesktopAlertsLoading ? '...' : isDesktopAlertsEnabled ? 'Desktop Alerts On' : 'Desktop Alerts Off' }}
+                          </span>
+                        </button>
                       </div>
                    </div>
                 </div>
@@ -583,6 +598,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { getWorkspace, updateWorkspace, archiveWorkspace, unarchiveWorkspace, deleteWorkspace, getWorkspaceToken, setWorkspaceSlackChannel, removeWorkspaceSlackChannel } from '../api';
 import { useToasts } from '../composables/useToasts';
 import { usePushNotifications } from '../composables/usePushNotifications';
+import { usePlatformStore } from '../stores/platformStore';
 import ArchiveModal from '../components/ArchiveModal.vue';
 import DeleteModal from '../components/DeleteModal.vue';
 import { useWorkspaceStore } from '../stores/workspaceStore';
@@ -634,6 +650,41 @@ const INPUT_SEND_DELAY_OPTIONS = [
 ];
 
 const { checkWorkspaceSubscription, subscribeWorkspace, unsubscribeWorkspace } = usePushNotifications();
+
+// Desktop-only alerts. The browser build has Web Push for this; the desktop app
+// cannot use it, so it raises native notifications from the event stream and
+// this is the per-workspace switch. Availability is read from the platform
+// store rather than probed from `window.agentrq`, so the browser build never
+// renders the control at all.
+const platformStore = usePlatformStore();
+const isDesktopAlertsAvailable = ref(false);
+const isDesktopAlertsEnabled = ref(false);
+const isDesktopAlertsLoading = ref(false);
+
+async function refreshDesktopAlerts() {
+  if (!platformStore.isDesktop || !window.agentrq?.notifications) return;
+  const state = await window.agentrq.notifications.get();
+  isDesktopAlertsAvailable.value = state.supported;
+  isDesktopAlertsEnabled.value = !state.mutedWorkspaces.includes(workspaceId.value);
+}
+
+async function toggleDesktopAlerts() {
+  if (isDesktopAlertsLoading.value) return;
+  isDesktopAlertsLoading.value = true;
+  try {
+    // Muted is the stored state, so enabling alerts means removing the mute.
+    const { mutedWorkspaces } = await window.agentrq.notifications.setMuted(
+      workspaceId.value,
+      isDesktopAlertsEnabled.value,
+    );
+    isDesktopAlertsEnabled.value = !mutedWorkspaces.includes(workspaceId.value);
+    notifySuccess(isDesktopAlertsEnabled.value ? 'Desktop alerts enabled' : 'Desktop alerts muted');
+  } catch (err) {
+    notifyError('Could not update desktop alerts');
+  } finally {
+    isDesktopAlertsLoading.value = false;
+  }
+}
 const isPushSubscribed = ref(false);
 const isPushLoading = ref(false);
 const isPushAvailable = ref(false); // true when browser supports push AND server has VAPID configured
@@ -920,6 +971,7 @@ async function load() {
 
     await initPushAvailability();
     await refreshPushStatus();
+    await refreshDesktopAlerts();
   } catch (err) {
     notifyError("Failed to load workspace settings: " + err.message);
     router.push('/');


### PR DESCRIPTION
> **Stacked on #363**, which is stacked on #362. Merge in order and each retargets cleanly.

## What changed

The desktop app now raises native system notifications when an agent creates a task, changes its status, or replies — with an unread badge, click-to-open, and a per-workspace mute switch in workspace settings.

## Why changed

The browser gets these through Web Push, which has no equivalent on the desktop. Rather than leave desktop users without notifications, the app derives them from the live event stream it already maintains, matching the browser's wording and behaviour so the two feel like one product.

## Test coverage report

New lines introduced: **100%** — 174 tests across statements, branches, functions and lines, enforced as a CI gate.

```
File              | % Stmts | % Branch | % Funcs | % Lines
All files         |     100 |      100 |     100 |     100
 auth.js          |     100 |      100 |     100 |     100
 menu.js          |     100 |      100 |     100 |     100
 notifications.js |     100 |      100 |     100 |     100
 protocol.js      |     100 |      100 |     100 |     100
 server-config.js |     100 |      100 |     100 |     100
 sse.js           |     100 |      100 |     100 |     100
```

Total coverage impact: desktop rises from 112 to 174 tests, still 100% on every main-process module. Frontend unchanged at 23 tests, 100%.

## Other reports

**Two bugs found by testing against a live backend rather than assuming.**

The first is in the backend, and predates this work: every task event is published *twice*, once by the request handler and once by the change-event consumer. The web UI never noticed, because re-rendering twice looks identical — but it would have fired two identical notifications for every single task. Confirmed live: two events in, one notification out after the fix. Handled on our side by collapsing on the same identifier browsers already use to collapse duplicate push notifications, so the backend's publishing is left alone.

The second was mine: after the server rejected the stream as unauthenticated, the client stopped reading but still reported itself as running, so restarting it after signing back in would have silently done nothing. A test written for coverage caught it before it could ship.

**A limitation worth stating.** For a reply, the stream carries the task rather than the message, so the desktop notification cannot show the reply text the browser shows; it names the workspace instead. Closing that gap needs a backend change and is not attempted here.

**First real use of the platform seam** added in #362: the mute switch appears only in the desktop build, from the same settings screen, with no fork of the view.

Verification: all nine end-to-end checks still pass, including the style guard added in #363.

## TaskID

0hua8txMLIn

Parent: 0huZWzzheT3 — plan in #359, phases 1–3 in #360, #362, #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)