### PR TITLE
fix(desktop): allow provider avatar hosts so profile photos render

### DIFF
--- a/desktop/src/main/protocol.js
+++ b/desktop/src/main/protocol.js
@@ -144,6 +144,17 @@ export function filterResponseHeaders(headers) {
  * connect-src — API traffic needs nothing beyond 'self' because it is proxied
  * through this same origin.
  *
+ * img-src carries the sign-in providers' avatar CDNs. `user.picture` is the URL
+ * the provider hands back verbatim, pointing at their own host, so 'self' alone
+ * silently blocked every profile photo and the sidebar fell back to the
+ * initial-letter placeholder — visible only in the desktop build, because the
+ * browser build is served without a CSP at all.
+ *
+ * These are listed host by host rather than opening img-src to `https:`. The
+ * point of the policy is that injected markup cannot reach an arbitrary origin,
+ * and an <img> to a URL of the attacker's choosing is a working beacon even
+ * though it renders nothing.
+ *
  * Deliberately absent: COOP/COEP. Cross-origin isolation would unlock
  * multi-threaded WASM, but `require-corp` also blocks every CDN response that
  * lacks a CORP header, including the model weights. Single-threaded inference
@@ -154,6 +165,10 @@ export function filterResponseHeaders(headers) {
  */
 export function buildCSP({ dev = false, devServerUrl = '' } = {}) {
   const hf = 'https://huggingface.co https://*.hf.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co'
+  // Google serves avatars from lh3/lh4/lh5.googleusercontent.com and rotates
+  // between them; GitHub uses a single host. Both are the providers the app
+  // offers, so a new sign-in provider means a new entry here.
+  const avatars = 'https://*.googleusercontent.com https://avatars.githubusercontent.com'
   const script = dev ? `'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'` : `'self' 'wasm-unsafe-eval'`
   const connect = dev ? `'self' ${hf} ${devServerUrl} ws://localhost:* ws://127.0.0.1:*` : `'self' ${hf}`
 
@@ -161,7 +176,7 @@ export function buildCSP({ dev = false, devServerUrl = '' } = {}) {
     `default-src 'self'`,
     `script-src ${script}`,
     `style-src 'self' 'unsafe-inline'`,
-    `img-src 'self' data: blob:`,
+    `img-src 'self' data: blob: ${avatars}`,
     `font-src 'self' data:`,
     `connect-src ${connect}`,
     `worker-src 'self' blob:`,

--- a/desktop/test/protocol.test.js
+++ b/desktop/test/protocol.test.js
@@ -185,6 +185,31 @@ describe('buildCSP', () => {
     expect(csp).not.toContain(`script-src 'self' 'unsafe-inline'`)
   })
 
+  it('allows the sign-in providers to serve profile photos', () => {
+    // user.picture is the provider's own URL, so 'self' alone blocked every
+    // avatar and the sidebar fell back to the initial-letter placeholder.
+    for (const csp of [buildCSP(), buildCSP({ dev: true, devServerUrl: 'http://localhost:5174' })]) {
+      const img = csp.split('; ').find((d) => d.startsWith('img-src'))
+      expect(img).toContain('https://*.googleusercontent.com')
+      expect(img).toContain('https://avatars.githubusercontent.com')
+      expect(img).toContain(`'self'`)
+      expect(img).toContain('data:')
+      expect(img).toContain('blob:')
+    }
+  })
+
+  it('does not open images to arbitrary origins', () => {
+    // An <img> to any host is a working beacon even though it renders nothing,
+    // so the avatar hosts are listed individually rather than allowing https:.
+    const img = buildCSP()
+      .split('; ')
+      .find((d) => d.startsWith('img-src'))
+    // A bare `https:` scheme source, or a lone `*`, would allow any host. The
+    // subdomain wildcard inside https://*.googleusercontent.com is not that.
+    expect(img).not.toMatch(/(^|\s)https:(\s|$)/)
+    expect(img).not.toMatch(/(^|\s)\*(\s|$)/)
+  })
+
   it('relaxes only in dev, where the Vite client needs it', () => {
     const csp = buildCSP({ dev: true, devServerUrl: 'http://localhost:5174' })
     expect(csp).toContain(`'unsafe-eval'`)


### PR DESCRIPTION
**What changed**

The desktop app now displays the signed-in user's profile photo, instead of falling back to the initial-letter placeholder.

**Why changed**

The photo's address points at whichever sign-in provider the user used, on that provider's own image servers. The desktop build's security policy only permitted images from the app itself, so every profile photo was blocked. Nothing reported an error — the image simply never arrived and the placeholder took its place, which reads as an intentional design rather than a blocked request. Only the desktop build applies such a policy, which is why the browser was unaffected and the two disagreed.

The two providers' image hosts are permitted individually rather than allowing images from anywhere. The policy exists so that injected markup cannot reach an arbitrary destination, and an image pointed at someone else's server still reports back even though it displays nothing. Adding a new sign-in provider will mean adding its host, which the code comment now says.

**Test coverage report**

New lines introduced: 100% covered. Two tests added — that both providers are permitted in development and production builds, and that the policy still refuses a blanket "any https host" or wildcard source, so the fix cannot quietly widen into permitting everything.

Total coverage impact: none, it stays at 100%. The desktop suite is 100% statements, branches, functions and lines both before and after; the changed file remains fully covered. Suite goes from 303 to 305 tests, all passing.

**Other reports**

Verified the diagnosis end to end rather than inferring it from the symptom: the profile photo is the only external image the interface loads, so this is the whole of the problem and not one instance of it; the stored photo address is the raw provider URL, confirmed in the sign-in handlers for both providers; and the browser build genuinely sets no equivalent policy, which is what makes this desktop-only.

**TaskID:** 0hxOczpqL0z