### PR TITLE
fix(frontend): scroll the chat to the newest message when returning from History

### DIFF
--- a/frontend/src/composables/useChatScroll.js
+++ b/frontend/src/composables/useChatScroll.js
@@ -1,0 +1,41 @@
+import { nextTick } from 'vue';
+
+/**
+ * Pin a chat pane to its newest message.
+ *
+ * The one rule worth extracting: **the container is looked up inside the
+ * scheduled callback, never before it.**
+ *
+ * The chat pane is rendered behind a `v-if`, so leaving it for the History view
+ * destroys the scroll container and the template ref becomes null. Coming back
+ * creates a brand new element, scrolled to the top. At the instant the view
+ * switches the ref is still null — the element does not exist until Vue has
+ * rendered — so a guard placed *before* the wait concludes "no container,
+ * nothing to do" and returns. The pane then opens at the oldest message, which
+ * is exactly the bug this fixes.
+ *
+ * `schedule` is injectable so the timing can be tested without a component.
+ *
+ * @param {() => HTMLElement | null | undefined} getContainer
+ * @param {(fn: () => void) => unknown} [schedule]
+ */
+export function scrollToBottom(getContainer, schedule = nextTick) {
+  return schedule(() => {
+    const el = getContainer();
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  });
+}
+
+/**
+ * Whether switching to `view` should drop the reader at the newest message.
+ *
+ * Only the chat pane scrolls: History keeps its own position, and returning to
+ * a timeline where you had scrolled to a particular tool call only to be thrown
+ * to the end would lose your place.
+ *
+ * @param {string} view
+ */
+export function shouldScrollOnViewChange(view) {
+  return view === 'chat';
+}

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -654,6 +654,7 @@ import { useTooltipStore } from '../stores/tooltipStore';
 import { useToasts } from '../composables/useToasts';
 import { useViewport } from '../composables/useViewport';
 import { useSpeechToText } from '../composables/useSpeechToText';
+import { scrollToBottom as scrollContainerToBottom, shouldScrollOnViewChange } from '../composables/useChatScroll';
 import { useEventBus } from '../useEventBus';
 import { renderMarkdown } from '../utils/markdown';
 import TrajectoryPanel from '../components/TrajectoryPanel.vue';
@@ -857,11 +858,8 @@ watch(() => sortedMessages.value.length, (count) => {
 }, { immediate: true });
 
 function scrollToBottom() {
-  if (scrollContainer.value) {
-    nextTick(() => {
-      scrollContainer.value.scrollTop = scrollContainer.value.scrollHeight;
-    });
-  }
+  // The container is resolved after the wait, not before: see useChatScroll.
+  scrollContainerToBottom(() => scrollContainer.value);
 }
 
 // Not deep: a new/updated message always produces a new array from the
@@ -871,6 +869,14 @@ function scrollToBottom() {
 // to the bottom just from expanding a card.
 watch(sortedMessages, () => {
   scrollToBottom();
+});
+
+// The chat pane is behind a v-if, so switching to History destroys the scroll
+// container and coming back builds a fresh one sitting at the top. Nothing
+// else brings it down again — the message list has not changed, so the watcher
+// above never fires — which left the reader at the oldest message.
+watch(activeView, (view) => {
+  if (shouldScrollOnViewChange(view)) scrollToBottom();
 });
 
 // Scroll when the pending bubble first appears, not on every countdown tick

--- a/frontend/test/chatScroll.test.js
+++ b/frontend/test/chatScroll.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { scrollToBottom, shouldScrollOnViewChange } from '../src/composables/useChatScroll'
+
+/** A scroll container with the geometry the real one has when full. */
+const makeContainer = () => ({ scrollTop: 0, scrollHeight: 4200 })
+
+/** Runs the callback immediately, standing in for Vue's nextTick. */
+const runNow = (fn) => {
+  fn()
+}
+
+describe('scrollToBottom', () => {
+  it('moves the container to its newest content', () => {
+    const el = makeContainer()
+
+    scrollToBottom(() => el, runNow)
+
+    expect(el.scrollTop).toBe(4200)
+  })
+
+  it('looks up the container after the wait, not before it', () => {
+    // This is the whole bug. The chat pane is behind a v-if, so at the moment
+    // the view switches back from History the ref is still null and the element
+    // only exists once Vue has rendered. A guard evaluated before the wait
+    // returns early, and the pane opens at the oldest message.
+    let el = null
+    const schedule = (fn) => {
+      el = makeContainer() // the render happens here
+      fn()
+    }
+
+    scrollToBottom(() => el, schedule)
+
+    expect(el.scrollTop).toBe(4200)
+  })
+
+  it('does nothing when the container never appears', () => {
+    // Switching away again before the render lands must not throw.
+    expect(() => scrollToBottom(() => null, runNow)).not.toThrow()
+    expect(() => scrollToBottom(() => undefined, runNow)).not.toThrow()
+  })
+
+  it('defers rather than scrolling inline', () => {
+    // If it scrolled synchronously it would read a stale scrollHeight, taken
+    // before the newest message had been laid out.
+    const el = makeContainer()
+    const schedule = vi.fn()
+
+    scrollToBottom(() => el, schedule)
+
+    expect(schedule).toHaveBeenCalledOnce()
+    expect(el.scrollTop).toBe(0)
+  })
+
+  it('hands back what the scheduler returns, so a caller can await it', () => {
+    const promise = Promise.resolve()
+
+    expect(scrollToBottom(() => makeContainer(), () => promise)).toBe(promise)
+  })
+})
+
+describe('shouldScrollOnViewChange', () => {
+  it('scrolls when the chat pane comes back', () => {
+    expect(shouldScrollOnViewChange('chat')).toBe(true)
+  })
+
+  it('leaves the history timeline where the reader left it', () => {
+    // Being thrown to the end of a timeline you had scrolled through to find a
+    // particular tool call would lose your place.
+    expect(shouldScrollOnViewChange('history')).toBe(false)
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -32,7 +32,12 @@ export default defineConfig({
     css: false,
     coverage: {
       provider: 'v8',
-      include: ['src/app.js', 'src/stores/platformStore.js', 'src/desktop/*.js'],
+      include: [
+        'src/app.js',
+        'src/stores/platformStore.js',
+        'src/desktop/*.js',
+        'src/composables/useChatScroll.js',
+      ],
       reporter: ['text', 'lcov'],
       thresholds: {
         lines: 100,


### PR DESCRIPTION
**What changed**

Switching from the History view back to the chat now lands on the newest message, instead of leaving the reader at the oldest one.

**Why changed**

The chat pane is removed from the page entirely while History is showing, so returning to it builds a fresh, empty-scrolled pane. Nothing brought it back down: the only thing that scrolls the chat is a change to the message list, and returning from History does not change any messages.

There was a second cause behind the first. The existing helper checked whether the pane existed *before* waiting for it to be drawn — and at the moment the view switches it does not exist yet, so it gave up before scheduling anything. Even adding the missing trigger would not have worked on its own. The pane is now looked up after the wait rather than before.

The History view deliberately keeps its own position: being thrown to the end of a timeline you had scrolled through to find one particular entry would lose your place.

**Test coverage report**

New lines introduced: 100% covered, with the timing bug pinned by its own regression test — a scheduler that creates the element only when it runs, which fails against the old ordering and passes against the new one.

Total coverage impact: none, it stays at 100%. The new module is 100% statements, branches, functions and lines, it has been added to the coverage scope so it is held to the existing 100% thresholds rather than sitting outside them, and the suite as a whole still meets those thresholds. 29 → 36 tests, all passing.

**Other reports**

The behaviour was extracted into its own small module rather than tested where it lived. The view it came from is a twelve-hundred-line component wired to a router, a store, a live event stream and network calls, and this project has no component-testing harness — no mounting library, and no view included in the coverage scope. Testing the fix in place would have meant introducing all of that for a three-line change; extracted, the part that actually broke is covered by seven plain assertions and no component at all.

Verified the fix compiles through a full production build of the frontend, including the service worker step.

**TaskID:** 0hxP7ENewYj