### PR TITLE
feat(desktop): electron-builder config and release pipeline

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,0 +1,155 @@
+name: Desktop Release
+
+# The published GitHub Release is also the auto-update feed: electron-updater
+# reads the latest*.yml manifests published alongside the installers. Anything
+# that breaks this workflow stops existing installs updating, not just new
+# downloads.
+on:
+  push:
+    tags:
+      - 'v*'
+  # A packaging break is invisible to the ordinary test workflow, which never
+  # runs electron-builder. This job builds without publishing so review catches
+  # it instead of a release attempt.
+  pull_request:
+    paths:
+      - 'desktop/**'
+      - 'frontend/**'
+      - '.github/workflows/desktop-release.yml'
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  # Cheap, and it fails the whole release before any 20-minute build starts.
+  versions:
+    name: Version sync
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Check desktop, frontend and backend agree
+        working-directory: desktop
+        # Also asserts the tag matches, so v0.5.0 cannot be cut from a tree
+        # still stamped 0.4.8 — that would publish artifacts named for one
+        # version inside a release named for another, and offer users an
+        # "update" to the build they already have.
+        run: node scripts/check-versions.mjs
+
+  build:
+    name: Build ${{ matrix.os }}
+    needs: versions
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # The renderer is built from ../frontend/src, and those modules resolve
+      # their own dependencies out of frontend/node_modules.
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install desktop dependencies
+        working-directory: desktop
+        run: npm ci
+
+      - name: Test
+        working-directory: desktop
+        run: npm run test:coverage
+
+      # Signing is credential-gated rather than assumed. Without a certificate
+      # the build still succeeds and ships unsigned: Windows and Linux install
+      # and update normally, while macOS auto-update stays unavailable because
+      # Squirrel.Mac refuses to install onto an unsigned app. Adding the
+      # secrets is all that is needed to turn it on.
+      - name: Detect signing credentials
+        id: signing
+        shell: bash
+        run: |
+          if [ -n "${{ secrets.MAC_CERTIFICATE }}${{ secrets.WIN_CERTIFICATE }}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No signing certificate configured; building unsigned. macOS auto-update will not work for this release."
+          fi
+
+      - name: Build and publish
+        working-directory: desktop
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # macOS Developer ID, and the Apple account used to notarize.
+          CSC_LINK: ${{ secrets.MAC_CERTIFICATE }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # Windows certificate, reusing electron-builder's CSC_* convention.
+          WIN_CSC_LINK: ${{ secrets.WIN_CERTIFICATE }}
+          WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CERTIFICATE_PASSWORD }}
+          # Without this, electron-builder hunts the runner's keychain and
+          # fails confusingly instead of building an unsigned app.
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ steps.signing.outputs.available }}
+        run: |
+          npm run build
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Prove it packages; publish nothing.
+            npx electron-builder --publish never
+          else
+            npx electron-builder --publish always
+          fi
+
+      # Kept for a tag build too: if publishing ever fails, the installers are
+      # still recoverable from the run rather than needing a rebuild.
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentrq-desktop-${{ matrix.os }}
+          retention-days: 14
+          if-no-files-found: error
+          path: |
+            desktop/release/*.dmg
+            desktop/release/*.zip
+            desktop/release/*.exe
+            desktop/release/*.AppImage
+            desktop/release/*.deb
+            desktop/release/latest*.yml
+
+  # electron-builder attaches to a draft; publishing only once every platform
+  # has finished means users never see a release missing the installer for
+  # their machine, and electron-updater never reads a half-populated feed.
+  publish:
+    name: Publish release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish the draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release edit "$TAG" --draft=false --repo "$GITHUB_REPOSITORY"
+          echo "Published $TAG" >> "$GITHUB_STEP_SUMMARY"

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -153,7 +153,7 @@ on all three platforms and publishes to a GitHub Release:
 | Runner | Targets |
 |---|---|
 | macos-latest | dmg + zip, arm64 and x64 |
-| windows-latest | NSIS, x64 |
+| windows-latest | NSIS, x64 and arm64 |
 | ubuntu-latest | AppImage + deb, x64 and arm64 |
 
 That Release is also the update feed, so the `latest*.yml` manifests published

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -11,8 +11,8 @@ frontend's platform store, which is how a component offers a desktop-only
 affordance without either build growing its own copy of the view.
 
 Plan and phase breakdown: `docs/DESKTOP_APP_PLAN.md`. This package covers
-phases 1-6: `0hua6QI7nXN`, `0hua7LpaQID`, `0hua8EL8awL`, `0hua8txMLIn`,
-`0huaA6sKHoX`, `0huaAvwzIuH`.
+phases 1-7: `0hua6QI7nXN`, `0hua7LpaQID`, `0hua8EL8awL`, `0hua8txMLIn`,
+`0huaA6sKHoX`, `0huaAvwzIuH`, `0huaBmzhpvl`.
 
 ## Running it
 
@@ -24,6 +24,9 @@ npm run dev                     # Vite dev server + Electron, with HMR
 npm run build                   # bundles renderer, main and preload into dist/
 npm start                       # build, then run the packaged entry
 npm run test:coverage           # unit tests, gated at 100% on main-process modules
+npm run check:versions          # desktop, frontend and backend must agree
+npm run package                 # real installers into release/, published nowhere
+npm run package:dir             # unpacked app, much faster, for checking the bundle
 ```
 
 On first run the app asks which AgentRQ server to connect to, defaulting to
@@ -141,6 +144,57 @@ any of it:
 The tray icon is deliberately an empty image for now: it is an art asset, and
 shipping a wrong-looking one is worse than the platform default. The menu, count
 and tooltip — the parts carrying information — are real.
+
+## Releasing
+
+Tagging `v<version>` runs `.github/workflows/desktop-release.yml`, which builds
+on all three platforms and publishes to a GitHub Release:
+
+| Runner | Targets |
+|---|---|
+| macos-latest | dmg + zip, arm64 and x64 |
+| windows-latest | NSIS, x64 |
+| ubuntu-latest | AppImage + deb, x64 |
+
+That Release is also the update feed, so the `latest*.yml` manifests published
+beside the installers matter as much as the installers do.
+
+Two things guard it. Versions are checked first, in a job that costs seconds and
+fails before any twenty-minute build starts: the desktop, frontend and backend
+versions must agree, and the tag must match them — `v0.5.0` cannot be cut from a
+tree stamped 0.4.8, which would name a release for one version and fill it with
+artifacts for another. And the release is assembled as a **draft**, published
+only once every platform has finished, so nobody ever sees a release missing the
+installer for their machine and no updater reads a half-populated feed.
+
+Pull requests touching `desktop/` or `frontend/` run the same build without
+publishing, because a packaging break is invisible to the ordinary test job —
+that one never runs electron-builder at all.
+
+### Signing
+
+Signing is credential-gated rather than assumed. With no certificate configured
+the build still succeeds and ships unsigned:
+
+- **Windows and Linux** install and update normally; Windows shows a SmartScreen
+  warning on first install.
+- **macOS cannot auto-update at all.** Squirrel.Mac validates the signature
+  before installing, so an unsigned macOS build can be downloaded and run but
+  never updates itself. The app reports this as *"This build is not signed, so
+  it cannot update itself"* rather than a raw error.
+
+Adding these secrets is all that is needed to turn signing on:
+`MAC_CERTIFICATE`, `MAC_CERTIFICATE_PASSWORD`, `APPLE_ID`,
+`APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`, and optionally
+`WIN_CERTIFICATE` / `WIN_CERTIFICATE_PASSWORD`.
+
+### Deep links have to be declared at packaging time
+
+`app.setAsDefaultProtocolClient()` at runtime is enough for Windows and Linux,
+but macOS only routes a scheme to an app that declares it in its bundle. The
+`protocols` entry in `electron-builder.yml` is what puts `CFBundleURLTypes` in
+`Info.plist`; without it `agentrq://` links silently do nothing on a packaged
+macOS build, and no amount of runtime code fixes that.
 
 ## Auto-update
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -154,7 +154,7 @@ on all three platforms and publishes to a GitHub Release:
 |---|---|
 | macos-latest | dmg + zip, arm64 and x64 |
 | windows-latest | NSIS, x64 |
-| ubuntu-latest | AppImage + deb, x64 |
+| ubuntu-latest | AppImage + deb, x64 and arm64 |
 
 That Release is also the update feed, so the `latest*.yml` manifests published
 beside the installers matter as much as the installers do.

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -78,8 +78,11 @@ nsis:
 linux:
   category: Development
   maintainer: AgentRQ <hi@agentrq.com>
+  # arm64 alongside x64: ARM single-board machines and ARM cloud instances are
+  # both ordinary places to run this. Nothing here has a native dependency, so
+  # both architectures cross-build from one runner.
   target:
     - target: AppImage
-      arch: [x64]
+      arch: [x64, arm64]
     - target: deb
-      arch: [x64]
+      arch: [x64, arm64]

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -63,9 +63,11 @@ dmg:
   artifactName: ${productName}-${version}-${arch}.${ext}
 
 win:
+  # arm64 alongside x64: ARM Windows laptops are no longer unusual, and running
+  # the x64 build under emulation there is measurably worse.
   target:
     - target: nsis
-      arch: [x64]
+      arch: [x64, arm64]
 
 nsis:
   oneClick: false

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -1,0 +1,85 @@
+# Packaging for the AgentRQ desktop app.
+#
+# The published GitHub Release is also the auto-update feed: electron-updater
+# reads the `latest*.yml` manifests electron-builder writes alongside the
+# installers, so those files matter as much as the artifacts themselves.
+
+appId: com.agentrq.desktop
+productName: AgentRQ
+copyright: Copyright © 2026 AgentRQ
+
+directories:
+  output: release
+  buildResources: resources
+
+# The renderer, main and preload bundles, plus package.json for the version.
+# Production dependencies (electron-updater) are included automatically.
+files:
+  - dist/**/*
+  - package.json
+
+# Both are the app's own icon, shared with the web build rather than duplicated.
+icon: ../frontend/public/large-icon.png
+
+# Deep links. `app.setAsDefaultProtocolClient()` at runtime is enough for
+# Windows and Linux, but macOS only routes a scheme to an app that declares it
+# in its bundle — without this, agentrq:// links silently do nothing on a
+# packaged macOS build, which no amount of runtime code can fix.
+protocols:
+  - name: AgentRQ
+    schemes: [agentrq]
+
+publish:
+  provider: github
+  owner: agentrq
+  repo: agentrq
+  # Artifacts are attached to a draft release; the workflow publishes it once
+  # every platform has finished, so users never see a release missing the
+  # installer for their machine.
+  releaseType: draft
+
+mac:
+  category: public.app-category.developer-tools
+  target:
+    # dmg is what people download; zip is what Squirrel.Mac reads to update.
+    # Both architectures, because an Intel user offered an arm64 update would
+    # be stuck.
+    - target: dmg
+      arch: [arm64, x64]
+    - target: zip
+      arch: [arm64, x64]
+  # Hardened runtime and the entitlements below are prerequisites for
+  # notarization; harmless on an unsigned build.
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  entitlements: resources/entitlements.mac.plist
+  entitlementsInherit: resources/entitlements.mac.plist
+  extendInfo:
+    # macOS refuses to show the microphone prompt without a reason string, and
+    # the speech-to-text pipeline would fail silently.
+    NSMicrophoneUsageDescription: AgentRQ uses the microphone for voice dictation.
+
+dmg:
+  artifactName: ${productName}-${version}-${arch}.${ext}
+
+win:
+  target:
+    - target: nsis
+      arch: [x64]
+
+nsis:
+  oneClick: false
+  perMachine: false
+  allowToChangeInstallationDirectory: true
+  # Updates are applied by the app itself, so the installer should not demand
+  # the user close and reopen it.
+  deleteAppDataOnUninstall: false
+
+linux:
+  category: Development
+  maintainer: AgentRQ <hi@agentrq.com>
+  target:
+    - target: AppImage
+      arch: [x64]
+    - target: deb
+      arch: [x64]

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "agentrq-desktop",
   "private": true,
   "version": "0.4.8",
-  "description": "AgentRQ desktop application",
+  "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {
@@ -13,7 +13,10 @@
     "test:coverage": "vitest run --coverage",
     "spike:eventsource": "npm run build && electron scripts/spike-eventsource.mjs",
     "verify:e2e": "npm run build && electron scripts/verify-e2e.mjs",
-    "verify:connection": "npm run build && electron scripts/verify-connection.mjs"
+    "verify:connection": "npm run build && electron scripts/verify-connection.mjs",
+    "check:versions": "node scripts/check-versions.mjs",
+    "package": "npm run build && electron-builder --publish never",
+    "package:dir": "npm run build && electron-builder --dir"
   },
   "dependencies": {
     "electron-updater": "^6.6.2"
@@ -30,5 +33,14 @@
   },
   "volta": {
     "node": "25.1.0"
+  },
+  "author": {
+    "name": "AgentRQ",
+    "email": "hi@agentrq.com"
+  },
+  "homepage": "https://agentrq.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/agentrq/agentrq.git"
   }
 }

--- a/desktop/resources/entitlements.mac.plist
+++ b/desktop/resources/entitlements.mac.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <!--
+      The hardened runtime is required for notarization, and it blocks the JIT
+      and unsigned-memory execution that Chromium and the WebAssembly speech
+      pipeline both rely on. These two exceptions are what Electron apps need to
+      run under it at all.
+    -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+
+    <!-- Dictation records audio; without this the prompt never appears. -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+  </dict>
+</plist>

--- a/desktop/scripts/check-versions.mjs
+++ b/desktop/scripts/check-versions.mjs
@@ -1,0 +1,55 @@
+/**
+ * Fail the build when the repository's versions have drifted apart.
+ *
+ * Run in CI before packaging. Optionally also checks the git tag being released,
+ * via GITHUB_REF.
+ *
+ *   node scripts/check-versions.mjs
+ */
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath, URL } from 'node:url'
+
+import {
+  VERSION_SOURCES,
+  compareVersions,
+  parseGoVersion,
+  parsePackageVersion,
+  tagMatchesVersion,
+} from '../src/version.js'
+
+const repoRoot = (p) => fileURLToPath(new URL(`../../${p}`, import.meta.url))
+
+const read = async (path) => {
+  try {
+    return await readFile(repoRoot(path), 'utf-8')
+  } catch {
+    return ''
+  }
+}
+
+const [desktop, frontend, backend] = await Promise.all([
+  read(VERSION_SOURCES.desktop),
+  read(VERSION_SOURCES.frontend),
+  read(VERSION_SOURCES.backend),
+])
+
+const result = compareVersions({
+  desktop: parsePackageVersion(desktop),
+  frontend: parsePackageVersion(frontend),
+  backend: parseGoVersion(backend),
+})
+
+if (!result.ok) {
+  console.error('✗ versions are out of step:')
+  for (const problem of result.problems) console.error(`  - ${problem}`)
+  process.exit(1)
+}
+
+const tag = tagMatchesVersion(process.env.GITHUB_REF, result.version)
+if (!tag.ok) {
+  console.error(`✗ ${tag.reason}`)
+  process.exit(1)
+}
+
+console.log(`✓ desktop, frontend and backend are all at ${result.version}`)
+if (process.env.GITHUB_REF?.startsWith('refs/tags/')) console.log(`✓ ${tag.reason}`)

--- a/desktop/src/main/updater.js
+++ b/desktop/src/main/updater.js
@@ -58,8 +58,13 @@ export function describeUpdateError(error) {
   if (/net::|ENOTFOUND|ETIMEDOUT|ECONNREFUSED|EAI_AGAIN/i.test(message)) {
     return 'Could not reach the update server'
   }
-  if (/404|no published versions|latest.yml/i.test(message)) {
+  if (/404|no published versions|latest.*\.yml/i.test(message)) {
     return 'No published release to update to'
+  }
+  // Only a build packaged with a publish configuration carries this file, so
+  // its absence means the build was never set up to update itself.
+  if (/app-update\.yml/i.test(message)) {
+    return 'This build has no update configuration'
   }
   return message
 }

--- a/desktop/src/version.js
+++ b/desktop/src/version.js
@@ -82,9 +82,17 @@ export function compareVersions(versions) {
  * @param {string} ref  a git ref such as `refs/tags/v0.5.0`, or a bare tag
  */
 export function tagMatchesVersion(ref, version) {
-  const tag = String(ref ?? '').replace(/^refs\/tags\//, '')
-  if (!tag) return { ok: true, reason: 'no tag to check' }
+  const raw = String(ref ?? '')
+  if (!raw) return { ok: true, reason: 'no tag to check' }
 
+  // GITHUB_REF is set on every build, not only releases: a pull request gets
+  // refs/pull/N/merge and a branch push gets refs/heads/<name>. Neither is a
+  // tag, so there is nothing here to disagree with the version.
+  if (raw.startsWith('refs/') && !raw.startsWith('refs/tags/')) {
+    return { ok: true, reason: 'not a tag build' }
+  }
+
+  const tag = raw.replace(/^refs\/tags\//, '')
   const tagged = tag.replace(/^v/, '')
   if (tagged !== version) {
     return { ok: false, reason: `tag ${tag} does not match version ${version}` }

--- a/desktop/src/version.js
+++ b/desktop/src/version.js
@@ -1,0 +1,93 @@
+/**
+ * Keeping the three versions in this repository in step.
+ *
+ * The desktop app, the web frontend and the Go backend each carry their own
+ * version, and they are meant to be the same number. That matters more for the
+ * desktop app than for the others: its version is what electron-updater
+ * compares against a GitHub Release to decide whether an update exists. A
+ * desktop build stamped lower than the release it came from would offer to
+ * update to itself, forever.
+ *
+ * Pure functions taking file contents rather than paths, so the rules are
+ * testable without a filesystem.
+ */
+
+/** Where each version lives, relative to the repository root. */
+export const VERSION_SOURCES = {
+  desktop: 'desktop/package.json',
+  frontend: 'frontend/package.json',
+  backend: 'backend/internal/service/config/config.go',
+}
+
+/**
+ * Pull the version out of a package.json's contents.
+ *
+ * @returns {string|null} null when the file is unreadable or has no version.
+ */
+export function parsePackageVersion(contents) {
+  try {
+    const version = JSON.parse(contents)?.version
+    return typeof version === 'string' && version !== '' ? version : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Pull the version out of the Go config source.
+ *
+ * It is a constant rather than anything machine-readable, so this reads the
+ * declaration directly. The leading `v` is dropped: everything else in the
+ * repository writes the bare number, and comparing `v0.4.8` with `0.4.8` would
+ * fail for no reason.
+ */
+export function parseGoVersion(contents) {
+  const match = /_appVersion\s*=\s*"v?([^"]+)"/.exec(String(contents ?? ''))
+  return match ? match[1] : null
+}
+
+/**
+ * Compare the three versions.
+ *
+ * @param {{desktop: string|null, frontend: string|null, backend: string|null}} versions
+ * @returns {{ok: boolean, version: string|null, problems: string[]}}
+ */
+export function compareVersions(versions) {
+  const problems = []
+
+  for (const [name, version] of Object.entries(versions)) {
+    if (!version) problems.push(`could not read the version from ${VERSION_SOURCES[name] ?? name}`)
+  }
+  if (problems.length > 0) return { ok: false, version: null, problems }
+
+  // The desktop version is the reference: it is the one electron-updater
+  // compares against a release, so it is the one that must be right.
+  const expected = versions.desktop
+  for (const [name, version] of Object.entries(versions)) {
+    if (version !== expected) {
+      problems.push(`${VERSION_SOURCES[name] ?? name} is ${version}, but desktop is ${expected}`)
+    }
+  }
+
+  return { ok: problems.length === 0, version: expected, problems }
+}
+
+/**
+ * Check that a git tag matches the version being built.
+ *
+ * Publishing `v0.5.0` from a tree stamped 0.4.8 would put artifacts named for
+ * one version inside a release named for another, and electron-updater would
+ * then hand users an "update" to the build they already have.
+ *
+ * @param {string} ref  a git ref such as `refs/tags/v0.5.0`, or a bare tag
+ */
+export function tagMatchesVersion(ref, version) {
+  const tag = String(ref ?? '').replace(/^refs\/tags\//, '')
+  if (!tag) return { ok: true, reason: 'no tag to check' }
+
+  const tagged = tag.replace(/^v/, '')
+  if (tagged !== version) {
+    return { ok: false, reason: `tag ${tag} does not match version ${version}` }
+  }
+  return { ok: true, reason: `tag ${tag} matches version ${version}` }
+}

--- a/desktop/test/updater.test.js
+++ b/desktop/test/updater.test.js
@@ -68,6 +68,13 @@ describe('describeUpdateError', () => {
     expect(describeUpdateError(new Error('Cannot find latest.yml'))).toBe('No published release to update to')
   })
 
+  it('recognises a build that was never set up to update itself', () => {
+    // Only a build packaged with a publish configuration carries app-update.yml;
+    // an unpackaged or --dir build hits this and the raw ENOENT explains nothing.
+    expect(describeUpdateError(new Error("ENOENT: no such file or directory, open '/x/app-update.yml'")))
+      .toBe('This build has no update configuration')
+  })
+
   it('passes an unrecognised message through rather than hiding it', () => {
     expect(describeUpdateError(new Error('something odd'))).toBe('something odd')
   })

--- a/desktop/test/version.test.js
+++ b/desktop/test/version.test.js
@@ -129,9 +129,14 @@ describe('tagMatchesVersion', () => {
     expect(tagMatchesVersion(null, '0.4.8').ok).toBe(true)
   })
 
-  it('is not fooled by a branch ref', () => {
-    // refs/heads/main is not a tag; stripping only the tag prefix leaves it
-    // unequal to the version, which is the correct answer for a release build.
-    expect(tagMatchesVersion('refs/heads/main', '0.4.8').ok).toBe(false)
+  it('ignores a ref that is not a tag at all', () => {
+    // This check runs on every build, not only releases. GITHUB_REF is
+    // refs/pull/N/merge on a pull request and refs/heads/<name> on a branch
+    // push; treating either as a mismatched tag fails every non-release build.
+    expect(tagMatchesVersion('refs/pull/367/merge', '0.4.8')).toEqual({
+      ok: true,
+      reason: 'not a tag build',
+    })
+    expect(tagMatchesVersion('refs/heads/main', '0.4.8').ok).toBe(true)
   })
 })

--- a/desktop/test/version.test.js
+++ b/desktop/test/version.test.js
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  VERSION_SOURCES,
+  compareVersions,
+  parseGoVersion,
+  parsePackageVersion,
+  tagMatchesVersion,
+} from '../src/version.js'
+
+describe('parsePackageVersion', () => {
+  it('reads the version', () => {
+    expect(parsePackageVersion('{"name":"x","version":"0.4.8"}')).toBe('0.4.8')
+  })
+
+  it('returns nothing when there is no usable version', () => {
+    expect(parsePackageVersion('{"name":"x"}')).toBeNull()
+    expect(parsePackageVersion('{"version":""}')).toBeNull()
+    expect(parsePackageVersion('{"version":42}')).toBeNull()
+  })
+
+  it('returns nothing rather than throwing on unreadable JSON', () => {
+    expect(parsePackageVersion('{ not json')).toBeNull()
+    expect(parsePackageVersion('')).toBeNull()
+    expect(parsePackageVersion(undefined)).toBeNull()
+  })
+})
+
+describe('parseGoVersion', () => {
+  it('reads the constant out of the Go source', () => {
+    const source = `const (\n\t_appName = "AgentRQ"\n\t_appVersion   = "v0.4.8"\n)`
+    expect(parseGoVersion(source)).toBe('0.4.8')
+  })
+
+  it('drops the leading v, which nothing else in the repo uses', () => {
+    // Comparing 'v0.4.8' with '0.4.8' would fail for no reason at all.
+    expect(parseGoVersion('_appVersion = "v1.2.3"')).toBe('1.2.3')
+    expect(parseGoVersion('_appVersion = "1.2.3"')).toBe('1.2.3')
+  })
+
+  it('tolerates whatever spacing the file happens to use', () => {
+    expect(parseGoVersion('_appVersion="v0.1.0"')).toBe('0.1.0')
+    expect(parseGoVersion('_appVersion    =    "v0.1.0"')).toBe('0.1.0')
+  })
+
+  it('returns nothing when the constant is absent', () => {
+    // Better to fail the release than to compare against a guess.
+    expect(parseGoVersion('const _other = "v1.0.0"')).toBeNull()
+    expect(parseGoVersion('')).toBeNull()
+    expect(parseGoVersion(null)).toBeNull()
+  })
+})
+
+describe('compareVersions', () => {
+  it('passes when all three agree', () => {
+    expect(compareVersions({ desktop: '0.4.8', frontend: '0.4.8', backend: '0.4.8' })).toEqual({
+      ok: true,
+      version: '0.4.8',
+      problems: [],
+    })
+  })
+
+  it('names what disagrees, and with what', () => {
+    const result = compareVersions({ desktop: '0.5.0', frontend: '0.4.8', backend: '0.4.8' })
+
+    expect(result.ok).toBe(false)
+    expect(result.problems).toEqual([
+      `${VERSION_SOURCES.frontend} is 0.4.8, but desktop is 0.5.0`,
+      `${VERSION_SOURCES.backend} is 0.4.8, but desktop is 0.5.0`,
+    ])
+  })
+
+  it('treats the desktop version as the reference', () => {
+    // It is the number electron-updater compares against a release, so it is
+    // the one that has to be right.
+    const result = compareVersions({ desktop: '0.4.8', frontend: '0.5.0', backend: '0.4.8' })
+    expect(result.problems).toEqual([`${VERSION_SOURCES.frontend} is 0.5.0, but desktop is 0.4.8`])
+  })
+
+  it('fails when a version could not be read at all', () => {
+    const result = compareVersions({ desktop: '0.4.8', frontend: null, backend: '0.4.8' })
+
+    expect(result.ok).toBe(false)
+    expect(result.problems).toEqual([`could not read the version from ${VERSION_SOURCES.frontend}`])
+  })
+
+  it('names an unknown source by its key rather than printing undefined', () => {
+    // A fourth version could be added to the repo; the message should still be
+    // readable if someone forgets to describe where it lives.
+    const missing = compareVersions({ desktop: '0.4.8', mobile: null })
+    expect(missing.problems).toEqual(['could not read the version from mobile'])
+
+    const mismatched = compareVersions({ desktop: '0.4.8', mobile: '0.1.0' })
+    expect(mismatched.problems).toEqual(['mobile is 0.1.0, but desktop is 0.4.8'])
+  })
+
+  it('reports every unreadable source rather than only the first', () => {
+    const result = compareVersions({ desktop: null, frontend: null, backend: null })
+    expect(result.problems).toHaveLength(3)
+    expect(result.version).toBeNull()
+  })
+})
+
+describe('tagMatchesVersion', () => {
+  it('accepts a tag that matches', () => {
+    expect(tagMatchesVersion('refs/tags/v0.4.8', '0.4.8')).toEqual({
+      ok: true,
+      reason: 'tag v0.4.8 matches version 0.4.8',
+    })
+  })
+
+  it('accepts a bare tag as well as a full ref', () => {
+    expect(tagMatchesVersion('v0.4.8', '0.4.8').ok).toBe(true)
+    expect(tagMatchesVersion('0.4.8', '0.4.8').ok).toBe(true)
+  })
+
+  it('rejects a tag that does not match the tree being built', () => {
+    // Otherwise the release is named for one version and its artifacts for
+    // another, and electron-updater offers users the build they already have.
+    expect(tagMatchesVersion('refs/tags/v0.5.0', '0.4.8')).toEqual({
+      ok: false,
+      reason: 'tag v0.5.0 does not match version 0.4.8',
+    })
+  })
+
+  it('passes when there is no tag, which is every non-release build', () => {
+    expect(tagMatchesVersion('', '0.4.8').ok).toBe(true)
+    expect(tagMatchesVersion(undefined, '0.4.8').ok).toBe(true)
+    expect(tagMatchesVersion(null, '0.4.8').ok).toBe(true)
+  })
+
+  it('is not fooled by a branch ref', () => {
+    // refs/heads/main is not a tag; stripping only the tag prefix leaves it
+    // unequal to the version, which is the correct answer for a release build.
+    expect(tagMatchesVersion('refs/heads/main', '0.4.8').ok).toBe(false)
+  })
+})

--- a/desktop/vitest.config.mjs
+++ b/desktop/vitest.config.mjs
@@ -6,7 +6,7 @@ export default defineConfig({
     include: ['test/**/*.test.js'],
     coverage: {
       provider: 'v8',
-      include: ['src/main/**/*.js'],
+      include: ['src/main/**/*.js', 'src/version.js'],
       // The Electron entry point is app lifecycle wiring: it imports `electron`
       // at module scope and its behaviour is only observable with a real
       // Electron binary. Every rule it depends on lives in the modules beside


### PR DESCRIPTION
> **Stacked on #366** → #365 → #364 → #363 → #362. Merge in order and each retargets cleanly.

## What changed

Tagging a version now builds the desktop app on macOS, Windows and Linux and publishes the installers to a GitHub Release, which is also where the app looks for its own updates. Pull requests that touch the desktop or frontend run the same build without publishing.

## Why changed

Everything built so far only runs from a developer checkout. This is what turns it into something a person can download, and what feeds the auto-updating added in the previous phase.

## Test coverage report

New lines introduced: **100%** — 301 tests across statements, branches, functions and lines, enforced as a CI gate.

```
desktop  | % Stmts | % Branch | % Funcs | % Lines
All files|     100 |      100 |     100 |     100
 (12 modules, version.js included)
```

Total coverage impact: desktop rises from 282 to 301 tests, still 100% on every covered module. Frontend unchanged at 29 tests, 100%.

The version check was verified by **breaking it**, not only by watching it pass:

```
✗ versions are out of step:
  - frontend/package.json is 0.9.9, but desktop is 0.4.8
✗ tag v0.5.0 does not match version 0.4.8
✓ desktop, frontend and backend are all at 0.4.8
```

## Other reports

**Building it for real found a bug that reading configuration would not.** The packaged macOS app had no URL-scheme declaration, so macOS would never have routed `agentrq://` links to it. Registering the scheme at runtime is enough for Windows and Linux, but macOS only routes a scheme an application declares in its own bundle — meaning the deep links added two phases ago would have shipped completely dead on macOS, with nothing in the code to suggest it. Fixed and verified in a rebuilt bundle.

I also built and **ran** the packaged application, which confirmed the update machinery genuinely activates once packaged — something that never happens in development, so the previous phase's safety guard is now proven from both sides.

**Signing is credential-gated, not assumed.** With no certificate the build still succeeds and ships unsigned: Windows and Linux install and update normally, while macOS can be downloaded and run but cannot update itself, because Apple's updater refuses to install onto an unsigned application. The app already explains that in plain words rather than failing cryptically. Adding the secrets turns signing on with no other change — this remains the open question from the plan.

**Two guards on releasing.** Versions are checked in a job costing seconds, so a mismatch fails before any twenty-minute build starts, and the tag must match the tree — a release cannot be named for one version and filled with artifacts for another. The release is assembled as a draft and only published once every platform has finished, so nobody sees a release missing the installer for their machine.

**One thing not yet validated.** The publish path itself cannot be exercised without pushing a tag, which would create a real release. The pull-request job proves packaging on all three platforms; I'd suggest a throwaway pre-release tag as the final check before the first real version, and I have not created one because that is an outward-facing action.

## TaskID

0huaBmzhpvl

Parent: 0huZWzzheT3 — plan in #359, phases 1–6 in #360, #362, #363, #364, #365, #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)