### PR TITLE
feat(desktop): auto-update via electron-updater

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -11,8 +11,8 @@ frontend's platform store, which is how a component offers a desktop-only
 affordance without either build growing its own copy of the view.
 
 Plan and phase breakdown: `docs/DESKTOP_APP_PLAN.md`. This package covers
-phases 1-5: `0hua6QI7nXN`, `0hua7LpaQID`, `0hua8EL8awL`, `0hua8txMLIn`,
-`0huaA6sKHoX`.
+phases 1-6: `0hua6QI7nXN`, `0hua7LpaQID`, `0hua8EL8awL`, `0hua8txMLIn`,
+`0huaA6sKHoX`, `0huaAvwzIuH`.
 
 ## Running it
 
@@ -142,6 +142,38 @@ The tray icon is deliberately an empty image for now: it is an art asset, and
 shipping a wrong-looking one is worse than the platform default. The menu, count
 and tooltip — the parts carrying information — are real.
 
+## Auto-update
+
+Updates come from this repository's GitHub Releases, published by the workflow
+in phase 7. The app checks at launch and every six hours, downloads in the
+background, and installs on quit if the user never acts on the prompt.
+
+The prompt itself is **App.vue's existing "a new version is available" banner** —
+the one the browser build shows when a service worker is waiting. The desktop
+build resolves `virtual:pwa-register/vue` to
+`frontend/src/desktop/useDesktopUpdates.js`, which presents the Electron updater
+through the same interface App.vue already consumes. So the desktop update
+prompt is pixel-identical to the web one by construction, App.vue knows about
+neither, and the design system's ban on native modals is satisfied without
+inventing anything.
+
+Transient states go through the toast system instead: checking, up to date, and
+failures. A background check that finds nothing stays **silent** — six-hourly
+"you are up to date" toasts would be pure noise — while the same answer to a
+question asked from the menu is reported, because someone is waiting for it.
+
+**Updates are hard-disabled when the app is unpackaged**, so `make dev` never
+reaches the update path. Asking from the menu in a development build says so
+rather than appearing broken.
+
+### macOS needs a signed build
+
+Squirrel.Mac validates the code signature before installing, so an unsigned
+macOS build cannot update itself at all. That is a phase 7 concern (signing
+certificates, still an open question in the plan); the failure is recognised and
+reported here as *"This build is not signed, so it cannot update itself"* rather
+than as a raw error nobody could act on. Windows and Linux are unaffected.
+
 ## Notifications
 
 Web Push cannot work in Electron - there is no push service behind it - so the
@@ -219,6 +251,7 @@ src/main/deep-link.js       agentrq:// links -> in-app routes
 src/main/tray.js            tray menu, recent workspaces
 src/main/theme.js           native chrome follows the app's theme store
 src/main/window-state.js    remembering where the window was, safely
+src/main/updater.js         auto-update state machine over electron-updater
 src/main/index.js           lifecycle, window creation, scheme registration, IPC
 src/preload/index.js        the narrow contextBridge surface
 scripts/                    dev launcher, build, spike, e2e verification

--- a/desktop/scripts/verify-e2e.mjs
+++ b/desktop/scripts/verify-e2e.mjs
@@ -70,8 +70,9 @@ const CHECKS = `(async () => {
   // The desktop bridge is visible to the renderer, with every surface the
   // shell needs to reach it.
   const bridge = window.agentrq ?? {};
-  const surfaces = ['connection', 'notifications', 'navigation', 'theme'].filter((k) => bridge[k]);
-  record('desktop bridge exposed', bridge.isDesktop === true && surfaces.length === 4,
+  const expected = ['connection', 'notifications', 'navigation', 'theme', 'updates'];
+  const surfaces = expected.filter((k) => bridge[k]);
+  record('desktop bridge exposed', bridge.isDesktop === true && surfaces.length === expected.length,
     'platform ' + bridge.platform + ', surfaces: ' + surfaces.join(', '));
 
   // Relative URL, exactly as src/api.js writes it — no absolute server URL anywhere.
@@ -103,8 +104,41 @@ const CHECKS = `(async () => {
   });
   record('SSE stream connects through proxy', sse.pass, sse.detail);
 
+  record('no update banner before there is an update',
+    !document.body.textContent.includes('A new version of AgentRQ is available'),
+    'banner absent');
+
   return out;
 })()`
+
+/** Run after an update is announced: the shared banner should be showing. */
+const UPDATE_CHECKS = `(async () => {
+  const out = [];
+  const record = (name, pass, detail) => out.push({ name, pass, detail });
+
+  const banner = [...document.querySelectorAll('div')].find(
+    (el) => el.textContent.trim().startsWith('A new version of AgentRQ is available')
+  );
+  record('a ready update raises the shared update banner', !!banner, banner ? 'banner shown' : 'not shown');
+
+  const button = banner && [...banner.querySelectorAll('button')].find(
+    (b) => b.textContent.trim().toLowerCase() === 'update now'
+  );
+  record('the banner offers Update now', !!button, button ? button.textContent.trim() : 'no button');
+
+  // Same component as the browser build, so the styling is the browser's.
+  record('the banner is styled', !!button && parseFloat(getComputedStyle(button).borderRadius) > 0,
+    button ? getComputedStyle(button).borderRadius : 'n/a');
+
+  return out;
+})()`
+
+// A verification script that hangs is worse than one that fails: it blocks a
+// run with no signal at all.
+setTimeout(() => {
+  console.error('✗ verification timed out')
+  app.exit(3)
+}, 60000)
 
 app.whenReady().then(async () => {
   // Electron persists the cookie jar across runs, so without this the
@@ -120,6 +154,14 @@ app.whenReady().then(async () => {
     serverUrl,
     locked: true,
   }))
+
+  // Update state, driven by the checks below. The real updater is exercised by
+  // its unit tests; what needs proving here is that a 'ready' state reaches
+  // App.vue's existing banner rather than needing a second one.
+  let updateState = { status: 'idle', detail: '', version: '', enabled: true, announce: false }
+  ipcMain.handle('agentrq:update:get', () => updateState)
+  ipcMain.handle('agentrq:update:install', () => true)
+  ipcMain.handle('agentrq:theme:set', () => ({ source: 'system', color: '#fafafa' }))
 
   protocol.handle(
     'app',
@@ -148,6 +190,17 @@ app.whenReady().then(async () => {
     console.error('✗ checks threw:', err)
     app.exit(1)
     return
+  }
+
+  // Announce a downloaded update and re-check: the desktop drives the same
+  // banner the browser build uses for a waiting service worker.
+  updateState = { status: 'ready', detail: '', version: '9.9.9', enabled: true, announce: true }
+  win.webContents.send('agentrq:update:status', updateState)
+  await new Promise((r) => setTimeout(r, 600))
+  try {
+    results.push(...(await win.webContents.executeJavaScript(UPDATE_CHECKS)))
+  } catch (err) {
+    results.push({ name: 'update banner checks', pass: false, detail: String(err?.message ?? err) })
   }
 
   console.log(`\n─── app:// proxy against ${serverUrl} ───`)

--- a/desktop/src/main/index.js
+++ b/desktop/src/main/index.js
@@ -30,6 +30,11 @@ import { AUTH_COOKIE, matchOAuthLogin, oauthStartUrl, runOAuthFlow } from './aut
 import { QUICK_CREATE_ACCELERATOR, buildMenuTemplate } from './menu.js'
 import { badgeFor, createNotificationGate, createUnreadCounter, mapEventToNotification } from './notifications.js'
 import { createEventStreamClient } from './sse.js'
+import { UpdateStatus, createUpdater } from './updater.js'
+// Externalised by the build, so this resolves from node_modules at runtime.
+// Importing it is inert; the dev guard is about never *using* it against a
+// development checkout.
+import electronUpdater from 'electron-updater'
 import { DEEP_LINK_SCHEME, deepLinkFromArgv, parseDeepLink } from './deep-link.js'
 import { buildTrayMenuTemplate, createRecentWorkspaces, trayTooltip } from './tray.js'
 import { applyTheme, backgroundColorFor } from './theme.js'
@@ -102,6 +107,9 @@ let tray = null
 let currentTheme = 'system'
 /** Set when a deep link arrives before the window is ready to receive it. */
 let pendingRoute = null
+let updater = null
+/** Last update state, so a renderer that loads later is not left in the dark. */
+let updateState = { status: UpdateStatus.Idle, detail: '', version: '', enabled: false }
 
 async function refreshWorkspaceNames() {
   if (!serverUrl) return
@@ -216,6 +224,7 @@ function refreshTray() {
         actions: {
           open: () => focusMainWindow(),
           newTask: () => navigate(newTaskRoute()),
+      checkForUpdates: () => updater?.checkNow(),
           openWorkspace: (id) => navigate(`/workspaces/${id}`),
           quit: () => app.quit(),
         },
@@ -366,6 +375,7 @@ function installMenu(getWindow) {
     appName: app.getName(),
     actions: {
       newTask: () => navigate(newTaskRoute()),
+      checkForUpdates: () => updater?.checkNow(),
       switchServer: async () => {
         if (isConnectionLocked) return
         await configStore.clear()
@@ -397,6 +407,10 @@ function registerIpc(getWindow) {
 
   // The renderer is the source of truth for appearance — the theme store the
   // web app already has — so the shell follows it rather than reading the OS.
+  ipcMain.handle('agentrq:update:get', () => updateState)
+  ipcMain.handle('agentrq:update:check', () => updater?.checkNow() ?? { ok: false, reason: 'Updater unavailable' })
+  ipcMain.handle('agentrq:update:install', () => updater?.installNow() ?? false)
+
   ipcMain.handle('agentrq:theme:set', (_event, theme) => {
     currentTheme = theme
     return applyTheme(theme, {
@@ -431,6 +445,21 @@ function registerIpc(getWindow) {
     reloadToRoot(getWindow())
     return { ok: true, url: saved.url }
   })
+}
+
+function installUpdater() {
+  updater = createUpdater({
+    autoUpdater: electronUpdater.autoUpdater,
+    // The real guard: unpackaged means no release to compare against, and no
+    // business replacing a development checkout with a downloaded build.
+    isPackaged: app.isPackaged,
+    onStatus: (state) => {
+      updateState = { ...state, enabled: updater?.state.enabled ?? false }
+      const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())
+      win?.webContents.send('agentrq:update:status', updateState)
+    },
+  })
+  updater.start()
 }
 
 function installTray() {
@@ -521,6 +550,7 @@ if (!app.requestSingleInstanceLock()) {
     startEventStream()
     installTray()
     installGlobalShortcut()
+    installUpdater()
 
     const launchLink = deepLinkFromArgv(process.argv)
     if (launchLink) openDeepLink(launchLink)
@@ -536,6 +566,7 @@ if (!app.requestSingleInstanceLock()) {
 
   app.on('before-quit', () => {
     eventStream?.stop()
+    updater?.stop()
     globalShortcut.unregisterAll()
     // A quit that does not close the window first — Cmd+Q, or the tray's Quit —
     // would otherwise lose whatever the debounced save had not yet written.

--- a/desktop/src/main/updater.js
+++ b/desktop/src/main/updater.js
@@ -1,0 +1,189 @@
+/**
+ * Auto-update.
+ *
+ * The browser build gets new code by reloading; the desktop app has to fetch
+ * and install it, which is the one capability a packaged app genuinely cannot
+ * do without. Updates come from this repository's GitHub Releases, published by
+ * the workflow in phase 7.
+ *
+ * The design rule the prompt has to respect: no native modals. The web app
+ * already has exactly the right piece of UI for this — the banner App.vue shows
+ * when a new service worker is waiting — so the desktop build drives that same
+ * banner rather than inventing a second one. Transient states (checking, up to
+ * date, failed) go through the toast system.
+ *
+ * electron-updater is injected rather than imported, so the whole state machine
+ * is testable in plain Node with no Electron and no network.
+ */
+
+/** Six hours: frequent enough to matter, rare enough to be invisible. */
+export const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000
+
+export const UpdateStatus = {
+  Idle: 'idle',
+  Checking: 'checking',
+  Available: 'available',
+  Downloading: 'downloading',
+  Ready: 'ready',
+  UpToDate: 'up-to-date',
+  Error: 'error',
+  Disabled: 'disabled',
+}
+
+/**
+ * Why updating is unavailable, or null when it is available.
+ *
+ * Running unpackaged is the important one: `make dev` must never reach the
+ * update path, where electron-updater would try to replace a development
+ * checkout with a release build.
+ */
+export function updaterDisabledReason({ isPackaged }) {
+  if (!isPackaged) return 'Updates are disabled in a development build'
+  return null
+}
+
+/**
+ * Turn an updater failure into something worth showing a person.
+ *
+ * The signature case is called out by name because it is the predictable one:
+ * macOS refuses to install an update onto an unsigned app, and the raw error
+ * says nothing a user could act on.
+ */
+export function describeUpdateError(error) {
+  const message = String(error?.message ?? error ?? 'Unknown error')
+
+  if (/code signature|not signed|SQRLUpdater|codesign/i.test(message)) {
+    return 'This build is not signed, so it cannot update itself'
+  }
+  if (/net::|ENOTFOUND|ETIMEDOUT|ECONNREFUSED|EAI_AGAIN/i.test(message)) {
+    return 'Could not reach the update server'
+  }
+  if (/404|no published versions|latest.yml/i.test(message)) {
+    return 'No published release to update to'
+  }
+  return message
+}
+
+/**
+ * Whether a status change should interrupt the user.
+ *
+ * A background check that finds nothing must stay silent — six-hourly "you are
+ * up to date" toasts would be pure noise. The same status *asked for* by the
+ * menu should answer, because the user is waiting for one.
+ */
+export function shouldAnnounce(status, { manual }) {
+  if (status === UpdateStatus.Ready || status === UpdateStatus.Available) return true
+  return Boolean(manual)
+}
+
+/**
+ * @param {object} deps
+ * @param {object} deps.autoUpdater      electron-updater's autoUpdater
+ * @param {boolean} deps.isPackaged
+ * @param {(state: object) => void} deps.onStatus
+ * @param {typeof setInterval} [deps.setTimer]
+ * @param {typeof clearInterval} [deps.clearTimer]
+ * @param {{ warn: Function }} [deps.logger]
+ */
+export function createUpdater({
+  autoUpdater,
+  isPackaged,
+  onStatus,
+  setTimer = setInterval,
+  clearTimer = clearInterval,
+  logger = console,
+}) {
+  const disabledReason = updaterDisabledReason({ isPackaged })
+
+  let status = disabledReason ? UpdateStatus.Disabled : UpdateStatus.Idle
+  let detail = disabledReason ?? ''
+  let manual = false
+  let timer = null
+  let version = ''
+
+  function publish(next, nextDetail = '') {
+    status = next
+    detail = nextDetail
+    onStatus({ status, detail, version, manual, announce: shouldAnnounce(next, { manual }) })
+  }
+
+  function bindEvents() {
+    autoUpdater.on('checking-for-update', () => publish(UpdateStatus.Checking))
+    autoUpdater.on('update-available', (info) => {
+      version = info?.version ?? ''
+      publish(UpdateStatus.Available)
+    })
+    autoUpdater.on('download-progress', (progress) => {
+      publish(UpdateStatus.Downloading, `${Math.round(progress?.percent ?? 0)}%`)
+    })
+    autoUpdater.on('update-downloaded', (info) => {
+      version = info?.version ?? version
+      publish(UpdateStatus.Ready)
+    })
+    autoUpdater.on('update-not-available', () => publish(UpdateStatus.UpToDate))
+    autoUpdater.on('error', (error) => {
+      logger.warn?.('update failed:', error)
+      publish(UpdateStatus.Error, describeUpdateError(error))
+    })
+  }
+
+  async function check({ manual: isManual = false } = {}) {
+    if (disabledReason) {
+      // Answer the question when it was actually asked, rather than silently
+      // doing nothing and leaving the menu looking broken.
+      manual = isManual
+      publish(UpdateStatus.Disabled, disabledReason)
+      return { ok: false, reason: disabledReason }
+    }
+
+    manual = isManual
+    try {
+      await autoUpdater.checkForUpdates()
+      return { ok: true }
+    } catch (error) {
+      // electron-updater also emits 'error'; catching here keeps a rejected
+      // promise from surfacing as an unhandled rejection.
+      const reason = describeUpdateError(error)
+      publish(UpdateStatus.Error, reason)
+      return { ok: false, reason }
+    }
+  }
+
+  return {
+    /** Wire up events, check once, then keep checking on a timer. */
+    start() {
+      if (disabledReason) {
+        publish(UpdateStatus.Disabled, disabledReason)
+        return
+      }
+
+      // Download in the background so an update is ready the moment the user
+      // agrees to it, and install on quit if they never do.
+      autoUpdater.autoDownload = true
+      autoUpdater.autoInstallOnAppQuit = true
+
+      bindEvents()
+      check({ manual: false })
+      timer = setTimer(() => check({ manual: false }), UPDATE_CHECK_INTERVAL_MS)
+    },
+
+    /** The menu's "Check for Updates…". */
+    checkNow: () => check({ manual: true }),
+
+    /** Restart into the new version now. */
+    installNow() {
+      if (status !== UpdateStatus.Ready) return false
+      autoUpdater.quitAndInstall()
+      return true
+    },
+
+    stop() {
+      if (timer !== null) clearTimer(timer)
+      timer = null
+    },
+
+    get state() {
+      return { status, detail, version, enabled: !disabledReason }
+    },
+  }
+}

--- a/desktop/src/preload/index.js
+++ b/desktop/src/preload/index.js
@@ -52,6 +52,30 @@ contextBridge.exposeInMainWorld('agentrq', {
     },
   },
 
+  updates: {
+    /** @returns {Promise<{status: string, detail: string, version: string, enabled: boolean}>} */
+    get: () => ipcRenderer.invoke('agentrq:update:get'),
+    /** The menu's "Check for Updates…" also routes through here. */
+    check: () => ipcRenderer.invoke('agentrq:update:check'),
+    /** Restart into the downloaded version. */
+    installNow: () => ipcRenderer.invoke('agentrq:update:install'),
+
+    /**
+     * Called on every change of update state. Only the state crosses the
+     * bridge — never the IPC event object.
+     *
+     * @returns {() => void} unsubscribe
+     */
+    onStatus: (callback) => {
+      const listener = (_event, state) => callback(state)
+      ipcRenderer.on('agentrq:update:status', listener)
+      // The shell may have settled on a state before this renderer existed —
+      // a check runs at launch — so the current one is delivered immediately.
+      ipcRenderer.invoke('agentrq:update:get').then(callback).catch(() => {})
+      return () => ipcRenderer.off('agentrq:update:status', listener)
+    },
+  },
+
   theme: {
     /**
      * Tell the shell which theme the app is using, so the native chrome follows

--- a/desktop/src/renderer/main.js
+++ b/desktop/src/renderer/main.js
@@ -24,6 +24,7 @@ import { createWebHistory } from 'vue-router'
 
 import { createAgentRQApp } from '@app/app'
 import { useThemeStore } from '@app/stores/themeStore'
+import { useToasts } from '@app/composables/useToasts'
 import ConnectionView from '@app/desktop/ConnectionView.vue'
 
 // A failure here means the shell could not answer, which is not something the
@@ -51,6 +52,26 @@ if (connection.configured) {
   })
 
   app.mount('#app')
+
+  // Transient update states are reported through the toast system. The one
+  // state that is not transient — an update downloaded and waiting — raises
+  // App.vue's existing "new version available" banner instead, which is both
+  // the right affordance and identical to what the browser build shows.
+  const { notifyInfo, notifySuccess, notifyError } = useToasts()
+  let lastUpdateStatus = null
+  window.agentrq.updates?.onStatus((state) => {
+    if (state.status === lastUpdateStatus) return
+    lastUpdateStatus = state.status
+    // A six-hourly background check that finds nothing must stay silent;
+    // the same answer to a question the user asked should be reported.
+    if (!state.announce) return
+
+    if (state.status === 'checking') notifyInfo('Checking for updates…', 'Updates')
+    else if (state.status === 'up-to-date') notifySuccess('AgentRQ is up to date', 'Updates')
+    else if (state.status === 'available') notifyInfo(`Downloading version ${state.version}…`, 'Updates')
+    else if (state.status === 'error') notifyError(state.detail, 'Update failed')
+    else if (state.status === 'disabled') notifyInfo(state.detail, 'Updates')
+  })
 
   // The theme store is the app's single source of truth for appearance, so the
   // native chrome follows it rather than the OS. Mounting first means pinia is

--- a/desktop/test/updater.test.js
+++ b/desktop/test/updater.test.js
@@ -1,0 +1,333 @@
+import { describe, it, expect, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+
+import {
+  UPDATE_CHECK_INTERVAL_MS,
+  UpdateStatus,
+  createUpdater,
+  describeUpdateError,
+  shouldAnnounce,
+  updaterDisabledReason,
+} from '../src/main/updater.js'
+
+/** Stand-in for electron-updater's autoUpdater. */
+function fakeAutoUpdater({ checkForUpdates } = {}) {
+  const updater = new EventEmitter()
+  updater.autoDownload = false
+  updater.autoInstallOnAppQuit = false
+  updater.checkForUpdates = checkForUpdates ?? vi.fn(async () => ({}))
+  updater.quitAndInstall = vi.fn()
+  return updater
+}
+
+function setup({ isPackaged = true, checkForUpdates } = {}) {
+  const autoUpdater = fakeAutoUpdater({ checkForUpdates })
+  const onStatus = vi.fn()
+  const setTimer = vi.fn(() => 'timer-id')
+  const clearTimer = vi.fn()
+  const logger = { warn: vi.fn() }
+
+  const updater = createUpdater({ autoUpdater, isPackaged, onStatus, setTimer, clearTimer, logger })
+  return { updater, autoUpdater, onStatus, setTimer, clearTimer, logger }
+}
+
+/** The status values reported, in order. */
+const statuses = (onStatus) => onStatus.mock.calls.map(([state]) => state.status)
+
+describe('updaterDisabledReason', () => {
+  it('allows updating in a packaged app', () => {
+    expect(updaterDisabledReason({ isPackaged: true })).toBeNull()
+  })
+
+  it('refuses in a development build', () => {
+    // The hard guard: `make dev` must never reach the update path, where
+    // electron-updater would try to replace a checkout with a release build.
+    expect(updaterDisabledReason({ isPackaged: false })).toBe('Updates are disabled in a development build')
+  })
+})
+
+describe('describeUpdateError', () => {
+  it('explains the macOS signing requirement in words a person can act on', () => {
+    // The predictable failure: Squirrel.Mac refuses to install onto an unsigned
+    // app, and the raw error says nothing useful.
+    expect(describeUpdateError(new Error('Could not get code signature for running application')))
+      .toBe('This build is not signed, so it cannot update itself')
+    expect(describeUpdateError(new Error('SQRLUpdater failed'))).toBe(
+      'This build is not signed, so it cannot update itself'
+    )
+  })
+
+  it('reports a network failure as one', () => {
+    for (const message of ['net::ERR_INTERNET_DISCONNECTED', 'getaddrinfo ENOTFOUND github.com', 'ETIMEDOUT']) {
+      expect(describeUpdateError(new Error(message))).toBe('Could not reach the update server')
+    }
+  })
+
+  it('recognises there being nothing to update to', () => {
+    expect(describeUpdateError(new Error('HttpError: 404 Not Found'))).toBe('No published release to update to')
+    expect(describeUpdateError(new Error('Cannot find latest.yml'))).toBe('No published release to update to')
+  })
+
+  it('passes an unrecognised message through rather than hiding it', () => {
+    expect(describeUpdateError(new Error('something odd'))).toBe('something odd')
+  })
+
+  it('copes with a thrown value that is not an Error', () => {
+    expect(describeUpdateError('plain string')).toBe('plain string')
+    expect(describeUpdateError(null)).toBe('Unknown error')
+    expect(describeUpdateError(undefined)).toBe('Unknown error')
+  })
+})
+
+describe('shouldAnnounce', () => {
+  it('always announces an update that exists', () => {
+    expect(shouldAnnounce(UpdateStatus.Available, { manual: false })).toBe(true)
+    expect(shouldAnnounce(UpdateStatus.Ready, { manual: false })).toBe(true)
+  })
+
+  it('stays silent about a background check that found nothing', () => {
+    // Six-hourly "you are up to date" toasts would be pure noise.
+    expect(shouldAnnounce(UpdateStatus.UpToDate, { manual: false })).toBe(false)
+    expect(shouldAnnounce(UpdateStatus.Checking, { manual: false })).toBe(false)
+    expect(shouldAnnounce(UpdateStatus.Error, { manual: false })).toBe(false)
+  })
+
+  it('answers a question the user actually asked', () => {
+    for (const status of [UpdateStatus.Checking, UpdateStatus.UpToDate, UpdateStatus.Error, UpdateStatus.Disabled]) {
+      expect(shouldAnnounce(status, { manual: true })).toBe(true)
+    }
+  })
+})
+
+describe('createUpdater', () => {
+  it('downloads in the background and installs on quit', () => {
+    // So an update is ready the moment the user agrees, and still lands if
+    // they never do.
+    const { updater, autoUpdater } = setup()
+    updater.start()
+
+    expect(autoUpdater.autoDownload).toBe(true)
+    expect(autoUpdater.autoInstallOnAppQuit).toBe(true)
+  })
+
+  it('checks at launch and then on a six-hourly timer', () => {
+    const { updater, autoUpdater, setTimer } = setup()
+    updater.start()
+
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalledOnce()
+    expect(setTimer).toHaveBeenCalledWith(expect.any(Function), UPDATE_CHECK_INTERVAL_MS)
+    expect(UPDATE_CHECK_INTERVAL_MS).toBe(6 * 60 * 60 * 1000)
+  })
+
+  it('keeps checking when the timer fires', () => {
+    const { updater, autoUpdater, setTimer } = setup()
+    updater.start()
+
+    setTimer.mock.calls[0][0]()
+
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(2)
+  })
+
+  it('reports the whole lifecycle of a successful update', () => {
+    const { updater, autoUpdater, onStatus } = setup()
+    updater.start()
+
+    autoUpdater.emit('checking-for-update')
+    autoUpdater.emit('update-available', { version: '0.5.0' })
+    autoUpdater.emit('download-progress', { percent: 42.4 })
+    autoUpdater.emit('update-downloaded', { version: '0.5.0' })
+
+    expect(statuses(onStatus)).toEqual([
+      UpdateStatus.Checking,
+      UpdateStatus.Available,
+      UpdateStatus.Downloading,
+      UpdateStatus.Ready,
+    ])
+    expect(updater.state).toMatchObject({ status: UpdateStatus.Ready, version: '0.5.0' })
+  })
+
+  it('reports download progress as a rounded percentage', () => {
+    const { updater, autoUpdater, onStatus } = setup()
+    updater.start()
+
+    autoUpdater.emit('download-progress', { percent: 42.4 })
+    expect(onStatus.mock.calls.at(-1)[0].detail).toBe('42%')
+
+    autoUpdater.emit('download-progress', {})
+    expect(onStatus.mock.calls.at(-1)[0].detail).toBe('0%')
+  })
+
+  it('reports being up to date', () => {
+    const { updater, autoUpdater } = setup()
+    updater.start()
+
+    autoUpdater.emit('update-not-available')
+
+    expect(updater.state.status).toBe(UpdateStatus.UpToDate)
+  })
+
+  it('reports a failure without throwing', () => {
+    const { updater, autoUpdater, logger } = setup()
+    updater.start()
+
+    autoUpdater.emit('error', new Error('net::ERR_INTERNET_DISCONNECTED'))
+
+    expect(updater.state).toMatchObject({
+      status: UpdateStatus.Error,
+      detail: 'Could not reach the update server',
+    })
+    expect(logger.warn).toHaveBeenCalled()
+  })
+
+  it('copes with an update-available carrying no version', () => {
+    const { updater, autoUpdater } = setup()
+    updater.start()
+
+    autoUpdater.emit('update-available', undefined)
+    expect(updater.state.version).toBe('')
+  })
+
+  it('keeps the version from update-available if the download omits it', () => {
+    const { updater, autoUpdater } = setup()
+    updater.start()
+
+    autoUpdater.emit('update-available', { version: '0.5.0' })
+    autoUpdater.emit('update-downloaded', {})
+
+    expect(updater.state.version).toBe('0.5.0')
+  })
+
+  it('marks a manual check as announceable and a background one as not', () => {
+    const { updater, autoUpdater, onStatus } = setup()
+    updater.start()
+
+    autoUpdater.emit('update-not-available')
+    expect(onStatus.mock.calls.at(-1)[0].announce).toBe(false)
+
+    updater.checkNow()
+    autoUpdater.emit('update-not-available')
+    expect(onStatus.mock.calls.at(-1)[0].announce).toBe(true)
+  })
+
+  it('surfaces a rejected check rather than leaving an unhandled rejection', () => {
+    const checkForUpdates = vi.fn(async () => {
+      throw new Error('HttpError: 404')
+    })
+    const { updater } = setup({ checkForUpdates })
+
+    return updater.checkNow().then((result) => {
+      expect(result).toEqual({ ok: false, reason: 'No published release to update to' })
+      expect(updater.state.status).toBe(UpdateStatus.Error)
+    })
+  })
+
+  it('reports a successful check', async () => {
+    const { updater } = setup()
+    expect(await updater.checkNow()).toEqual({ ok: true })
+  })
+
+  describe('in a development build', () => {
+    it('never touches the updater', () => {
+      const { updater, autoUpdater, setTimer } = setup({ isPackaged: false })
+      updater.start()
+
+      expect(autoUpdater.checkForUpdates).not.toHaveBeenCalled()
+      expect(setTimer).not.toHaveBeenCalled()
+      expect(autoUpdater.autoDownload).toBe(false)
+    })
+
+    it('says so, rather than appearing broken', async () => {
+      // The menu item is reachable in dev; silently doing nothing would look
+      // like a bug.
+      const { updater, onStatus } = setup({ isPackaged: false })
+
+      const result = await updater.checkNow()
+
+      expect(result).toEqual({ ok: false, reason: 'Updates are disabled in a development build' })
+      expect(onStatus.mock.calls.at(-1)[0]).toMatchObject({
+        status: UpdateStatus.Disabled,
+        announce: true,
+      })
+    })
+
+    it('starts in the disabled state', () => {
+      const { updater } = setup({ isPackaged: false })
+      expect(updater.state).toMatchObject({ status: UpdateStatus.Disabled, enabled: false })
+
+      updater.start()
+      expect(updater.state.status).toBe(UpdateStatus.Disabled)
+    })
+  })
+
+  describe('installNow', () => {
+    it('restarts into the new version once one is downloaded', () => {
+      const { updater, autoUpdater } = setup()
+      updater.start()
+      autoUpdater.emit('update-downloaded', { version: '0.5.0' })
+
+      expect(updater.installNow()).toBe(true)
+      expect(autoUpdater.quitAndInstall).toHaveBeenCalledOnce()
+    })
+
+    it('does nothing when there is nothing downloaded', () => {
+      // Quitting the app to install an update that does not exist would be a
+      // spectacular way to lose someone's work.
+      const { updater, autoUpdater } = setup()
+      updater.start()
+
+      expect(updater.installNow()).toBe(false)
+      autoUpdater.emit('update-available', { version: '0.5.0' })
+      expect(updater.installNow()).toBe(false)
+
+      expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('stop', () => {
+    it('cancels the timer', () => {
+      const { updater, clearTimer } = setup()
+      updater.start()
+      updater.stop()
+
+      expect(clearTimer).toHaveBeenCalledWith('timer-id')
+    })
+
+    it('is safe when nothing was started', () => {
+      const { updater, clearTimer } = setup()
+      updater.stop()
+
+      expect(clearTimer).not.toHaveBeenCalled()
+    })
+
+    it('is safe to call twice', () => {
+      const { updater, clearTimer } = setup()
+      updater.start()
+      updater.stop()
+      updater.stop()
+
+      expect(clearTimer).toHaveBeenCalledOnce()
+    })
+  })
+
+  it('falls back to console when no logger is supplied', () => {
+    const autoUpdater = fakeAutoUpdater()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const updater = createUpdater({ autoUpdater, isPackaged: true, onStatus: () => {}, setTimer: () => 1 })
+
+    updater.start()
+    autoUpdater.emit('error', new Error('boom'))
+
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('uses real timers when none are injected', async () => {
+    const autoUpdater = fakeAutoUpdater()
+    const updater = createUpdater({ autoUpdater, isPackaged: true, onStatus: () => {} })
+
+    updater.start()
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalledOnce()
+    // Leaving a six-hour interval armed would keep the test process alive.
+    updater.stop()
+  })
+})

--- a/desktop/vite.renderer.config.mjs
+++ b/desktop/vite.renderer.config.mjs
@@ -26,10 +26,12 @@ export default defineConfig({
       // The whole point of the desktop package: the renderer is built from the
       // frontend's own sources, not a copy of them.
       { find: '@app', replacement: FRONTEND_SRC },
-      // vite-plugin-pwa is not in this build, so its virtual module needs a
-      // stand-in — see the stub for why the desktop ships no service worker.
-      // It lives in frontend/ because the frontend's own test run needs it too.
-      { find: 'virtual:pwa-register/vue', replacement: resolvePath('../frontend/stubs/pwa-register.js') },
+      // The desktop ships no service worker, so vite-plugin-pwa's virtual
+      // module needs a stand-in. Rather than an inert one, it resolves to the
+      // Electron updater bridge: App.vue's existing "new version available"
+      // banner is exactly the prompt an app update needs, so the desktop drives
+      // that instead of growing a second banner beside it.
+      { find: 'virtual:pwa-register/vue', replacement: resolvePath('../frontend/src/desktop/useDesktopUpdates.js') },
       // The shared runtime packages come from frontend/node_modules. This
       // package deliberately installs no copy of its own: a file under
       // desktop/src could not otherwise resolve `vue-router`, and two copies of

--- a/frontend/src/desktop/useDesktopUpdates.js
+++ b/frontend/src/desktop/useDesktopUpdates.js
@@ -1,0 +1,44 @@
+import { ref } from 'vue'
+
+/**
+ * Desktop stand-in for `virtual:pwa-register/vue`.
+ *
+ * App.vue already has the right piece of UI for "a new version is available":
+ * the banner it shows when a service worker is waiting, with an "Update now"
+ * button and a dismiss. The desktop app has no service worker, but it has the
+ * same thing to say — so rather than build a second banner that looks almost
+ * the same, this presents the Electron updater through the interface App.vue
+ * already consumes.
+ *
+ * The result is that the desktop update prompt is, by construction, pixel
+ * identical to the web one, and App.vue needs no knowledge of either.
+ *
+ * The shape must match what App.vue destructures: a writable `needRefresh` ref
+ * and an awaitable `updateServiceWorker`.
+ *
+ * With no bridge present — the frontend's own test run, say — everything stays
+ * inert, exactly as the plain stub does.
+ */
+export function useRegisterSW() {
+  const needRefresh = ref(false)
+  const offlineReady = ref(false)
+
+  const updates = globalThis.window?.agentrq?.updates
+  if (updates) {
+    updates.onStatus((state) => {
+      // 'ready' means downloaded and waiting: the only state where restarting
+      // achieves anything, and so the only one that raises the banner.
+      needRefresh.value = state.status === 'ready'
+    })
+  }
+
+  return {
+    needRefresh,
+    offlineReady,
+    updateServiceWorker: async () => {
+      // App.vue clears needRefresh and awaits this; on success the app is
+      // replaced by the new version, so nothing after it runs.
+      await updates?.installNow()
+    },
+  }
+}

--- a/frontend/stubs/pwa-register.js
+++ b/frontend/stubs/pwa-register.js
@@ -1,18 +1,16 @@
 import { ref } from 'vue'
 
 /**
- * Stand-in for `virtual:pwa-register/vue`, which only exists when
+ * Inert stand-in for `virtual:pwa-register/vue`, which only exists when
  * vite-plugin-pwa is part of the build.
  *
- * Two builds need it: the desktop renderer, which deliberately ships no service
- * worker (its assets are already local, and updates come through
- * electron-updater), and the test run, which has no PWA plugin either. App.vue
- * imports the virtual module directly, so without this stand-in neither build
- * would resolve.
+ * Used by the test run, which has no PWA plugin. (The desktop build resolves
+ * the same virtual module to `src/desktop/useDesktopUpdates.js`, which drives
+ * App.vue's banner from the Electron updater instead.)
  *
  * The shape must match what App.vue destructures: a writable `needRefresh` ref
  * and an awaitable `updateServiceWorker`. Both are inert, so App.vue's
- * "new version — reload" banner simply never appears.
+ * "new version" banner simply never appears in a test.
  */
 export function useRegisterSW() {
   return {

--- a/frontend/test/useDesktopUpdates.test.js
+++ b/frontend/test/useDesktopUpdates.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+import { useRegisterSW } from '../src/desktop/useDesktopUpdates'
+
+/** Install a fake desktop bridge and return the status callback it captured. */
+function withBridge({ installNow = vi.fn() } = {}) {
+  let emit = () => {}
+  window.agentrq = {
+    updates: {
+      onStatus: (callback) => {
+        emit = callback
+      },
+      installNow,
+    },
+  }
+  return { emit: (state) => emit(state), installNow }
+}
+
+afterEach(() => {
+  delete window.agentrq
+})
+
+describe('useRegisterSW on the desktop', () => {
+  it('matches the shape App.vue destructures', () => {
+    // App.vue does `const { needRefresh, updateServiceWorker } = useRegisterSW()`
+    // and writes to needRefresh, so it has to be a writable ref.
+    const { needRefresh, offlineReady, updateServiceWorker } = useRegisterSW()
+
+    expect(needRefresh.value).toBe(false)
+    expect(offlineReady.value).toBe(false)
+    expect(typeof updateServiceWorker).toBe('function')
+
+    needRefresh.value = true
+    expect(needRefresh.value).toBe(true)
+  })
+
+  it('raises the banner only once an update is downloaded and waiting', () => {
+    // 'ready' is the one state where restarting achieves anything; prompting
+    // during a download would offer a restart that does nothing.
+    const bridge = withBridge()
+    const { needRefresh } = useRegisterSW()
+
+    for (const status of ['checking', 'available', 'downloading', 'up-to-date', 'error', 'disabled']) {
+      bridge.emit({ status })
+      expect(needRefresh.value, status).toBe(false)
+    }
+
+    bridge.emit({ status: 'ready' })
+    expect(needRefresh.value).toBe(true)
+  })
+
+  it('lowers the banner if the state moves on', () => {
+    const bridge = withBridge()
+    const { needRefresh } = useRegisterSW()
+
+    bridge.emit({ status: 'ready' })
+    bridge.emit({ status: 'error' })
+
+    expect(needRefresh.value).toBe(false)
+  })
+
+  it('installs when App.vue calls updateServiceWorker', async () => {
+    const bridge = withBridge()
+    const { updateServiceWorker } = useRegisterSW()
+
+    await updateServiceWorker(true)
+
+    expect(bridge.installNow).toHaveBeenCalledOnce()
+  })
+
+  it('stays inert with no bridge, exactly as the plain stub does', async () => {
+    // This is what the frontend's own test run and any non-Electron context see.
+    const { needRefresh, updateServiceWorker } = useRegisterSW()
+
+    expect(needRefresh.value).toBe(false)
+    await expect(updateServiceWorker(true)).resolves.toBeUndefined()
+  })
+
+  it('stays inert when the bridge exists without an updates surface', async () => {
+    window.agentrq = { isDesktop: true }
+    const { needRefresh, updateServiceWorker } = useRegisterSW()
+
+    expect(needRefresh.value).toBe(false)
+    await expect(updateServiceWorker(true)).resolves.toBeUndefined()
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -32,7 +32,7 @@ export default defineConfig({
     css: false,
     coverage: {
       provider: 'v8',
-      include: ['src/app.js', 'src/stores/platformStore.js'],
+      include: ['src/app.js', 'src/stores/platformStore.js', 'src/desktop/*.js'],
       reporter: ['text', 'lcov'],
       thresholds: {
         lines: 100,


### PR DESCRIPTION
> **Stacked on #365** → #364 → #363 → #362. Merge in order and each retargets cleanly.

## What changed

The desktop app now keeps itself up to date: it checks on launch and every six hours, downloads new versions quietly in the background, and offers a restart when one is ready. Checking manually from the menu now works and reports what it found.

## Why changed

A packaged application cannot get new code by reloading the way a web page can, so updating itself is the one capability it genuinely must have. Doing it in the background means people get fixes without ever going looking for them.

## Test coverage report

New lines introduced: **100%** — 282 desktop tests and 29 frontend tests, each at 100% across statements, branches, functions and lines, both enforced as CI gates.

```
desktop  | % Stmts | % Branch | % Funcs | % Lines
All files|     100 |      100 |     100 |     100
 (11 main-process modules, updater.js included)

frontend | % Stmts | % Branch | % Funcs | % Lines
All files|     100 |      100 |     100 |     100
```

Total coverage impact: desktop rises from 250 to 282 tests, frontend from 23 to 29, both still at 100% on every covered module.

## Other reports

**The update prompt is not new UI.** The web app already shows a banner when a new version is waiting — the right words, the right buttons, the right styling. Rather than build a second one that looks almost the same and would drift, the desktop build presents its updater through the very same interface that banner already consumes. The result is a prompt identical to the browser's by construction, with the shared component knowing about neither, and no native dialog anywhere. Proven end-to-end: announcing a ready update raises that banner, styled, with its working button.

**Quiet by default, talkative when asked.** A background check that finds nothing says nothing — six-hourly "you're up to date" notices would be noise. The same check run from the menu answers, because someone is waiting for it.

**Two safety rules worth stating.** Updating is hard-disabled unless the app is packaged, so development runs can never replace a working checkout with a downloaded build; asking from the menu there explains itself instead of appearing broken. And restarting to install does nothing unless something has actually been downloaded — quitting to install an update that does not exist is a memorable way to lose someone's work.

**macOS still needs the certificate.** Squirrel.Mac refuses to install onto an unsigned application, so macOS updating cannot work until signing lands in the next phase. That specific failure is recognised and reported as *"This build is not signed, so it cannot update itself"* rather than a raw error. Windows and Linux are unaffected and testable today.

**Also fixed:** the end-to-end script could hang instead of failing, which is worse than a failure because it gives no signal at all. It now has a hard timeout and reports a broken check rather than stalling.

## TaskID

0huaAvwzIuH

Parent: 0huZWzzheT3 — plan in #359, phases 1–5 in #360, #362, #363, #364, #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)