### PR TITLE
chore: bump patch version to v0.4.12

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.4.11"
+	_appVersion   = "v0.4.12"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.4.11" {
-			t.Errorf("Expected version v0.4.11, got %s", s.Version())
+		if s.Version() != "v0.4.12" {
+			t.Errorf("Expected version v0.4.12, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.4.11",
+  "version": "0.4.12",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
**What changed**

The project version moves from 0.4.11 to 0.4.12 everywhere it is declared — the desktop and web packages with their lockfiles, and the server's application version constant with the test asserting it.

**Why changed**

To cut the release carrying the ten changes merged since the last one: the new working directory setting, and fixes for a message that could be sent to the wrong task, a crash when opening an attachment named by macOS, missing profile photos, links leaving the app, an empty Scheduled page, and the chat not scrolling on return from the trajectory view.

**What ships since v0.4.11**

- feat: workspaces take an optional working directory, typed or chosen with the platform's folder dialog, on both the create form and settings (#382, #384)
- fix: a message held by the send delay goes to the task it was written in rather than whichever is on screen when the countdown ends, and switching tasks no longer carries the draft across (#383)
- fix: attachment filenames are encoded so the response header stays valid — a macOS screenshot name crashed the desktop app, and the old formatting also allowed header injection (#381)
- fix: the Scheduled page shows its heading and empty state instead of a blank column (#380)
- fix: returning from the trajectory view scrolls the chat to the newest message (#378)
- fix: links open in a window belonging to the app, and addresses that execute script or reach the local filesystem are refused (#377)
- fix: profile photos render in the desktop app (#376)
- chore: the tool call view is called Trajectory in the interface (#379)
- chore: copyright attributed to Contextual, Inc. (#375)

**Test coverage report**

No executable code was added, so no new lines require coverage and total coverage is unaffected. The two changed assertions are the existing version test updated to the new value. All three suites pass: the server package, 75 on the web front end, 317 in the desktop shell.

**Other reports**

The version-sync guard was exercised as CI runs it: `GITHUB_REF=refs/tags/v0.4.12` reports both that the sources agree and that the tag matches the tree.

Both lockfiles were edited in place rather than regenerated, so this changes the version and nothing about dependency resolution; `npm ci` was confirmed to still install cleanly from each.

**TaskID:** 0hxXW2FHX3R