### PR TITLE
chore: bump patch version to v0.4.9

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.4.8"
+	_appVersion   = "v0.4.9"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.4.8" {
-			t.Errorf("Expected version v0.4.8, got %s", s.Version())
+		if s.Version() != "v0.4.9" {
+			t.Errorf("Expected version v0.4.9, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.4.8",
+  "version": "0.4.9",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
**What changed**

The project version moves from 0.4.8 to 0.4.9 everywhere it is declared — the desktop and frontend packages with their lockfiles, and the backend's application version constant with the test that asserts it.

**Why changed**

To cut the release that ships the desktop application. This is the first tag since the release pipeline landed, so pushing `v0.4.9` will produce the project's first published GitHub Release — and the install command now documented in the README will finally have something to fetch.

**What ships in this version** (since `v0.4.8`)

- feat: Electron shell rendering the same Vue app as the browser, sharing one route table so the builds cannot drift (#360, #362)
- feat: server connection screen, OAuth sign-in and application menu (#363)
- feat: native notifications driven from the event stream (#364)
- feat: native shell — menu, tray, global shortcut, deep links, window state (#365)
- feat: auto-update via electron-updater (#366)
- feat: electron-builder config and the tagged release pipeline (#367)
- fix: SSE headers flushed on connect so `EventSource` fires `onopen` (#361)
- docs: desktop user guide, README sections and make targets (#368)

**Test coverage report**

No executable code was added, so no new lines require coverage and total coverage is unaffected. The two changed assertions are the existing version test, updated to the new value. Backend config package passes; the desktop suite passes at 303 tests across 12 files.

**Other reports**

The version-sync guard was exercised in both directions, since it gates the release before any packaging starts: `GITHUB_REF=refs/tags/v0.4.9` reports the tag matches, and a deliberately wrong `refs/tags/v0.5.0` is rejected.

`npm install --package-lock-only` also wanted to add ~35 lines of unrelated bundled-dependency entries to the desktop lockfile. Those were reverted so this change is purely the version — dependency resolution should not shift underneath the first release run. `npm ci` was confirmed to still install cleanly from the restored lockfile.

**TaskID:** 0huaCOrjhtR