### PR TITLE
fix(desktop): create the release draft up front so publishers cannot race

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -27,7 +27,9 @@ jobs:
     name: Version sync
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # write, not read, because this job now also creates the draft release
+      # the build matrix publishes into. See the step at the end.
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -42,6 +44,34 @@ jobs:
         # version inside a release named for another, and offer users an
         # "update" to the build they already have.
         run: node scripts/check-versions.mjs
+
+      # Create the draft up front so nothing downstream ever has to.
+      #
+      # electron-builder creates the release when it finds none, and in v0.4.10
+      # that raced three ways: the matrix runs in parallel, and a single job
+      # runs several publishers at once (macOS logged "creating GitHub release
+      # reason=release doesn't exist" twice in the same second). GitHub permits
+      # more than one *draft* sharing a tag, so the duplicates were accepted
+      # silently and the uploads scattered across them. The publish job then
+      # promoted whichever one `gh` resolved, and v0.4.10 shipped with the
+      # macOS and Windows artifacts but none of the four Linux ones — every job
+      # green, the release quietly incomplete.
+      #
+      # With the draft already present, every publisher takes the "found it"
+      # path and they all upload to the same release.
+      - name: Create the draft release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; leaving it alone."
+          else
+            gh release create "$TAG" --draft --title "$TAG" \
+              --generate-notes --repo "$GITHUB_REPOSITORY"
+            echo "Created draft release $TAG"
+          fi
 
   build:
     name: Build ${{ matrix.os }}


### PR DESCRIPTION
**What changed**

The release draft is now created once, up front, before any packaging starts, instead of being created on demand by whichever build gets there first.

**Why changed**

Version 0.4.10 published with the macOS and Windows downloads and none of the four Linux ones, while every job reported success. The packaging tool creates the release when it cannot find one, and that raced three ways — the platform builds run in parallel, and a single build runs several publishers at once. GitHub allows more than one *draft* release to share a tag, so the duplicates were accepted silently, the Linux uploads went into one of them, and the step that publishes promoted a different one.

Nothing failed, which is what makes it worth fixing properly: a Linux user following the documented install command is told the release has no Linux download, and Linux auto-update has no manifest to read.

Creating the draft in the version-sync step — which already completes before any build begins — removes the "no release yet" branch from the race for every publisher, including the concurrent ones inside a single build. Serialising the platform builds would not have covered that second case.

**Test coverage report**

No application code changed, so no new lines require coverage and total coverage is unaffected. This is CI configuration, verified by a tag build; the pull request path is untouched because the new step only runs for tags.

**Other reports**

Verified against the 0.4.10 run rather than inferred: the Linux job's log shows all four artifacts uploading successfully, and the published release does not contain them. The macOS log shows the duplicate release creation in the same second. Confirmed the practical impact by running the published install command — macOS installs correctly and passes its checksum, while both Linux architectures stop with "release v0.4.10 has no Linux AppImage".

Note this does not repair 0.4.10 itself, which needs either the missing files attached to the existing release by hand or a fresh version.

**TaskID:** 0huaCOrjhtR