### PR TITLE
fix(desktop): open links in an app window instead of the system browser

### DIFF
--- a/desktop/src/main/index.js
+++ b/desktop/src/main/index.js
@@ -30,6 +30,7 @@ import { AUTH_COOKIE, matchOAuthLogin, oauthStartUrl, runOAuthFlow } from './aut
 import { QUICK_CREATE_ACCELERATOR, buildMenuTemplate } from './menu.js'
 import { badgeFor, createNotificationGate, createUnreadCounter, mapEventToNotification } from './notifications.js'
 import { createEventStreamClient } from './sse.js'
+import { LinkTarget, classifyLink, linkWindowBounds } from './links.js'
 import { UpdateStatus, createUpdater } from './updater.js'
 // Externalised by the build, so this resolves from node_modules at runtime.
 // Importing it is inert; the dev guard is about never *using* it against a
@@ -145,6 +146,66 @@ function connectionState() {
 /** Send the window back to the app root, picking up whatever the state now is. */
 function reloadToRoot(win) {
   if (win && !win.isDestroyed()) win.loadURL(`${APP_ORIGIN}/`)
+}
+
+/**
+ * Show a link in a window belonging to the app.
+ *
+ * Hardened exactly like the OAuth window below, and for the same reason: this
+ * is rendering a page the app does not control, so it gets no preload, no node
+ * and a sandbox. It also gets its own session partition — the default session
+ * is where the `at` cookie lives, and an arbitrary website has no business
+ * sharing that jar.
+ *
+ * No `parent`, deliberately: a child window is pinned above its parent, which
+ * is the wrong behaviour for something the user may want to read beside the
+ * app rather than on top of it.
+ */
+function openLinkWindow(url, parentWin) {
+  const alive = parentWin && !parentWin.isDestroyed()
+  const { width, height } = linkWindowBounds(alive ? parentWin.getBounds() : null)
+
+  const child = new BrowserWindow({
+    width,
+    height,
+    autoHideMenuBar: true,
+    backgroundColor: backgroundColorFor(currentTheme),
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+      partition: 'persist:agentrq-links',
+    },
+  })
+
+  // A page opened this way must not be able to spawn further app windows. Its
+  // own popups go to the real browser, where an unfamiliar site belongs.
+  child.webContents.setWindowOpenHandler(({ url: next }) => {
+    const target = classifyLink(next, { appOrigin: APP_ORIGIN })
+    if (target === LinkTarget.Window || target === LinkTarget.System) shell.openExternal(next)
+    return { action: 'deny' }
+  })
+
+  child.loadURL(url)
+  return child
+}
+
+/**
+ * Send a link where it belongs. Blocked targets fall through to nothing on
+ * purpose: a javascript: or file: URL in a message body is not a link the user
+ * meant to follow, and reporting it would only teach them to click through.
+ */
+function routeLink(url, parentWin) {
+  switch (classifyLink(url, { appOrigin: APP_ORIGIN })) {
+    case LinkTarget.Window:
+      openLinkWindow(url, parentWin)
+      break
+    case LinkTarget.System:
+      shell.openExternal(url)
+      break
+    default:
+      break
+  }
 }
 
 async function startOAuth(win, pathname, search) {
@@ -341,16 +402,19 @@ function createWindow() {
     win.webContents.send('agentrq:navigate', route)
   })
 
-  // Anything that is not the app itself belongs in the user's real browser.
+  // A link out of the app opens in a window of the app's own, which the user
+  // closes to get straight back to what they were doing. Handing these to the
+  // system browser instead put the docs, the terms and any URL on a message
+  // behind a context switch with nothing to come back to.
   win.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url)
+    routeLink(url, win)
     return { action: 'deny' }
   })
 
   win.webContents.on('will-navigate', (event, url) => {
     if (!url.startsWith(APP_ORIGIN)) {
       event.preventDefault()
-      shell.openExternal(url)
+      routeLink(url, win)
       return
     }
 

--- a/desktop/src/main/links.js
+++ b/desktop/src/main/links.js
@@ -1,0 +1,82 @@
+/**
+ * Where a link should open.
+ *
+ * The shell used to hand every link that was not the app itself to the system
+ * browser. Reading the docs, the terms, or a URL attached to a message threw
+ * the user out of AgentRQ entirely, with nothing to come back to — the PWA
+ * opens the same links in a window of its own that can simply be closed, and
+ * this is what restores that.
+ *
+ * Not everything belongs in a window, which is why this is a classification
+ * rather than a boolean:
+ *
+ * - `app://` is the application; the router already handles those in place.
+ * - http(s) is web content, and an in-app window can show it.
+ * - `mailto:`, `tel:` and their siblings address a program that is not a
+ *   browser. A BrowserWindow cannot render them, so they go to the OS.
+ * - `javascript:`, `data:` and `file:` are never opened from a link at all.
+ *   Handing any of those to `shell.openExternal` is the well-worn way for
+ *   injected markup in a message body to reach the machine it is running on.
+ *
+ * Kept apart from index.js because that module needs a live Electron to import,
+ * and this decision is the part worth testing.
+ */
+
+export const LinkTarget = {
+  /** The app itself; let the renderer's router handle it. */
+  App: 'app',
+  /** Web content, shown in a closable window belonging to the app. */
+  Window: 'window',
+  /** Hand to the operating system: mail client, dialler, and so on. */
+  System: 'system',
+  /** Refuse. */
+  Blocked: 'blocked',
+}
+
+/**
+ * Schemes that address something other than a browser, and that are safe to
+ * pass to the OS. An allowlist, because the interesting failure is the scheme
+ * nobody thought about.
+ */
+const SYSTEM_SCHEMES = new Set(['mailto:', 'tel:', 'sms:', 'facetime:'])
+
+/**
+ * `URL.origin` is useless here: Node returns the string "null" for any scheme
+ * it does not consider special, and `app://` is not special. Protocol and host
+ * are populated for every scheme, so they are what the comparison uses.
+ */
+function originOf(url) {
+  return `${url.protocol}//${url.host}`
+}
+
+/**
+ * @param {string} rawUrl
+ * @param {{ appOrigin?: string }} [options]
+ * @returns {typeof LinkTarget[keyof typeof LinkTarget]}
+ */
+export function classifyLink(rawUrl, { appOrigin = '' } = {}) {
+  let url
+  try {
+    url = new URL(String(rawUrl ?? ''))
+  } catch {
+    // Not a URL at all — a relative href that reached here, or junk.
+    return LinkTarget.Blocked
+  }
+
+  if (appOrigin && originOf(url) === appOrigin) return LinkTarget.App
+  if (url.protocol === 'http:' || url.protocol === 'https:') return LinkTarget.Window
+  if (SYSTEM_SCHEMES.has(url.protocol)) return LinkTarget.System
+  return LinkTarget.Blocked
+}
+
+/**
+ * Size for a link window, derived from the parent so the result is usable on a
+ * laptop and not comically small beside a large main window.
+ *
+ * @param {{ width: number, height: number } | null | undefined} parentBounds
+ */
+export function linkWindowBounds(parentBounds) {
+  const width = Math.round(Math.min(Math.max((parentBounds?.width ?? 1024) * 0.8, 640), 1200))
+  const height = Math.round(Math.min(Math.max((parentBounds?.height ?? 768) * 0.85, 480), 900))
+  return { width, height }
+}

--- a/desktop/test/links.test.js
+++ b/desktop/test/links.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+
+import { LinkTarget, classifyLink, linkWindowBounds } from '../src/main/links.js'
+
+const APP_ORIGIN = 'app://agentrq'
+const classify = (url) => classifyLink(url, { appOrigin: APP_ORIGIN })
+
+describe('classifyLink', () => {
+  it('leaves the app to its own router', () => {
+    expect(classify('app://agentrq/tasks/123')).toBe(LinkTarget.App)
+    expect(classify('app://agentrq/')).toBe(LinkTarget.App)
+  })
+
+  it('does not mistake another app:// host for the app', () => {
+    // URL.origin is the string "null" for a non-special scheme, so a comparison
+    // written against it would treat every app:// URL as ours.
+    expect(classify('app://elsewhere/tasks/123')).toBe(LinkTarget.Blocked)
+  })
+
+  it('opens web content in a window', () => {
+    // The links the interface actually renders: docs, terms, privacy, and the
+    // URL attached to a message.
+    expect(classify('https://agentrq.com/docs')).toBe(LinkTarget.Window)
+    expect(classify('https://agentrq.com/tos')).toBe(LinkTarget.Window)
+    expect(classify('http://192.168.1.10:3000/report')).toBe(LinkTarget.Window)
+  })
+
+  it('hands schemes a browser cannot render to the system', () => {
+    expect(classify('mailto:hi@agentrq.com')).toBe(LinkTarget.System)
+    expect(classify('tel:+15551234')).toBe(LinkTarget.System)
+    expect(classify('sms:+15551234')).toBe(LinkTarget.System)
+  })
+
+  it('refuses schemes that reach the machine rather than the web', () => {
+    // A message body is attacker-influenced text. Passing any of these to
+    // shell.openExternal is how that text starts executing things.
+    expect(classify('javascript:alert(1)')).toBe(LinkTarget.Blocked)
+    expect(classify('data:text/html,<script>alert(1)</script>')).toBe(LinkTarget.Blocked)
+    expect(classify('file:///etc/passwd')).toBe(LinkTarget.Blocked)
+    expect(classify('vbscript:msgbox(1)')).toBe(LinkTarget.Blocked)
+  })
+
+  it('is not fooled by an unusual spelling of the scheme', () => {
+    expect(classify('JavaScript:alert(1)')).toBe(LinkTarget.Blocked)
+    expect(classify('HTTPS://agentrq.com/docs')).toBe(LinkTarget.Window)
+  })
+
+  it('refuses anything that is not a URL', () => {
+    expect(classify('/tasks/123')).toBe(LinkTarget.Blocked)
+    expect(classify('')).toBe(LinkTarget.Blocked)
+    expect(classify(null)).toBe(LinkTarget.Blocked)
+    expect(classify(undefined)).toBe(LinkTarget.Blocked)
+  })
+
+  it('treats app:// as ordinary when no app origin is given', () => {
+    // Without an origin to compare against, nothing may claim to be the app.
+    expect(classifyLink('app://agentrq/tasks')).toBe(LinkTarget.Blocked)
+  })
+})
+
+describe('linkWindowBounds', () => {
+  it('follows the main window without copying it exactly', () => {
+    const { width, height } = linkWindowBounds({ width: 1400, height: 1000 })
+    expect(width).toBe(1120)
+    expect(height).toBe(850)
+  })
+
+  it('stays usable beside a very small main window', () => {
+    const { width, height } = linkWindowBounds({ width: 400, height: 300 })
+    expect(width).toBe(640)
+    expect(height).toBe(480)
+  })
+
+  it('stops growing beside a very large one', () => {
+    const { width, height } = linkWindowBounds({ width: 5120, height: 2880 })
+    expect(width).toBe(1200)
+    expect(height).toBe(900)
+  })
+
+  it('has an answer when the parent has no bounds yet', () => {
+    expect(linkWindowBounds(null)).toEqual({ width: 819, height: 653 })
+    expect(linkWindowBounds(undefined)).toEqual({ width: 819, height: 653 })
+  })
+})


### PR DESCRIPTION
**What changed**

Links now open in a window belonging to the app, which the user closes to get straight back to what they were doing, instead of being handed to the system browser.

**Why changed**

Following the documentation link, the terms, or a URL attached to a message threw the user out of the app entirely, with nothing to come back to. The installed web app opens the same links in a window of its own that can be closed, so the desktop app was the odd one out.

Deciding where a link goes turns out not to be a yes-or-no question, so it is now a classification: the app's own addresses are left to its router, ordinary web addresses open in a closable window, addresses aimed at a mail client or dialler are handed to the operating system, and everything else is refused.

**Test coverage report**

New lines introduced: 100% covered. The decision logic lives in a new module precisely so it can be tested — the shell file it came from needs a live Electron to import and no test can reach it. 12 new tests: each category of address, unusual spellings of a scheme, input that is not an address at all, and the window sizing at both extremes.

Total coverage impact: none, it stays at 100%. The new module is 100% statements, branches, functions and lines, and so is the suite as a whole, before and after. 305 → 317 tests, all passing.

**Other reports**

This also closes a real hole rather than only moving links around. Addresses that execute script, embed their own content, or point at the local filesystem were previously passed straight to the operating system's "open this" call. A message body is attacker-influenced text, and that is the well-worn path from injected markup to the machine rendering it. Those are now refused — silently, since a warning would only teach people to click through.

One subtlety worth flagging for review: the obvious way to write the "is this the app?" check does not work. The standard address parser reports no origin at all for a custom scheme, so a comparison written the natural way would treat *any* address using the app's scheme as the app's own. The check compares the parts that are always populated, and there is a test that fails if someone rewrites it the obvious way.

The new window is hardened the same way the existing sign-in window is, and given its own separate session, since the app's session holds the login cookie and an arbitrary website has no business sharing it. Pages opened this way cannot spawn further app windows — their own pop-ups go to the real browser.

**TaskID:** 0hxOrNVZsGH