### PR TITLE
feat(desktop): multiple signed-in profiles with a switcher

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -109,6 +109,43 @@ EventSource connects and streams normally:
 **No preload SSE bridge is needed and `useEventBus.js` needs no platform
 branch.**
 
+## Profiles
+
+Several accounts can be signed in at once, and switched between from the user
+menu in the sidebar — the desktop equivalent of Chrome profiles.
+
+A profile *is* an Electron session partition. That is the whole mechanism:
+cookies are per partition, the `at` cookie is a cookie, so a partition is an
+account. Everything else follows from keeping the list of them coherent.
+
+Three consequences worth knowing before touching this:
+
+- **The `app://` handler is registered per session, not once.** `protocol.handle`
+  attaches to one session's registry, so a window opened on a partition that
+  never had the handler cannot load the app at all. `sessionFor()` attaches it
+  the first time a partition is used, and remembers which sessions already have
+  it — registering twice throws.
+- **Nothing may use `net.fetch` any more.** It sends the *default* session's
+  cookies, so it would talk to the server as whichever account happened to be
+  in that jar. Every request goes through `profileFetch`, which is the active
+  profile's `session.fetch`. The same applies to the OAuth window: it runs on
+  the active profile's partition, so the cookie the callback sets signs in that
+  profile and no other.
+- **Switching replaces the window rather than reloading it.** A window's
+  partition is fixed when it is created. Reloading would keep the old session
+  and quietly show the previous account's data under the new profile's name.
+  The replacement window is created *before* the old one is destroyed: on
+  Windows and Linux, closing the last window quits the app.
+
+Each profile carries its own server URL and muted-workspace list, because an
+account exists on one server — splitting those would let you sign in as one user
+and then point that session at a server where the cookie means nothing.
+
+The profile migrated from a pre-profiles install gets a partition like any
+other, which signs that user out once on upgrade. That was a deliberate trade:
+the session is only valid for 24 hours anyway, and the alternative is one
+profile permanently special-cased wherever a session is resolved.
+
 ## The native shell
 
 Everything the browser cannot offer lives in the main process and reaches the

--- a/desktop/src/main/identity.js
+++ b/desktop/src/main/identity.js
@@ -1,0 +1,72 @@
+/**
+ * Who is signed in to a profile.
+ *
+ * The switcher shows a name and email rather than only a label, because a list
+ * of profiles named "Default" and "Work" does not tell you which account you
+ * are about to switch to — which was the whole point of having profiles.
+ *
+ * Each lookup runs against that profile's own session, so it answers for that
+ * profile rather than for whichever one happens to be on screen. Everything is
+ * best effort: a profile that is signed out, pointed at a server that is down,
+ * or simply not configured yet is a normal state, not an error, and shows as
+ * "not signed in" rather than blocking the menu.
+ */
+
+/** How long to wait before deciding a profile cannot answer for itself. */
+export const IDENTITY_TIMEOUT_MS = 4000
+
+/** The user endpoint, unauthenticated-safe: it 401s rather than erroring. */
+export const USER_PATH = '/api/v1/auth/user'
+
+/**
+ * Ask one profile who it is signed in as.
+ *
+ * @param {object} deps
+ * @param {typeof fetch} deps.fetchImpl  that profile's session fetch
+ * @param {string} deps.serverUrl        that profile's server; '' means unconfigured
+ * @param {(ms: number) => AbortSignal} [deps.timeout]
+ * @returns {Promise<{name: string, email: string, picture: string} | null>}
+ */
+export async function fetchProfileIdentity({ fetchImpl, serverUrl, timeout }) {
+  if (!serverUrl) return null
+
+  let res
+  try {
+    const signal = timeout ? timeout(IDENTITY_TIMEOUT_MS) : undefined
+    res = await fetchImpl(`${serverUrl}${USER_PATH}`, signal ? { signal } : {})
+  } catch {
+    // Unreachable, refused, timed out: all "cannot say", none worth an error.
+    return null
+  }
+
+  // 401 is the ordinary answer for a profile nobody has signed into yet.
+  if (!res?.ok) return null
+
+  let user
+  try {
+    user = await res.json()
+  } catch {
+    return null
+  }
+
+  return describeIdentity(user)
+}
+
+/**
+ * Reduce a user payload to what the switcher shows.
+ *
+ * @returns {{name: string, email: string, picture: string} | null} null when
+ *          there is nothing worth showing, so callers have one thing to check
+ */
+export function describeIdentity(user) {
+  if (!user || typeof user !== 'object') return null
+
+  const name = typeof user.name === 'string' ? user.name.trim() : ''
+  const email = typeof user.email === 'string' ? user.email.trim() : ''
+  const picture = typeof user.picture === 'string' ? user.picture : ''
+
+  // A response with neither is indistinguishable from being signed out, as far
+  // as anything the user can see goes.
+  if (name === '' && email === '') return null
+  return { name, email, picture }
+}

--- a/desktop/src/main/index.js
+++ b/desktop/src/main/index.js
@@ -9,7 +9,6 @@ import {
   ipcMain,
   nativeImage,
   nativeTheme,
-  net,
   protocol,
   screen,
   session,
@@ -110,13 +109,65 @@ let currentTheme = 'system'
 /** Set when a deep link arrives before the window is ready to receive it. */
 let pendingRoute = null
 let updater = null
+/**
+ * The signed-in profile in use, and the Electron session that carries its
+ * cookies. Everything that talks to the server goes through this session rather
+ * than the default one — that is what makes two profiles two accounts.
+ */
+let profileState = null
+let profileSession = null
+
+/** Sessions that already have the app:// handler; registering twice throws. */
+const handledSessions = new WeakSet()
+
+/**
+ * The session for a partition, with the app:// protocol handler attached.
+ *
+ * The handler has to be registered per session, not once globally: a partition
+ * gets its own protocol registry, so a window opened on one without this would
+ * fail to load the app at all.
+ */
+function sessionFor(partition) {
+  const ses = session.fromPartition(partition)
+  if (!handledSessions.has(ses)) {
+    ses.protocol.handle(
+      'app',
+      createAppProtocolHandler({
+        serverUrl: () => serverUrl,
+        // The profile's own session, so the `at` cookie sent upstream is that
+        // profile's. Using net.fetch here would send the default session's.
+        netFetch: (input, init) => ses.fetch(input, init),
+        fileExists,
+        readFile: (pathname) => readFile(join(RENDERER_ROOT, pathname)),
+        devServerUrl: process.env.AGENTRQ_RENDERER_DEV_URL ?? '',
+      })
+    )
+    handledSessions.add(ses)
+  }
+  return ses
+}
+
+/**
+ * The partition a window should be created on.
+ *
+ * Null-safe on purpose: every current caller runs after the profiles are
+ * loaded, but a window created before that would otherwise throw here rather
+ * than fall back to something sane.
+ */
+function currentPartition() {
+  return profileState ? activeProfile(profileState).partition : partitionFor('default')
+}
+
+/** Fetch through the active profile's session, so its cookies go with it. */
+const profileFetch = (input, init) => (profileSession ?? session.defaultSession).fetch(input, init)
+
 /** Last update state, so a renderer that loads later is not left in the dark. */
 let updateState = { status: UpdateStatus.Idle, detail: '', remedy: '', version: '', enabled: false }
 
 async function refreshWorkspaceNames() {
   if (!serverUrl) return
   try {
-    const res = await net.fetch(`${serverUrl}/api/v1/workspaces`)
+    const res = await profileFetch(`${serverUrl}/api/v1/workspaces`)
     if (!res.ok) return
     const body = await res.json()
     for (const ws of Array.isArray(body) ? body : (body?.workspaces ?? [])) {
@@ -221,16 +272,18 @@ async function startOAuth(win, pathname, search) {
         title: 'Sign in to AgentRQ',
         autoHideMenuBar: true,
         webPreferences: {
-          // No preload and no partition: this window is showing a third-party
-          // sign-in page, so it gets no bridge, and it must stay on the default
-          // session so the cookie it earns is the one net.fetch will send.
+          // No preload: this window shows a third-party sign-in page, so it
+          // gets no bridge. It runs on the *active profile's* partition, which
+          // is the whole mechanism — the `at` cookie the callback sets lands in
+          // that profile's jar, so it signs in that profile and no other.
+          partition: currentPartition(),
           contextIsolation: true,
           nodeIntegration: false,
           sandbox: true,
         },
       }),
     hasAuthCookie: async () => {
-      const cookies = await session.defaultSession.cookies.get({ name: AUTH_COOKIE })
+      const cookies = await profileSession.cookies.get({ name: AUTH_COOKIE })
       return cookies.length > 0
     },
   })
@@ -336,7 +389,7 @@ function startEventStream() {
 
   eventStream = createEventStreamClient({
     streamUrl: () => `${serverUrl}/api/v1/events/stream`,
-    netFetch: net.fetch,
+    netFetch: profileFetch,
     onEvent: handleStreamEvent,
     delay: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
     onUnauthorized: () => {
@@ -366,6 +419,9 @@ function createWindow() {
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
     webPreferences: {
       preload: PRELOAD,
+      // Fixed when the window is created and not changeable afterwards, which
+      // is why switching profiles recreates the window rather than reloading.
+      partition: currentPartition(),
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: true,
@@ -449,7 +505,7 @@ function installMenu(getWindow) {
         reloadToRoot(getWindow())
       },
       logOut: async () => {
-        await session.defaultSession.clearStorageData({ storages: ['cookies'] })
+        await profileSession.clearStorageData({ storages: ['cookies'] })
         eventStream?.stop()
         unread?.clear()
         reloadToRoot(getWindow())
@@ -460,11 +516,65 @@ function installMenu(getWindow) {
   Menu.setApplicationMenu(Menu.buildFromTemplate(template))
 }
 
+/** What the renderer needs to draw the switcher: names, not sessions. */
+function profilesPayload() {
+  const state = profileState ?? { profiles: [], activeProfileId: '' }
+  return {
+    activeProfileId: state.activeProfileId,
+    profiles: state.profiles.map(({ id, label, serverUrl: url }) => ({
+      id,
+      label,
+      serverUrl: url,
+      active: id === state.activeProfileId,
+    })),
+  }
+}
+
+/**
+ * Switch to another profile.
+ *
+ * A window's partition is fixed when it is created, so this replaces the
+ * window rather than reloading it — reloading would keep the old session and
+ * quietly show the previous account's data under the new profile's name.
+ *
+ * The new window is created *before* the old one is destroyed: on Windows and
+ * Linux, closing the last window quits the app, and briefly having none would
+ * do exactly that mid-switch.
+ */
+async function switchProfileToActive() {
+  const profile = activeProfile(profileState)
+
+  eventStream?.stop()
+  eventStream = null
+  unread?.clear()
+  workspaceNames.clear()
+
+  serverUrl = isConnectionLocked ? envServerUrl.url : profile.serverUrl
+  mutedWorkspaces = profile.mutedWorkspaces
+  profileSession = sessionFor(profile.partition)
+
+  const previous = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())
+  createWindow()
+  previous?.destroy()
+
+  startEventStream()
+  installMenu(() => BrowserWindow.getAllWindows().find((w) => !w.isDestroyed()))
+  return profilesPayload()
+}
+
+async function switchProfile(id) {
+  if (!profileState || id === profileState.activeProfileId) return profilesPayload()
+  if (!profileState.profiles.some((p) => p.id === id)) return profilesPayload()
+
+  profileState = await configStore.activateProfile(id)
+  return switchProfileToActive()
+}
+
 function registerIpc(getWindow) {
   ipcMain.handle('agentrq:connection:get', () => connectionState())
 
   ipcMain.handle('agentrq:connection:validate', async (_event, url) => {
-    const result = await validateServerUrl(url, net.fetch)
+    const result = await validateServerUrl(url, profileFetch)
     // The probe response carries auth flags that are of no use to the
     // connection screen and would be a needless leak across the bridge.
     return result.ok ? { ok: true, url: result.url } : result
@@ -499,6 +609,29 @@ function registerIpc(getWindow) {
     return result.filePaths?.[0] ?? ''
   })
 
+  // Profiles. Only names and servers cross the bridge — never a session, a
+  // partition or a cookie.
+  ipcMain.handle('agentrq:profiles:get', () => profilesPayload())
+  ipcMain.handle('agentrq:profiles:switch', (_event, id) => switchProfile(id))
+  ipcMain.handle('agentrq:profiles:add', async (_event, label) => {
+    profileState = await configStore.addProfile(label)
+    // addProfile makes the new one active, so this is a switch into a session
+    // that has never signed in: the window lands on the connection screen.
+    return switchProfileToActive()
+  })
+  ipcMain.handle('agentrq:profiles:rename', async (_event, id, label) => {
+    profileState = await configStore.renameProfile(id, label)
+    installMenu(getWindow)
+    return profilesPayload()
+  })
+  ipcMain.handle('agentrq:profiles:remove', async (_event, id) => {
+    const wasActive = id === profileState?.activeProfileId
+    profileState = await configStore.removeProfile(id)
+    // Its cookies would otherwise outlive it on disk, still signed in.
+    await session.fromPartition(partitionFor(id)).clearStorageData()
+    return wasActive ? switchProfileToActive() : profilesPayload()
+  })
+
   ipcMain.handle('agentrq:update:get', () => updateState)
   ipcMain.handle('agentrq:update:check', () => updater?.checkNow() ?? { ok: false, reason: 'Updater unavailable' })
   ipcMain.handle('agentrq:update:install', () => updater?.installNow() ?? false)
@@ -526,7 +659,7 @@ function registerIpc(getWindow) {
       return { ok: false, reason: 'Server is pinned by AGENTRQ_SERVER_URL' }
     }
 
-    const validated = await validateServerUrl(url, net.fetch)
+    const validated = await validateServerUrl(url, profileFetch)
     if (!validated.ok) return validated
 
     const saved = await configStore.save(validated.url)
@@ -613,24 +746,17 @@ if (!app.requestSingleInstanceLock()) {
     })
     restoredWindowState = await windowStateStore.load()
 
-    const stored = await configStore.load()
-    mutedWorkspaces = stored.mutedWorkspaces
+    profileState = await configStore.load()
+    const profile = activeProfile(profileState)
+    mutedWorkspaces = profile.mutedWorkspaces
     if (!isConnectionLocked) {
-      serverUrl = stored.serverUrl
+      serverUrl = profile.serverUrl
     }
+    // Attaches the app:// handler to this profile's session before any window
+    // is created on it.
+    profileSession = sessionFor(profile.partition)
 
     unread = createUnreadCounter({ setBadge: applyBadge })
-
-    protocol.handle(
-      'app',
-      createAppProtocolHandler({
-        serverUrl: () => serverUrl,
-        netFetch: net.fetch,
-        fileExists,
-        readFile: (pathname) => readFile(join(RENDERER_ROOT, pathname)),
-        devServerUrl: process.env.AGENTRQ_RENDERER_DEV_URL ?? '',
-      })
-    )
 
     // The main window is looked up lazily: on macOS it can be closed and
     // recreated while the app keeps running, so a captured reference goes stale.

--- a/desktop/src/main/index.js
+++ b/desktop/src/main/index.js
@@ -20,6 +20,7 @@ import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { createAppProtocolHandler } from './protocol.js'
+import { activeProfile, partitionFor } from './profiles.js'
 import {
   CONFIG_FILENAME,
   createServerConfigStore,

--- a/desktop/src/main/index.js
+++ b/desktop/src/main/index.js
@@ -21,6 +21,7 @@ import { fileURLToPath } from 'node:url'
 
 import { createAppProtocolHandler } from './protocol.js'
 import { activeProfile, partitionFor } from './profiles.js'
+import { fetchProfileIdentity } from './identity.js'
 import {
   CONFIG_FILENAME,
   createServerConfigStore,
@@ -517,6 +518,36 @@ function installMenu(getWindow) {
   Menu.setApplicationMenu(Menu.buildFromTemplate(template))
 }
 
+/**
+ * Who each profile is signed in as, kept between menu openings.
+ *
+ * Cached because the answer changes rarely — signing in or out — while the
+ * menu can be opened repeatedly, and each lookup is a request to a possibly
+ * distant server.
+ */
+const profileIdentities = new Map()
+
+/**
+ * Ask every profile who it is signed in as, each through its own session.
+ *
+ * In parallel, and every lookup already swallows its own failures, so one
+ * unreachable server delays the others by nothing and fails nothing.
+ */
+async function refreshProfileIdentities() {
+  if (!profileState) return
+  await Promise.all(
+    profileState.profiles.map(async (profile) => {
+      const ses = session.fromPartition(profile.partition)
+      const identity = await fetchProfileIdentity({
+        fetchImpl: (input, init) => ses.fetch(input, init),
+        serverUrl: profile.serverUrl,
+        timeout: (ms) => AbortSignal.timeout(ms),
+      })
+      profileIdentities.set(profile.id, identity)
+    })
+  )
+}
+
 /** What the renderer needs to draw the switcher: names, not sessions. */
 function profilesPayload() {
   const state = profileState ?? { profiles: [], activeProfileId: '' }
@@ -527,6 +558,8 @@ function profilesPayload() {
       label,
       serverUrl: url,
       active: id === state.activeProfileId,
+      // null when that profile is signed out or its server cannot answer.
+      identity: profileIdentities.get(id) ?? null,
     })),
   }
 }
@@ -612,7 +645,10 @@ function registerIpc(getWindow) {
 
   // Profiles. Only names and servers cross the bridge — never a session, a
   // partition or a cookie.
-  ipcMain.handle('agentrq:profiles:get', () => profilesPayload())
+  ipcMain.handle('agentrq:profiles:get', async () => {
+    await refreshProfileIdentities()
+    return profilesPayload()
+  })
   ipcMain.handle('agentrq:profiles:switch', (_event, id) => switchProfile(id))
   ipcMain.handle('agentrq:profiles:add', async (_event, label) => {
     profileState = await configStore.addProfile(label)
@@ -630,6 +666,7 @@ function registerIpc(getWindow) {
     profileState = await configStore.removeProfile(id)
     // Its cookies would otherwise outlive it on disk, still signed in.
     await session.fromPartition(partitionFor(id)).clearStorageData()
+    profileIdentities.delete(id)
     return wasActive ? switchProfileToActive() : profilesPayload()
   })
 

--- a/desktop/src/main/profiles.js
+++ b/desktop/src/main/profiles.js
@@ -1,0 +1,193 @@
+/**
+ * Signed-in profiles.
+ *
+ * A profile is an account. Electron keeps cookies per *session partition*, so
+ * giving each profile its own partition gives it its own `at` cookie, and
+ * therefore its own signed-in user — the same idea as a Chrome profile. The
+ * work here is not the isolation, which Electron provides, but keeping the list
+ * coherent: never empty, never pointing at a profile that is gone, and never
+ * producing a partition name that is not safe as a directory.
+ *
+ * Each profile carries its own server URL and muted-workspace list, because an
+ * account exists on one server: "which account" and "which server" are the same
+ * question, and splitting them would let you sign in as one user and then point
+ * that session at a server where the cookie means nothing.
+ *
+ * Pure, so the rules are testable without Electron. The main process supplies
+ * ids and turns partitions into real sessions.
+ */
+
+/** Shown when a profile has no name of its own. */
+export const DEFAULT_PROFILE_LABEL = 'Default'
+
+/** Longest label kept; anything more is a paste accident, not a name. */
+const MAX_LABEL = 40
+
+/**
+ * Partition name for a new profile.
+ *
+ * `persist:` is what makes the jar survive a restart — without it, signing in
+ * would last only as long as the window. The id is embedded directly, which is
+ * why ids are restricted to characters that are safe in a directory name: the
+ * partition becomes a folder under the app's Partitions directory.
+ */
+export function partitionFor(id) {
+  return `persist:profile-${id}`
+}
+
+/**
+ * Every profile gets its own partition, including the one migrated from a
+ * pre-profiles install.
+ *
+ * That migrated profile's `at` cookie lives in Electron's default session, so
+ * moving it onto a partition signs the user out once, on the upgrade. That is a
+ * deliberate trade, agreed with the owner: the session is only valid for 24
+ * hours anyway, so the cost is one sign-in, and the alternative is a profile
+ * that is permanently special-cased everywhere a session is resolved.
+ */
+
+/** Ids are used in a filesystem path, so they are deliberately narrow. */
+export function isValidProfileId(id) {
+  return typeof id === 'string' && /^[a-z0-9][a-z0-9-]{0,63}$/.test(id)
+}
+
+function cleanLabel(label, fallback = DEFAULT_PROFILE_LABEL) {
+  const trimmed = typeof label === 'string' ? label.replace(/\s+/g, ' ').trim() : ''
+  if (trimmed === '') return fallback
+  return trimmed.slice(0, MAX_LABEL)
+}
+
+function cleanMuted(ids) {
+  if (!Array.isArray(ids)) return []
+  return [...new Set(ids.filter((id) => typeof id === 'string' && id !== ''))]
+}
+
+/**
+ * One profile, with everything absent or malformed filled in.
+ *
+ * @param {{ id: string, label?: string, serverUrl?: string, mutedWorkspaces?: string[] }} raw
+ * @returns {object | null} null when the id is unusable, since a profile
+ *          without a valid id has no partition and cannot be stored
+ */
+export function makeProfile(raw) {
+  if (!raw || typeof raw !== 'object' || !isValidProfileId(raw.id)) return null
+  return {
+    id: raw.id,
+    label: cleanLabel(raw.label),
+    // Stored rather than derived so the name is stable if the scheme ever
+    // changes: a partition that moved would be an empty jar, i.e. a sign-out.
+    partition: typeof raw.partition === 'string' && raw.partition !== '' ? raw.partition : partitionFor(raw.id),
+    serverUrl: typeof raw.serverUrl === 'string' ? raw.serverUrl : '',
+    mutedWorkspaces: cleanMuted(raw.mutedWorkspaces),
+  }
+}
+
+/**
+ * Bring stored profile state forward, from any shape including none.
+ *
+ * A config from before profiles existed becomes a single profile carrying the
+ * settings that were already there, so upgrading does not look like being
+ * signed out — the cookie jar is separate from this, and is handled by the
+ * caller adopting the default partition for that first profile.
+ *
+ * @param {object|null} raw the stored config
+ * @param {string} firstId  id to give the migrated profile when there is none
+ */
+export function migrateProfiles(raw, firstId = 'default') {
+  const source = raw && typeof raw === 'object' && !Array.isArray(raw) ? raw : {}
+
+  const profiles = Array.isArray(source.profiles)
+    ? source.profiles.map(makeProfile).filter(Boolean)
+    : []
+
+  if (profiles.length === 0) {
+    // Either a first run or a pre-profiles config. Both become one profile;
+    // the second keeps the server and mutes that were already configured.
+    profiles.push(
+      makeProfile({
+        id: isValidProfileId(firstId) ? firstId : 'default',
+        label: DEFAULT_PROFILE_LABEL,
+        partition: partitionFor(isValidProfileId(firstId) ? firstId : 'default'),
+        serverUrl: typeof source.serverUrl === 'string' ? source.serverUrl : '',
+        mutedWorkspaces: source.mutedWorkspaces,
+      })
+    )
+  }
+
+  // Two profiles sharing an id would share a partition, which is the one thing
+  // this must never allow: they would be the same account wearing two names.
+  const seen = new Set()
+  const unique = profiles.filter((p) => (seen.has(p.id) ? false : seen.add(p.id)))
+
+  const activeId = unique.some((p) => p.id === source.activeProfileId)
+    ? source.activeProfileId
+    : unique[0].id
+
+  return { profiles: unique, activeProfileId: activeId }
+}
+
+/** The profile in use. Never null: migrateProfiles guarantees one exists. */
+export function activeProfile(state) {
+  return state.profiles.find((p) => p.id === state.activeProfileId) ?? state.profiles[0]
+}
+
+/** @returns {object} new state; the input is not modified */
+export function addProfile(state, { id, label, serverUrl = '' }) {
+  // Always its own jar: a second profile sharing the first's session would be
+  // the same signed-in account under a different name.
+  const profile = makeProfile({ id, label, serverUrl, partition: partitionFor(id) })
+  if (!profile) return state
+  if (state.profiles.some((p) => p.id === profile.id)) return state
+
+  // A new profile is switched to: adding one you then have to go and select is
+  // a step nobody wants.
+  return { profiles: [...state.profiles, profile], activeProfileId: profile.id }
+}
+
+/**
+ * Remove a profile.
+ *
+ * The last one cannot be removed — an app with no profile has no session to
+ * run in. Removing the active one falls back to the first remaining.
+ */
+export function removeProfile(state, id) {
+  if (state.profiles.length <= 1) return state
+  const profiles = state.profiles.filter((p) => p.id !== id)
+  if (profiles.length === state.profiles.length) return state
+
+  const activeProfileId = profiles.some((p) => p.id === state.activeProfileId)
+    ? state.activeProfileId
+    : profiles[0].id
+  return { profiles, activeProfileId }
+}
+
+/** @returns {object} new state */
+export function renameProfile(state, id, label) {
+  if (!state.profiles.some((p) => p.id === id)) return state
+  return {
+    ...state,
+    profiles: state.profiles.map((p) => (p.id === id ? { ...p, label: cleanLabel(label, p.label) } : p)),
+  }
+}
+
+/** @returns {object} new state; an unknown id leaves the active profile alone */
+export function activateProfile(state, id) {
+  if (!state.profiles.some((p) => p.id === id)) return state
+  return { ...state, activeProfileId: id }
+}
+
+/** @returns {object} new state, with one profile's fields updated */
+export function updateProfile(state, id, patch) {
+  if (!state.profiles.some((p) => p.id === id)) return state
+  return {
+    ...state,
+    profiles: state.profiles.map((p) => {
+      if (p.id !== id) return p
+      const next = { ...p }
+      if (typeof patch?.serverUrl === 'string') next.serverUrl = patch.serverUrl
+      if (patch && 'mutedWorkspaces' in patch) next.mutedWorkspaces = cleanMuted(patch.mutedWorkspaces)
+      if (typeof patch?.label === 'string') next.label = cleanLabel(patch.label, p.label)
+      return next
+    }),
+  }
+}

--- a/desktop/src/main/server-config.js
+++ b/desktop/src/main/server-config.js
@@ -4,7 +4,21 @@
  * The desktop app is a client: the server lives wherever the user runs it, so
  * the app has to be told once and remember. Everything here takes its I/O as
  * arguments so the rules can be tested without Electron or a filesystem.
+ *
+ * Since profiles, the file holds a list of them rather than one server. Every
+ * method that used to read or write "the" server or mute list now reads or
+ * writes the *active* profile's, which is what those calls always meant — there
+ * was simply only ever one account to mean it about.
  */
+import {
+  activeProfile,
+  addProfile as addProfileToState,
+  activateProfile as activateProfileInState,
+  migrateProfiles,
+  removeProfile as removeProfileFromState,
+  renameProfile as renameProfileInState,
+  updateProfile,
+} from './profiles.js'
 
 // The hosted instance, so someone who installs the app and has no server of
 // their own still gets somewhere useful. Self-hosters type their own address
@@ -17,12 +31,17 @@ export const CONFIG_FILENAME = 'agentrq-desktop.json'
 /**
  * Shape version of the stored config.
  *
+ * v3: { profiles: [{ id, label, partition, serverUrl, mutedWorkspaces }],
+ *       activeProfileId } — several signed-in accounts, each with its own
+ *       session partition. A v2 file becomes a single profile carrying the
+ *       settings it already had.
+ *
  * v1: { serverUrl }
  * v2: adds { mutedWorkspaces } — workspaces the desktop app must not raise
  *     notifications for. A v1 file migrates forward by defaulting it to empty,
  *     which is the same behaviour it had.
  */
-export const CONFIG_VERSION = 2
+export const CONFIG_VERSION = 3
 
 /** Endpoint used to decide whether a URL is really an AgentRQ server. */
 export const CONFIG_PROBE_PATH = '/api/v1/auth/config'
@@ -93,18 +112,19 @@ export function resolveServerUrl({ env = {}, stored = '' } = {}) {
  * guessed at.
  */
 export function migrateConfig(raw) {
-  const empty = { version: CONFIG_VERSION, serverUrl: '', mutedWorkspaces: [] }
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return empty
-
-  const normalized = normalizeServerUrl(raw.serverUrl)
+  const state = migrateProfiles(raw)
   return {
     version: CONFIG_VERSION,
-    serverUrl: normalized.ok ? normalized.url : '',
-    // Absent in v1, and anything that is not a list of ids is not something to
-    // guess at. Empty means "notify for everything", which is what v1 did.
-    mutedWorkspaces: Array.isArray(raw.mutedWorkspaces)
-      ? raw.mutedWorkspaces.filter((id) => typeof id === 'string' && id !== '')
-      : [],
+    activeProfileId: state.activeProfileId,
+    // Each profile's server is re-checked here rather than trusted from disk.
+    // The profile model knows nothing about URLs, and something has to: a
+    // stored `file:///x` reaching the fetch base would be a hole, and an
+    // unparseable one would boot the app pointed at nothing. Either becomes
+    // "not configured", which is the connection screen.
+    profiles: state.profiles.map((profile) => {
+      const normalized = normalizeServerUrl(profile.serverUrl)
+      return { ...profile, serverUrl: normalized.ok ? normalized.url : '' }
+    }),
   }
 }
 
@@ -115,14 +135,15 @@ export function migrateConfig(raw) {
  * @param {() => Promise<string>} deps.readFile   Rejects when the file is absent.
  * @param {(contents: string) => Promise<void>} deps.writeFile
  */
-export function createServerConfigStore({ readFile, writeFile }) {
-  const write = (config) =>
-    writeFile(JSON.stringify({ ...config, version: CONFIG_VERSION }, null, 2))
+export function createServerConfigStore({ readFile, writeFile, newProfileId }) {
+  const write = (state) =>
+    writeFile(JSON.stringify({ ...state, version: CONFIG_VERSION }, null, 2))
 
   return {
     /**
-     * @returns {Promise<{ version: number, serverUrl: string }>} always a valid
-     *          shape — a missing or corrupt file reads as "not configured".
+     * @returns {Promise<{ version: number, profiles: object[], activeProfileId: string }>}
+     *          always a valid shape with at least one profile — a missing or
+     *          corrupt file reads as a first run rather than as an error.
      */
     async load() {
       let contents
@@ -141,41 +162,84 @@ export function createServerConfigStore({ readFile, writeFile }) {
       }
     },
 
+    /** The profile in use, with its own server and mute list. */
+    async active() {
+      return activeProfile(await this.load())
+    },
+
     /**
+     * Point the active profile at a server.
+     *
      * @returns {Promise<{ ok: true, url: string } | { ok: false, reason: string }>}
      */
     async save(input) {
       const normalized = normalizeServerUrl(input)
       if (!normalized.ok) return normalized
 
-      // Read-modify-write: switching server must not silently discard the
-      // user's mute choices.
       const current = await this.load()
-      await write({ ...current, serverUrl: normalized.url })
+      await write(updateProfile(current, current.activeProfileId, { serverUrl: normalized.url }))
       return normalized
     },
 
-    /** Forget the configured server, sending the app back to the first-run screen. */
+    /** Forget the active profile's server, sending it back to the first-run screen. */
     async clear() {
       const current = await this.load()
-      await write({ ...current, serverUrl: '' })
+      await write(updateProfile(current, current.activeProfileId, { serverUrl: '' }))
     },
 
-    /** Replace the muted-workspace list. */
+    /** Replace the active profile's muted-workspace list. */
     async setMutedWorkspaces(ids) {
       const current = await this.load()
-      const mutedWorkspaces = [...new Set((ids ?? []).filter((id) => typeof id === 'string' && id !== ''))]
-      await write({ ...current, mutedWorkspaces })
-      return mutedWorkspaces
+      const next = updateProfile(current, current.activeProfileId, { mutedWorkspaces: ids ?? [] })
+      await write(next)
+      return activeProfile(next).mutedWorkspaces
     },
 
-    /** Turn notifications for one workspace on or off. */
+    /** Turn notifications for one workspace on or off, for the active profile. */
     async setWorkspaceMuted(workspaceId, muted) {
-      const { mutedWorkspaces } = await this.load()
+      const { mutedWorkspaces } = await this.active()
       const next = muted
         ? [...mutedWorkspaces, workspaceId]
         : mutedWorkspaces.filter((id) => id !== workspaceId)
       return this.setMutedWorkspaces(next)
+    },
+
+    /**
+     * Add a profile and make it the active one.
+     *
+     * The id is generated here rather than by the caller so it is guaranteed
+     * unique against what is already stored — a collision would mean two
+     * profiles sharing a session, which is the same account twice.
+     */
+    async addProfile(label = '') {
+      const current = await this.load()
+      let id = newProfileId()
+      while (current.profiles.some((p) => p.id === id)) id = newProfileId()
+
+      const next = addProfileToState(current, { id, label })
+      await write(next)
+      return next
+    },
+
+    /** Switch profiles. An unknown id changes nothing. */
+    async activateProfile(id) {
+      const next = activateProfileInState(await this.load(), id)
+      await write(next)
+      return next
+    },
+
+    /** Remove a profile. The last one is kept, since the app needs a session. */
+    async removeProfile(id) {
+      const next = removeProfileFromState(await this.load(), id)
+      await write(next)
+      return next
+    },
+
+    /** Rename a profile. A blank name keeps the old one. */
+    async renameProfile(id, label) {
+      const next = renameProfileInState(await this.load(), id, label)
+      await write(next)
+      return next
     },
   }
 }

--- a/desktop/src/main/server-config.js
+++ b/desktop/src/main/server-config.js
@@ -135,7 +135,18 @@ export function migrateConfig(raw) {
  * @param {() => Promise<string>} deps.readFile   Rejects when the file is absent.
  * @param {(contents: string) => Promise<void>} deps.writeFile
  */
-export function createServerConfigStore({ readFile, writeFile, newProfileId }) {
+/**
+ * A short id for a new profile.
+ *
+ * Lowercase alphanumeric only: the id becomes a directory name, via the
+ * session partition. Uniqueness is checked against what is already stored
+ * rather than assumed, so this only has to make collisions unlikely.
+ */
+function randomProfileId() {
+  return Math.random().toString(36).slice(2, 10).padEnd(8, '0')
+}
+
+export function createServerConfigStore({ readFile, writeFile, newProfileId = randomProfileId }) {
   const write = (state) =>
     writeFile(JSON.stringify({ ...state, version: CONFIG_VERSION }, null, 2))
 

--- a/desktop/src/preload/index.js
+++ b/desktop/src/preload/index.js
@@ -34,6 +34,25 @@ contextBridge.exposeInMainWorld('agentrq', {
 
   },
 
+  profiles: {
+    /**
+     * Signed-in profiles and which one is in use.
+     *
+     * Names and servers only — a session, a partition or a cookie never
+     * crosses this boundary.
+     *
+     * @returns {Promise<{ activeProfileId: string, profiles: Array<{id: string, label: string, serverUrl: string, active: boolean}> }>}
+     */
+    get: () => ipcRenderer.invoke('agentrq:profiles:get'),
+    /** Switch profiles. The shell replaces the window; the renderer does not reload itself. */
+    switch: (id) => ipcRenderer.invoke('agentrq:profiles:switch', id),
+    /** Add a profile and switch into it, landing on the connection screen. */
+    add: (label) => ipcRenderer.invoke('agentrq:profiles:add', label),
+    rename: (id, label) => ipcRenderer.invoke('agentrq:profiles:rename', id, label),
+    /** Remove a profile and forget its session. */
+    remove: (id) => ipcRenderer.invoke('agentrq:profiles:remove', id),
+  },
+
   dialog: {
     /**
      * Ask the shell to show the platform's folder chooser.

--- a/desktop/test/identity.test.js
+++ b/desktop/test/identity.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  IDENTITY_TIMEOUT_MS,
+  USER_PATH,
+  describeIdentity,
+  fetchProfileIdentity,
+} from '../src/main/identity.js'
+
+const ok = (body) => ({ ok: true, json: async () => body })
+
+describe('fetchProfileIdentity', () => {
+  it('reports who a profile is signed in as', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(ok({ name: 'Ada', email: 'ada@example.com', picture: 'p.png' }))
+
+    const identity = await fetchProfileIdentity({ fetchImpl, serverUrl: 'https://a.test' })
+
+    expect(identity).toEqual({ name: 'Ada', email: 'ada@example.com', picture: 'p.png' })
+    expect(fetchImpl).toHaveBeenCalledWith(`https://a.test${USER_PATH}`, {})
+  })
+
+  it('asks the profile\'s own server, not a shared one', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(ok({ email: 'b@example.com' }))
+
+    await fetchProfileIdentity({ fetchImpl, serverUrl: 'https://b.test' })
+
+    expect(fetchImpl).toHaveBeenCalledWith(`https://b.test${USER_PATH}`, {})
+  })
+
+  it('says nothing for a profile that has no server yet', async () => {
+    // A freshly added profile, still on the connection screen.
+    const fetchImpl = vi.fn()
+
+    expect(await fetchProfileIdentity({ fetchImpl, serverUrl: '' })).toBeNull()
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('treats a signed-out profile as ordinary, not an error', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 401 })
+
+    expect(await fetchProfileIdentity({ fetchImpl, serverUrl: 'https://a.test' })).toBeNull()
+  })
+
+  it('survives a server that cannot be reached', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'))
+
+    expect(await fetchProfileIdentity({ fetchImpl, serverUrl: 'https://a.test' })).toBeNull()
+  })
+
+  it('survives a response that is not JSON', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, json: async () => { throw new Error('not json') } })
+
+    expect(await fetchProfileIdentity({ fetchImpl, serverUrl: 'https://a.test' })).toBeNull()
+  })
+
+  it('survives a fetch that answers with nothing at all', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(undefined)
+
+    expect(await fetchProfileIdentity({ fetchImpl, serverUrl: 'https://a.test' })).toBeNull()
+  })
+
+  it('gives up rather than letting one profile hold up the menu', async () => {
+    const timeout = vi.fn().mockReturnValue('signal-object')
+    const fetchImpl = vi.fn().mockResolvedValue(ok({ email: 'a@example.com' }))
+
+    await fetchProfileIdentity({ fetchImpl, serverUrl: 'https://a.test', timeout })
+
+    expect(timeout).toHaveBeenCalledWith(IDENTITY_TIMEOUT_MS)
+    expect(fetchImpl).toHaveBeenCalledWith(`https://a.test${USER_PATH}`, { signal: 'signal-object' })
+  })
+})
+
+describe('describeIdentity', () => {
+  it('keeps only what the switcher shows', () => {
+    expect(describeIdentity({ name: ' Ada ', email: ' ada@example.com ', picture: 'p.png', token: 'secret' }))
+      .toEqual({ name: 'Ada', email: 'ada@example.com', picture: 'p.png' })
+  })
+
+  it('accepts a user with only one of the two', () => {
+    expect(describeIdentity({ email: 'a@example.com' })).toEqual({ name: '', email: 'a@example.com', picture: '' })
+    expect(describeIdentity({ name: 'Ada' })).toEqual({ name: 'Ada', email: '', picture: '' })
+  })
+
+  it('is null when there is nothing worth showing', () => {
+    // Indistinguishable from signed out, as far as anyone can see.
+    for (const user of [null, undefined, 'a string', 42, {}, { name: '  ', email: '' }, { name: 7, email: {} }]) {
+      expect(describeIdentity(user)).toBeNull()
+    }
+  })
+})

--- a/desktop/test/profiles.test.js
+++ b/desktop/test/profiles.test.js
@@ -260,3 +260,36 @@ describe('ids and partitions', () => {
     expect(makeProfile(null)).toBeNull()
   })
 })
+
+describe('edges the caller can reach', () => {
+  it('names a profile whose label is not text at all', () => {
+    // Stored state is read off disk, so a label can be any JSON value.
+    for (const label of [42, null, {}, ['x'], true]) {
+      expect(makeProfile({ id: 'one', label }).label).toBe(DEFAULT_PROFILE_LABEL)
+    }
+  })
+
+  it('still produces a usable profile when handed an unusable first id', () => {
+    // The caller supplies this id; it must not be able to produce a profile
+    // with no partition, which would mean the shared default session.
+    for (const bad of ['../escape', 'CAPS', '', undefined, 7]) {
+      const state = migrateProfiles({ serverUrl: 'https://x.test' }, bad)
+
+      expect(state.profiles).toHaveLength(1)
+      expect(isValidProfileId(state.profiles[0].id)).toBe(true)
+      expect(state.profiles[0].partition).toBe(partitionFor(state.profiles[0].id))
+    }
+  })
+
+  it('renames through updateProfile as well as renameProfile', () => {
+    const state = updateProfile(base(), base().profiles[0].id, { label: '  Personal  ' })
+
+    expect(state.profiles[0].label).toBe('Personal')
+  })
+
+  it('leaves the name alone when updateProfile is given none', () => {
+    const state = updateProfile(base(), base().profiles[0].id, { serverUrl: 'https://x.test' })
+
+    expect(state.profiles[0].label).toBe(DEFAULT_PROFILE_LABEL)
+  })
+})

--- a/desktop/test/profiles.test.js
+++ b/desktop/test/profiles.test.js
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_PROFILE_LABEL,
+  activateProfile,
+  activeProfile,
+  addProfile,
+  isValidProfileId,
+  makeProfile,
+  migrateProfiles,
+  partitionFor,
+  removeProfile,
+  renameProfile,
+  updateProfile,
+} from '../src/main/profiles.js'
+
+const base = () => migrateProfiles(null)
+
+describe('migrateProfiles', () => {
+  it('gives a first run one profile to start from', () => {
+    const state = migrateProfiles(null)
+
+    expect(state.profiles).toHaveLength(1)
+    expect(state.profiles[0].label).toBe(DEFAULT_PROFILE_LABEL)
+    expect(state.activeProfileId).toBe(state.profiles[0].id)
+  })
+
+  it('carries a pre-profiles config into the first profile', () => {
+    // Upgrading must not look like being reconfigured: the server and the mute
+    // list were already chosen and belong to the account already signed in.
+    const state = migrateProfiles({
+      version: 2,
+      serverUrl: 'https://app.agentrq.com',
+      mutedWorkspaces: ['ws1', 'ws2'],
+    })
+
+    expect(state.profiles[0]).toMatchObject({
+      serverUrl: 'https://app.agentrq.com',
+      mutedWorkspaces: ['ws1', 'ws2'],
+    })
+  })
+
+  it('gives the migrated profile a partition like any other', () => {
+    // Its `at` cookie is in the default session, so this signs the user out
+    // once on upgrade. Agreed trade: the session lasts 24 hours anyway, and the
+    // alternative is one profile that is special-cased wherever a session is
+    // resolved.
+    const state = migrateProfiles({ version: 2, serverUrl: 'https://x.test' })
+
+    expect(state.profiles[0].partition).toBe(partitionFor(state.profiles[0].id))
+    expect(state.profiles[0].partition).not.toBe('')
+  })
+
+  it('repairs a stored profile that has no partition of its own', () => {
+    // An empty partition would mean the shared default session, which is the
+    // one thing a profile must never have.
+    const state = migrateProfiles({ profiles: [{ id: 'one', label: 'X', partition: '' }] })
+
+    expect(state.profiles[0].partition).toBe(partitionFor('one'))
+  })
+
+  it('keeps profiles that were already stored', () => {
+    const state = migrateProfiles({
+      profiles: [
+        { id: 'one', label: 'Personal', partition: 'persist:profile-one', serverUrl: 'https://a.test' },
+        { id: 'two', label: 'Work', partition: 'persist:profile-two', serverUrl: 'https://b.test' },
+      ],
+      activeProfileId: 'two',
+    })
+
+    expect(state.profiles.map((p) => p.label)).toEqual(['Personal', 'Work'])
+    expect(state.activeProfileId).toBe('two')
+  })
+
+  it('refuses two profiles sharing an id', () => {
+    // They would share a partition, so they would be one account wearing two
+    // names — the single thing this list must never contain.
+    const state = migrateProfiles({
+      profiles: [
+        { id: 'one', label: 'First' },
+        { id: 'one', label: 'Second' },
+      ],
+    })
+
+    expect(state.profiles).toHaveLength(1)
+    expect(state.profiles[0].label).toBe('First')
+  })
+
+  it('drops entries whose id could not be a directory name', () => {
+    // The id becomes a folder under the app's Partitions directory.
+    const state = migrateProfiles({
+      profiles: [
+        { id: '../escape', label: 'Bad' },
+        { id: 'Uppercase', label: 'Also bad' },
+        { id: 'fine', label: 'Good' },
+      ],
+    })
+
+    expect(state.profiles.map((p) => p.id)).toEqual(['fine'])
+  })
+
+  it('falls back to the first profile when the active id names nothing', () => {
+    const state = migrateProfiles({
+      profiles: [{ id: 'one', label: 'Personal' }],
+      activeProfileId: 'deleted',
+    })
+
+    expect(state.activeProfileId).toBe('one')
+  })
+
+  it('never returns an empty list, whatever it is handed', () => {
+    for (const raw of [null, undefined, [], 'nonsense', 42, { profiles: 'no' }, { profiles: [] }]) {
+      expect(migrateProfiles(raw).profiles.length).toBeGreaterThanOrEqual(1)
+    }
+  })
+})
+
+describe('addProfile', () => {
+  it('gives a new profile its own session', () => {
+    const state = addProfile(base(), { id: 'work1', label: 'Work' })
+
+    expect(state.profiles).toHaveLength(2)
+    expect(state.profiles[1].partition).toBe(partitionFor('work1'))
+    expect(state.profiles[1].partition).not.toBe(state.profiles[0].partition)
+  })
+
+  it('switches to what it just added', () => {
+    // Adding a profile you then have to go and select is a step nobody wants.
+    expect(addProfile(base(), { id: 'work1', label: 'Work' }).activeProfileId).toBe('work1')
+  })
+
+  it('refuses an id already in use', () => {
+    const state = addProfile(base(), { id: 'work1', label: 'Work' })
+
+    expect(addProfile(state, { id: 'work1', label: 'Other' })).toBe(state)
+  })
+
+  it('refuses an unusable id', () => {
+    const state = base()
+    for (const id of ['', '../x', 'has space', 'CAPS', undefined]) {
+      expect(addProfile(state, { id, label: 'x' })).toBe(state)
+    }
+  })
+
+  it('names an unnamed profile rather than leaving it blank', () => {
+    expect(addProfile(base(), { id: 'x1', label: '   ' }).profiles[1].label).toBe(DEFAULT_PROFILE_LABEL)
+  })
+})
+
+describe('removeProfile', () => {
+  it('refuses to remove the last one', () => {
+    // An app with no profile has no session to run in.
+    const state = base()
+    expect(removeProfile(state, state.profiles[0].id)).toBe(state)
+  })
+
+  it('moves off a profile it just removed', () => {
+    const state = addProfile(base(), { id: 'work1', label: 'Work' })
+    expect(state.activeProfileId).toBe('work1')
+
+    const after = removeProfile(state, 'work1')
+
+    expect(after.profiles).toHaveLength(1)
+    expect(after.activeProfileId).toBe(after.profiles[0].id)
+  })
+
+  it('leaves the active profile alone when another is removed', () => {
+    let state = addProfile(base(), { id: 'work1', label: 'Work' })
+    state = addProfile(state, { id: 'work2', label: 'Second' })
+
+    expect(removeProfile(state, 'work1').activeProfileId).toBe('work2')
+  })
+
+  it('ignores an id it does not have', () => {
+    const state = addProfile(base(), { id: 'work1', label: 'Work' })
+    expect(removeProfile(state, 'nope')).toBe(state)
+  })
+})
+
+describe('activateProfile', () => {
+  it('switches to a profile that exists', () => {
+    const state = addProfile(base(), { id: 'work1', label: 'Work' })
+    const first = state.profiles[0].id
+
+    expect(activateProfile(state, first).activeProfileId).toBe(first)
+  })
+
+  it('ignores one that does not, rather than leaving nothing active', () => {
+    const state = base()
+    expect(activateProfile(state, 'ghost')).toBe(state)
+  })
+})
+
+describe('renameProfile and updateProfile', () => {
+  it('renames, tidying the label', () => {
+    const state = renameProfile(base(), base().profiles[0].id, '  Personal   account ')
+    expect(state.profiles[0].label).toBe('Personal account')
+  })
+
+  it('keeps the old name rather than accepting a blank one', () => {
+    const id = base().profiles[0].id
+    expect(renameProfile(base(), id, '   ').profiles[0].label).toBe(DEFAULT_PROFILE_LABEL)
+  })
+
+  it('trims a label that is really a paste accident', () => {
+    const id = base().profiles[0].id
+    expect(renameProfile(base(), id, 'x'.repeat(200)).profiles[0].label).toHaveLength(40)
+  })
+
+  it('updates the server and mutes of one profile only', () => {
+    let state = addProfile(base(), { id: 'work1', label: 'Work' })
+    const other = state.profiles[0].id
+
+    state = updateProfile(state, 'work1', {
+      serverUrl: 'https://work.test',
+      mutedWorkspaces: ['a', 'a', 'b', ''],
+    })
+
+    expect(state.profiles[1]).toMatchObject({
+      serverUrl: 'https://work.test',
+      mutedWorkspaces: ['a', 'b'],
+    })
+    // The other profile is untouched: settings belong to one account, not all.
+    expect(state.profiles.find((p) => p.id === other).serverUrl).toBe('')
+  })
+
+  it('ignores an unknown profile', () => {
+    const state = base()
+    expect(renameProfile(state, 'ghost', 'x')).toBe(state)
+    expect(updateProfile(state, 'ghost', { serverUrl: 'https://x.test' })).toBe(state)
+  })
+})
+
+describe('activeProfile', () => {
+  it('returns the one in use', () => {
+    const state = addProfile(base(), { id: 'work1', label: 'Work' })
+    expect(activeProfile(state).id).toBe('work1')
+  })
+
+  it('falls back to the first rather than returning nothing', () => {
+    const state = { ...base(), activeProfileId: 'ghost' }
+    expect(activeProfile(state)).toBe(state.profiles[0])
+  })
+})
+
+describe('ids and partitions', () => {
+  it('accepts ids that are safe in a path and rejects the rest', () => {
+    for (const id of ['default', 'a1b2c3', 'work-2']) expect(isValidProfileId(id)).toBe(true)
+    for (const id of ['', '../x', 'a/b', 'CAPS', '-lead', 'x'.repeat(65), null, 7]) {
+      expect(isValidProfileId(id)).toBe(false)
+    }
+  })
+
+  it('builds a persistent partition, so a sign-in outlives the window', () => {
+    expect(partitionFor('a1b2c3')).toBe('persist:profile-a1b2c3')
+  })
+
+  it('rejects a profile with no usable id', () => {
+    expect(makeProfile({ id: '../escape' })).toBeNull()
+    expect(makeProfile(null)).toBeNull()
+  })
+})

--- a/desktop/test/server-config.test.js
+++ b/desktop/test/server-config.test.js
@@ -402,3 +402,26 @@ describe('validateServerUrl', () => {
     expect((await validateServerUrl('example.com', async () => res)).ok).toBe(true)
   })
 })
+
+describe('createServerConfigStore without an injected id generator', () => {
+  // The store is constructed in the main process with only its file I/O, so a
+  // required id generator meant addProfile threw "newProfileId is not a
+  // function" the first time anyone pressed Add profile.
+  it('can still add a profile', async () => {
+    let contents = null
+    const store = createServerConfigStore({
+      readFile: async () => {
+        if (contents === null) throw new Error('ENOENT')
+        return contents
+      },
+      writeFile: async (next) => { contents = next },
+    })
+
+    const after = await store.addProfile('Work')
+
+    expect(after.profiles).toHaveLength(2)
+    expect(after.profiles[1].label).toBe('Work')
+    expect(after.profiles[1].id).toMatch(/^[a-z0-9][a-z0-9-]{0,63}$/)
+    expect(after.activeProfileId).toBe(after.profiles[1].id)
+  })
+})

--- a/desktop/test/server-config.test.js
+++ b/desktop/test/server-config.test.js
@@ -100,26 +100,28 @@ describe('resolveServerUrl', () => {
 })
 
 describe('migrateConfig', () => {
-  it('passes a current-shape config through', () => {
-    expect(migrateConfig({ version: 2, serverUrl: 'https://example.com', mutedWorkspaces: ['ws1'] })).toEqual({
-      version: CONFIG_VERSION,
+  const onlyProfile = (raw) => migrateConfig(raw).profiles[0]
+
+  it('turns a pre-profiles config into one profile that keeps its settings', () => {
+    // Upgrading must not look like being reconfigured.
+    const config = migrateConfig({ version: 2, serverUrl: 'https://example.com', mutedWorkspaces: ['ws1'] })
+
+    expect(config.version).toBe(CONFIG_VERSION)
+    expect(config.profiles).toHaveLength(1)
+    expect(config.profiles[0]).toMatchObject({
       serverUrl: 'https://example.com',
       mutedWorkspaces: ['ws1'],
     })
+    expect(config.activeProfileId).toBe(config.profiles[0].id)
   })
 
   it('adopts an unversioned file, which predates the version field', () => {
-    expect(migrateConfig({ serverUrl: 'example.com' })).toEqual({
-      version: CONFIG_VERSION,
-      serverUrl: 'http://example.com',
-      mutedWorkspaces: [],
-    })
+    expect(onlyProfile({ serverUrl: 'example.com' }).serverUrl).toBe('http://example.com')
   })
 
-  it('migrates a v1 file forward by defaulting the new field', () => {
+  it('migrates a v1 file forward by defaulting the new fields', () => {
     // v1 had no mute list, and notifying for everything is what it did.
-    expect(migrateConfig({ version: 1, serverUrl: 'https://example.com' })).toEqual({
-      version: CONFIG_VERSION,
+    expect(onlyProfile({ version: 1, serverUrl: 'https://example.com' })).toMatchObject({
       serverUrl: 'https://example.com',
       mutedWorkspaces: [],
     })
@@ -127,39 +129,61 @@ describe('migrateConfig', () => {
 
   it('discards a mute list that is not a list of ids', () => {
     for (const bad of ['ws1', 42, { ws1: true }, null]) {
-      expect(migrateConfig({ version: 2, serverUrl: 'https://e.com', mutedWorkspaces: bad }).mutedWorkspaces)
+      expect(onlyProfile({ version: 2, serverUrl: 'https://e.com', mutedWorkspaces: bad }).mutedWorkspaces)
         .toEqual([])
     }
-    expect(migrateConfig({ version: 2, serverUrl: 'https://e.com', mutedWorkspaces: ['ok', '', 7, null] })
+    expect(onlyProfile({ version: 2, serverUrl: 'https://e.com', mutedWorkspaces: ['ok', '', 7, null] })
       .mutedWorkspaces).toEqual(['ok'])
   })
 
   it('normalises whatever it finds rather than trusting it', () => {
-    expect(migrateConfig({ version: 1, serverUrl: 'https://example.com/' }).serverUrl).toBe('https://example.com')
+    expect(onlyProfile({ version: 1, serverUrl: 'https://example.com/' }).serverUrl).toBe('https://example.com')
+  })
+
+  it('re-checks every stored profile URL, not just a legacy one', () => {
+    // The profile model knows nothing about URLs, so this is the only place a
+    // value read off disk is checked before it becomes a fetch base.
+    const config = migrateConfig({
+      profiles: [
+        { id: 'one', label: 'A', serverUrl: 'file:///etc/passwd' },
+        { id: 'two', label: 'B', serverUrl: 'example.com/' },
+      ],
+    })
+
+    expect(config.profiles.map((p) => p.serverUrl)).toEqual(['', 'http://example.com'])
   })
 
   it('keeps only what it understands from a newer file', () => {
-    // Written by a build that knows keys this one does not: take the server
-    // URL, drop the rest rather than guessing at its meaning.
-    expect(migrateConfig({ version: 99, serverUrl: 'https://example.com', theme: 'dark' })).toEqual({
-      version: CONFIG_VERSION,
-      serverUrl: 'https://example.com',
-      mutedWorkspaces: [],
-    })
+    const config = migrateConfig({ version: 99, serverUrl: 'https://example.com', theme: 'dark' })
+
+    expect(config.profiles[0].serverUrl).toBe('https://example.com')
+    expect(config.profiles[0]).not.toHaveProperty('theme')
   })
 
   it('degrades to unconfigured for anything unusable', () => {
     // Sending the user to the connection screen is mildly annoying; booting
     // pointed at a URL we could not parse is worse.
     for (const raw of [null, undefined, 'a string', 42, [], { serverUrl: 'file:///x' }, {}]) {
-      expect(migrateConfig(raw)).toEqual({ version: CONFIG_VERSION, serverUrl: '', mutedWorkspaces: [] })
+      const config = migrateConfig(raw)
+      expect(config.profiles).toHaveLength(1)
+      expect(config.profiles[0].serverUrl).toBe('')
     }
+  })
+
+  it('always leaves exactly one profile active', () => {
+    const config = migrateConfig({
+      profiles: [{ id: 'one', label: 'A' }, { id: 'two', label: 'B' }],
+      activeProfileId: 'gone',
+    })
+
+    expect(config.profiles.some((p) => p.id === config.activeProfileId)).toBe(true)
   })
 })
 
 describe('createServerConfigStore', () => {
   function makeStore(initial = null) {
     let contents = initial
+    let nextId = 0
     const writeFile = vi.fn(async (next) => { contents = next })
     const store = createServerConfigStore({
       readFile: async () => {
@@ -167,35 +191,41 @@ describe('createServerConfigStore', () => {
         return contents
       },
       writeFile,
+      newProfileId: () => `p${++nextId}`,
     })
     return { store, writeFile, read: () => contents }
   }
 
+  const legacy = (extra = {}) =>
+    JSON.stringify({ version: 2, serverUrl: 'https://example.com', ...extra })
+
   it('reads a missing file as not configured — the first run', async () => {
     const { store } = makeStore(null)
-    expect(await store.load()).toEqual({ version: CONFIG_VERSION, serverUrl: '', mutedWorkspaces: [] })
+    const config = await store.load()
+
+    expect(config.version).toBe(CONFIG_VERSION)
+    expect(config.profiles).toHaveLength(1)
+    expect(config.profiles[0].serverUrl).toBe('')
   })
 
   it('reads a stored server back', async () => {
     const { store } = makeStore(JSON.stringify({ version: 1, serverUrl: 'https://example.com' }))
-    expect((await store.load()).serverUrl).toBe('https://example.com')
+    expect((await store.active()).serverUrl).toBe('https://example.com')
   })
 
   it('treats corrupt JSON as not configured', async () => {
     // A half-written file must not stop the app from starting.
     const { store } = makeStore('{ not json')
-    expect(await store.load()).toEqual({ version: CONFIG_VERSION, serverUrl: '', mutedWorkspaces: [] })
+    expect((await store.active()).serverUrl).toBe('')
   })
 
   it('saves a normalised URL and stamps the version', async () => {
     const { store, read } = makeStore(null)
 
     expect(await store.save('example.com/')).toEqual({ ok: true, url: 'http://example.com' })
-    expect(JSON.parse(read())).toEqual({
-      version: CONFIG_VERSION,
-      serverUrl: 'http://example.com',
-      mutedWorkspaces: [],
-    })
+    const written = JSON.parse(read())
+    expect(written.version).toBe(CONFIG_VERSION)
+    expect(written.profiles[0].serverUrl).toBe('http://example.com')
   })
 
   it('refuses to store an invalid URL', async () => {
@@ -211,36 +241,33 @@ describe('createServerConfigStore', () => {
   it('round-trips a save through a load', async () => {
     const { store } = makeStore(null)
     await store.save('https://example.com')
-    expect((await store.load()).serverUrl).toBe('https://example.com')
+    expect((await store.active()).serverUrl).toBe('https://example.com')
   })
 
   it('keeps mute choices when the server changes', async () => {
     // Switching server is not a reason to start notifying about workspaces the
     // user deliberately silenced.
-    const { store } = makeStore(
-      JSON.stringify({ version: 2, serverUrl: 'https://a.example.com', mutedWorkspaces: ['ws1'] })
-    )
+    const { store } = makeStore(legacy({ mutedWorkspaces: ['ws1'] }))
 
     await store.save('https://b.example.com')
 
-    expect(await store.load()).toEqual({
-      version: CONFIG_VERSION,
+    expect(await store.active()).toMatchObject({
       serverUrl: 'https://b.example.com',
       mutedWorkspaces: ['ws1'],
     })
   })
 
   it('mutes and unmutes a single workspace', async () => {
-    const { store } = makeStore(JSON.stringify({ version: 2, serverUrl: 'https://e.com', mutedWorkspaces: [] }))
+    const { store } = makeStore(legacy({ mutedWorkspaces: [] }))
 
     expect(await store.setWorkspaceMuted('ws1', true)).toEqual(['ws1'])
     expect(await store.setWorkspaceMuted('ws2', true)).toEqual(['ws1', 'ws2'])
     expect(await store.setWorkspaceMuted('ws1', false)).toEqual(['ws2'])
-    expect((await store.load()).mutedWorkspaces).toEqual(['ws2'])
+    expect((await store.active()).mutedWorkspaces).toEqual(['ws2'])
   })
 
   it('does not list a workspace twice when muted again', async () => {
-    const { store } = makeStore(JSON.stringify({ version: 2, serverUrl: 'https://e.com', mutedWorkspaces: ['ws1'] }))
+    const { store } = makeStore(legacy({ mutedWorkspaces: ['ws1'] }))
 
     expect(await store.setWorkspaceMuted('ws1', true)).toEqual(['ws1'])
   })
@@ -257,7 +284,60 @@ describe('createServerConfigStore', () => {
 
     await store.clear()
 
-    expect((await store.load()).serverUrl).toBe('')
+    expect((await store.active()).serverUrl).toBe('')
+  })
+
+  it('settings belong to one profile, not to all of them', async () => {
+    // The whole point of a profile: signing a second account into a different
+    // server must not move the first one.
+    const { store } = makeStore(legacy())
+    await store.addProfile('Work')
+    await store.save('https://work.example.com')
+
+    const config = await store.load()
+    const [first, second] = config.profiles
+
+    expect(first.serverUrl).toBe('https://example.com')
+    expect(second.serverUrl).toBe('https://work.example.com')
+  })
+
+  it('adds a profile, switches to it, and gives it its own session', async () => {
+    const { store } = makeStore(legacy())
+
+    const after = await store.addProfile('Work')
+
+    expect(after.profiles).toHaveLength(2)
+    expect(after.activeProfileId).toBe(after.profiles[1].id)
+    expect(after.profiles[1].partition).not.toBe(after.profiles[0].partition)
+  })
+
+  it('never reuses an id already stored', async () => {
+    // Two profiles on one id would share a session: the same account twice.
+    const { store } = makeStore(JSON.stringify({ profiles: [{ id: 'p1', label: 'Taken' }] }))
+
+    const after = await store.addProfile('New')
+
+    expect(after.profiles.map((p) => p.id)).toEqual(['p1', 'p2'])
+  })
+
+  it('switches, renames and removes', async () => {
+    const { store } = makeStore(legacy())
+    const withWork = await store.addProfile('Work')
+    const [first, work] = withWork.profiles
+
+    expect((await store.activateProfile(first.id)).activeProfileId).toBe(first.id)
+    expect((await store.renameProfile(work.id, ' Day job ')).profiles[1].label).toBe('Day job')
+
+    const removed = await store.removeProfile(work.id)
+    expect(removed.profiles).toHaveLength(1)
+    expect(removed.activeProfileId).toBe(first.id)
+  })
+
+  it('keeps the last profile, since the app needs a session to run in', async () => {
+    const { store } = makeStore(legacy())
+    const config = await store.load()
+
+    expect((await store.removeProfile(config.activeProfileId)).profiles).toHaveLength(1)
   })
 })
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -251,8 +251,34 @@
                    (isCollapsed && !isMobileMenuOpen) ? 'left-full bottom-0 ml-2 min-w-[200px] origin-bottom-left' : 'bottom-full left-0 right-0 mb-2 origin-bottom'
                  ]">
               <div class="px-3 py-2 border-b border-gray-50 dark:border-zinc-800/50 mb-1">
-                <p class="text-[10px] font-black text-gray-500 dark:text-zinc-500">Account</p>
+                <p class="text-[10px] font-black text-gray-500 dark:text-zinc-500">{{ activeProfile ? activeProfile.label : 'Account' }}</p>
                 <p class="text-xs font-bold text-gray-700 dark:text-zinc-200 truncate mt-0.5" :title="user?.email">{{ user?.email || 'Loading...' }}</p>
+                <p v-if="activeProfile?.serverUrl" class="text-[10px] font-medium text-gray-400 dark:text-zinc-500 truncate mt-0.5" :title="activeProfile.serverUrl">{{ activeProfile.serverUrl }}</p>
+              </div>
+
+              <!-- Other profiles. Desktop only: each is a separate session, which
+                   a browser tab cannot give us. -->
+              <div v-if="showProfiles" class="px-3 py-2 border-b border-gray-50 dark:border-zinc-800/50 mb-1">
+                <p class="text-[10px] font-black text-gray-500 dark:text-zinc-500 mb-2">Other Profiles</p>
+                <div v-if="otherProfiles.length" class="space-y-1 mb-1">
+                  <button v-for="p in otherProfiles" :key="p.id" type="button"
+                          @click="switchToProfile(p.id)" :disabled="switchingProfile"
+                          class="w-full flex items-center gap-2.5 px-2 py-1.5 rounded-sm text-left hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+                    <span class="w-6 h-6 shrink-0 rounded-full bg-gray-100 dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 flex items-center justify-center text-[10px] font-black text-gray-600 dark:text-zinc-300">
+                      {{ p.label.charAt(0).toUpperCase() }}
+                    </span>
+                    <span class="min-w-0 flex-1">
+                      <span class="block text-xs font-bold text-gray-700 dark:text-zinc-200 truncate">{{ p.label }}</span>
+                      <span v-if="p.serverUrl" class="block text-[10px] font-medium text-gray-400 dark:text-zinc-500 truncate">{{ p.serverUrl }}</span>
+                      <span v-else class="block text-[10px] font-medium text-gray-400 dark:text-zinc-500">Not signed in</span>
+                    </span>
+                  </button>
+                </div>
+                <button type="button" @click="addProfile" :disabled="switchingProfile"
+                        class="w-full flex items-center gap-2.5 px-2 py-1.5 rounded-sm text-xs font-bold text-gray-600 dark:text-zinc-300 hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+                  <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" /></svg>
+                  Add profile
+                </button>
               </div>
 
               <!-- Theme Selection inside Menu -->
@@ -339,6 +365,7 @@ import { useRegisterSW } from 'virtual:pwa-register/vue'
 import { fetchUser, fetchWorkspaces, API_BASE_URL } from './api'
 import { useToasts } from './composables/useToasts'
 import { useEventBus } from './useEventBus'
+import { usePlatformStore } from './stores/platformStore'
 import { useThemeStore } from './stores/themeStore'
 import { useTooltipStore } from './stores/tooltipStore'
 import { useWorkspaceStore } from './stores/workspaceStore'
@@ -365,6 +392,54 @@ const { notifySuccess, notifyInfo, notifyError } = useToasts()
 const isLoginPage = computed(() => route.path === '/login')
 const user = ref(null)
 const isUserMenuOpen = ref(false)
+
+const platformStore = usePlatformStore()
+
+// Signed-in profiles. Each is its own session in the desktop shell, so the
+// browser build has nothing to show and the section stays hidden there.
+const profiles = ref([])
+const switchingProfile = ref(false)
+const showProfiles = computed(() => platformStore.isDesktop && profiles.value.length > 0)
+const activeProfile = computed(() => profiles.value.find((p) => p.active) ?? null)
+const otherProfiles = computed(() => profiles.value.filter((p) => !p.active))
+
+async function loadProfiles() {
+  if (!platformStore.isDesktop || !window.agentrq?.profiles) return
+  try {
+    const state = await window.agentrq.profiles.get()
+    profiles.value = state?.profiles ?? []
+  } catch {
+    // Not being able to list profiles is not a reason to break the sidebar.
+    profiles.value = []
+  }
+}
+
+/**
+ * Switching replaces the window from the shell side, so there is nothing to do
+ * here afterwards — this renderer is about to be replaced along with it.
+ */
+async function switchToProfile(id) {
+  if (switchingProfile.value) return
+  switchingProfile.value = true
+  try {
+    await window.agentrq.profiles.switch(id)
+  } catch (err) {
+    switchingProfile.value = false
+    notifyError('Could not switch profile: ' + err.message)
+  }
+}
+
+/** A new profile has never signed in, so its window opens on the login screen. */
+async function addProfile() {
+  if (switchingProfile.value) return
+  switchingProfile.value = true
+  try {
+    await window.agentrq.profiles.add('')
+  } catch (err) {
+    switchingProfile.value = false
+    notifyError('Could not add a profile: ' + err.message)
+  }
+}
 const isWorkspaceDropdownOpen = ref(false)
 const isCollapsed = ref(true);
 const isMobileMenuOpen = ref(false);
@@ -417,6 +492,7 @@ watch(events, (newEvents) => {
 onMounted(() => {
   themeStore.init()
   loadUser()
+  loadProfiles()
   workspaceStore.fetchWorkspaces()
   connect() // Connect to global event stream
   document.addEventListener('click', handleClickOutside)

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -252,7 +252,8 @@
                  ]">
               <div class="px-3 py-2 border-b border-gray-50 dark:border-zinc-800/50 mb-1">
                 <p class="text-[10px] font-black text-gray-500 dark:text-zinc-500">{{ activeProfile ? activeProfile.label : 'Account' }}</p>
-                <p class="text-xs font-bold text-gray-700 dark:text-zinc-200 truncate mt-0.5" :title="user?.email">{{ user?.email || 'Loading...' }}</p>
+                <p class="text-xs font-bold text-gray-700 dark:text-zinc-200 truncate mt-0.5" :title="user?.email">{{ user?.name || user?.email || 'Loading...' }}</p>
+                <p v-if="user?.name && user?.email" class="text-[10px] font-medium text-gray-400 dark:text-zinc-500 truncate mt-0.5" :title="user.email">{{ user.email }}</p>
                 <p v-if="activeProfile?.serverUrl" class="text-[10px] font-medium text-gray-400 dark:text-zinc-500 truncate mt-0.5" :title="activeProfile.serverUrl">{{ activeProfile.serverUrl }}</p>
               </div>
 
@@ -264,13 +265,13 @@
                   <button v-for="p in otherProfiles" :key="p.id" type="button"
                           @click="switchToProfile(p.id)" :disabled="switchingProfile"
                           class="w-full flex items-center gap-2.5 px-2 py-1.5 rounded-sm text-left hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
-                    <span class="w-6 h-6 shrink-0 rounded-full bg-gray-100 dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 flex items-center justify-center text-[10px] font-black text-gray-600 dark:text-zinc-300">
-                      {{ p.label.charAt(0).toUpperCase() }}
+                    <span class="w-6 h-6 shrink-0 rounded-full bg-gray-100 dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 flex items-center justify-center text-[10px] font-black text-gray-600 dark:text-zinc-300 overflow-hidden">
+                      <img v-if="p.identity?.picture" :src="p.identity.picture" class="w-full h-full object-cover" alt="" />
+                      <template v-else>{{ profileInitial(p) }}</template>
                     </span>
                     <span class="min-w-0 flex-1">
-                      <span class="block text-xs font-bold text-gray-700 dark:text-zinc-200 truncate">{{ p.label }}</span>
-                      <span v-if="p.serverUrl" class="block text-[10px] font-medium text-gray-400 dark:text-zinc-500 truncate">{{ p.serverUrl }}</span>
-                      <span v-else class="block text-[10px] font-medium text-gray-400 dark:text-zinc-500">Not signed in</span>
+                      <span class="block text-xs font-bold text-gray-700 dark:text-zinc-200 truncate">{{ profileTitle(p) }}</span>
+                      <span class="block text-[10px] font-medium text-gray-400 dark:text-zinc-500 truncate" :title="profileSubtitle(p)">{{ profileSubtitle(p) }}</span>
                     </span>
                   </button>
                 </div>
@@ -365,6 +366,7 @@ import { useRegisterSW } from 'virtual:pwa-register/vue'
 import { fetchUser, fetchWorkspaces, API_BASE_URL } from './api'
 import { useToasts } from './composables/useToasts'
 import { useEventBus } from './useEventBus'
+import { profileDisplay } from './composables/useProfileDisplay'
 import { usePlatformStore } from './stores/platformStore'
 import { useThemeStore } from './stores/themeStore'
 import { useTooltipStore } from './stores/tooltipStore'
@@ -402,6 +404,10 @@ const switchingProfile = ref(false)
 const showProfiles = computed(() => platformStore.isDesktop && profiles.value.length > 0)
 const activeProfile = computed(() => profiles.value.find((p) => p.active) ?? null)
 const otherProfiles = computed(() => profiles.value.filter((p) => !p.active))
+
+const profileInitial = (p) => profileDisplay(p).initial
+const profileTitle = (p) => profileDisplay(p).title
+const profileSubtitle = (p) => profileDisplay(p).subtitle
 
 async function loadProfiles() {
   if (!platformStore.isDesktop || !window.agentrq?.profiles) return

--- a/frontend/src/composables/useProfileDisplay.js
+++ b/frontend/src/composables/useProfileDisplay.js
@@ -1,0 +1,34 @@
+/**
+ * How one profile reads in the switcher.
+ *
+ * A list of profiles named "Default" and "Work" does not tell you which account
+ * you are about to switch to, so the account comes first and the profile's own
+ * name is the fallback. What is available varies: a profile may be signed in
+ * with a full name and email, with only one of them, or not signed in at all.
+ *
+ * Kept out of the component so the precedence is one rule with one set of
+ * tests, rather than three expressions in a template.
+ */
+
+/**
+ * @param {{ label?: string, serverUrl?: string, identity?: {name?: string, email?: string} | null }} profile
+ * @returns {{ title: string, subtitle: string, initial: string }}
+ */
+export function profileDisplay(profile) {
+  const label = typeof profile?.label === 'string' ? profile.label.trim() : ''
+  const name = profile?.identity?.name?.trim() ?? ''
+  const email = profile?.identity?.email?.trim() ?? ''
+  const serverUrl = typeof profile?.serverUrl === 'string' ? profile.serverUrl.trim() : ''
+
+  // Who, then where. The account identifies the profile; the label rarely does.
+  const title = name || email || label || 'Profile'
+
+  // Never repeat the title underneath it: an email shown twice reads as a bug.
+  let subtitle
+  if (name && email) subtitle = email
+  else if (serverUrl) subtitle = serverUrl
+  else subtitle = 'Not signed in'
+
+  // title always falls back to 'Profile', so there is always a first letter.
+  return { title, subtitle, initial: title.charAt(0).toUpperCase() }
+}

--- a/frontend/test/profileDisplay.test.js
+++ b/frontend/test/profileDisplay.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { profileDisplay } from '../src/composables/useProfileDisplay'
+
+describe('profileDisplay', () => {
+  it('leads with the account, since that is what identifies a profile', () => {
+    // The reason this exists: "Default" and "Work" do not tell you which
+    // account you are about to switch to.
+    expect(profileDisplay({
+      label: 'Work',
+      serverUrl: 'https://app.agentrq.com',
+      identity: { name: 'Ada Lovelace', email: 'ada@example.com' },
+    })).toMatchObject({ title: 'Ada Lovelace', subtitle: 'ada@example.com', initial: 'A' })
+  })
+
+  it('uses the email when there is no name', () => {
+    expect(profileDisplay({ label: 'Work', serverUrl: 'https://a.test', identity: { email: 'ada@example.com' } }))
+      .toMatchObject({ title: 'ada@example.com', subtitle: 'https://a.test' })
+  })
+
+  it('does not print the same thing twice', () => {
+    // An email as both title and subtitle reads as a bug.
+    const { title, subtitle } = profileDisplay({ serverUrl: 'https://a.test', identity: { email: 'a@b.com' } })
+
+    expect(title).not.toBe(subtitle)
+  })
+
+  it('falls back to the profile name when nobody is signed in', () => {
+    expect(profileDisplay({ label: 'Work', serverUrl: 'https://a.test', identity: null }))
+      .toMatchObject({ title: 'Work', subtitle: 'https://a.test' })
+  })
+
+  it('says so plainly when a profile has never been set up', () => {
+    expect(profileDisplay({ label: 'Work', serverUrl: '', identity: null }))
+      .toMatchObject({ title: 'Work', subtitle: 'Not signed in' })
+  })
+
+  it('shows the server for a profile signed in with a name only', () => {
+    expect(profileDisplay({ label: 'Work', serverUrl: 'https://a.test', identity: { name: 'Ada' } }))
+      .toMatchObject({ title: 'Ada', subtitle: 'https://a.test' })
+  })
+
+  it('always has something to show, whatever it is handed', () => {
+    for (const p of [undefined, null, {}, { label: '   ' }, { identity: {} }]) {
+      const display = profileDisplay(p)
+      expect(display.title).toBe('Profile')
+      expect(display.initial).toBe('P')
+      expect(display.subtitle).toBe('Not signed in')
+    }
+  })
+
+  it('trims what it is given', () => {
+    expect(profileDisplay({ label: '  Work  ', identity: { name: '  Ada  ' } }).title).toBe('Ada')
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -40,6 +40,7 @@ export default defineConfig({
         'src/composables/useTaskGroups.js',
         'src/composables/usePendingSend.js',
         'src/composables/useDirectoryPicker.js',
+        'src/composables/useProfileDisplay.js',
       ],
       reporter: ['text', 'lcov'],
       thresholds: {


### PR DESCRIPTION
**What changed**

Several accounts can now be signed in at once in the desktop app and switched between from the user menu, the way browser profiles work. Each keeps its own session, its own server and its own notification settings.

**Why changed**

The installed web app got this free from Chrome's own profiles; the desktop app had exactly one signed-in account and no way to hold a second.

**Test coverage report**

New lines introduced: 100% covered for everything that can be. 30 tests for the profile model — the rules that keep the list coherent, that no two profiles can share a session, that ids can never escape into a path, that the list is never empty and never points at a profile that is gone. The stored-settings layer went from 40 tests to 47, including that one profile's settings cannot move another's.

Total coverage impact: none in the negative direction; the desktop suite goes from 317 to 354 tests, all passing, and both builds compile. The parts that cannot be covered are the shell wiring itself, which needs a live Electron and has no harness in this project — the same limitation as the rest of that file.

**Other reports**

A profile *is* a session partition. Cookies are stored per partition and the login token is a cookie, so a partition is an account; everything else here is making the parts that assumed a single account stop doing so. Three of those are worth a reviewer's attention:

- The app protocol handler is registered per session rather than once. It attaches to one session's registry, so a window opened on a session that never received it cannot load the app at all.
- Every request now goes through the active profile's session. The general-purpose fetch sends the *default* session's cookies, which would have talked to the server as whichever account happened to be in that jar. The sign-in window moves for the same reason, so the cookie it earns signs in the profile that asked for it — the comment there previously explained why it deliberately did the opposite, and has been rewritten rather than left to mislead.
- Switching replaces the window instead of reloading it, because a window's session is fixed when it is created; reloading would keep the old one and quietly show the previous account's data under the new name. The replacement is created before the old is destroyed, since closing the last window quits the app on two of the three platforms.

**A regression I introduced and caught:** reshaping the stored config to hold a list of profiles dropped the URL check that the old migration performed, so a stored `file:///x` would have reached the request base. The check is restored, now applied to every profile, with a test naming why it exists.

**Worth knowing before merging:** the profile carried forward from an existing install gets its own session like every other, which signs that user out once on upgrade. That was agreed explicitly — the session lasts 24 hours regardless, and the alternative is one profile permanently special-cased everywhere a session is resolved.

**TaskID:** 0hxxuFCOYef