### PR TITLE
fix(frontend): show the Scheduled section when nothing is scheduled

### DIFF
--- a/frontend/src/composables/useTaskGroups.js
+++ b/frontend/src/composables/useTaskGroups.js
@@ -1,0 +1,100 @@
+/**
+ * Which sections a task list shows for a given filter, and what goes in each.
+ *
+ * The distinction that matters here is **primary** versus **supplementary**
+ * sections, because it decides what an empty one does:
+ *
+ * - A *primary* section is the reason you opened the page. It is always
+ *   returned, empty or not, so the list can say "No … tasks found" rather than
+ *   rendering a blank column. Ongoing, Not Started, Action Required, Completed
+ *   and — on its own page — Scheduled.
+ * - A *supplementary* section only appears alongside others on the combined
+ *   Active view. Blocked, Rejected, and Scheduled when seen from Active. An
+ *   empty one is omitted, because five "nothing here" cards stacked up is
+ *   noise, not information.
+ *
+ * Scheduled is the section that is primary on one page and supplementary on
+ * another, and treating it as supplementary everywhere is what left the
+ * Scheduled page rendering an entirely empty column.
+ *
+ * Extracted from TaskListView so this can be tested: the view is a large
+ * component wired to a router, a store and network calls, and the project has
+ * no component-test harness.
+ */
+
+/**
+ * Tasks awaiting something from the person, rather than from the agent.
+ *
+ * @param {Array<object>} tasks
+ */
+export function pendingOnHuman(tasks) {
+  return tasks.filter(
+    (t) =>
+      t.status !== 'completed' &&
+      t.status !== 'rejected' &&
+      ((t.status === 'notstarted' && t.assignee === 'human') ||
+        (t.messages &&
+          t.messages.some(
+            (m) => m.metadata?.type === 'permission_request' && m.metadata?.status === 'pending'
+          )))
+  );
+}
+
+/**
+ * @param {Array<object>} tasks
+ * @param {string} filter  'active' | 'ongoing' | 'notstarted' | 'pending' | 'completed' | 'scheduled'
+ * @param {{ nextRunAt?: (cronSchedule: string) => Date }} [options]
+ *        nextRunAt orders the scheduled section by when each task next fires.
+ *        Injected rather than imported so this stays free of the cron composable.
+ * @returns {Array<{ title: string, tasks: Array<object> }>}
+ */
+export function buildTaskGroups(tasks, filter, { nextRunAt } = {}) {
+  const all = Array.isArray(tasks) ? tasks : [];
+  const f = filter || 'active';
+  const withStatus = (status) => all.filter((t) => t.status === status);
+
+  const blocked = withStatus('blocked');
+  const rejected = withStatus('rejected');
+  const groups = [];
+
+  if (f === 'active' || f === 'ongoing') {
+    groups.push({ title: 'Ongoing', tasks: withStatus('ongoing') });
+    if (blocked.length > 0) groups.push({ title: 'Blocked', tasks: blocked });
+  }
+
+  if (f === 'active' || f === 'notstarted') {
+    groups.push({ title: 'Not Started', tasks: withStatus('notstarted') });
+  }
+
+  if (f === 'pending') {
+    groups.push({ title: 'Action Required', tasks: pendingOnHuman(all) });
+  }
+
+  if (f === 'completed') {
+    groups.push({ title: 'Completed', tasks: withStatus('completed') });
+    if (rejected.length > 0) groups.push({ title: 'Rejected', tasks: rejected });
+  }
+
+  if (f === 'active' || f === 'scheduled') {
+    const scheduled = sortByNextRun(withStatus('cron'), nextRunAt);
+    // Primary on its own page, supplementary on Active. Omitting it when empty
+    // on the Scheduled page is what left that page with nothing in the column
+    // at all — no heading, no count, no empty state.
+    if (f === 'scheduled' || scheduled.length > 0) {
+      groups.push({ title: 'Scheduled', tasks: scheduled });
+    }
+  }
+
+  return groups;
+}
+
+/**
+ * Soonest first. Without a way to read the next run time the original order is
+ * kept, which is better than throwing inside a computed property.
+ */
+function sortByNextRun(tasks, nextRunAt) {
+  if (typeof nextRunAt !== 'function') return [...tasks];
+  return [...tasks].sort(
+    (a, b) => nextRunAt(a.cronSchedule).getTime() - nextRunAt(b.cronSchedule).getTime()
+  );
+}

--- a/frontend/src/views/TaskListView.vue
+++ b/frontend/src/views/TaskListView.vue
@@ -159,6 +159,7 @@ import { fetchGlobalTasks, fetchWorkspaces, sendPermissionVerdict, updateTaskAss
 import { useToasts } from '../composables/useToasts';
 import { useTooltipStore } from '../stores/tooltipStore';
 import { useCron } from '../composables/useCron';
+import { buildTaskGroups, pendingOnHuman } from '../composables/useTaskGroups';
 import { useEventBus } from '../useEventBus';
 import { useViewport } from '../composables/useViewport';
 import LoadingState from '../components/LoadingState.vue';
@@ -234,61 +235,13 @@ const filters = [
   { id: 'scheduled', label: 'Scheduled', icon: 'M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z' }
 ];
 
-const displayGroups = computed(() => {
-  const f = filterType.value || 'active';
-  
-  const ongoing = tasks.value.filter(t => t.status === 'ongoing');
-  const blocked = tasks.value.filter(t => t.status === 'blocked');
-  const notStarted = tasks.value.filter(t => t.status === 'notstarted');
-  const completed = tasks.value.filter(t => t.status === 'completed');
-  const rejected = tasks.value.filter(t => t.status === 'rejected');
-  const cron = tasks.value.filter(t => t.status === 'cron');
-
-  const groups = [];
-  if (f === 'active' || f === 'ongoing') {
-    groups.push({ title: 'Ongoing', tasks: ongoing });
-    if (blocked.length > 0) groups.push({ title: 'Blocked', tasks: blocked });
-  }
-  if (f === 'active' || f === 'notstarted') {
-    groups.push({ title: 'Not Started', tasks: notStarted });
-  }
-  if (f === 'pending') {
-    const pendingActions = tasks.value.filter(t => 
-      t.status !== 'completed' && t.status !== 'rejected' && (
-        (t.status === 'notstarted' && t.assignee === 'human') ||
-        (t.messages && t.messages.some(m => m.metadata?.type === 'permission_request' && m.metadata?.status === 'pending'))
-      )
-    );
-    groups.push({ title: 'Action Required', tasks: pendingActions });
-  }
-  if (f === 'completed') {
-    groups.push({ title: 'Completed', tasks: completed });
-    if (rejected.length > 0) groups.push({ title: 'Rejected', tasks: rejected });
-  }
-  if (f === 'active' || f === 'scheduled') {
-    // Sort cron tasks by next run time
-    const sortedCron = [...cron].sort((a, b) => {
-      const aTime = getNextRunDate(a.cronSchedule).getTime();
-      const bTime = getNextRunDate(b.cronSchedule).getTime();
-      return aTime - bTime;
-    });
-    
-    if (sortedCron.length > 0) {
-      groups.push({ title: 'Scheduled', tasks: sortedCron });
-    }
-  }
-
-  return groups;
-});
+const displayGroups = computed(() =>
+  buildTaskGroups(tasks.value, filterType.value, { nextRunAt: getNextRunDate })
+);
 
 const activeTaskCount = computed(() => tasks.value.filter(t => t.status !== 'cron').length);
 const scheduledCount = computed(() => tasks.value.filter(t => t.status === 'cron').length);
-const pendingInputCount = computed(() => tasks.value.filter(t => 
-  t.status !== 'completed' && t.status !== 'rejected' && (
-    (t.status === 'notstarted' && t.assignee === 'human') ||
-    (t.messages && t.messages.some(m => m.metadata?.type === 'permission_request' && m.metadata?.status === 'pending'))
-  )
-).length);
+const pendingInputCount = computed(() => pendingOnHuman(tasks.value).length);
 
 const getWorkspaceName = (workspaceId) => {
   const ws = workspaces.value.find(w => w.id === workspaceId);

--- a/frontend/test/taskGroups.test.js
+++ b/frontend/test/taskGroups.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest'
+
+import { buildTaskGroups, pendingOnHuman } from '../src/composables/useTaskGroups'
+
+const task = (props) => ({ id: Math.random().toString(36).slice(2), messages: [], ...props })
+const titles = (groups) => groups.map((g) => g.title)
+const titled = (groups, title) => groups.find((g) => g.title === title)
+
+/** Orders cron tasks by a number parked on the schedule string, for legibility. */
+const nextRunAt = (schedule) => new Date(Number(schedule))
+
+describe('buildTaskGroups', () => {
+  describe('the Scheduled page', () => {
+    it('shows the section even when nothing is scheduled', () => {
+      // The bug: the section was omitted when empty, so the page rendered an
+      // entirely blank column — no heading, no count, no "none found" card,
+      // while every other list page showed one.
+      const groups = buildTaskGroups([task({ status: 'ongoing' })], 'scheduled', { nextRunAt })
+
+      expect(titles(groups)).toEqual(['Scheduled'])
+      expect(titled(groups, 'Scheduled').tasks).toEqual([])
+    })
+
+    it('shows the section with nothing at all in the list', () => {
+      const groups = buildTaskGroups([], 'scheduled', { nextRunAt })
+
+      expect(titles(groups)).toEqual(['Scheduled'])
+    })
+
+    it('orders what is scheduled by which fires next', () => {
+      const soon = task({ status: 'cron', cronSchedule: '200' })
+      const later = task({ status: 'cron', cronSchedule: '900' })
+
+      const groups = buildTaskGroups([later, soon], 'scheduled', { nextRunAt })
+
+      expect(titled(groups, 'Scheduled').tasks).toEqual([soon, later])
+    })
+
+    it('keeps the given order when it cannot tell when they run', () => {
+      const a = task({ status: 'cron', cronSchedule: '900' })
+      const b = task({ status: 'cron', cronSchedule: '200' })
+
+      expect(titled(buildTaskGroups([a, b], 'scheduled'), 'Scheduled').tasks).toEqual([a, b])
+    })
+  })
+
+  describe('the Active page', () => {
+    it('keeps Scheduled out of the way when nothing is scheduled', () => {
+      // Here it is one section among several, so an empty one is noise. This
+      // is the behaviour the Scheduled page was wrongly inheriting.
+      const groups = buildTaskGroups([task({ status: 'ongoing' })], 'active', { nextRunAt })
+
+      expect(titles(groups)).toEqual(['Ongoing', 'Not Started'])
+    })
+
+    it('brings Scheduled in once something is scheduled', () => {
+      const groups = buildTaskGroups([task({ status: 'cron', cronSchedule: '1' })], 'active', {
+        nextRunAt,
+      })
+
+      expect(titles(groups)).toEqual(['Ongoing', 'Not Started', 'Scheduled'])
+    })
+
+    it('shows Ongoing and Not Started even when both are empty', () => {
+      expect(titles(buildTaskGroups([], 'active', { nextRunAt }))).toEqual([
+        'Ongoing',
+        'Not Started',
+      ])
+    })
+
+    it('adds Blocked only when something is blocked', () => {
+      expect(titles(buildTaskGroups([], 'active'))).not.toContain('Blocked')
+      expect(titles(buildTaskGroups([task({ status: 'blocked' })], 'active'))).toContain('Blocked')
+    })
+  })
+
+  describe('the other pages', () => {
+    it('shows Completed empty, and Rejected only when there is one', () => {
+      expect(titles(buildTaskGroups([], 'completed'))).toEqual(['Completed'])
+      expect(titles(buildTaskGroups([task({ status: 'rejected' })], 'completed'))).toEqual([
+        'Completed',
+        'Rejected',
+      ])
+    })
+
+    it('shows Action Required empty', () => {
+      expect(titles(buildTaskGroups([], 'pending'))).toEqual(['Action Required'])
+    })
+
+    it('shows Ongoing on its own, without Not Started', () => {
+      expect(titles(buildTaskGroups([], 'ongoing'))).toEqual(['Ongoing'])
+    })
+
+    it('shows Not Started on its own, without Ongoing', () => {
+      expect(titles(buildTaskGroups([], 'notstarted'))).toEqual(['Not Started'])
+    })
+
+    it('treats a missing filter as the Active page', () => {
+      expect(titles(buildTaskGroups([], undefined))).toEqual(['Ongoing', 'Not Started'])
+      expect(titles(buildTaskGroups([], ''))).toEqual(['Ongoing', 'Not Started'])
+    })
+
+    it('survives being handed no task list at all', () => {
+      expect(titles(buildTaskGroups(null, 'scheduled'))).toEqual(['Scheduled'])
+      expect(titles(buildTaskGroups(undefined, 'completed'))).toEqual(['Completed'])
+    })
+  })
+})
+
+describe('pendingOnHuman', () => {
+  it('counts a not-started task assigned to the person', () => {
+    const mine = task({ status: 'notstarted', assignee: 'human' })
+
+    expect(pendingOnHuman([mine, task({ status: 'notstarted', assignee: 'agent' })])).toEqual([mine])
+  })
+
+  it('counts a task waiting on a permission decision', () => {
+    const waiting = task({
+      status: 'ongoing',
+      messages: [{ metadata: { type: 'permission_request', status: 'pending' } }],
+    })
+    const answered = task({
+      status: 'ongoing',
+      messages: [{ metadata: { type: 'permission_request', status: 'approved' } }],
+    })
+
+    expect(pendingOnHuman([waiting, answered])).toEqual([waiting])
+  })
+
+  it('ignores tasks that are already finished', () => {
+    // A completed task with an unanswered permission request is history, not
+    // something still being asked of anyone.
+    const done = task({
+      status: 'completed',
+      messages: [{ metadata: { type: 'permission_request', status: 'pending' } }],
+    })
+
+    expect(pendingOnHuman([done, task({ status: 'rejected', assignee: 'human' })])).toEqual([])
+  })
+
+  it('copes with a task that has no messages', () => {
+    expect(pendingOnHuman([task({ status: 'ongoing', messages: undefined })])).toEqual([])
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -37,6 +37,7 @@ export default defineConfig({
         'src/stores/platformStore.js',
         'src/desktop/*.js',
         'src/composables/useChatScroll.js',
+        'src/composables/useTaskGroups.js',
       ],
       reporter: ['text', 'lcov'],
       thresholds: {


### PR DESCRIPTION
**What changed**

The Scheduled page now shows its heading, its count and a "none found" message when nothing is scheduled, the same as every other task list, instead of leaving the whole column blank.

**Why changed**

The Scheduled section was only added to the page when it had something in it. On the combined Active view that is correct — an empty extra section is noise. But on the page whose only section *is* Scheduled, it meant nothing was rendered at all, so the empty message already written in the template was never reached and the user was left looking at a blank column with no explanation.

The underlying distinction the code was missing: some sections are the reason you opened the page and should appear even when empty, others are supplementary and should stay out of the way. Scheduled is the first on its own page and the second on the combined view, and it was being treated as supplementary in both.

**Test coverage report**

New lines introduced: 100% covered. 18 tests covering which sections each page shows, both empty cases that this bug sits between — empty on the Scheduled page must appear, empty on the Active page must not — ordering by which task fires next, and degenerate input.

Total coverage impact: none, it stays at 100%. The extracted module is 100% statements, branches, functions and lines and has been added to the coverage scope so it is held to the existing thresholds rather than sitting outside them. Suite 29 → 47 tests, all passing.

**Other reports**

The grouping logic was extracted from the view so it could be tested at all: the view is a large component wired to a router, a store and network calls, and this project has no component-testing harness. The extraction is behaviour-preserving apart from the fix — 61 lines out, 13 in — and one duplicated predicate now has a single definition, since the "waiting on a person" rule was written out twice in the same file.

Worth knowing for review: the equivalent component used by the workspace feed already handled this correctly, returning an empty Scheduled group explicitly. That is why the bug appeared on the global task list and not there, and it is good evidence for which behaviour is the intended one.

Verified against both screenshots on the task: the working page shows a heading, a zero count and a bordered message, and the Scheduled page now produces the same structure.

**TaskID:** 0hxPocr9LQP