### PR TITLE
chore: bump patch version to v0.4.10

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.4.9"
+	_appVersion   = "v0.4.10"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.4.9" {
-			t.Errorf("Expected version v0.4.9, got %s", s.Version())
+		if s.Version() != "v0.4.10" {
+			t.Errorf("Expected version v0.4.10, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.4.9",
+      "version": "0.4.10",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.4.9",
+      "version": "0.4.10",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.4.9",
+  "version": "0.4.10",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
**What changed**

The project version moves from 0.4.9 to 0.4.10 everywhere it is declared — the desktop and frontend packages with their lockfiles, and the backend's application version constant with the test asserting it.

**Why changed**

To re-cut the release that 0.4.9 could not finish. The 0.4.9 tag build packaged Linux and Windows but failed on macOS before producing anything, so no complete release was ever published from that tag. The packaging fault is fixed on main now, and this version number is the clean way to try again rather than moving an existing tag.

**What ships since v0.4.9**

- fix: an unsigned macOS build now packages instead of failing the release. A missing secret is defined as an empty value rather than being absent, and the packaging tool treated that empty certificate path as a real one. Pull request builds could not catch it, because the packaging tool skips code signing on pull requests entirely (#371).

Everything else in this release was already described in v0.4.9: the desktop application, the SSE `onopen` fix, and the desktop documentation.

**Test coverage report**

No executable code was added, so no new lines require coverage and total coverage is unaffected. The two changed assertions are the existing version test updated to the new value. Backend config package passes; the desktop suite passes at 303 tests across 12 files.

**Other reports**

The version-sync guard was exercised as CI runs it: `GITHUB_REF=refs/tags/v0.4.10` reports the tag matches the tree.

Both lockfiles were edited in place rather than regenerated, so this changes the version and nothing about dependency resolution — regenerating wanted to pull in unrelated bundled-dependency entries, which should not shift underneath a release. `npm ci` was confirmed to still install cleanly.

This branch is rebased on the commit carrying the packaging fix, so merging it puts both on main before the tag is cut.

**TaskID:** 0huaCOrjhtR