### PR TITLE
chore: bump patch version to v0.4.11

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.4.10"
+	_appVersion   = "v0.4.11"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.4.10" {
-			t.Errorf("Expected version v0.4.10, got %s", s.Version())
+		if s.Version() != "v0.4.11" {
+			t.Errorf("Expected version v0.4.11, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.4.10",
+  "version": "0.4.11",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
**What changed**

The project version moves from 0.4.10 to 0.4.11 everywhere it is declared — the desktop and frontend packages with their lockfiles, and the backend's application version constant with the test asserting it.

**Why changed**

To produce the first complete release. Version 0.4.10 shipped without any Linux downloads, because concurrent publishers each created their own draft for the same tag and the Linux uploads landed in one that was never promoted — with every job reporting success. That race is fixed on main now, and this version is what proves it: the fix only runs on a tag build, so no pull request check can exercise it.

**What ships since v0.4.10**

- fix: the release draft is created once, up front, so parallel publishers all upload into the same release (#373)

**Test coverage report**

No executable code was added, so no new lines require coverage and total coverage is unaffected. The two changed assertions are the existing version test updated to the new value. Backend config package passes; the desktop suite passes at 303 tests across 12 files.

**Other reports**

The version-sync guard was exercised as CI runs it: `GITHUB_REF=refs/tags/v0.4.11` reports the tag matches the tree. Both lockfiles were edited in place rather than regenerated, so dependency resolution does not shift underneath a release; `npm ci` confirmed clean.

Success for this release means eleven assets plus the four Linux ones and `latest-linux.yml` — the check on the last one is not "the jobs went green", since they did last time too.

**TaskID:** 0huaCOrjhtR