### PR TITLE
feat(desktop): native shell — menu, tray, shortcut, deep links, window state

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -11,7 +11,8 @@ frontend's platform store, which is how a component offers a desktop-only
 affordance without either build growing its own copy of the view.
 
 Plan and phase breakdown: `docs/DESKTOP_APP_PLAN.md`. This package covers
-phases 1-4: `0hua6QI7nXN`, `0hua7LpaQID`, `0hua8EL8awL`, `0hua8txMLIn`.
+phases 1-5: `0hua6QI7nXN`, `0hua7LpaQID`, `0hua8EL8awL`, `0hua8txMLIn`,
+`0huaA6sKHoX`.
 
 ## Running it
 
@@ -105,6 +106,42 @@ EventSource connects and streams normally:
 **No preload SSE bridge is needed and `useEventBus.js` needs no platform
 branch.**
 
+## The native shell
+
+Everything the browser cannot offer lives in the main process and reaches the
+app through one navigation channel, so the shared Vue app needs no knowledge of
+any of it:
+
+- **Application menu** with the platform roles plus New Task, Switch Server, Log
+  Out and Check for Updates. The last is present but disabled until phase 6
+  supplies an updater — a menu item that silently does nothing is worse than one
+  that is visibly not ready.
+- **Tray item** carrying the unread count and the workspaces that have been
+  active most recently, ordered by activity rather than alphabetically: it is a
+  shortcut to what is happening now, not a second sidebar.
+- **Global shortcut** `Cmd/Ctrl+Shift+N` for a new task. `Shift` keeps it clear
+  of the browser-standard new-window binding, which matters for a shortcut
+  registered system-wide. Registration failing because another app owns the
+  combination is the user's environment, not an error worth interrupting them
+  over — the same action stays on the menu and the tray.
+- **`agentrq://` deep links**, e.g. `agentrq://workspaces/<id>/tasks/<id>`.
+  These are untrusted input from outside the app, so a link is checked against
+  the routes that actually exist rather than passed to the router; an
+  unrecognised one opens the default view. macOS delivers them as an event,
+  Windows and Linux as an argument to a second launch, which the single-instance
+  lock forwards rather than opening a rival window.
+- **Window state** across restarts, clamped to a display that still exists.
+  Restoring saved coordinates blindly is how a window ends up off-screen after a
+  monitor is unplugged — visible to no one, draggable by no one.
+- **Theme** follows the app's own `themeStore`, never `prefers-color-scheme`. A
+  user who chose light inside AgentRQ should not get a dark title bar because
+  their system is dark. The window background is set from it too, which is what
+  stops a white flash on reload in dark mode.
+
+The tray icon is deliberately an empty image for now: it is an art asset, and
+shipping a wrong-looking one is worse than the platform default. The menu, count
+and tooltip — the parts carrying information — are real.
+
 ## Notifications
 
 Web Push cannot work in Electron - there is no push service behind it - so the
@@ -178,6 +215,10 @@ src/main/auth.js            OAuth sign-in taken over from the login view's links
 src/main/menu.js            application menu (switch server, log out)
 src/main/sse.js             event-stream client for the main process
 src/main/notifications.js   events -> native notifications, mute rules, badge
+src/main/deep-link.js       agentrq:// links -> in-app routes
+src/main/tray.js            tray menu, recent workspaces
+src/main/theme.js           native chrome follows the app's theme store
+src/main/window-state.js    remembering where the window was, safely
 src/main/index.js           lifecycle, window creation, scheme registration, IPC
 src/preload/index.js        the narrow contextBridge surface
 scripts/                    dev launcher, build, spike, e2e verification

--- a/desktop/scripts/verify-e2e.mjs
+++ b/desktop/scripts/verify-e2e.mjs
@@ -67,8 +67,12 @@ const CHECKS = `(async () => {
   probe.remove();
   record('stylesheet is applied', parseFloat(radius) > 0, 'rounded-3xl -> ' + radius);
 
-  // The desktop bridge is visible to the renderer.
-  record('desktop bridge exposed', window.agentrq?.isDesktop === true, 'platform ' + window.agentrq?.platform);
+  // The desktop bridge is visible to the renderer, with every surface the
+  // shell needs to reach it.
+  const bridge = window.agentrq ?? {};
+  const surfaces = ['connection', 'notifications', 'navigation', 'theme'].filter((k) => bridge[k]);
+  record('desktop bridge exposed', bridge.isDesktop === true && surfaces.length === 4,
+    'platform ' + bridge.platform + ', surfaces: ' + surfaces.join(', '));
 
   // Relative URL, exactly as src/api.js writes it — no absolute server URL anywhere.
   const anon = await fetch('/api/v1/auth/user');

--- a/desktop/src/main/deep-link.js
+++ b/desktop/src/main/deep-link.js
@@ -1,0 +1,77 @@
+/**
+ * `agentrq://` deep links.
+ *
+ * A link from a Slack message, an email or another app should open the desktop
+ * app at the right place. The URL maps onto the shared route table, so
+ * `agentrq://workspaces/<id>/tasks/<id>` becomes the in-app route
+ * `/workspaces/<id>/tasks/<id>`.
+ *
+ * A deep link is untrusted input from outside the app, so the result is checked
+ * against the routes that actually exist rather than passed through. Anything
+ * unrecognised opens the app at its default view — the user asked to see
+ * AgentRQ, and showing them the wrong screen is worse than showing them home.
+ *
+ * Pure, so the parsing rules are testable without Electron.
+ */
+
+export const DEEP_LINK_SCHEME = 'agentrq'
+
+/**
+ * Top-level sections a link may address. These mirror the route table in
+ * `frontend/src/app.js`; a link outside them has no destination.
+ */
+export const LINKABLE_SECTIONS = ['workspaces', 'tasks', 'events', 'workflows']
+
+/**
+ * Turn a deep-link URL into an in-app route.
+ *
+ * @param {string} url
+ * @returns {string|null} the route, or null when the link is not one we serve.
+ */
+export function parseDeepLink(url) {
+  let parsed
+  try {
+    parsed = new URL(String(url ?? ''))
+  } catch {
+    return null
+  }
+
+  if (parsed.protocol !== `${DEEP_LINK_SCHEME}:`) return null
+
+  // `agentrq://workspaces/abc` parses with host 'workspaces' and pathname
+  // '/abc', while `agentrq:///workspaces/abc` puts it all in the pathname.
+  // Both are things a link can look like in the wild, so both are accepted.
+  const raw = `${parsed.host}${parsed.pathname}`
+  const segments = raw
+    .split('/')
+    .filter((segment) => segment !== '')
+    .map((segment) => {
+      try {
+        return decodeURIComponent(segment)
+      } catch {
+        return segment
+      }
+    })
+
+  if (segments.length === 0) return '/'
+  if (!LINKABLE_SECTIONS.includes(segments[0])) return null
+
+  // Every remaining segment must be a plain identifier. This is external input,
+  // and a segment carrying a slash, a traversal or a control character has no
+  // business reaching the router.
+  const rest = segments.slice(1)
+  if (rest.some((segment) => !/^[A-Za-z0-9_-]+$/.test(segment))) return null
+
+  return `/${segments.join('/')}${parsed.search}`
+}
+
+/**
+ * Find the deep link in a set of process arguments.
+ *
+ * Windows and Linux deliver the link as an argv entry on the second launch,
+ * rather than through the `open-url` event macOS uses.
+ */
+export function deepLinkFromArgv(argv = []) {
+  const match = argv.find((arg) => typeof arg === 'string' && arg.startsWith(`${DEEP_LINK_SCHEME}://`))
+  return match ?? null
+}

--- a/desktop/src/main/index.js
+++ b/desktop/src/main/index.js
@@ -1,4 +1,19 @@
-import { app, BrowserWindow, Menu, Notification, ipcMain, nativeImage, net, protocol, session, shell } from 'electron'
+import {
+  app,
+  BrowserWindow,
+  Menu,
+  Notification,
+  Tray,
+  globalShortcut,
+  ipcMain,
+  nativeImage,
+  nativeTheme,
+  net,
+  protocol,
+  screen,
+  session,
+  shell,
+} from 'electron'
 import { readFile, writeFile, access } from 'node:fs/promises'
 import { constants } from 'node:fs'
 import { join, dirname } from 'node:path'
@@ -12,9 +27,19 @@ import {
   validateServerUrl,
 } from './server-config.js'
 import { AUTH_COOKIE, matchOAuthLogin, oauthStartUrl, runOAuthFlow } from './auth.js'
-import { buildMenuTemplate } from './menu.js'
+import { QUICK_CREATE_ACCELERATOR, buildMenuTemplate } from './menu.js'
 import { badgeFor, createNotificationGate, createUnreadCounter, mapEventToNotification } from './notifications.js'
 import { createEventStreamClient } from './sse.js'
+import { DEEP_LINK_SCHEME, deepLinkFromArgv, parseDeepLink } from './deep-link.js'
+import { buildTrayMenuTemplate, createRecentWorkspaces, trayTooltip } from './tray.js'
+import { applyTheme, backgroundColorFor } from './theme.js'
+import {
+  WINDOW_STATE_FILENAME,
+  captureWindowState,
+  clampToDisplays,
+  createWindowStateStore,
+  debounce,
+} from './window-state.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -70,6 +95,14 @@ let unread = null
 // have to be collapsed before they reach the user.
 const notificationGate = createNotificationGate()
 
+const recentWorkspaces = createRecentWorkspaces()
+let windowStateStore
+let restoredWindowState = null
+let tray = null
+let currentTheme = 'system'
+/** Set when a deep link arrives before the window is ready to receive it. */
+let pendingRoute = null
+
 async function refreshWorkspaceNames() {
   if (!serverUrl) return
   try {
@@ -85,6 +118,7 @@ async function refreshWorkspaceNames() {
 }
 
 function applyBadge(count) {
+  refreshTray()
   const { badge, overlay } = badgeFor(count, process.platform)
 
   if (app.dock) app.dock.setBadge(badge)
@@ -139,6 +173,57 @@ async function startOAuth(win, pathname, search) {
   }
 }
 
+/**
+ * Ask the renderer to navigate. The renderer owns the router the shared factory
+ * built, so routing is its job; the shell only ever names a destination.
+ *
+ * A route arriving before the window exists is held rather than dropped — a
+ * deep link is often what *launched* the app.
+ */
+function navigate(route) {
+  if (!route) return
+  const win = focusMainWindow()
+  if (!win || win.webContents.isLoading()) {
+    pendingRoute = route
+    return
+  }
+  win.webContents.send('agentrq:navigate', route)
+}
+
+function openDeepLink(url) {
+  const route = parseDeepLink(url)
+  // An unrecognised link still opens the app: the user asked to see AgentRQ,
+  // and the default view is a better answer than nothing happening.
+  focusMainWindow()
+  if (route) navigate(route)
+}
+
+/** Where "New Task" goes: the most recent workspace, else the workspace list. */
+function newTaskRoute() {
+  const [recent] = recentWorkspaces.list
+  return recent ? `/workspaces/${recent.id}/tasks/new` : '/'
+}
+
+function refreshTray() {
+  if (!tray) return
+  const count = unread?.value ?? 0
+  tray.setToolTip(trayTooltip(count))
+  tray.setContextMenu(
+    Menu.buildFromTemplate(
+      buildTrayMenuTemplate({
+        workspaces: recentWorkspaces.list,
+        unreadCount: count,
+        actions: {
+          open: () => focusMainWindow(),
+          newTask: () => navigate(newTaskRoute()),
+          openWorkspace: (id) => navigate(`/workspaces/${id}`),
+          quit: () => app.quit(),
+        },
+      })
+    )
+  )
+}
+
 function focusMainWindow() {
   const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())
   if (!win) return null
@@ -164,13 +249,14 @@ function handleStreamEvent(event) {
 
   const native = new Notification({ title: notification.title, body: notification.body })
   native.on('click', () => {
-    const win = focusMainWindow()
     unread?.clear()
-    // The renderer owns routing: it has the router the shared factory built.
-    win?.webContents.send('agentrq:notification:activate', notification.route)
+    navigate(notification.route)
   })
   native.show()
   unread?.increment()
+  // The tray is the at-a-glance version of the same news.
+  recentWorkspaces.touch(event.payload.workspaceId, workspaceNames.get(event.payload.workspaceId))
+  refreshTray()
 }
 
 function startEventStream() {
@@ -192,13 +278,20 @@ function startEventStream() {
 }
 
 function createWindow() {
+  // Saved coordinates are only safe if the display they referred to still
+  // exists — clamping is what stops a window reopening off-screen after a
+  // monitor is unplugged.
+  const bounds = clampToDisplays(
+    restoredWindowState,
+    screen.getAllDisplays().map((display) => display.workArea)
+  )
+
   const win = new BrowserWindow({
-    width: 1280,
-    height: 860,
+    ...bounds,
     minWidth: 940,
     minHeight: 600,
     show: false,
-    backgroundColor: '#fafafa',
+    backgroundColor: backgroundColorFor(currentTheme, nativeTheme.shouldUseDarkColors),
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
     webPreferences: {
       preload: PRELOAD,
@@ -208,10 +301,36 @@ function createWindow() {
     },
   })
 
-  win.once('ready-to-show', () => win.show())
+  win.once('ready-to-show', () => {
+    if (restoredWindowState?.maximized) win.maximize()
+    win.show()
+  })
 
   // A badge answers "is there anything new"; looking at the app answers it.
   win.on('focus', () => unread?.clear())
+
+  // Dragging a window emits these continuously, so the write is debounced —
+  // otherwise one gesture would be hundreds of writes.
+  const persist = debounce(() => {
+    restoredWindowState = captureWindowState(win)
+    windowStateStore?.save(restoredWindowState)
+  }, 500)
+  for (const event of ['resize', 'move', 'maximize', 'unmaximize']) {
+    win.on(event, persist)
+  }
+  win.on('close', () => {
+    restoredWindowState = captureWindowState(win)
+    windowStateStore?.save(restoredWindowState)
+  })
+
+  // A deep link often *is* what launched the app, so a route that arrived
+  // before the renderer existed is delivered once it is ready.
+  win.webContents.on('did-finish-load', () => {
+    if (!pendingRoute) return
+    const route = pendingRoute
+    pendingRoute = null
+    win.webContents.send('agentrq:navigate', route)
+  })
 
   // Anything that is not the app itself belongs in the user's real browser.
   win.webContents.setWindowOpenHandler(({ url }) => {
@@ -246,6 +365,7 @@ function installMenu(getWindow) {
     platform: process.platform,
     appName: app.getName(),
     actions: {
+      newTask: () => navigate(newTaskRoute()),
       switchServer: async () => {
         if (isConnectionLocked) return
         await configStore.clear()
@@ -273,6 +393,16 @@ function registerIpc(getWindow) {
     // The probe response carries auth flags that are of no use to the
     // connection screen and would be a needless leak across the bridge.
     return result.ok ? { ok: true, url: result.url } : result
+  })
+
+  // The renderer is the source of truth for appearance — the theme store the
+  // web app already has — so the shell follows it rather than reading the OS.
+  ipcMain.handle('agentrq:theme:set', (_event, theme) => {
+    currentTheme = theme
+    return applyTheme(theme, {
+      nativeTheme,
+      windows: () => BrowserWindow.getAllWindows().filter((w) => !w.isDestroyed()),
+    })
   })
 
   ipcMain.handle('agentrq:notifications:get', async () => ({
@@ -303,18 +433,50 @@ function registerIpc(getWindow) {
   })
 }
 
+function installTray() {
+  // An empty image is a deliberate placeholder: a tray icon is an art asset,
+  // and shipping a wrong-looking one is worse than the platform's default. The
+  // menu, count and tooltip — the parts that carry information — are real.
+  tray = new Tray(nativeImage.createEmpty())
+  refreshTray()
+  tray.on('click', () => focusMainWindow())
+}
+
+function installGlobalShortcut() {
+  // Registration fails when another application already owns the combination.
+  // That is the user's environment, not an error worth interrupting them over;
+  // the same action stays available from the menu and the tray.
+  globalShortcut.register(QUICK_CREATE_ACCELERATOR, () => navigate(newTaskRoute()))
+}
+
 // A second launch should surface the running app, not start a rival instance
 // with its own cookie jar.
 if (!app.requestSingleInstanceLock()) {
   app.quit()
 } else {
-  app.on('second-instance', () => {
-    const [win] = BrowserWindow.getAllWindows()
-    if (win) {
-      if (win.isMinimized()) win.restore()
-      win.focus()
-    }
+  // Windows and Linux deliver a deep link as an argument to a second launch,
+  // which the single-instance lock forwards here rather than opening a rival
+  // window.
+  app.on('second-instance', (_event, argv) => {
+    const url = deepLinkFromArgv(argv)
+    if (url) openDeepLink(url)
+    else focusMainWindow()
   })
+
+  // macOS delivers it as an event instead, and can do so before the app is
+  // ready — hence the pending-route handling in navigate().
+  app.on('open-url', (event, url) => {
+    event.preventDefault()
+    openDeepLink(url)
+  })
+
+  // Claim the scheme so the OS routes agentrq:// links here. In development the
+  // executable is Electron itself, which needs the path spelled out.
+  if (process.defaultApp && process.argv.length >= 2) {
+    app.setAsDefaultProtocolClient(DEEP_LINK_SCHEME, process.execPath, [process.argv[1]])
+  } else {
+    app.setAsDefaultProtocolClient(DEEP_LINK_SCHEME)
+  }
 
   app.whenReady().then(async () => {
     const configPath = join(app.getPath('userData'), CONFIG_FILENAME)
@@ -322,6 +484,13 @@ if (!app.requestSingleInstanceLock()) {
       readFile: () => readFile(configPath, 'utf-8'),
       writeFile: (contents) => writeFile(configPath, contents, 'utf-8'),
     })
+
+    const windowStatePath = join(app.getPath('userData'), WINDOW_STATE_FILENAME)
+    windowStateStore = createWindowStateStore({
+      readFile: () => readFile(windowStatePath, 'utf-8'),
+      writeFile: (contents) => writeFile(windowStatePath, contents, 'utf-8'),
+    })
+    restoredWindowState = await windowStateStore.load()
 
     const stored = await configStore.load()
     mutedWorkspaces = stored.mutedWorkspaces
@@ -350,6 +519,11 @@ if (!app.requestSingleInstanceLock()) {
     installMenu(getWindow)
     createWindow()
     startEventStream()
+    installTray()
+    installGlobalShortcut()
+
+    const launchLink = deepLinkFromArgv(process.argv)
+    if (launchLink) openDeepLink(launchLink)
 
     app.on('activate', () => {
       if (BrowserWindow.getAllWindows().length === 0) createWindow()
@@ -360,5 +534,12 @@ if (!app.requestSingleInstanceLock()) {
     if (process.platform !== 'darwin') app.quit()
   })
 
-  app.on('before-quit', () => eventStream?.stop())
+  app.on('before-quit', () => {
+    eventStream?.stop()
+    globalShortcut.unregisterAll()
+    // A quit that does not close the window first — Cmd+Q, or the tray's Quit —
+    // would otherwise lose whatever the debounced save had not yet written.
+    const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())
+    if (win) windowStateStore?.save(captureWindowState(win))
+  })
 }

--- a/desktop/src/main/menu.js
+++ b/desktop/src/main/menu.js
@@ -1,13 +1,23 @@
 /**
  * Application menu.
  *
- * Only the entries phase 3 needs live here — switching server and signing out,
- * both of which are shell concerns the web app has no equivalent for. The full
- * menu, tray and shortcuts arrive with phase 5 (task 0huaA6sKHoX).
+ * Two kinds of entry live here: the standard platform roles a desktop app is
+ * expected to have, and the AgentRQ actions the web app has no equivalent for —
+ * creating a task from anywhere, switching server, signing out, and checking
+ * for updates.
  *
  * The template is built as plain data so it can be asserted on without
  * launching Electron.
  */
+
+/**
+ * Global shortcut for quick task creation.
+ *
+ * Cmd/Ctrl+Shift+N: `Shift` keeps it clear of the browser-standard "new window"
+ * on Cmd/Ctrl+N, and this is registered *globally*, so it must not collide with
+ * a common system binding.
+ */
+export const QUICK_CREATE_ACCELERATOR = 'CommandOrControl+Shift+N'
 
 /**
  * @param {object} options
@@ -23,15 +33,34 @@ export function buildMenuTemplate({ platform, appName = 'AgentRQ', actions = {} 
     { id: 'log-out', label: 'Log Out', click: actions.logOut },
   ]
 
+  const newTaskItem = {
+    id: 'new-task',
+    label: 'New Task',
+    accelerator: QUICK_CREATE_ACCELERATOR,
+    click: actions.newTask,
+  }
+
+  // Present from the start so the menu does not shift under users later, but
+  // disabled until phase 6 (task 0huaAvwzIuH) supplies a handler — a menu item
+  // that silently does nothing is worse than one that is visibly not ready.
+  const updateItem = {
+    id: 'check-for-updates',
+    label: 'Check for Updates…',
+    enabled: Boolean(actions.checkForUpdates),
+    click: actions.checkForUpdates,
+  }
+
   const template = []
 
   if (isMac) {
-    // macOS convention puts account-level actions in the application menu,
-    // above Quit.
+    // macOS convention: about and update checks at the top of the application
+    // menu, account actions above Quit.
     template.push({
       label: appName,
       submenu: [
         { role: 'about' },
+        { type: 'separator' },
+        updateItem,
         { type: 'separator' },
         ...accountItems,
         { type: 'separator' },
@@ -49,10 +78,18 @@ export function buildMenuTemplate({ platform, appName = 'AgentRQ', actions = {} 
   template.push({
     label: 'File',
     submenu: isMac
-      ? [{ role: 'close' }]
-      : // Elsewhere there is no application menu, so the same actions live
-        // under File alongside Quit.
-        [...accountItems, { type: 'separator' }, { role: 'quit' }],
+      ? [newTaskItem, { type: 'separator' }, { role: 'close' }]
+      : // Elsewhere there is no application menu, so everything lives under
+        // File alongside Quit.
+        [
+          newTaskItem,
+          { type: 'separator' },
+          ...accountItems,
+          { type: 'separator' },
+          updateItem,
+          { type: 'separator' },
+          { role: 'quit' },
+        ],
   })
 
   template.push({ label: 'Edit', role: 'editMenu' })
@@ -71,6 +108,10 @@ export function buildMenuTemplate({ platform, appName = 'AgentRQ', actions = {} 
     ],
   })
   template.push({ label: 'Window', role: 'windowMenu' })
+
+  if (!isMac) {
+    template.push({ label: 'Help', submenu: [{ role: 'about' }] })
+  }
 
   return template
 }

--- a/desktop/src/main/theme.js
+++ b/desktop/src/main/theme.js
@@ -1,0 +1,62 @@
+/**
+ * Keeping the native chrome in step with the app's own theme.
+ *
+ * The web app has one source of truth for appearance: the `theme` value in
+ * `frontend/src/stores/themeStore.js`, which toggles a `.dark` class. The
+ * desktop shell has to follow *that*, not the OS — a user who has explicitly
+ * chosen light mode inside AgentRQ should not get a dark title bar because
+ * their system is dark.
+ *
+ * The one case where the OS does decide is the store's own 'system' setting,
+ * which is exactly what it means.
+ */
+
+/** Values the theme store can hold. */
+export const THEMES = ['system', 'light', 'dark']
+
+/**
+ * Map the app's theme onto Electron's `nativeTheme.themeSource`.
+ *
+ * The names line up, but the mapping is explicit so an unrecognised stored
+ * value degrades to following the system rather than to an arbitrary choice.
+ */
+export function themeSourceFor(theme) {
+  return THEMES.includes(theme) ? theme : 'system'
+}
+
+/**
+ * Window background colour for a theme.
+ *
+ * This is what shows during a reload, before the renderer has painted. Getting
+ * it wrong produces a white flash in dark mode on every navigation — the values
+ * match the app's own surfaces (`bg-zinc-50` and `zinc-950`).
+ *
+ * @param {string} theme       the app's setting
+ * @param {boolean} systemDark whether the OS is currently dark, used only when
+ *                             the setting is 'system'
+ */
+export function backgroundColorFor(theme, systemDark = false) {
+  const dark = theme === 'dark' || (themeSourceFor(theme) === 'system' && systemDark)
+  return dark ? '#09090b' : '#fafafa'
+}
+
+/**
+ * Apply a theme to the shell.
+ *
+ * @param {object} deps
+ * @param {{ themeSource: string, shouldUseDarkColors: boolean }} deps.nativeTheme
+ * @param {() => Array<{ setBackgroundColor: (color: string) => void }>} deps.windows
+ */
+export function applyTheme(theme, { nativeTheme, windows }) {
+  const source = themeSourceFor(theme)
+  nativeTheme.themeSource = source
+
+  // Read back rather than recomputing: with 'system' the answer is the OS's,
+  // and nativeTheme is the thing that knows it.
+  const color = backgroundColorFor(theme, nativeTheme.shouldUseDarkColors)
+  for (const win of windows()) {
+    win.setBackgroundColor(color)
+  }
+
+  return { source, color }
+}

--- a/desktop/src/main/tray.js
+++ b/desktop/src/main/tray.js
@@ -1,0 +1,90 @@
+/**
+ * Tray / menu-bar item.
+ *
+ * The point of a tray item is to answer "is anything waiting for me?" without
+ * switching to the app, and to get somewhere in one click when the answer is
+ * yes. So it carries the unread count and the workspaces the user has heard
+ * from most recently.
+ *
+ * Built as plain data, so the contents are testable without a running Electron.
+ */
+
+/** Most recent workspaces to offer. Enough to be useful, short enough to scan. */
+export const MAX_RECENT_WORKSPACES = 5
+
+/**
+ * Track which workspaces have been active most recently.
+ *
+ * Ordered by last activity rather than alphabetically: the tray is a shortcut
+ * to what is happening now, and a fixed list would make it a worse version of
+ * the sidebar.
+ */
+export function createRecentWorkspaces({ limit = MAX_RECENT_WORKSPACES } = {}) {
+  let recent = []
+
+  return {
+    /** Record activity, moving the workspace to the front. */
+    touch(id, name) {
+      if (!id) return recent
+      recent = [{ id, name: name ?? '' }, ...recent.filter((entry) => entry.id !== id)].slice(0, limit)
+      return recent
+    },
+
+    /** Fill in names that were unknown when the activity was recorded. */
+    rename(id, name) {
+      recent = recent.map((entry) => (entry.id === id ? { ...entry, name } : entry))
+      return recent
+    },
+
+    get list() {
+      return recent
+    },
+  }
+}
+
+/**
+ * Tray menu contents.
+ *
+ * @param {object} options
+ * @param {Array<{id: string, name: string}>} [options.workspaces]
+ * @param {number} [options.unreadCount]
+ * @param {object} [options.actions]
+ */
+export function buildTrayMenuTemplate({ workspaces = [], unreadCount = 0, actions = {} }) {
+  const template = [
+    {
+      id: 'status',
+      // The count is the whole reason to glance at the tray, so it leads.
+      label: unreadCount > 0 ? `${unreadCount} unread` : 'No unread notifications',
+      enabled: false,
+    },
+    { type: 'separator' },
+    { id: 'open', label: 'Open AgentRQ', click: actions.open },
+    { id: 'new-task', label: 'New Task…', click: actions.newTask },
+  ]
+
+  if (workspaces.length > 0) {
+    template.push({ type: 'separator' })
+    template.push({ id: 'recent-heading', label: 'Recent Workspaces', enabled: false })
+    for (const workspace of workspaces) {
+      template.push({
+        id: `workspace-${workspace.id}`,
+        // A workspace whose name has not been resolved yet still deserves a
+        // usable entry rather than a blank line.
+        label: workspace.name || 'Untitled workspace',
+        click: () => actions.openWorkspace?.(workspace.id),
+      })
+    }
+  }
+
+  template.push({ type: 'separator' })
+  template.push({ id: 'quit', label: 'Quit AgentRQ', click: actions.quit })
+
+  return template
+}
+
+/** Tooltip shown on hover. */
+export function trayTooltip(unreadCount) {
+  if (unreadCount <= 0) return 'AgentRQ'
+  return `AgentRQ — ${unreadCount} unread notification${unreadCount === 1 ? '' : 's'}`
+}

--- a/desktop/src/main/window-state.js
+++ b/desktop/src/main/window-state.js
@@ -1,0 +1,141 @@
+/**
+ * Remembering where the window was.
+ *
+ * Restoring a window to its last position is only safe if that position still
+ * exists: a laptop undocked from a second monitor, or a display resolution
+ * change, can leave saved coordinates entirely off-screen — a window the user
+ * cannot see, drag or close. Everything here is about avoiding that.
+ *
+ * Stored separately from the app settings because it changes on every move and
+ * resize; rewriting the settings file that often would be needless churn on a
+ * file that matters more.
+ */
+
+export const WINDOW_STATE_FILENAME = 'agentrq-window.json'
+
+export const DEFAULT_WINDOW_STATE = {
+  width: 1280,
+  height: 860,
+  maximized: false,
+}
+
+/** Never restore a window smaller than this; it matches the window's minimums. */
+export const MIN_WIDTH = 940
+export const MIN_HEIGHT = 600
+
+function isFiniteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+/**
+ * Constrain saved bounds to a display that actually exists.
+ *
+ * @param {object} bounds  the saved `{ x, y, width, height }`
+ * @param {Array<{x:number,y:number,width:number,height:number}>} displays
+ *        work areas of the currently attached displays
+ * @returns {object} bounds guaranteed to be visible, or size-only when there is
+ *          no sensible position (letting the platform centre the window)
+ */
+export function clampToDisplays(bounds, displays) {
+  const width = Math.max(MIN_WIDTH, isFiniteNumber(bounds?.width) ? bounds.width : DEFAULT_WINDOW_STATE.width)
+  const height = Math.max(MIN_HEIGHT, isFiniteNumber(bounds?.height) ? bounds.height : DEFAULT_WINDOW_STATE.height)
+
+  if (!Array.isArray(displays) || displays.length === 0) return { width, height }
+  if (!isFiniteNumber(bounds?.x) || !isFiniteNumber(bounds?.y)) return { width, height }
+
+  // "Visible" means a real overlap with some display, not merely a corner
+  // touching it — a window one pixel on screen is a window the user has lost.
+  const MIN_VISIBLE = 80
+  const target = displays.find((display) => {
+    const overlapX = Math.min(bounds.x + width, display.x + display.width) - Math.max(bounds.x, display.x)
+    const overlapY = Math.min(bounds.y + height, display.y + display.height) - Math.max(bounds.y, display.y)
+    return overlapX >= MIN_VISIBLE && overlapY >= MIN_VISIBLE
+  })
+
+  // The saved position is gone — a monitor was unplugged, most likely. Return
+  // size only so the window opens centred on the primary display rather than
+  // somewhere the user cannot reach it.
+  if (!target) return { width, height }
+
+  // Shrink to fit a smaller display before positioning, so a window saved on a
+  // large monitor does not overflow a laptop screen.
+  const fittedWidth = Math.min(width, target.width)
+  const fittedHeight = Math.min(height, target.height)
+
+  return {
+    x: Math.round(Math.min(Math.max(bounds.x, target.x), target.x + target.width - fittedWidth)),
+    y: Math.round(Math.min(Math.max(bounds.y, target.y), target.y + target.height - fittedHeight)),
+    width: Math.round(fittedWidth),
+    height: Math.round(fittedHeight),
+  }
+}
+
+/** Coerce whatever was on disk into a state object. */
+export function normalizeWindowState(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { ...DEFAULT_WINDOW_STATE }
+
+  return {
+    ...(isFiniteNumber(raw.x) ? { x: raw.x } : {}),
+    ...(isFiniteNumber(raw.y) ? { y: raw.y } : {}),
+    width: isFiniteNumber(raw.width) ? Math.max(MIN_WIDTH, raw.width) : DEFAULT_WINDOW_STATE.width,
+    height: isFiniteNumber(raw.height) ? Math.max(MIN_HEIGHT, raw.height) : DEFAULT_WINDOW_STATE.height,
+    maximized: raw.maximized === true,
+  }
+}
+
+/**
+ * @param {object} deps
+ * @param {() => Promise<string>} deps.readFile   rejects when absent
+ * @param {(contents: string) => Promise<void>} deps.writeFile
+ */
+export function createWindowStateStore({ readFile, writeFile }) {
+  return {
+    async load() {
+      try {
+        return normalizeWindowState(JSON.parse(await readFile()))
+      } catch {
+        // Missing or corrupt: the defaults are a perfectly good window.
+        return { ...DEFAULT_WINDOW_STATE }
+      }
+    },
+
+    async save(state) {
+      await writeFile(JSON.stringify(normalizeWindowState(state), null, 2))
+    },
+  }
+}
+
+/**
+ * Capture a window's current state.
+ *
+ * A maximized or minimized window reports its *current* bounds, which are the
+ * screen, not the size to restore to. `getNormalBounds` gives the size the
+ * window had before, which is what should be remembered.
+ */
+export function captureWindowState(win) {
+  const bounds = win.getNormalBounds ? win.getNormalBounds() : win.getBounds()
+  return {
+    x: bounds.x,
+    y: bounds.y,
+    width: bounds.width,
+    height: bounds.height,
+    maximized: win.isMaximized(),
+  }
+}
+
+/**
+ * Collapse a burst of move/resize events into one write.
+ *
+ * Dragging a window emits these continuously; writing the file on each would be
+ * hundreds of writes for one gesture.
+ */
+export function debounce(fn, ms, { setTimer = setTimeout, clearTimer = clearTimeout } = {}) {
+  let handle = null
+  return (...args) => {
+    if (handle !== null) clearTimer(handle)
+    handle = setTimer(() => {
+      handle = null
+      fn(...args)
+    }, ms)
+  }
+}

--- a/desktop/src/preload/index.js
+++ b/desktop/src/preload/index.js
@@ -32,17 +32,31 @@ contextBridge.exposeInMainWorld('agentrq', {
     setMuted: (workspaceId, muted) =>
       ipcRenderer.invoke('agentrq:notifications:setMuted', workspaceId, muted),
 
+  },
+
+  navigation: {
     /**
-     * Called with the in-app route when the user clicks a notification.
+     * Called with an in-app route whenever the shell asks the app to go
+     * somewhere: a notification click, a deep link, the tray, the global
+     * shortcut, or the menu.
+     *
      * Only the callback crosses the bridge — never the IPC event object, which
      * would hand the renderer a handle back into the main process.
      *
      * @returns {() => void} unsubscribe
      */
-    onActivate: (callback) => {
+    onNavigate: (callback) => {
       const listener = (_event, route) => callback(route)
-      ipcRenderer.on('agentrq:notification:activate', listener)
-      return () => ipcRenderer.off('agentrq:notification:activate', listener)
+      ipcRenderer.on('agentrq:navigate', listener)
+      return () => ipcRenderer.off('agentrq:navigate', listener)
     },
+  },
+
+  theme: {
+    /**
+     * Tell the shell which theme the app is using, so the native chrome follows
+     * the app's own setting rather than the operating system's.
+     */
+    set: (theme) => ipcRenderer.invoke('agentrq:theme:set', theme),
   },
 })

--- a/desktop/src/renderer/main.js
+++ b/desktop/src/renderer/main.js
@@ -19,10 +19,11 @@
  * and updates arrive through electron-updater (phase 6, task 0huaAvwzIuH)
  * rather than a waiting worker.
  */
-import { createApp } from 'vue'
+import { createApp, watch } from 'vue'
 import { createWebHistory } from 'vue-router'
 
 import { createAgentRQApp } from '@app/app'
+import { useThemeStore } from '@app/stores/themeStore'
 import ConnectionView from '@app/desktop/ConnectionView.vue'
 
 // A failure here means the shell could not answer, which is not something the
@@ -38,16 +39,28 @@ if (connection.configured) {
     platform: 'desktop',
   })
 
-  // Clicking a native notification lands here: the shell has already focused
-  // the window, and the router the shared factory built does the navigating.
-  window.agentrq.notifications?.onActivate((route) => {
+  // Every "go here" from the shell arrives on one channel: notification
+  // clicks, agentrq:// deep links, the tray, the global shortcut and the menu.
+  // The shell names a destination; the router the shared factory built does
+  // the navigating.
+  window.agentrq.navigation?.onNavigate((route) => {
     router.push(route).catch(() => {
       // An unknown or unchanged route is not worth surfacing — the window is
-      // focused either way, which is most of what the click asked for.
+      // focused either way, which is most of what the request asked for.
     })
   })
 
   app.mount('#app')
+
+  // The theme store is the app's single source of truth for appearance, so the
+  // native chrome follows it rather than the OS. Mounting first means pinia is
+  // active and the stored preference has already been applied.
+  const themeStore = useThemeStore()
+  window.agentrq.theme?.set(themeStore.theme)
+  watch(
+    () => themeStore.theme,
+    (theme) => window.agentrq.theme?.set(theme)
+  )
 } else {
   createApp(ConnectionView, { initialUrl: connection.serverUrl }).mount('#app')
 }

--- a/desktop/test/deep-link.test.js
+++ b/desktop/test/deep-link.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  DEEP_LINK_SCHEME,
+  LINKABLE_SECTIONS,
+  deepLinkFromArgv,
+  parseDeepLink,
+} from '../src/main/deep-link.js'
+
+describe('parseDeepLink', () => {
+  it('maps a workspace link onto its route', () => {
+    expect(parseDeepLink('agentrq://workspaces/0ZzhYQG2qtl')).toBe('/workspaces/0ZzhYQG2qtl')
+  })
+
+  it('maps a task link onto its route', () => {
+    expect(parseDeepLink('agentrq://workspaces/0ZzhYQG2qtl/tasks/0hua6QI7nXN')).toBe(
+      '/workspaces/0ZzhYQG2qtl/tasks/0hua6QI7nXN'
+    )
+  })
+
+  it('accepts every section the route table exposes', () => {
+    for (const section of LINKABLE_SECTIONS) {
+      expect(parseDeepLink(`agentrq://${section}/abc`)).toBe(`/${section}/abc`)
+    }
+  })
+
+  it('accepts the triple-slash form a link can also take', () => {
+    // agentrq://workspaces/x puts 'workspaces' in the host; agentrq:///workspaces/x
+    // puts it in the path. Both are things that turn up in the wild.
+    expect(parseDeepLink('agentrq:///workspaces/abc')).toBe('/workspaces/abc')
+  })
+
+  it('opens the default view for a bare link', () => {
+    expect(parseDeepLink('agentrq://')).toBe('/')
+    expect(parseDeepLink('agentrq:///')).toBe('/')
+  })
+
+  it('keeps a query string', () => {
+    expect(parseDeepLink('agentrq://tasks/all?filter=mine')).toBe('/tasks/all?filter=mine')
+  })
+
+  it('decodes percent-encoded segments', () => {
+    expect(parseDeepLink('agentrq://workspaces/abc%2Ddef')).toBe('/workspaces/abc-def')
+  })
+
+  it('refuses another scheme', () => {
+    // Otherwise any page could hand the shell an https:// URL to "navigate" to.
+    expect(parseDeepLink('https://evil.example.com/workspaces/abc')).toBeNull()
+    expect(parseDeepLink('file:///etc/passwd')).toBeNull()
+  })
+
+  it('refuses a section that is not a route', () => {
+    expect(parseDeepLink('agentrq://admin/abc')).toBeNull()
+    expect(parseDeepLink('agentrq://api/v1/auth/user')).toBeNull()
+  })
+
+  it('refuses a segment that is not a plain identifier', () => {
+    // Deep links are external input; a segment carrying a traversal, a slash or
+    // a control character has no business reaching the router.
+    expect(parseDeepLink('agentrq://workspaces/..%2F..%2Fetc')).toBeNull()
+    expect(parseDeepLink('agentrq://workspaces/a%00b')).toBeNull()
+    expect(parseDeepLink('agentrq://workspaces/a b')).toBeNull()
+  })
+
+  it('refuses anything unparseable', () => {
+    expect(parseDeepLink('not a url')).toBeNull()
+    expect(parseDeepLink('')).toBeNull()
+    expect(parseDeepLink(null)).toBeNull()
+    expect(parseDeepLink(undefined)).toBeNull()
+  })
+
+  it('tolerates a malformed escape rather than throwing', () => {
+    // decodeURIComponent throws on '%zz'; the segment is then judged as-is,
+    // and '%' is not a valid identifier character.
+    expect(parseDeepLink('agentrq://workspaces/%zz')).toBeNull()
+  })
+
+  it('names its scheme', () => {
+    expect(DEEP_LINK_SCHEME).toBe('agentrq')
+  })
+})
+
+describe('deepLinkFromArgv', () => {
+  it('finds the link Windows and Linux pass as an argument', () => {
+    const argv = ['/path/to/AgentRQ', '--flag', 'agentrq://workspaces/abc']
+    expect(deepLinkFromArgv(argv)).toBe('agentrq://workspaces/abc')
+  })
+
+  it('returns nothing when there is no link', () => {
+    expect(deepLinkFromArgv(['/path/to/AgentRQ', '--flag'])).toBeNull()
+    expect(deepLinkFromArgv([])).toBeNull()
+    expect(deepLinkFromArgv()).toBeNull()
+  })
+
+  it('ignores non-string arguments', () => {
+    expect(deepLinkFromArgv([null, 42, 'agentrq://events'])).toBe('agentrq://events')
+  })
+})

--- a/desktop/test/menu.test.js
+++ b/desktop/test/menu.test.js
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from 'vitest'
 
-import { buildMenuTemplate, findMenuItems } from '../src/main/menu.js'
+import { QUICK_CREATE_ACCELERATOR, buildMenuTemplate, findMenuItems } from '../src/main/menu.js'
 
-const actions = { switchServer: vi.fn(), logOut: vi.fn() }
+const actions = { switchServer: vi.fn(), logOut: vi.fn(), newTask: vi.fn(), checkForUpdates: vi.fn() }
 
 describe('buildMenuTemplate', () => {
   it('offers switch-server and log-out on macOS', () => {
@@ -62,6 +62,55 @@ describe('buildMenuTemplate', () => {
 
     expect(template[0].label).toBe('AgentRQ')
     expect(findMenuItems(template, 'switch-server')[0].click).toBeUndefined()
+  })
+})
+
+describe('buildMenuTemplate — AgentRQ actions', () => {
+  it('offers New Task on every platform, with the global accelerator', () => {
+    for (const platform of ['darwin', 'win32', 'linux']) {
+      const item = findMenuItems(buildMenuTemplate({ platform, actions }), 'new-task')[0]
+      expect(item, platform).toBeTruthy()
+      expect(item.accelerator).toBe(QUICK_CREATE_ACCELERATOR)
+    }
+  })
+
+  it('keeps the quick-create shortcut clear of the standard new-window binding', () => {
+    // It is registered globally, so it must not collide with Cmd/Ctrl+N.
+    expect(QUICK_CREATE_ACCELERATOR).toBe('CommandOrControl+Shift+N')
+  })
+
+  it('offers Check for Updates on every platform', () => {
+    for (const platform of ['darwin', 'win32', 'linux']) {
+      expect(findMenuItems(buildMenuTemplate({ platform, actions }), 'check-for-updates'), platform)
+        .toHaveLength(1)
+    }
+  })
+
+  it('disables Check for Updates until an updater is wired in', () => {
+    // Phase 6 supplies the handler. A menu item that silently does nothing is
+    // worse than one that is visibly not ready.
+    const without = buildMenuTemplate({ platform: 'darwin', actions: { switchServer: vi.fn() } })
+    expect(findMenuItems(without, 'check-for-updates')[0].enabled).toBe(false)
+
+    const with_ = buildMenuTemplate({ platform: 'darwin', actions })
+    expect(findMenuItems(with_, 'check-for-updates')[0].enabled).toBe(true)
+  })
+
+  it('dispatches the AgentRQ actions', () => {
+    const newTask = vi.fn()
+    const checkForUpdates = vi.fn()
+    const template = buildMenuTemplate({ platform: 'darwin', actions: { newTask, checkForUpdates } })
+
+    findMenuItems(template, 'new-task')[0].click()
+    findMenuItems(template, 'check-for-updates')[0].click()
+
+    expect(newTask).toHaveBeenCalledOnce()
+    expect(checkForUpdates).toHaveBeenCalledOnce()
+  })
+
+  it('gives Windows and Linux a Help menu, which macOS gets for free', () => {
+    expect(buildMenuTemplate({ platform: 'linux', actions }).map((i) => i.label)).toContain('Help')
+    expect(buildMenuTemplate({ platform: 'darwin', actions }).map((i) => i.label)).not.toContain('Help')
   })
 })
 

--- a/desktop/test/theme.test.js
+++ b/desktop/test/theme.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { THEMES, applyTheme, backgroundColorFor, themeSourceFor } from '../src/main/theme.js'
+
+describe('themeSourceFor', () => {
+  it('passes the app\'s own setting through', () => {
+    for (const theme of THEMES) {
+      expect(themeSourceFor(theme)).toBe(theme)
+    }
+  })
+
+  it('follows the system for an unrecognised value', () => {
+    for (const bad of ['sepia', '', null, undefined, 42]) {
+      expect(themeSourceFor(bad)).toBe('system')
+    }
+  })
+})
+
+describe('backgroundColorFor', () => {
+  it('uses the app\'s dark surface in dark mode', () => {
+    expect(backgroundColorFor('dark')).toBe('#09090b')
+  })
+
+  it('uses the app\'s light surface in light mode', () => {
+    expect(backgroundColorFor('light')).toBe('#fafafa')
+  })
+
+  it('ignores the system when the user chose explicitly', () => {
+    // The whole point: a user who picked light inside AgentRQ should not get a
+    // dark shell because their OS is dark.
+    expect(backgroundColorFor('light', true)).toBe('#fafafa')
+    expect(backgroundColorFor('dark', false)).toBe('#09090b')
+  })
+
+  it('follows the system only when the setting says to', () => {
+    expect(backgroundColorFor('system', true)).toBe('#09090b')
+    expect(backgroundColorFor('system', false)).toBe('#fafafa')
+  })
+
+  it('treats an unknown setting as system', () => {
+    expect(backgroundColorFor('sepia', true)).toBe('#09090b')
+  })
+})
+
+describe('applyTheme', () => {
+  const makeWindow = () => ({ setBackgroundColor: vi.fn() })
+
+  it('sets the native theme source from the app setting', () => {
+    const nativeTheme = { themeSource: 'system', shouldUseDarkColors: true }
+
+    const result = applyTheme('light', { nativeTheme, windows: () => [] })
+
+    expect(nativeTheme.themeSource).toBe('light')
+    expect(result.source).toBe('light')
+  })
+
+  it('repaints every open window', () => {
+    // The background is what shows during a reload, before the renderer paints
+    // — getting it wrong is a white flash on every navigation in dark mode.
+    const windows = [makeWindow(), makeWindow()]
+    const nativeTheme = { themeSource: 'system', shouldUseDarkColors: false }
+
+    applyTheme('dark', { nativeTheme, windows: () => windows })
+
+    for (const win of windows) {
+      expect(win.setBackgroundColor).toHaveBeenCalledWith('#09090b')
+    }
+  })
+
+  it('asks nativeTheme what system currently means', () => {
+    // With 'system' the answer belongs to the OS, and nativeTheme is the thing
+    // that knows it — recomputing here would be a guess.
+    const nativeTheme = { themeSource: 'light', shouldUseDarkColors: true }
+
+    const result = applyTheme('system', { nativeTheme, windows: () => [] })
+
+    expect(result).toEqual({ source: 'system', color: '#09090b' })
+  })
+
+  it('degrades an unknown setting to following the system', () => {
+    const nativeTheme = { themeSource: 'dark', shouldUseDarkColors: false }
+
+    expect(applyTheme('nonsense', { nativeTheme, windows: () => [] })).toEqual({
+      source: 'system',
+      color: '#fafafa',
+    })
+  })
+})

--- a/desktop/test/tray.test.js
+++ b/desktop/test/tray.test.js
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import {
+  MAX_RECENT_WORKSPACES,
+  buildTrayMenuTemplate,
+  createRecentWorkspaces,
+  trayTooltip,
+} from '../src/main/tray.js'
+import { findMenuItems } from '../src/main/menu.js'
+
+describe('createRecentWorkspaces', () => {
+  it('records activity', () => {
+    const recent = createRecentWorkspaces()
+    expect(recent.touch('ws1', 'Alpha')).toEqual([{ id: 'ws1', name: 'Alpha' }])
+  })
+
+  it('orders by most recent, not by name', () => {
+    // The tray is a shortcut to what is happening now; a fixed order would
+    // make it a worse version of the sidebar.
+    const recent = createRecentWorkspaces()
+    recent.touch('ws1', 'Alpha')
+    recent.touch('ws2', 'Beta')
+
+    expect(recent.list.map((w) => w.id)).toEqual(['ws2', 'ws1'])
+  })
+
+  it('moves a repeat visitor to the front without duplicating it', () => {
+    const recent = createRecentWorkspaces()
+    recent.touch('ws1', 'Alpha')
+    recent.touch('ws2', 'Beta')
+    recent.touch('ws1', 'Alpha')
+
+    expect(recent.list.map((w) => w.id)).toEqual(['ws1', 'ws2'])
+  })
+
+  it('keeps the list short enough to scan', () => {
+    const recent = createRecentWorkspaces()
+    for (let i = 0; i < 12; i += 1) recent.touch(`ws${i}`, `W${i}`)
+
+    expect(recent.list).toHaveLength(MAX_RECENT_WORKSPACES)
+    expect(recent.list[0].id).toBe('ws11')
+  })
+
+  it('honours a custom limit', () => {
+    const recent = createRecentWorkspaces({ limit: 2 })
+    recent.touch('a')
+    recent.touch('b')
+    recent.touch('c')
+
+    expect(recent.list.map((w) => w.id)).toEqual(['c', 'b'])
+  })
+
+  it('ignores activity with no workspace', () => {
+    const recent = createRecentWorkspaces()
+    expect(recent.touch(undefined, 'Nameless')).toEqual([])
+  })
+
+  it('fills in a name that was unknown at the time', () => {
+    // Activity can arrive before the workspace list has been fetched.
+    const recent = createRecentWorkspaces()
+    recent.touch('ws1')
+
+    expect(recent.rename('ws1', 'Alpha')).toEqual([{ id: 'ws1', name: 'Alpha' }])
+    expect(recent.rename('unknown', 'x')).toEqual([{ id: 'ws1', name: 'Alpha' }])
+  })
+
+  it('stores an empty name rather than undefined', () => {
+    const recent = createRecentWorkspaces()
+    expect(recent.touch('ws1')).toEqual([{ id: 'ws1', name: '' }])
+  })
+})
+
+describe('buildTrayMenuTemplate', () => {
+  const actions = { open: vi.fn(), newTask: vi.fn(), openWorkspace: vi.fn(), quit: vi.fn() }
+
+  it('leads with the unread count, which is why anyone looks', () => {
+    expect(buildTrayMenuTemplate({ unreadCount: 3, actions })[0]).toMatchObject({
+      id: 'status',
+      label: '3 unread',
+      enabled: false,
+    })
+  })
+
+  it('says so plainly when there is nothing waiting', () => {
+    expect(buildTrayMenuTemplate({ unreadCount: 0, actions })[0].label).toBe('No unread notifications')
+  })
+
+  it('always offers open, new task and quit', () => {
+    const template = buildTrayMenuTemplate({ actions })
+
+    for (const id of ['open', 'new-task', 'quit']) {
+      expect(findMenuItems(template, id)).toHaveLength(1)
+    }
+  })
+
+  it('lists recent workspaces when there are any', () => {
+    const template = buildTrayMenuTemplate({
+      workspaces: [{ id: 'ws1', name: 'Alpha' }, { id: 'ws2', name: 'Beta' }],
+      actions,
+    })
+
+    expect(findMenuItems(template, 'workspace-ws1')[0].label).toBe('Alpha')
+    expect(findMenuItems(template, 'workspace-ws2')[0].label).toBe('Beta')
+    expect(findMenuItems(template, 'recent-heading')).toHaveLength(1)
+  })
+
+  it('omits the recent section entirely when there is nothing to list', () => {
+    const template = buildTrayMenuTemplate({ workspaces: [], actions })
+    expect(findMenuItems(template, 'recent-heading')).toEqual([])
+  })
+
+  it('gives an unnamed workspace a usable label rather than a blank line', () => {
+    const template = buildTrayMenuTemplate({ workspaces: [{ id: 'ws1', name: '' }], actions })
+    expect(findMenuItems(template, 'workspace-ws1')[0].label).toBe('Untitled workspace')
+  })
+
+  it('wires each action', () => {
+    const open = vi.fn()
+    const newTask = vi.fn()
+    const openWorkspace = vi.fn()
+    const quit = vi.fn()
+    const template = buildTrayMenuTemplate({
+      workspaces: [{ id: 'ws1', name: 'Alpha' }],
+      actions: { open, newTask, openWorkspace, quit },
+    })
+
+    findMenuItems(template, 'open')[0].click()
+    findMenuItems(template, 'new-task')[0].click()
+    findMenuItems(template, 'workspace-ws1')[0].click()
+    findMenuItems(template, 'quit')[0].click()
+
+    expect(open).toHaveBeenCalledOnce()
+    expect(newTask).toHaveBeenCalledOnce()
+    expect(openWorkspace).toHaveBeenCalledWith('ws1')
+    expect(quit).toHaveBeenCalledOnce()
+  })
+
+  it('does not throw when no actions are supplied', () => {
+    const template = buildTrayMenuTemplate({ workspaces: [{ id: 'ws1', name: 'Alpha' }] })
+    expect(() => findMenuItems(template, 'workspace-ws1')[0].click()).not.toThrow()
+  })
+})
+
+describe('trayTooltip', () => {
+  it('is just the name when nothing is waiting', () => {
+    expect(trayTooltip(0)).toBe('AgentRQ')
+  })
+
+  it('carries the count when something is', () => {
+    expect(trayTooltip(4)).toBe('AgentRQ — 4 unread notifications')
+  })
+
+  it('gets the singular right', () => {
+    expect(trayTooltip(1)).toBe('AgentRQ — 1 unread notification')
+  })
+})

--- a/desktop/test/window-state.test.js
+++ b/desktop/test/window-state.test.js
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import {
+  DEFAULT_WINDOW_STATE,
+  MIN_HEIGHT,
+  MIN_WIDTH,
+  captureWindowState,
+  clampToDisplays,
+  createWindowStateStore,
+  debounce,
+  normalizeWindowState,
+} from '../src/main/window-state.js'
+
+const laptop = { x: 0, y: 0, width: 1440, height: 900 }
+const external = { x: 1440, y: 0, width: 2560, height: 1440 }
+
+describe('clampToDisplays', () => {
+  it('keeps a position that is still on a display', () => {
+    expect(clampToDisplays({ x: 100, y: 100, width: 1200, height: 800 }, [laptop])).toEqual({
+      x: 100,
+      y: 100,
+      width: 1200,
+      height: 800,
+    })
+  })
+
+  it('keeps a position on a secondary display', () => {
+    expect(clampToDisplays({ x: 1600, y: 200, width: 1200, height: 800 }, [laptop, external])).toMatchObject({
+      x: 1600,
+      y: 200,
+    })
+  })
+
+  it('drops a position whose display is gone', () => {
+    // The classic case: saved on an external monitor, reopened after
+    // undocking. Returning size only lets the platform centre the window
+    // rather than placing it where the user cannot see or drag it.
+    expect(clampToDisplays({ x: 2000, y: 300, width: 1200, height: 800 }, [laptop])).toEqual({
+      width: 1200,
+      height: 800,
+    })
+  })
+
+  it('drops a position that is barely on screen', () => {
+    // A window with a few pixels showing is a window the user has lost.
+    expect(clampToDisplays({ x: 1400, y: 100, width: 1200, height: 800 }, [laptop])).toEqual({
+      width: 1200,
+      height: 800,
+    })
+  })
+
+  it('pulls a partly off-screen window back into view', () => {
+    const result = clampToDisplays({ x: 1000, y: 700, width: 1200, height: 800 }, [laptop])
+    expect(result.x).toBe(240)
+    expect(result.y).toBe(100)
+  })
+
+  it('shrinks a window saved on a larger display', () => {
+    const result = clampToDisplays({ x: 1440, y: 0, width: 2400, height: 1300 }, [external])
+    expect(result.width).toBe(2400)
+    expect(clampToDisplays({ x: 0, y: 0, width: 2400, height: 1300 }, [laptop])).toEqual({
+      x: 0,
+      y: 0,
+      width: 1440,
+      height: 900,
+    })
+  })
+
+  it('never restores a window below its minimum size', () => {
+    expect(clampToDisplays({ x: 0, y: 0, width: 100, height: 100 }, [laptop])).toMatchObject({
+      width: MIN_WIDTH,
+      height: MIN_HEIGHT,
+    })
+  })
+
+  it('falls back to defaults when there is nothing usable', () => {
+    expect(clampToDisplays(null, [laptop])).toEqual({
+      width: DEFAULT_WINDOW_STATE.width,
+      height: DEFAULT_WINDOW_STATE.height,
+    })
+    expect(clampToDisplays({ width: 1200, height: 800 }, [])).toEqual({ width: 1200, height: 800 })
+    expect(clampToDisplays({ width: 1200, height: 800 }, null)).toEqual({ width: 1200, height: 800 })
+  })
+
+  it('ignores a position that is not a real number', () => {
+    for (const bad of [NaN, Infinity, '100', null]) {
+      expect(clampToDisplays({ x: bad, y: 0, width: 1200, height: 800 }, [laptop])).toEqual({
+        width: 1200,
+        height: 800,
+      })
+    }
+  })
+})
+
+describe('normalizeWindowState', () => {
+  it('keeps a well-formed state', () => {
+    expect(normalizeWindowState({ x: 10, y: 20, width: 1200, height: 800, maximized: true })).toEqual({
+      x: 10,
+      y: 20,
+      width: 1200,
+      height: 800,
+      maximized: true,
+    })
+  })
+
+  it('drops a position that is not usable but keeps the size', () => {
+    expect(normalizeWindowState({ width: 1200, height: 800 })).toEqual({
+      width: 1200,
+      height: 800,
+      maximized: false,
+    })
+  })
+
+  it('raises a too-small size to the minimum', () => {
+    expect(normalizeWindowState({ width: 10, height: 10 })).toMatchObject({
+      width: MIN_WIDTH,
+      height: MIN_HEIGHT,
+    })
+  })
+
+  it('falls back to the default size when the stored one is unusable', () => {
+    // A file written by an older build, or one truncated mid-write, can carry a
+    // position but no size.
+    expect(normalizeWindowState({ x: 10, y: 20 })).toEqual({
+      x: 10,
+      y: 20,
+      width: DEFAULT_WINDOW_STATE.width,
+      height: DEFAULT_WINDOW_STATE.height,
+      maximized: false,
+    })
+    expect(normalizeWindowState({ width: NaN, height: '800' })).toMatchObject({
+      width: DEFAULT_WINDOW_STATE.width,
+      height: DEFAULT_WINDOW_STATE.height,
+    })
+  })
+
+  it('falls back to defaults for anything unusable', () => {
+    for (const raw of [null, undefined, 'string', 42, []]) {
+      expect(normalizeWindowState(raw)).toEqual(DEFAULT_WINDOW_STATE)
+    }
+  })
+
+  it('treats a non-boolean maximized as false', () => {
+    expect(normalizeWindowState({ width: 1200, height: 800, maximized: 'yes' }).maximized).toBe(false)
+  })
+})
+
+describe('createWindowStateStore', () => {
+  function makeStore(initial = null) {
+    let contents = initial
+    return {
+      store: createWindowStateStore({
+        readFile: async () => {
+          if (contents === null) throw new Error('ENOENT')
+          return contents
+        },
+        writeFile: async (next) => {
+          contents = next
+        },
+      }),
+      read: () => contents,
+    }
+  }
+
+  it('returns defaults on first run', async () => {
+    const { store } = makeStore(null)
+    expect(await store.load()).toEqual(DEFAULT_WINDOW_STATE)
+  })
+
+  it('returns defaults for a corrupt file rather than failing to open', async () => {
+    const { store } = makeStore('{ not json')
+    expect(await store.load()).toEqual(DEFAULT_WINDOW_STATE)
+  })
+
+  it('round-trips a state', async () => {
+    const { store } = makeStore(null)
+    await store.save({ x: 10, y: 20, width: 1200, height: 800, maximized: false })
+    expect(await store.load()).toEqual({ x: 10, y: 20, width: 1200, height: 800, maximized: false })
+  })
+
+  it('normalises on the way in as well as out', async () => {
+    const { store, read } = makeStore(null)
+    await store.save({ width: 10, height: 10 })
+    expect(JSON.parse(read())).toMatchObject({ width: MIN_WIDTH, height: MIN_HEIGHT })
+  })
+})
+
+describe('captureWindowState', () => {
+  it('records the restore size, not the maximized size', () => {
+    // getBounds on a maximized window reports the screen; restoring to that
+    // would lose the size the user actually chose.
+    const win = {
+      getNormalBounds: () => ({ x: 10, y: 20, width: 1200, height: 800 }),
+      getBounds: () => ({ x: 0, y: 0, width: 2560, height: 1440 }),
+      isMaximized: () => true,
+    }
+
+    expect(captureWindowState(win)).toEqual({ x: 10, y: 20, width: 1200, height: 800, maximized: true })
+  })
+
+  it('falls back to getBounds when normal bounds are unavailable', () => {
+    const win = {
+      getBounds: () => ({ x: 5, y: 6, width: 1000, height: 700 }),
+      isMaximized: () => false,
+    }
+
+    expect(captureWindowState(win)).toEqual({ x: 5, y: 6, width: 1000, height: 700, maximized: false })
+  })
+})
+
+describe('debounce', () => {
+  it('runs once for a burst of calls', () => {
+    // Dragging a window emits move events continuously; one write is enough.
+    let timer = null
+    const setTimer = vi.fn((fn) => {
+      timer = fn
+      return 1
+    })
+    const clearTimer = vi.fn()
+    const fn = vi.fn()
+    const debounced = debounce(fn, 500, { setTimer, clearTimer })
+
+    debounced('a')
+    debounced('b')
+    debounced('c')
+    timer()
+
+    expect(clearTimer).toHaveBeenCalledTimes(2)
+    expect(fn).toHaveBeenCalledOnce()
+    expect(fn).toHaveBeenCalledWith('c')
+  })
+
+  it('runs again after the previous call settled', () => {
+    let timer = null
+    const setTimer = (fn) => {
+      timer = fn
+      return 1
+    }
+    const fn = vi.fn()
+    const debounced = debounce(fn, 500, { setTimer, clearTimer: () => {} })
+
+    debounced('first')
+    timer()
+    debounced('second')
+    timer()
+
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('really does defer, using the default timer', async () => {
+    const fn = vi.fn()
+    const debounced = debounce(fn, 5)
+
+    debounced()
+    expect(fn).not.toHaveBeenCalled()
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(fn).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
> **Stacked on #364** → #363 → #362. Merge in order and each retargets cleanly.

## What changed

The desktop app gains the things a desktop app is expected to have: a proper application menu, a tray item showing what is waiting, a keyboard shortcut that creates a task from anywhere, links that open it at the right place, a window that reopens where it was left, and native chrome that follows the app's own light or dark setting.

## Why changed

These are the capabilities the browser cannot offer, and they are the reason for having a desktop app at all rather than a bookmark. All of it lives in the shell and reaches the application through a single channel, so the shared interface stays exactly the interface the browser gets.

## Test coverage report

New lines introduced: **100%** — 250 tests across statements, branches, functions and lines, enforced as a CI gate.

```
File              | % Stmts | % Branch | % Funcs | % Lines
All files         |     100 |      100 |     100 |     100
 auth.js          |     100 |      100 |     100 |     100
 deep-link.js     |     100 |      100 |     100 |     100
 menu.js          |     100 |      100 |     100 |     100
 notifications.js |     100 |      100 |     100 |     100
 protocol.js      |     100 |      100 |     100 |     100
 server-config.js |     100 |      100 |     100 |     100
 sse.js           |     100 |      100 |     100 |     100
 theme.js         |     100 |      100 |     100 |     100
 tray.js          |     100 |      100 |     100 |     100
 window-state.js  |     100 |      100 |     100 |     100
```

Total coverage impact: desktop rises from 174 to 250 tests, still 100% on every main-process module. Frontend unchanged at 23 tests, 100%.

## Other reports

**Three judgement calls worth surfacing.**

Saved window coordinates are checked against the displays that currently exist before being reused. Restoring them blindly is how a window ends up on a monitor that was unplugged — visible to nobody and draggable by nobody. When the position is unreachable, only the size is restored and the platform centres the window.

Incoming links are treated as untrusted input from outside the app: each is checked against the destinations that actually exist rather than handed straight to the router, and anything unrecognised opens the default view. The user asked to see AgentRQ, and the wrong screen is worse than the front door.

"Check for Updates" is present in the menu but greyed out, because the updater arrives in the next phase. Shipping it enabled and inert would be worse, and adding it later would shift the menu under people who had learned it.

**Verified against the real thing, not only stand-ins.** Beyond the unit tests, an integration check exercises window capture and restore against a real window, position clamping against the machine's real displays, and the theme switch against the real system theme — all seven checks pass. The application itself was launched and ran clean.

**The tray icon is deliberately blank** for now: it is an art asset, and a wrong-looking one is worse than the platform default. Everything in the tray that carries information — the count, the menu, the tooltip — is real.

## TaskID

0huaA6sKHoX

Parent: 0huZWzzheT3 — plan in #359, phases 1–4 in #360, #362, #363, #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)