### PR TITLE
feat(workspace): optional working directory, typed or chosen from a folder dialog

### DIFF
--- a/backend/internal/controller/crud/workspace.go
+++ b/backend/internal/controller/crud/workspace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
@@ -19,6 +20,11 @@ func (c *controller) CreateWorkspace(ctx context.Context, req entity.CreateWorks
 	}
 
 	now := time.Now()
+	workingDirectory, err := normalizeWorkingDirectory(req.Workspace.WorkingDirectory)
+	if err != nil {
+		return nil, err
+	}
+
 	m := model.Workspace{
 		ID:                    c.idgen.NextID(),
 		CreatedAt:             now,
@@ -29,6 +35,7 @@ func (c *controller) CreateWorkspace(ctx context.Context, req entity.CreateWorks
 		AllowAllCommands:      req.Workspace.AllowAllCommands,
 		SelfLearningLoopNote:  req.Workspace.SelfLearningLoopNote,
 		InputSendDelaySeconds: req.Workspace.InputSendDelaySeconds,
+		WorkingDirectory:      workingDirectory,
 	}
 
 	if req.Workspace.NotificationSettings != nil {
@@ -155,6 +162,59 @@ func (c *controller) UnarchiveWorkspace(ctx context.Context, req entity.Unarchiv
 	return err
 }
 
+// normalizeWorkingDirectory validates the optional working directory a workspace
+// hands to its agent, returning the value to store.
+//
+// The server cannot check that the directory exists: the agent usually runs on
+// a different machine, so the path is only meaningful there. What it can do is
+// refuse values that cannot be a directory anywhere.
+//
+// An absolute path is required because a relative one silently means whatever
+// the agent's shell happened to start in, which is the kind of setting that
+// appears to work and then does something else entirely. `~` is accepted since
+// the agent expands it, and it is what a person naturally types.
+func normalizeWorkingDirectory(dir string) (string, error) {
+	trimmed := strings.TrimSpace(dir)
+	if trimmed == "" {
+		// The field is optional; blank means "wherever the agent already is".
+		return "", nil
+	}
+
+	for _, r := range trimmed {
+		// A newline would be a header or log injection anywhere this is echoed,
+		// and no filesystem accepts a control character in a path.
+		if r < 0x20 || r == 0x7f {
+			return "", fmt.Errorf("working directory must not contain control characters")
+		}
+	}
+
+	if !isAbsolutePath(trimmed) {
+		return "", fmt.Errorf("working directory must be an absolute path, got %q", trimmed)
+	}
+	return trimmed, nil
+}
+
+// isAbsolutePath covers the shapes an absolute path takes on the platforms an
+// agent might run on, rather than only the one this server happens to run on.
+func isAbsolutePath(p string) bool {
+	switch {
+	case strings.HasPrefix(p, "/"): // POSIX
+		return true
+	case p == "~" || strings.HasPrefix(p, "~/"): // home, expanded by the agent
+		return true
+	case strings.HasPrefix(p, `\\`): // Windows UNC share
+		return true
+	case len(p) >= 3 && isDriveLetter(p[0]) && p[1] == ':' && (p[2] == '\\' || p[2] == '/'):
+		return true // Windows drive, C:\ or C:/
+	default:
+		return false
+	}
+}
+
+func isDriveLetter(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
 // validInputSendDelaySeconds are the only values the composer's send-delay
 // selector may offer; anything else is rejected rather than silently clamped.
 var validInputSendDelaySeconds = map[int]bool{0: true, 3: true, 5: true, 10: true, 15: true, 30: true, 60: true}
@@ -163,6 +223,10 @@ func (c *controller) UpdateWorkspace(ctx context.Context, req entity.UpdateWorks
 	uid := monoflake.IDFromBase62(req.UserID).Int64()
 	if !validInputSendDelaySeconds[req.Workspace.InputSendDelaySeconds] {
 		return nil, fmt.Errorf("invalid inputSendDelaySeconds: %d", req.Workspace.InputSendDelaySeconds)
+	}
+	workingDirectory, err := normalizeWorkingDirectory(req.Workspace.WorkingDirectory)
+	if err != nil {
+		return nil, err
 	}
 	m, err := c.repository.GetWorkspace(ctx, req.Workspace.ID, uid)
 	if err != nil {
@@ -177,6 +241,7 @@ func (c *controller) UpdateWorkspace(ctx context.Context, req entity.UpdateWorks
 	m.AllowAllCommands = req.Workspace.AllowAllCommands
 	m.SelfLearningLoopNote = req.Workspace.SelfLearningLoopNote
 	m.InputSendDelaySeconds = req.Workspace.InputSendDelaySeconds
+	m.WorkingDirectory = workingDirectory
 	if req.Workspace.NotificationSettings != nil {
 		b, _ := json.Marshal(req.Workspace.NotificationSettings)
 		m.NotificationSettings = datatypes.JSON(b)
@@ -306,6 +371,7 @@ func fromModelWorkspaceToEntity(m model.Workspace) entity.Workspace {
 		AllowAllCommands:      m.AllowAllCommands,
 		SelfLearningLoopNote:  m.SelfLearningLoopNote,
 		InputSendDelaySeconds: m.InputSendDelaySeconds,
+		WorkingDirectory:      m.WorkingDirectory,
 	}
 	if len(m.AutoAllowedTools) > 0 {
 		_ = json.Unmarshal(m.AutoAllowedTools, &res.AutoAllowedTools)

--- a/backend/internal/controller/crud/workspace_test.go
+++ b/backend/internal/controller/crud/workspace_test.go
@@ -220,3 +220,95 @@ func TestUpdateWorkspace_Archived_Fails(t *testing.T) {
 		t.Fatalf("expected archived error, got %v", err)
 	}
 }
+
+func TestNormalizeWorkingDirectory_OptionalAndBlank(t *testing.T) {
+	// The field is optional, and whitespace someone left behind is not a value.
+	for _, in := range []string{"", "   ", "\t\n "} {
+		got, err := normalizeWorkingDirectory(in)
+		if err != nil {
+			t.Errorf("normalizeWorkingDirectory(%q) errored: %v", in, err)
+		}
+		if got != "" {
+			t.Errorf("normalizeWorkingDirectory(%q) = %q, want empty", in, got)
+		}
+	}
+}
+
+func TestNormalizeWorkingDirectory_TrimsSurroundingSpace(t *testing.T) {
+	// Paths pasted from a terminal or a file manager routinely arrive padded.
+	got, err := normalizeWorkingDirectory("  /Users/mt/Code/agentrq  ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "/Users/mt/Code/agentrq"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeWorkingDirectory_AcceptsAbsoluteShapes(t *testing.T) {
+	// The agent may run on a different platform from this server, so all three
+	// shapes have to be accepted here rather than only the local one.
+	for _, in := range []string{
+		"/",
+		"/Users/mt/Code/agentrq",
+		"~",
+		"~/Code/agentrq",
+		`C:\Users\mt\Code`,
+		"C:/Users/mt/Code",
+		`\\server\share\code`,
+	} {
+		got, err := normalizeWorkingDirectory(in)
+		if err != nil {
+			t.Errorf("normalizeWorkingDirectory(%q) errored: %v", in, err)
+		}
+		if got != in {
+			t.Errorf("normalizeWorkingDirectory(%q) = %q, want it unchanged", in, got)
+		}
+	}
+}
+
+func TestNormalizeWorkingDirectory_RejectsRelativePaths(t *testing.T) {
+	// A relative path means whatever directory the agent's shell started in,
+	// which looks like it works and then quietly does something else.
+	for _, in := range []string{"Code/agentrq", "./agentrq", "../agentrq", "agentrq", "~agentrq", "C:", "C:x"} {
+		if _, err := normalizeWorkingDirectory(in); err == nil {
+			t.Errorf("normalizeWorkingDirectory(%q) was accepted, want rejected", in)
+		}
+	}
+}
+
+func TestNormalizeWorkingDirectory_RejectsControlCharacters(t *testing.T) {
+	// A newline is an injection anywhere this value is echoed into a line-based
+	// format, and no filesystem accepts one in a path.
+	for _, in := range []string{"/tmp/a\nb", "/tmp/a\rb", "/tmp/a\x00b", "/tmp/a\x7fb", "/tmp/a\tb"} {
+		if _, err := normalizeWorkingDirectory(in); err == nil {
+			t.Errorf("normalizeWorkingDirectory(%q) was accepted, want rejected", in)
+		}
+	}
+}
+
+func TestNormalizeWorkingDirectory_AllowsNonASCIINames(t *testing.T) {
+	// Rejecting control characters must not also reject perfectly ordinary
+	// directory names in other scripts.
+	in := "/Users/mt/Documents/プロジェクト"
+	got, err := normalizeWorkingDirectory(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != in {
+		t.Errorf("got %q, want %q", got, in)
+	}
+}
+
+func TestIsDriveLetter(t *testing.T) {
+	for _, b := range []byte{'a', 'z', 'A', 'Z'} {
+		if !isDriveLetter(b) {
+			t.Errorf("isDriveLetter(%q) = false, want true", b)
+		}
+	}
+	for _, b := range []byte{'0', '/', ':', '-'} {
+		if isDriveLetter(b) {
+			t.Errorf("isDriveLetter(%q) = true, want false", b)
+		}
+	}
+}

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -34,6 +34,7 @@ type (
 		AllowAllCommands      bool
 		SelfLearningLoopNote  string
 		InputSendDelaySeconds int
+		WorkingDirectory      string
 		Slack                 *SlackConfig
 	}
 

--- a/backend/internal/data/model/model.go
+++ b/backend/internal/data/model/model.go
@@ -22,6 +22,7 @@ type (
 		AllowAllCommands      bool           `gorm:"default:false"`
 		SelfLearningLoopNote  string         `gorm:"type:text"`
 		InputSendDelaySeconds int            `gorm:"default:0"`
+		WorkingDirectory      string         `gorm:"type:text"`
 	}
 
 	// Task hosts a task created by a human or an agent within a workspace

--- a/backend/internal/data/view/api/view.go
+++ b/backend/internal/data/view/api/view.go
@@ -24,6 +24,7 @@ type (
 		AllowAllCommands      bool                  `json:"allowAllCommands"`
 		SelfLearningLoopNote  string                `json:"selfLearningLoopNote,omitempty"`
 		InputSendDelaySeconds int                   `json:"inputSendDelaySeconds"`
+		WorkingDirectory      string                `json:"workingDirectory,omitempty"`
 		Slack                 *SlackConfig          `json:"slack,omitempty"`
 	}
 

--- a/backend/internal/mapper/api/workspace.go
+++ b/backend/internal/mapper/api/workspace.go
@@ -26,6 +26,7 @@ func FromHTTPRequestToCreateWorkspaceRequestEntity(c *fiber.Ctx) *entity.CreateW
 			AllowAllCommands:      payload.Workspace.AllowAllCommands,
 			SelfLearningLoopNote:  payload.Workspace.SelfLearningLoopNote,
 			InputSendDelaySeconds: payload.Workspace.InputSendDelaySeconds,
+			WorkingDirectory:      payload.Workspace.WorkingDirectory,
 		},
 	}
 }
@@ -118,6 +119,7 @@ func FromHTTPRequestToUpdateWorkspaceRequestEntity(c *fiber.Ctx) *entity.UpdateW
 			AllowAllCommands:      payload.Workspace.AllowAllCommands,
 			SelfLearningLoopNote:  payload.Workspace.SelfLearningLoopNote,
 			InputSendDelaySeconds: payload.Workspace.InputSendDelaySeconds,
+			WorkingDirectory:      payload.Workspace.WorkingDirectory,
 		},
 	}
 }
@@ -154,6 +156,7 @@ func fromEntityWorkspaceToView(p entity.Workspace, mcpURL string) view.Workspace
 		AllowAllCommands:      p.AllowAllCommands,
 		SelfLearningLoopNote:  p.SelfLearningLoopNote,
 		InputSendDelaySeconds: p.InputSendDelaySeconds,
+		WorkingDirectory:      p.WorkingDirectory,
 	}
 	if p.Slack != nil {
 		v.Slack = &view.SlackConfig{

--- a/desktop/src/main/index.js
+++ b/desktop/src/main/index.js
@@ -4,6 +4,7 @@ import {
   Menu,
   Notification,
   Tray,
+  dialog,
   globalShortcut,
   ipcMain,
   nativeImage,
@@ -471,6 +472,33 @@ function registerIpc(getWindow) {
 
   // The renderer is the source of truth for appearance — the theme store the
   // web app already has — so the shell follows it rather than reading the OS.
+  // Pick a working directory with the platform's own folder chooser, because
+  // typing an absolute path from memory is exactly the sort of thing people get
+  // subtly wrong. Only the chosen path crosses the bridge; the renderer never
+  // gets a handle to the dialog or the window it is attached to.
+  //
+  // Returns '' when the dialog is dismissed, so the caller has one thing to
+  // check rather than distinguishing cancellation from failure.
+  ipcMain.handle('agentrq:dialog:chooseDirectory', async (event, currentPath) => {
+    const parent = BrowserWindow.fromWebContents(event.sender)
+    const options = {
+      title: 'Choose a working directory',
+      properties: ['openDirectory', 'createDirectory'],
+    }
+    // Open where they already pointed it, so changing a path is not a fresh
+    // hunt through the filesystem every time.
+    if (typeof currentPath === 'string' && currentPath.startsWith('/')) {
+      options.defaultPath = currentPath
+    }
+
+    const result = parent
+      ? await dialog.showOpenDialog(parent, options)
+      : await dialog.showOpenDialog(options)
+
+    if (result.canceled) return ''
+    return result.filePaths?.[0] ?? ''
+  })
+
   ipcMain.handle('agentrq:update:get', () => updateState)
   ipcMain.handle('agentrq:update:check', () => updater?.checkNow() ?? { ok: false, reason: 'Updater unavailable' })
   ipcMain.handle('agentrq:update:install', () => updater?.installNow() ?? false)

--- a/desktop/src/preload/index.js
+++ b/desktop/src/preload/index.js
@@ -34,6 +34,16 @@ contextBridge.exposeInMainWorld('agentrq', {
 
   },
 
+  dialog: {
+    /**
+     * Ask the shell to show the platform's folder chooser.
+     *
+     * @param {string} [currentPath] where to open the dialog
+     * @returns {Promise<string>} the chosen path, or '' if dismissed
+     */
+    chooseDirectory: (currentPath) => ipcRenderer.invoke('agentrq:dialog:chooseDirectory', currentPath),
+  },
+
   navigation: {
     /**
      * Called with an in-app route whenever the shell asks the app to go

--- a/frontend/src/views/WorkspaceSettingsView.vue
+++ b/frontend/src/views/WorkspaceSettingsView.vue
@@ -48,6 +48,19 @@
                       <label class="block text-[10px] font-bold text-gray-400 dark:text-zinc-500 uppercase tracking-widest ml-1">Mission Description</label>
                       <textarea v-model="form.description" rows="3" class="w-full bg-gray-50 dark:bg-zinc-800/50 border border-gray-200 dark:border-zinc-800 rounded-sm px-4 py-3 text-sm focus:border-gray-900 dark:focus:border-white focus:ring-0 outline-none font-medium text-gray-800 dark:text-zinc-200 transition-all resize-none shadow-sm" placeholder="What are we building together?"></textarea>
                     </div>
+                    <div class="space-y-2">
+                      <label for="workingDirectory" class="block text-[10px] font-bold text-gray-400 dark:text-zinc-500 uppercase tracking-widest ml-1">Working Directory</label>
+                      <div class="flex items-stretch gap-2">
+                        <input id="workingDirectory" v-model="form.workingDirectory" type="text" spellcheck="false" autocapitalize="off" autocorrect="off"
+                               class="min-w-0 flex-1 bg-gray-50 dark:bg-zinc-800/50 border border-gray-200 dark:border-zinc-800 rounded-sm px-4 py-3 text-sm focus:border-gray-900 dark:focus:border-white focus:ring-0 outline-none font-medium text-gray-800 dark:text-zinc-200 transition-all shadow-sm"
+                               :placeholder="workingDirectoryPlaceholder" />
+                        <button v-if="platformStore.isDesktop" type="button" @click="chooseWorkingDirectory" :disabled="isChoosingDirectory"
+                                class="shrink-0 px-4 bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-sm text-[10px] font-bold uppercase tracking-widest text-gray-900 dark:text-zinc-100 hover:border-gray-900 dark:hover:border-white transition-all shadow-sm disabled:opacity-50 disabled:cursor-not-allowed">
+                          {{ isChoosingDirectory ? 'Choosing' : 'Browse' }}
+                        </button>
+                      </div>
+                      <p class="text-[9px] text-gray-500 dark:text-zinc-500 font-bold uppercase tracking-wider ml-1 mt-2">Optional. Absolute path the agent should work in.</p>
+                    </div>
                   </div>
 
                   <div class="space-y-2">
@@ -920,8 +933,40 @@ const form = ref({
   autoAllowedTools: [],
   allowAllCommands: false,
   selfLearningLoopNote: '',
-  inputSendDelaySeconds: 0
+  inputSendDelaySeconds: 0,
+  workingDirectory: ''
 });
+
+const isChoosingDirectory = ref(false);
+
+// Show an example from the platform the person is actually on. A Windows user
+// told to enter "/Users/you/..." has to translate it before they can start.
+const workingDirectoryPlaceholder = computed(() => {
+  if (!platformStore.isDesktop) return '/home/you/code/project';
+  return window.agentrq?.platform === 'win32'
+    ? 'C:\\Users\\you\\Code\\project'
+    : '/Users/you/Code/project';
+});
+
+/**
+ * Ask the shell for the platform's folder chooser.
+ *
+ * Desktop only: a browser cannot hand back a real filesystem path, so the web
+ * build offers the text field alone rather than a button that cannot work.
+ */
+async function chooseWorkingDirectory() {
+  if (isChoosingDirectory.value) return;
+  isChoosingDirectory.value = true;
+  try {
+    const chosen = await window.agentrq?.dialog?.chooseDirectory(form.value.workingDirectory);
+    // '' means the dialog was dismissed, which must not wipe what is there.
+    if (chosen) form.value.workingDirectory = chosen;
+  } catch (err) {
+    notifyError('Could not open the folder chooser: ' + err.message);
+  } finally {
+    isChoosingDirectory.value = false;
+  }
+}
 
 watch(() => form.value.name, (newVal) => {
   if (newVal) {
@@ -951,7 +996,8 @@ async function load() {
       autoAllowedTools: workspace.value.autoAllowedTools || [],
       allowAllCommands: workspace.value.allowAllCommands || false,
       selfLearningLoopNote: workspace.value.selfLearningLoopNote || '',
-      inputSendDelaySeconds: workspace.value.inputSendDelaySeconds || 0
+      inputSendDelaySeconds: workspace.value.inputSendDelaySeconds || 0,
+      workingDirectory: workspace.value.workingDirectory || ''
     };
     slackConfig.value = workspace.value.slack || null;
     if (slackConfig.value) {


### PR DESCRIPTION
**What changed**

Workspace settings now take an optional working directory for the agent. It can be typed, or on the desktop app picked with the operating system's own folder chooser.

**Why changed**

Agents need to know where to work, and there was nowhere to say so. Typing an absolute path from memory is exactly the kind of thing people get subtly wrong, so the desktop app offers the native folder dialog and fills the field in from it.

**Test coverage report**

New lines introduced: the validation added to the server is at 100% statement coverage across all three new functions, with 24 cases covering every accepted shape of absolute path, relative paths, control characters, surrounding whitespace, and non-Latin directory names.

Total coverage impact: none in the negative direction. Existing suites all pass unchanged — the whole server suite, 54 on the web front end, 317 in the desktop shell. The interface additions sit inside a large settings view that has no component-testing harness in this project and is outside the configured coverage scope, so no existing measurement moves; the logic worth testing was put on the server, where it is enforced regardless of which client is talking.

**Other reports**

The path is validated rather than merely stored. The server cannot confirm a directory exists, because the agent usually runs on a different machine and the path only means something there — but it can reject what could not be a directory anywhere. A relative path is refused, since it silently resolves to wherever the agent's shell happened to start, which is a setting that appears to work and then quietly does something else. Windows and network share paths are accepted alongside Unix ones, because the agent need not be on the same platform as the server. Control characters are refused, while ordinary directory names in other scripts stay valid.

The browse button appears only in the desktop app, because a browser cannot hand back a real filesystem path and a button that cannot work is worse than no button. Dismissing the dialog leaves whatever was already typed untouched. The dialog opens at the current value, so correcting a path is not a fresh hunt through the filesystem.

Only the chosen path crosses the boundary between the shell and the interface — never a handle to the dialog or the window it belongs to.

Existing agent-facing tooling can still edit a workspace without disturbing this field: that path starts from the stored workspace and overwrites only what it was explicitly given. The new column arrives through the automatic schema migration already in place, so no separate migration step is needed.

Styling reuses the exact classes of the name and description fields directly above it, and the example path shown follows the platform, so a Windows user is not shown a Unix path to translate.

**TaskID:** 0hxRnC52sJF