### PR TITLE
chore(desktop): attribute copyright to Contextual, Inc.

### DIFF
--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -6,7 +6,12 @@
 
 appId: com.agentrq.desktop
 productName: AgentRQ
-copyright: Copyright © 2026 AgentRQ
+# The legal owner of the app, which is not the product name: this string is
+# what macOS puts in NSHumanReadableCopyright and shows in the About panel
+# the app menu opens, and what Windows records as the executable's legal
+# copyright. appId and productName stay AgentRQ -- changing either would
+# rename the app or orphan existing installs from their updates.
+copyright: Copyright © 2026 Contextual, Inc.
 
 directories:
   output: release


### PR DESCRIPTION
**What changed**

The desktop app's copyright notice now credits Contextual, Inc. rather than AgentRQ. This is the line macOS shows in the About panel and Windows records as the executable's legal copyright.

**Why changed**

The notice named the product instead of the company that owns it. Copyright belongs to the legal entity, so the packaged app should say so.

The application's name and identifier are deliberately left alone — AgentRQ is still the product, and changing either would rename the app or cut existing installations off from their update feed.

**Test coverage report**

No executable code changed; this is packaging metadata, so no new lines require coverage and total coverage is unaffected. The existing desktop suite passes at 303 tests across 12 files.

**Other reports**

Verified by packaging rather than by reading the config. A build of this branch produces a bundle whose metadata reads:

```
NSHumanReadableCopyright:   Copyright © 2026 Contextual, Inc.
CFBundleName:               AgentRQ
CFBundleIdentifier:         com.agentrq.desktop
```

confirming the new notice ships and that the name and identifier are untouched. For contrast, the currently released 0.4.11 build installed on disk reads `Copyright © 2026 AgentRQ`.

Two adjacent fields still name AgentRQ and were left as-is, since they are authorship and packaging contacts rather than copyright: the package author, and the Linux package maintainer. Say the word if those should change too.

**TaskID:** 0hxODlyHCDJ