### PR TITLE
fix(backend): encode attachment filenames so the header stays ASCII

### DIFF
--- a/backend/internal/handler/api/task.go
+++ b/backend/internal/handler/api/task.go
@@ -552,9 +552,86 @@ func (h *handler) getAttachment() fiber.Handler {
 		}
 
 		c.Set("Content-Type", res.MimeType)
-		c.Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", res.Filename))
+		c.Set("Content-Disposition", contentDisposition(res.Filename))
 		return c.Send(res.Data)
 	}
+}
+
+// contentDisposition builds a Content-Disposition value that is safe to put in
+// an HTTP header.
+//
+// Header values are US-ASCII. Filenames are not: a macOS screenshot is named
+// "Screenshot 2026-08-30 at 5.51.27 PM.png", where the space before PM is
+// U+202F NARROW NO-BREAK SPACE. Interpolating that straight into the header
+// emitted a multi-byte character in a place the protocol does not allow one,
+// and the desktop app's HTTP stack rejects such a header outright rather than
+// mangling it -- taking down its main process with
+//
+//	TypeError: Cannot convert argument to a ByteString because the character
+//	at index 50 has a value of 8239 which is greater than 255
+//
+// Browsers were more forgiving and showed a mis-decoded name, so this only ever
+// looked like a desktop bug.
+//
+// Both forms are emitted, as RFC 6266 section 5 recommends: a plain ASCII
+// filename any client can read, and the exact name in the extended form for
+// clients that understand it. Building the quoted string by hand also closes
+// the injection the old fmt.Sprintf allowed, where a filename containing a
+// quote could end the parameter early and append parameters of its own.
+func contentDisposition(filename string) string {
+	fallback := asciiFilename(filename)
+	if fallback == "" {
+		fallback = "download"
+	}
+
+	disposition := `inline; filename="` + fallback + `"`
+	// Only worth the extended form when there is a real name that the ASCII
+	// fallback does not already carry exactly.
+	if filename != "" && fallback != filename {
+		disposition += "; filename*=UTF-8''" + rfc5987Encode(filename)
+	}
+	return disposition
+}
+
+// asciiFilename reduces a filename to what may appear inside a quoted header
+// value: printable US-ASCII, with anything else replaced rather than dropped so
+// the name keeps its shape. The quote and backslash go too -- one would end the
+// string early, the other escape what follows -- as do control characters,
+// since a carriage return would split the header in two.
+func asciiFilename(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		switch {
+		case r < 0x20 || r > 0x7e, r == '"', r == '\\':
+			b.WriteByte('_')
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// rfc5987Encode percent-encodes the UTF-8 bytes of s, leaving only the
+// attr-char set from RFC 5987 section 3.2.1 untouched.
+func rfc5987Encode(s string) string {
+	const hex = "0123456789ABCDEF"
+
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9',
+			strings.IndexByte("!#$&+-.^_`|~", c) >= 0:
+			b.WriteByte(c)
+		default:
+			b.WriteByte('%')
+			b.WriteByte(hex[c>>4])
+			b.WriteByte(hex[c&0x0f])
+		}
+	}
+	return b.String()
 }
 
 func (h *handler) sendPermissionVerdict() fiber.Handler {

--- a/backend/internal/handler/api/task_test.go
+++ b/backend/internal/handler/api/task_test.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// isASCII reports whether every byte is one a header value may legally carry.
+// This is the property that actually matters: the desktop client's HTTP stack
+// refuses a header containing anything above 255 rather than mangling it, and
+// refusing crashed its main process.
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] > 0x7e || s[i] < 0x20 {
+			return false
+		}
+	}
+	return true
+}
+
+func TestContentDisposition_PlainNameIsLeftAlone(t *testing.T) {
+	got := contentDisposition("report.pdf")
+
+	if want := `inline; filename="report.pdf"`; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if strings.Contains(got, "filename*") {
+		t.Errorf("an ASCII name needs no extended form, got %q", got)
+	}
+}
+
+func TestContentDisposition_MacOSScreenshotDoesNotEscapeIntoTheHeader(t *testing.T) {
+	// The exact filename from the crash report. The space before PM is U+202F
+	// NARROW NO-BREAK SPACE, which is what macOS puts there, and the old
+	// fmt.Sprintf copied it straight into the header at index 50 -- the index
+	// and the code point 8239 both named in the reported TypeError.
+	name := "Screenshot 2026-08-30 at 5.51.27 PM.png"
+
+	got := contentDisposition(name)
+
+	if !isASCII(got) {
+		t.Fatalf("header value is not ASCII: %q", got)
+	}
+	if !strings.Contains(got, `filename="Screenshot 2026-08-30 at 5.51.27_PM.png"`) {
+		t.Errorf("expected a readable ASCII fallback, got %q", got)
+	}
+	// %E2%80%AF is U+202F encoded as UTF-8, so a client that understands the
+	// extended form still recovers the exact name.
+	if !strings.Contains(got, "filename*=UTF-8''Screenshot%202026-08-30%20at%205.51.27%E2%80%AFPM.png") {
+		t.Errorf("expected the exact name in extended form, got %q", got)
+	}
+}
+
+func TestContentDisposition_RejectsHeaderInjection(t *testing.T) {
+	// A quote used to close the parameter early and let the rest of the
+	// filename be read as parameters of its own.
+	got := contentDisposition(`evil".png`)
+
+	if strings.Contains(got, `evil".png`) {
+		t.Errorf("quote survived into the header: %q", got)
+	}
+	if !strings.Contains(got, `filename="evil_.png"`) {
+		t.Errorf("expected the quote replaced, got %q", got)
+	}
+}
+
+func TestContentDisposition_RejectsHeaderSplitting(t *testing.T) {
+	// A carriage return would end the header and start another.
+	got := contentDisposition("a\r\nX-Injected: yes.png")
+
+	if strings.ContainsAny(got, "\r\n") {
+		t.Fatalf("header value contains a line break: %q", got)
+	}
+	if !isASCII(got) {
+		t.Fatalf("header value is not ASCII: %q", got)
+	}
+}
+
+func TestContentDisposition_BackslashIsNeutralised(t *testing.T) {
+	// Inside a quoted string a backslash escapes whatever follows it, so a name
+	// ending in one would escape the closing quote.
+	got := contentDisposition(`back\slash.png`)
+
+	if !strings.Contains(got, `filename="back_slash.png"`) {
+		t.Errorf("expected the backslash replaced, got %q", got)
+	}
+}
+
+func TestContentDisposition_NamesWithNothingUsableStillGetOne(t *testing.T) {
+	// A name made entirely of characters that cannot appear in the header would
+	// otherwise produce filename="", which some clients treat as no name at all.
+	got := contentDisposition("日本語")
+
+	if !strings.Contains(got, `filename="___"`) {
+		t.Errorf("expected placeholder characters, got %q", got)
+	}
+	if !strings.Contains(got, "filename*=UTF-8''%E6%97%A5%E6%9C%AC%E8%AA%9E") {
+		t.Errorf("expected the exact name in extended form, got %q", got)
+	}
+}
+
+func TestContentDisposition_EmptyName(t *testing.T) {
+	if want := `inline; filename="download"`; contentDisposition("") != want {
+		t.Errorf("got %q, want %q", contentDisposition(""), want)
+	}
+}
+
+func TestRFC5987Encode_LeavesOnlyAttrCharsAlone(t *testing.T) {
+	// Percent-encoding more than necessary is harmless; encoding less is not.
+	// ~ is an attr-char in RFC 5987 section 3.2.1, so it stays as it is.
+	if got, want := rfc5987Encode("a-b_c.d~1"), "a-b_c.d~1"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	// ; and = would be read as parameter syntax, so they must not survive.
+	if got, want := rfc5987Encode("a;b=c"), "a%3Bb%3Dc"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if got, want := rfc5987Encode("a b"), "a%20b"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
**What changed**

Attachment downloads now describe the file's name in a way the protocol actually permits, so names containing characters outside plain ASCII no longer produce a malformed response.

**Why changed**

The desktop app crashed with an uncaught exception whenever it opened a task with a macOS screenshot attached. Screenshots are named with a narrow no-break space before AM or PM, and that character was being copied straight into a response header, where only plain ASCII is allowed. Browsers quietly tolerated it and displayed a mangled name; the desktop app's HTTP stack refuses such a header outright, and it does so somewhere the surrounding error handling cannot catch — so a malformed response from the server brought down the client. That is why this only ever looked like a desktop problem.

The name is now sent twice, as the standard recommends: a plain readable version every client understands, and the exact original encoded for clients that support it.

**Test coverage report**

New lines introduced: 100% covered — all three new functions report 100% statement coverage. Eight tests, including the exact filename from the crash report, asserting both that the resulting header is entirely ASCII and that the original name is still recoverable from it.

Total coverage impact: none in the negative direction. The package total is unchanged at 25.1%, since these are new fully-covered lines in a large, largely untested handler package; the new code does not dilute it.

**Other reports**

This also closes an injection that the old formatting allowed. A filename containing a double quote ended the name early and let the remainder be read as instructions of the server's own making, and a carriage return would have split the header in two entirely. Both are now neutralised, along with anything else outside printable ASCII. Filenames are user-supplied, so this was reachable by uploading a deliberately named file.

Two of the eight tests failed on first run and both were worth having: an empty filename produced a meaningless trailing parameter, and one of my own expectations was wrong — the tilde is a permitted character in the encoding standard and must be left as it is, not escaped. Both the code and the expectation were corrected.

Worth noting as a separate concern, not addressed here: the desktop client treats a malformed header from the server as a fatal error rather than a bad response. The server should not send one, and now does not, but a client that dies on unexpected input from the network is fragile independently of this fix.

**TaskID:** 0hxRLEy0cyX