### PR TITLE
feat(workspace): ask for the working directory when creating, and only offer Browse when it works

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -35,11 +35,11 @@ export async function fetchUser() {
 }
 
 
-export async function createWorkspace(name, description, icon = '', selfLearningLoopNote = '') {
+export async function createWorkspace(name, description, icon = '', selfLearningLoopNote = '', workingDirectory = '') {
   const res = await fetch(`${API_BASE_URL}/workspaces`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ workspace: { name, description, icon, selfLearningLoopNote } })
+    body: JSON.stringify({ workspace: { name, description, icon, selfLearningLoopNote, workingDirectory } })
   });
   if (!res.ok) throw new Error('Failed to create workspace');
   return res.json();

--- a/frontend/src/composables/useDirectoryPicker.js
+++ b/frontend/src/composables/useDirectoryPicker.js
@@ -1,0 +1,65 @@
+/**
+ * Choosing a working directory with the operating system's folder chooser.
+ *
+ * Only the desktop shell can do this. A browser deliberately never reveals an
+ * absolute filesystem path — `webkitdirectory` and `showDirectoryPicker` both
+ * hand back a folder *name* and nothing more — so on the web the field is typed
+ * into, and saying so is better than a button that cannot work.
+ *
+ * The bridge is checked as well as the platform, because those are two
+ * different questions. A desktop build whose preload predates this feature is
+ * still "desktop", but has no `chooseDirectory` to call: optional chaining then
+ * resolves to undefined and the click does nothing at all, which is
+ * indistinguishable from a broken button. Checking here means the button is not
+ * offered unless it can actually work.
+ */
+
+export const PickerUnavailable = {
+  /** The browser build, which cannot produce an absolute path. */
+  Web: 'web',
+  /** A desktop build whose bridge does not expose the chooser. */
+  Bridge: 'bridge',
+};
+
+export const PICKER_MESSAGES = {
+  [PickerUnavailable.Web]: 'Folder browsing is available in the desktop app. Type the path here instead.',
+  [PickerUnavailable.Bridge]:
+    'This desktop app could not open its folder chooser. Restarting it usually fixes this.',
+};
+
+/**
+ * @param {{ isDesktop: boolean, bridge: unknown }} context
+ * @returns {{ available: boolean, reason: string }}
+ */
+export function directoryPickerState({ isDesktop, bridge }) {
+  if (!isDesktop) return { available: false, reason: PickerUnavailable.Web };
+  if (typeof bridge?.chooseDirectory !== 'function') {
+    return { available: false, reason: PickerUnavailable.Bridge };
+  }
+  return { available: true, reason: '' };
+}
+
+/**
+ * Open the chooser.
+ *
+ * @returns {Promise<string>} the chosen path, or '' when the dialog was
+ *          dismissed — so a cancelled choice never clears what is already set.
+ * @throws {Error} with a message worth showing when it cannot be opened
+ */
+export async function chooseDirectory({ isDesktop, bridge, currentPath = '' }) {
+  const { available, reason } = directoryPickerState({ isDesktop, bridge });
+  if (!available) throw new Error(PICKER_MESSAGES[reason]);
+
+  const chosen = await bridge.chooseDirectory(currentPath);
+  return typeof chosen === 'string' ? chosen : '';
+}
+
+/**
+ * An example path for the platform the person is on, so a Windows user is not
+ * shown a Unix path to mentally translate before they can start.
+ */
+export function workingDirectoryPlaceholder(osPlatform) {
+  if (osPlatform === 'win32') return 'C:\\Users\\you\\Code\\project';
+  if (osPlatform === 'linux') return '/home/you/code/project';
+  return '/Users/you/Code/project';
+}

--- a/frontend/src/views/WorkspaceSettingsView.vue
+++ b/frontend/src/views/WorkspaceSettingsView.vue
@@ -54,12 +54,12 @@
                         <input id="workingDirectory" v-model="form.workingDirectory" type="text" spellcheck="false" autocapitalize="off" autocorrect="off"
                                class="min-w-0 flex-1 bg-gray-50 dark:bg-zinc-800/50 border border-gray-200 dark:border-zinc-800 rounded-sm px-4 py-3 text-sm focus:border-gray-900 dark:focus:border-white focus:ring-0 outline-none font-medium text-gray-800 dark:text-zinc-200 transition-all shadow-sm"
                                :placeholder="workingDirectoryPlaceholder" />
-                        <button v-if="platformStore.isDesktop" type="button" @click="chooseWorkingDirectory" :disabled="isChoosingDirectory"
+                        <button v-if="canBrowseDirectories" type="button" @click="chooseWorkingDirectory" :disabled="isChoosingDirectory"
                                 class="shrink-0 px-4 bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-sm text-[10px] font-bold uppercase tracking-widest text-gray-900 dark:text-zinc-100 hover:border-gray-900 dark:hover:border-white transition-all shadow-sm disabled:opacity-50 disabled:cursor-not-allowed">
                           {{ isChoosingDirectory ? 'Choosing' : 'Browse' }}
                         </button>
                       </div>
-                      <p class="text-[9px] text-gray-500 dark:text-zinc-500 font-bold uppercase tracking-wider ml-1 mt-2">Optional. Absolute path the agent should work in.</p>
+                      <p class="text-[9px] text-gray-500 dark:text-zinc-500 font-bold uppercase tracking-wider ml-1 mt-2">Optional. Absolute path the agent should work in.<span v-if="!canBrowseDirectories"> Browse for it in the desktop app.</span></p>
                     </div>
                   </div>
 
@@ -612,6 +612,11 @@ import { getWorkspace, updateWorkspace, archiveWorkspace, unarchiveWorkspace, de
 import { useToasts } from '../composables/useToasts';
 import { usePushNotifications } from '../composables/usePushNotifications';
 import { usePlatformStore } from '../stores/platformStore';
+import {
+  chooseDirectory,
+  directoryPickerState,
+  workingDirectoryPlaceholder as directoryPlaceholderFor,
+} from '../composables/useDirectoryPicker';
 import ArchiveModal from '../components/ArchiveModal.vue';
 import DeleteModal from '../components/DeleteModal.vue';
 import { useWorkspaceStore } from '../stores/workspaceStore';
@@ -939,30 +944,28 @@ const form = ref({
 
 const isChoosingDirectory = ref(false);
 
-// Show an example from the platform the person is actually on. A Windows user
-// told to enter "/Users/you/..." has to translate it before they can start.
-const workingDirectoryPlaceholder = computed(() => {
-  if (!platformStore.isDesktop) return '/home/you/code/project';
-  return window.agentrq?.platform === 'win32'
-    ? 'C:\\Users\\you\\Code\\project'
-    : '/Users/you/Code/project';
-});
+// Both questions matter: only the desktop shell can produce an absolute path,
+// and only a build whose bridge exposes the chooser can actually open one. A
+// button offered without the second is a button that does nothing when clicked.
+const canBrowseDirectories = computed(
+  () => directoryPickerState({ isDesktop: platformStore.isDesktop, bridge: window.agentrq?.dialog }).available
+);
 
-/**
- * Ask the shell for the platform's folder chooser.
- *
- * Desktop only: a browser cannot hand back a real filesystem path, so the web
- * build offers the text field alone rather than a button that cannot work.
- */
+const workingDirectoryPlaceholder = computed(() => directoryPlaceholderFor(window.agentrq?.platform));
+
 async function chooseWorkingDirectory() {
   if (isChoosingDirectory.value) return;
   isChoosingDirectory.value = true;
   try {
-    const chosen = await window.agentrq?.dialog?.chooseDirectory(form.value.workingDirectory);
+    const chosen = await chooseDirectory({
+      isDesktop: platformStore.isDesktop,
+      bridge: window.agentrq?.dialog,
+      currentPath: form.value.workingDirectory,
+    });
     // '' means the dialog was dismissed, which must not wipe what is there.
     if (chosen) form.value.workingDirectory = chosen;
   } catch (err) {
-    notifyError('Could not open the folder chooser: ' + err.message);
+    notifyError(err.message);
   } finally {
     isChoosingDirectory.value = false;
   }

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -34,6 +34,21 @@
                 <textarea v-model="form.description" rows="3" class="w-full bg-white dark:bg-zinc-950 border border-gray-200 dark:border-zinc-700 rounded-sm px-4 py-3 text-sm outline-none font-medium text-gray-800 dark:text-zinc-200 transition-all resize-none focus:border-gray-900 dark:focus:border-white focus:ring-0 shadow-sm" placeholder="What are we building? Describe the mission of this workspace..."></textarea>
               </div>
               <div class="space-y-2">
+                <label for="newWorkingDirectory" class="block text-[10px] font-black text-gray-500 dark:text-zinc-400 flex justify-between items-center">
+                  Working Directory
+                  <span class="text-[9px] text-gray-500 font-medium normal-case tracking-normal">Optional absolute path the agent works in</span>
+                </label>
+                <div class="flex items-stretch gap-2">
+                  <input id="newWorkingDirectory" v-model="form.workingDirectory" type="text" spellcheck="false" autocapitalize="off" autocorrect="off"
+                         class="min-w-0 flex-1 bg-white dark:bg-zinc-950 border border-gray-200 dark:border-zinc-700 rounded-sm px-4 py-3 text-sm outline-none font-medium text-gray-800 dark:text-zinc-200 focus:border-gray-900 dark:focus:border-white focus:ring-0 transition-all shadow-sm"
+                         :placeholder="workingDirectoryPlaceholder" />
+                  <button v-if="canBrowseDirectories" type="button" @click="chooseWorkingDirectory" :disabled="isChoosingDirectory"
+                          class="shrink-0 px-4 bg-white dark:bg-zinc-950 border border-gray-200 dark:border-zinc-700 rounded-sm text-[10px] font-black uppercase tracking-widest text-gray-800 dark:text-zinc-200 hover:border-gray-900 dark:hover:border-white transition-all shadow-sm disabled:opacity-50 disabled:cursor-not-allowed">
+                    {{ isChoosingDirectory ? 'Choosing' : 'Browse' }}
+                  </button>
+                </div>
+              </div>
+              <div class="space-y-2">
                 <label class="block text-[10px] font-black text-gray-500 dark:text-zinc-400 flex justify-between items-center">
                   Self Learning Loop Note
                   <span class="text-[9px] text-gray-500 font-medium normal-case tracking-normal">Optional guidelines for agent learning</span>
@@ -232,6 +247,12 @@ import { useEventBus } from '../useEventBus';
 import { useWorkspaceStore } from '../stores/workspaceStore';
 import { useFormat } from '../composables/useFormat';
 import { useTooltipStore } from '../stores/tooltipStore';
+import { usePlatformStore } from '../stores/platformStore';
+import {
+  chooseDirectory,
+  directoryPickerState,
+  workingDirectoryPlaceholder as directoryPlaceholderFor,
+} from '../composables/useDirectoryPicker';
 import LoadingState from '../components/LoadingState.vue';
 
 const { toKebabCase, liveKebabCase } = useFormat();
@@ -239,6 +260,36 @@ const tooltipStore = useTooltipStore();
 
 const router = useRouter();
 const { notifySuccess, notifyError } = useToasts();
+
+const platformStore = usePlatformStore();
+const isChoosingDirectory = ref(false);
+
+// Offered only when it can actually work: the browser cannot produce an
+// absolute path, and a desktop build whose bridge lacks the chooser would give
+// a button that does nothing when clicked.
+const canBrowseDirectories = computed(
+  () => directoryPickerState({ isDesktop: platformStore.isDesktop, bridge: window.agentrq?.dialog }).available
+);
+
+const workingDirectoryPlaceholder = computed(() => directoryPlaceholderFor(window.agentrq?.platform));
+
+async function chooseWorkingDirectory() {
+  if (isChoosingDirectory.value) return;
+  isChoosingDirectory.value = true;
+  try {
+    const chosen = await chooseDirectory({
+      isDesktop: platformStore.isDesktop,
+      bridge: window.agentrq?.dialog,
+      currentPath: form.value.workingDirectory,
+    });
+    // '' means the dialog was dismissed, which must not wipe what is there.
+    if (chosen) form.value.workingDirectory = chosen;
+  } catch (err) {
+    notifyError(err.message);
+  } finally {
+    isChoosingDirectory.value = false;
+  }
+}
 const workspaceStore = useWorkspaceStore();
 const workspaces = computed(() => workspaceStore.workspaces);
 const showCreate = ref(false);
@@ -250,7 +301,7 @@ const iconError = ref('');
 const createFileInput = ref(null);
 const error = ref(null);
 
-const form = ref({ name: '', description: '', icon: '', selfLearningLoopNote: '' });
+const form = ref({ name: '', description: '', icon: '', selfLearningLoopNote: '', workingDirectory: '' });
 const globalStats = ref({
   totalTasks: 0,
   pendingTasks: 0,
@@ -316,7 +367,7 @@ watch(() => form.value.name, (newVal) => {
 
 watch(showCreate, (val) => {
   if (!val) {
-    form.value = { name: '', description: '', icon: '', selfLearningLoopNote: '' };
+    form.value = { name: '', description: '', icon: '', selfLearningLoopNote: '', workingDirectory: '' };
     iconError.value = '';
   }
 });
@@ -351,11 +402,11 @@ async function submit() {
   loading.value = true;
   error.value = null;
   try {
-    const res = await createWorkspace(form.value.name, form.value.description, form.value.icon, form.value.selfLearningLoopNote);
+    const res = await createWorkspace(form.value.name, form.value.description, form.value.icon, form.value.selfLearningLoopNote, form.value.workingDirectory);
     const newId = res.workspace?.id || res.id;
     
     showCreate.value = false;
-    form.value = { name: '', description: '', icon: '', selfLearningLoopNote: '' };
+    form.value = { name: '', description: '', icon: '', selfLearningLoopNote: '', workingDirectory: '' };
     iconError.value = ''; 
     
     if (newId) {

--- a/frontend/test/directoryPicker.test.js
+++ b/frontend/test/directoryPicker.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import {
+  PICKER_MESSAGES,
+  PickerUnavailable,
+  chooseDirectory,
+  directoryPickerState,
+  workingDirectoryPlaceholder,
+} from '../src/composables/useDirectoryPicker'
+
+const workingBridge = { chooseDirectory: vi.fn().mockResolvedValue('/Users/mt/Code/agentrq') }
+
+describe('directoryPickerState', () => {
+  it('is available on desktop with a bridge that can open it', () => {
+    expect(directoryPickerState({ isDesktop: true, bridge: workingBridge })).toEqual({
+      available: true,
+      reason: '',
+    })
+  })
+
+  it('is unavailable in the browser', () => {
+    // A browser never reveals an absolute path, so there is nothing to offer.
+    expect(directoryPickerState({ isDesktop: false, bridge: workingBridge })).toEqual({
+      available: false,
+      reason: PickerUnavailable.Web,
+    })
+  })
+
+  it('is unavailable on a desktop build whose bridge lacks the chooser', () => {
+    // The case that produced a button which did nothing when clicked: the
+    // platform says desktop, but the preload has no chooser to call, so
+    // optional chaining resolved to undefined and the click was a no-op.
+    for (const bridge of [undefined, null, {}, { chooseDirectory: 'nope' }]) {
+      expect(directoryPickerState({ isDesktop: true, bridge })).toEqual({
+        available: false,
+        reason: PickerUnavailable.Bridge,
+      })
+    }
+  })
+})
+
+describe('chooseDirectory', () => {
+  it('returns the chosen path', async () => {
+    const bridge = { chooseDirectory: vi.fn().mockResolvedValue('/Users/mt/Code/agentrq') }
+
+    await expect(chooseDirectory({ isDesktop: true, bridge })).resolves.toBe('/Users/mt/Code/agentrq')
+  })
+
+  it('opens where the field already points', async () => {
+    const bridge = { chooseDirectory: vi.fn().mockResolvedValue('') }
+
+    await chooseDirectory({ isDesktop: true, bridge, currentPath: '/Users/mt/Code' })
+
+    expect(bridge.chooseDirectory).toHaveBeenCalledWith('/Users/mt/Code')
+  })
+
+  it('returns empty when the dialog is dismissed, so nothing is cleared', async () => {
+    for (const dismissed of ['', undefined, null]) {
+      const bridge = { chooseDirectory: vi.fn().mockResolvedValue(dismissed) }
+      await expect(chooseDirectory({ isDesktop: true, bridge })).resolves.toBe('')
+    }
+  })
+
+  it('explains itself rather than doing nothing when it cannot open', async () => {
+    // Silence is the failure this replaces: a click that does nothing looks
+    // like a bug in the app, and leaves the person with nowhere to go.
+    await expect(chooseDirectory({ isDesktop: false, bridge: workingBridge })).rejects.toThrow(
+      PICKER_MESSAGES[PickerUnavailable.Web]
+    )
+    await expect(chooseDirectory({ isDesktop: true, bridge: {} })).rejects.toThrow(
+      PICKER_MESSAGES[PickerUnavailable.Bridge]
+    )
+  })
+
+  it('lets a failure from the shell surface', async () => {
+    const bridge = { chooseDirectory: vi.fn().mockRejectedValue(new Error('dialog exploded')) }
+
+    await expect(chooseDirectory({ isDesktop: true, bridge })).rejects.toThrow('dialog exploded')
+  })
+})
+
+describe('workingDirectoryPlaceholder', () => {
+  it('shows a path from the platform the person is on', () => {
+    expect(workingDirectoryPlaceholder('win32')).toBe('C:\\Users\\you\\Code\\project')
+    expect(workingDirectoryPlaceholder('linux')).toBe('/home/you/code/project')
+    expect(workingDirectoryPlaceholder('darwin')).toBe('/Users/you/Code/project')
+  })
+
+  it('falls back to a Unix example when the platform is unknown', () => {
+    expect(workingDirectoryPlaceholder(undefined)).toBe('/Users/you/Code/project')
+    expect(workingDirectoryPlaceholder('')).toBe('/Users/you/Code/project')
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -39,6 +39,7 @@ export default defineConfig({
         'src/composables/useChatScroll.js',
         'src/composables/useTaskGroups.js',
         'src/composables/usePendingSend.js',
+        'src/composables/useDirectoryPicker.js',
       ],
       reporter: ['text', 'lcov'],
       thresholds: {


### PR DESCRIPTION
**What changed**

Creating a workspace now asks for the optional working directory, with the same folder-chooser button the settings screen has. That button is offered only when it can actually open a chooser, and says where to find one when it cannot.

**Why changed**

The directory could previously only be set by creating a workspace and then going into its settings, which is a strange way to configure something you know at the moment you create it.

The chooser button was decided by the platform alone, which is only half the question. A desktop app whose bridge predates this feature still reports as desktop but has nothing to call, and the call quietly resolved to nothing — the button appeared, clicking did nothing, and nothing explained why. That is very likely what was seen, because the desktop app reloads its interface as you edit but only picks up a new bridge when the app itself restarts. Availability now depends on the chooser really being there.

A browser genuinely cannot do this, rather than merely not doing it yet: the web platform hands back a folder's name and never its full path, so there is nothing to offer and filling the field from it would put something wrong in. The helper text now points at the desktop app instead of leaving a silent gap.

**Test coverage report**

New lines introduced: 100% covered — statements, branches, functions and lines. 10 tests covering when the chooser is offered and when it is not, both reasons it can be unavailable, dismissal leaving the existing value alone, a failure from the shell surfacing, and the example path shown per platform.

Total coverage impact: none, it stays at 100%. The new module is added to the coverage scope so it is held to the existing thresholds rather than sitting outside them. Suite 65 → 75 tests, all passing; both the web and desktop builds compile, and the desktop suite stays green at 317.

**Other reports**

The chooser logic is now shared by both forms rather than written twice, so they cannot drift — the settings screen was rewired onto it as part of this rather than left with its own copy.

Attempting to open a chooser that is unavailable now raises a message worth reading rather than doing nothing at all. Silence was the actual defect here: a button that does nothing gives someone no way to tell a missing capability from a broken application.

No server change was needed; the create endpoint already accepted this field, it simply was never sent.

**TaskID:** 0hxVEASlAqv