### PR TITLE
fix(desktop): unset empty signing variables so an unsigned macOS build packages

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -110,6 +110,22 @@ jobs:
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ steps.signing.outputs.available }}
         run: |
           npm run build
+
+          # An empty CSC_LINK is not the same as an unset one. GitHub Actions
+          # defines the variable as "" when the secret does not exist, and
+          # electron-builder then resolves that empty string as a certificate
+          # path -- landing on the working directory and dying with
+          # "<projectDir> not a file" before it packages anything.
+          #
+          # Pull request builds cannot catch this: electron-builder detects a
+          # PR and skips code signing entirely ("Current build is a part of
+          # pull request, code signing will be skipped"), so the empty value is
+          # never resolved. It only surfaces on a tag build, which is the worst
+          # possible moment to find out.
+          if [ "${{ steps.signing.outputs.available }}" != "true" ]; then
+            unset CSC_LINK CSC_KEY_PASSWORD WIN_CSC_LINK WIN_CSC_KEY_PASSWORD
+          fi
+
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             # Prove it packages; publish nothing.
             npx electron-builder --publish never


### PR DESCRIPTION
**What changed**

When no code-signing certificate is configured, the release build now clears the signing variables entirely instead of passing them through empty, so packaging an unsigned macOS build succeeds.

**Why changed**

The v0.4.9 tag build failed on macOS with `⨯ <projectDir> not a file` and produced no macOS artifacts. An empty environment variable is not the same as an absent one: the packaging tool treated the empty certificate path as a real path, resolved it to the project directory, and stopped before building anything. Linux and Windows were unaffected.

**Why this was not caught in review**

The packaging tool skips code signing altogether on pull request builds, so the empty value is never resolved there. Every pull request build passed, including the two run against this workflow. This failure is only reachable from a tag build, which means the pull request check cannot catch this class of problem — that reasoning is now a comment in the workflow so the gap is visible to the next reader.

**Test coverage report**

No application code changed, so no new lines require coverage and total coverage is unaffected. This is CI configuration; it is verified by the tag build itself, which is the only context that exercises the failing path.

**Other reports**

The two unaffected platforms completed and published, so the fixed run needs to produce the macOS artifacts and let the publish job promote the draft. Recommend deleting the existing v0.4.9 draft release before re-running, so assets are not uploaded twice into it.

**TaskID:** 0huaCOrjhtR