### PR TITLE
docs: add Message Send Delay to the README feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ Click the mic on any task description or reply and dictate it instead. Transcrip
 </td>
 <td width="50%"><img src="https://agentrq.com/assets/feature-speech-to-text.gif" alt="AgentRQ speech-to-text mic entry point" width="320" /></td>
 </tr>
+<tr>
+<td width="50%"><img src="https://agentrq.com/assets/feature-message-send-delay.gif" alt="AgentRQ message send delay countdown with Send Now and Cancel" width="320" /></td>
+<td width="50%" valign="middle">
+
+### Message Send Delay
+
+Give a workspace a countdown — 3s, 5s, 10s, 15s, 30s or 60s — and every chat message waits that long in the thread before it reaches the agent. **Send Now** delivers it early, **Cancel** pulls it back unsent and puts the exact text and attachments back in your composer. Off by default, per workspace.
+
+</td>
+</tr>
 </table>
 
 See the full list at [agentrq.com/features](https://agentrq.com/features).


### PR DESCRIPTION
**What changed**

The repository's feature list now documents the per-workspace message send delay: a chat message waits a chosen number of seconds in the thread before it reaches the agent, and while it waits you can deliver it early or pull it back unsent.

**Why changed**

The feature has shipped and is already presented on the website, but the repository's own feature list never mentioned it, so anyone reading the project here would not know it exists.

**Test coverage report**

Documentation only — no executable code was added or changed, so there are no new lines to cover and total coverage is unaffected.

**Other reports**

Every claim was checked against the implementation rather than the marketing copy: the offered intervals (3s, 5s, 10s, 15s, 30s, 60s) match the values the backend accepts and rejects anything else; off-by-default matches the stored default; and the described "Send Now" and "Cancel" controls, the in-thread countdown, and Cancel restoring both the text and the attachments to the composer all match the current behaviour. The illustrating capture was confirmed to be live (HTTP 200) before being referenced, and the feature table's alternating left/right image layout is preserved.

**TaskID:** 0hwsXDyYKUT