### PR TITLE
feat(auth): refresh tokens, so a session survives longer than a day

### DIFF
--- a/backend/internal/controller/crud/crud.go
+++ b/backend/internal/controller/crud/crud.go
@@ -90,6 +90,7 @@ type WorkspaceController interface {
 type UserController interface {
 	CreateUser(ctx context.Context, u entity.User) (entity.User, error)
 	FindUserByEmail(ctx context.Context, email string) (entity.User, error)
+	FindUserByID(ctx context.Context, id int64) (entity.User, error)
 	FindOrCreateUser(ctx context.Context, req entity.FindOrCreateUserRequest) (*entity.FindOrCreateUserResponse, error)
 }
 

--- a/backend/internal/controller/crud/user.go
+++ b/backend/internal/controller/crud/user.go
@@ -127,6 +127,27 @@ func (c *controller) CreateUser(ctx context.Context, u entity.User) (entity.User
 	}, nil
 }
 
+// FindUserByID looks a user up by the id carried in a token subject.
+//
+// Refreshing a session mints a new access token, and that token carries the
+// name and picture the interface displays. Reading them here rather than
+// copying them out of the refresh token means a profile edited during a long
+// session is picked up at the next refresh instead of being frozen at sign-in.
+func (c *controller) FindUserByID(ctx context.Context, id int64) (entity.User, error) {
+	u, err := c.repository.SystemGetUser(ctx, id)
+	if err != nil {
+		return entity.User{}, err
+	}
+	return entity.User{
+		ID:        u.ID,
+		CreatedAt: u.CreatedAt,
+		UpdatedAt: u.UpdatedAt,
+		Email:     u.Email,
+		Name:      u.Name,
+		Picture:   u.Picture,
+	}, nil
+}
+
 func (c *controller) FindUserByEmail(ctx context.Context, email string) (entity.User, error) {
 	u, err := c.repository.FindUserByEmail(ctx, email)
 	if err != nil {

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -71,6 +71,14 @@ type (
 const (
 	_routeBasePath = "/api/v1"
 
+	// Cookie names. `at` is sent with every request; `rt` is scoped to the one
+	// route that consumes it, so the long-lived credential is not attached to
+	// every API call the app makes.
+	_accessCookie  = "at"
+	_refreshCookie = "rt"
+
+	_accessTokenTTL = 24 * time.Hour
+
 	_headerContentType = fiber.HeaderContentType
 	_mimeJSON          = fiber.MIMEApplicationJSON
 	_mimeEventStream   = "text/event-stream"
@@ -168,6 +176,10 @@ func (h *handler) registerPublicAuthRoutes() {
 	r.Get("/github/login", h.githubLogin())
 	r.Get("/github/callback", h.githubCallback())
 	r.Post("/root/login", h.rootLogin())
+	// Public on purpose: the whole point is that the access token has expired,
+	// so this route cannot sit behind the middleware that checks it. It
+	// authenticates with the refresh cookie instead.
+	r.Post("/refresh", h.refreshSession())
 }
 
 func (h *handler) registerProtectedAuthRoutes() {
@@ -176,21 +188,106 @@ func (h *handler) registerProtectedAuthRoutes() {
 	r.Post("/logout", h.logout())
 }
 
+// refreshCookiePath scopes the refresh cookie to the route that reads it.
+//
+// Derived from the same base path the routes are mounted under, plus the SPA
+// base path a reverse-proxied deployment adds in front. Getting this wrong
+// fails silently — the browser simply never sends the cookie, and sessions
+// expire exactly as they did before the refresh flow existed — so there is a
+// test asserting it matches where the route actually lives.
+func (h *handler) refreshCookiePath() string {
+	return h.basePath + _routeBasePath + "/auth/refresh"
+}
+
+// sessionCookie applies the settings every session cookie shares.
+func (h *handler) sessionCookie(name, value string, expires time.Time, path string) *fiber.Cookie {
+	cookie := &fiber.Cookie{
+		Name:     name,
+		Value:    value,
+		Expires:  expires,
+		HTTPOnly: true,
+		Secure:   h.cookieSecure,
+		SameSite: "Lax",
+		Path:     path,
+	}
+	if h.domain != "" && !strings.HasPrefix(h.domain, "localhost") {
+		cookie.Domain = "." + h.domain
+	}
+	return cookie
+}
+
+// issueSession sets both halves of a session.
+//
+// One function rather than a block copied into each sign-in path: three of
+// those already existed, and a fourth that set only the access cookie would
+// leave that provider's users signed out after a day with nothing to show why.
+func (h *handler) issueSession(c *fiber.Ctx, accessToken, userID string) {
+	now := time.Now()
+	c.Cookie(h.sessionCookie(_accessCookie, accessToken, now.Add(_accessTokenTTL), "/"))
+
+	refreshToken, err := h.tokenSvc.CreateRefreshToken(userID)
+	if err != nil {
+		// Deliberately not fatal. The person is signed in either way; without
+		// this they simply have the session they would have had before refresh
+		// tokens existed, which is a far better outcome than refusing a login
+		// that otherwise succeeded.
+		zlog.Error().Err(err).Msg("Failed to mint refresh token; session will not survive expiry")
+		return
+	}
+	c.Cookie(h.sessionCookie(_refreshCookie, refreshToken, now.Add(auth.RefreshTokenTTL), h.refreshCookiePath()))
+}
+
+// clearSession expires both halves. The refresh cookie has to be cleared at the
+// path it was set on; a deletion at "/" would not match it and would leave the
+// session renewable after signing out.
+func (h *handler) clearSession(c *fiber.Ctx) {
+	expired := time.Now().Add(-1 * time.Hour)
+	c.Cookie(h.sessionCookie(_accessCookie, "", expired, "/"))
+	c.Cookie(h.sessionCookie(_refreshCookie, "", expired, h.refreshCookiePath()))
+}
+
+// refreshSession exchanges a valid refresh cookie for a fresh session.
+//
+// Both cookies are reissued, so a session in regular use never reaches the idle
+// limit while one that is genuinely abandoned still expires.
+func (h *handler) refreshSession() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+
+		claims, err := h.tokenSvc.ValidateRefreshToken(c.Cookies(_refreshCookie))
+		if err != nil || claims == nil {
+			// Missing or expired is the ordinary end of a session, not a fault.
+			// Clearing both cookies stops the client retrying with a credential
+			// that will never work again.
+			h.clearSession(c)
+			return c.Status(http.StatusUnauthorized).JSON(fiber.Map{"error": "session expired"})
+		}
+
+		ctx, cancel := newContext(c)
+		defer cancel()
+
+		user, err := h.crud.FindUserByID(ctx, monoflake.IDFromBase62(claims.Subject).Int64())
+		if err != nil {
+			// A token that outlived the account it names.
+			h.clearSession(c)
+			return c.Status(http.StatusUnauthorized).JSON(fiber.Map{"error": "session expired"})
+		}
+
+		userID := monoflake.ID(user.ID).String()
+		accessToken, err := h.tokenSvc.CreateToken(userID, user.Email, user.Name, user.Picture)
+		if err != nil {
+			zlog.Error().Err(err).Msg("Failed to mint access token on refresh")
+			return c.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": "could not refresh session"})
+		}
+
+		h.issueSession(c, accessToken, userID)
+		return c.JSON(fiber.Map{"status": "ok"})
+	}
+}
+
 func (h *handler) logout() fiber.Handler {
 	return func(c *fiber.Ctx) error {
-		cookie := &fiber.Cookie{
-			Name:     "at",
-			Value:    "",
-			Expires:  time.Now().Add(-1 * time.Hour),
-			HTTPOnly: true,
-			Secure:   h.cookieSecure,
-			SameSite: "Lax",
-			Path:     "/",
-		}
-		if h.domain != "" && !strings.HasPrefix(h.domain, "localhost") {
-			cookie.Domain = "." + h.domain
-		}
-		c.Cookie(cookie)
+		h.clearSession(c)
 		return c.SendStatus(fiber.StatusNoContent)
 	}
 }
@@ -295,19 +392,7 @@ func (h *handler) rootLogin() fiber.Handler {
 			return c.Send(e)
 		}
 
-		cookie := &fiber.Cookie{
-			Name:     "at",
-			Value:    tokenString,
-			Expires:  time.Now().Add(24 * time.Hour),
-			HTTPOnly: true,
-			Secure:   h.cookieSecure,
-			SameSite: "Lax",
-			Path:     "/",
-		}
-		if h.domain != "" && !strings.HasPrefix(h.domain, "localhost") {
-			cookie.Domain = "." + h.domain
-		}
-		c.Cookie(cookie)
+		h.issueSession(c, tokenString, userID)
 
 		return c.JSON(fiber.Map{"status": "ok"})
 	}
@@ -377,19 +462,7 @@ func (h *handler) googleCallback() fiber.Handler {
 			return c.Send(e)
 		}
 
-		cookie := &fiber.Cookie{
-			Name:     "at",
-			Value:    tokenString,
-			Expires:  time.Now().Add(24 * time.Hour),
-			HTTPOnly: true,
-			Secure:   h.cookieSecure,
-			SameSite: "Lax",
-			Path:     "/",
-		}
-		if h.domain != "" && !strings.HasPrefix(h.domain, "localhost") {
-			cookie.Domain = "." + h.domain
-		}
-		c.Cookie(cookie)
+		h.issueSession(c, tokenString, userID)
 
 		redirectURL := "/"
 		if h.basePath != "" {
@@ -464,19 +537,7 @@ func (h *handler) githubCallback() fiber.Handler {
 			return c.Send(e)
 		}
 
-		cookie := &fiber.Cookie{
-			Name:     "at",
-			Value:    tokenString,
-			Expires:  time.Now().Add(24 * time.Hour),
-			HTTPOnly: true,
-			Secure:   h.cookieSecure,
-			SameSite: "Lax",
-			Path:     "/",
-		}
-		if h.domain != "" && !strings.HasPrefix(h.domain, "localhost") {
-			cookie.Domain = "." + h.domain
-		}
-		c.Cookie(cookie)
+		h.issueSession(c, tokenString, userID)
 
 		redirectURL := "/"
 		if h.basePath != "" {

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -3,8 +3,10 @@ package api
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/agentrq/agentrq/backend/internal/controller/crud"
@@ -12,6 +14,7 @@ import (
 	"github.com/agentrq/agentrq/backend/internal/repository/base"
 	"github.com/agentrq/agentrq/backend/internal/service/auth"
 	"github.com/gofiber/fiber/v2"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/mustafaturan/monoflake"
 )
 
@@ -453,4 +456,166 @@ func TestRespondToElicitation_InvalidPayload(t *testing.T) {
 			}
 		})
 	}
+}
+
+// refreshTokenSvc is the minimum TokenService the refresh handler touches.
+type refreshTokenSvc struct {
+	auth.TokenService
+	validateRefreshFunc func(tokenStr string) (*auth.Claims, error)
+	createTokenFunc     func(userID, email, name, picture string) (string, error)
+	createRefreshFunc   func(userID string) (string, error)
+}
+
+func (m *refreshTokenSvc) ValidateRefreshToken(tokenStr string) (*auth.Claims, error) {
+	return m.validateRefreshFunc(tokenStr)
+}
+
+func (m *refreshTokenSvc) CreateToken(userID, email, name, picture string) (string, error) {
+	return m.createTokenFunc(userID, email, name, picture)
+}
+
+func (m *refreshTokenSvc) CreateRefreshToken(userID string) (string, error) {
+	if m.createRefreshFunc == nil {
+		return "new-refresh", nil
+	}
+	return m.createRefreshFunc(userID)
+}
+
+type refreshCrud struct {
+	crud.Controller
+	findUserByIDFunc func(ctx context.Context, id int64) (entity.User, error)
+}
+
+func (m *refreshCrud) FindUserByID(ctx context.Context, id int64) (entity.User, error) {
+	return m.findUserByIDFunc(ctx, id)
+}
+
+// TestRefreshCookiePath pins the refresh cookie to the route that reads it.
+//
+// This is the one part of the flow that fails silently: if the path does not
+// match where the route is mounted, the browser simply never sends the cookie,
+// refreshing never happens, and sessions expire exactly as they did before —
+// with nothing in any log to say why.
+func TestRefreshCookiePath(t *testing.T) {
+	if got, want := (&handler{}).refreshCookiePath(), _routeBasePath+"/auth/refresh"; got != want {
+		t.Errorf("refreshCookiePath() = %q, want %q — the route is mounted at %q", got, want, want)
+	}
+
+	// A reverse-proxied deployment serves the API under a prefix; the cookie
+	// has to carry it or the browser will not match the request path.
+	if got, want := (&handler{basePath: "/agentrq"}).refreshCookiePath(), "/agentrq/api/v1/auth/refresh"; got != want {
+		t.Errorf("with a base path: got %q, want %q", got, want)
+	}
+}
+
+func TestRefreshSession(t *testing.T) {
+	newApp := func(h *handler) *fiber.App {
+		app := fiber.New()
+		app.Post("/api/v1/auth/refresh", h.refreshSession())
+		return app
+	}
+
+	post := func(app *fiber.App, cookie string) *http.Response {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/refresh", nil)
+		if cookie != "" {
+			req.Header.Set("Cookie", "rt="+cookie)
+		}
+		res, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		return res
+	}
+
+	t.Run("renews a session and reissues both cookies", func(t *testing.T) {
+		h := &handler{
+			tokenSvc: &refreshTokenSvc{
+				validateRefreshFunc: func(string) (*auth.Claims, error) {
+					return &auth.Claims{RegisteredClaims: jwt.RegisteredClaims{Subject: "1"}}, nil
+				},
+				createTokenFunc: func(userID, email, name, picture string) (string, error) {
+					if email != "a@b.com" {
+						t.Errorf("access token minted with email %q, want the one from the database", email)
+					}
+					return "new-access", nil
+				},
+			},
+			crud: &refreshCrud{
+				findUserByIDFunc: func(context.Context, int64) (entity.User, error) {
+					return entity.User{ID: 1, Email: "a@b.com", Name: "Ada"}, nil
+				},
+			},
+		}
+
+		res := post(newApp(h), "a-valid-refresh-token")
+
+		if res.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", res.StatusCode)
+		}
+		cookies := res.Header.Values("Set-Cookie")
+		joined := strings.Join(cookies, "\n")
+		if !strings.Contains(joined, "at=new-access") {
+			t.Errorf("no new access cookie in %q", joined)
+		}
+		if !strings.Contains(joined, "rt=new-refresh") {
+			t.Errorf("refresh cookie was not rotated: %q", joined)
+		}
+	})
+
+	t.Run("refuses and clears when the token is rejected", func(t *testing.T) {
+		// Clearing matters: leaving a dead refresh cookie in place makes the
+		// client retry a credential that can never work again.
+		h := &handler{
+			tokenSvc: &refreshTokenSvc{
+				validateRefreshFunc: func(string) (*auth.Claims, error) {
+					return nil, errors.New("expired")
+				},
+			},
+		}
+
+		res := post(newApp(h), "an-expired-token")
+
+		if res.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", res.StatusCode)
+		}
+		if joined := strings.Join(res.Header.Values("Set-Cookie"), "\n"); !strings.Contains(joined, "rt=;") {
+			t.Errorf("refresh cookie was not cleared: %q", joined)
+		}
+	})
+
+	t.Run("refuses when there is no cookie at all", func(t *testing.T) {
+		h := &handler{
+			tokenSvc: &refreshTokenSvc{
+				validateRefreshFunc: func(tokenStr string) (*auth.Claims, error) {
+					if tokenStr != "" {
+						t.Errorf("expected an empty token, got %q", tokenStr)
+					}
+					return nil, errors.New("no token")
+				},
+			},
+		}
+
+		if res := post(newApp(h), ""); res.StatusCode != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401", res.StatusCode)
+		}
+	})
+
+	t.Run("refuses a token that outlived its account", func(t *testing.T) {
+		h := &handler{
+			tokenSvc: &refreshTokenSvc{
+				validateRefreshFunc: func(string) (*auth.Claims, error) {
+					return &auth.Claims{RegisteredClaims: jwt.RegisteredClaims{Subject: "1"}}, nil
+				},
+			},
+			crud: &refreshCrud{
+				findUserByIDFunc: func(context.Context, int64) (entity.User, error) {
+					return entity.User{}, errors.New("not found")
+				},
+			},
+		}
+
+		if res := post(newApp(h), "valid-but-orphaned"); res.StatusCode != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401", res.StatusCode)
+		}
+	})
 }

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -619,3 +619,49 @@ func TestRefreshSession(t *testing.T) {
 		}
 	})
 }
+
+// TestSignInIssuesBothCookies covers what a sign-in actually puts in the
+// browser. The refresh half is invisible in normal use — nothing breaks without
+// it until a day later — so a login that quietly set only the access cookie
+// would look completely healthy right up until everyone was signed out.
+func TestSignInIssuesBothCookies(t *testing.T) {
+	h := &handler{
+		rootLoginEnabled: true,
+		rootToken:        "root-secret",
+		crud: &mockCrudController{
+			findOrCreateUserFunc: func(context.Context, entity.FindOrCreateUserRequest) (*entity.FindOrCreateUserResponse, error) {
+				return &entity.FindOrCreateUserResponse{User: entity.User{ID: 1, Email: "root@agentrq.local"}}, nil
+			},
+		},
+		tokenSvc: &refreshTokenSvc{
+			createTokenFunc:   func(string, string, string, string) (string, error) { return "access-token", nil },
+			createRefreshFunc: func(string) (string, error) { return "refresh-token", nil },
+		},
+	}
+
+	app := fiber.New()
+	app.Post("/api/v1/auth/root/login", h.rootLogin())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/root/login",
+		bytes.NewBufferString(`{"rootToken":"root-secret"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+
+	joined := strings.Join(res.Header.Values("Set-Cookie"), "\n")
+	if !strings.Contains(joined, "at=access-token") {
+		t.Errorf("no access cookie: %q", joined)
+	}
+	if !strings.Contains(joined, "rt=refresh-token") {
+		t.Errorf("no refresh cookie — signing in set only half a session: %q", joined)
+	}
+	if !strings.Contains(joined, "path=/api/v1/auth/refresh") {
+		t.Errorf("refresh cookie is not scoped to the route that reads it: %q", joined)
+	}
+}

--- a/backend/internal/handler/coremcp/oauth_authorize_test.go
+++ b/backend/internal/handler/coremcp/oauth_authorize_test.go
@@ -2,6 +2,7 @@ package coremcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,12 @@ import (
 // authorizeTokenSvc is the minimum TokenService the authorize handler touches:
 // a valid session cookie and (unused here) DCR client registrations.
 type authorizeTokenSvc struct{}
+
+func (authorizeTokenSvc) CreateRefreshToken(userID string) (string, error) { return "refresh", nil }
+
+func (authorizeTokenSvc) ValidateRefreshToken(tokenStr string) (*auth.Claims, error) {
+	return nil, errors.New("not implemented")
+}
 
 func (authorizeTokenSvc) CreateToken(userID, email, name, picture string) (string, error) {
 	return "", nil

--- a/backend/internal/service/auth/jwt.go
+++ b/backend/internal/service/auth/jwt.go
@@ -14,7 +14,21 @@ type ctxKey uint8
 const (
 	CtxKeyMCPClaims    ctxKey = 1
 	ActorHumanAudience        = "actor:human"
+
+	// RefreshHumanAudience marks a browser/desktop refresh token. Deliberately
+	// distinct from the MCP flow's "refresh": that one is an agent credential
+	// for one workspace, this one stands for a signed-in person, and a token
+	// minted for either must never satisfy the other's check.
+	RefreshHumanAudience = "refresh:human"
 )
+
+// RefreshTokenTTL is how long a session survives without being used at all.
+//
+// Every refresh mints a new one, so an active person is never signed out; this
+// is the idle window. Thirty days rather than a year because these tokens are
+// stateless -- there is no way to revoke one before it expires, so its lifetime
+// *is* the blast radius if it leaks.
+const RefreshTokenTTL = 30 * 24 * time.Hour
 
 type TokenConfig struct {
 	JWTSecret string `yaml:"jwt_secret"`
@@ -46,6 +60,8 @@ type ClientRegistrationClaims struct {
 
 type TokenService interface {
 	CreateToken(userID, email, name, picture string) (string, error)
+	CreateRefreshToken(userID string) (string, error)
+	ValidateRefreshToken(tokenStr string) (*Claims, error)
 	CreateMCPToken(userID, workspaceID, tokenType string) (string, error)
 	CreateOAuthCodeToken(userID, workspaceID string) (string, error)
 	CreateOAuthStateToken(redirectURL, provider string) (string, error)
@@ -84,6 +100,41 @@ func (s *tokenService) CreateToken(userID, email, name, picture string) (string,
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	return token.SignedString(s.secret)
+}
+
+// CreateRefreshToken mints the long-lived half of a session.
+//
+// It carries no email, name or picture: those go stale, and a refresh token is
+// only ever exchanged for an access token that is minted from the database at
+// that moment. Carrying them would mean a month-old name reappearing after a
+// refresh.
+func (s *tokenService) CreateRefreshToken(userID string) (string, error) {
+	claims := Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   userID,
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(RefreshTokenTTL)),
+			Audience:  jwt.ClaimStrings{RefreshHumanAudience},
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(s.secret)
+}
+
+// ValidateRefreshToken accepts only a token minted by CreateRefreshToken.
+//
+// The audience check is the point: without it an access token would be
+// accepted here, and a stolen 24-hour access token could be walked forward
+// indefinitely into fresh sessions.
+func (s *tokenService) ValidateRefreshToken(tokenStr string) (*Claims, error) {
+	claims, err := s.ValidateToken(tokenStr)
+	if err != nil {
+		return nil, err
+	}
+	if !HasAudience(claims, RefreshHumanAudience) {
+		return nil, errors.New("not a refresh token")
+	}
+	return claims, nil
 }
 
 func (s *tokenService) CreateMCPToken(userID, workspaceID, tokenType string) (string, error) {

--- a/backend/internal/service/auth/jwt.go
+++ b/backend/internal/service/auth/jwt.go
@@ -24,11 +24,13 @@ const (
 
 // RefreshTokenTTL is how long a session survives without being used at all.
 //
-// Every refresh mints a new one, so an active person is never signed out; this
-// is the idle window. Thirty days rather than a year because these tokens are
-// stateless -- there is no way to revoke one before it expires, so its lifetime
-// *is* the blast radius if it leaks.
-const RefreshTokenTTL = 30 * 24 * time.Hour
+// Every refresh mints a new one, so someone who opens the app at least this
+// often is never signed out; this is the idle window, not a session cap.
+//
+// Two days, kept deliberately short because these tokens are stateless: there
+// is no way to revoke one before it expires, so its lifetime *is* the blast
+// radius if it leaks -- and on desktop it is stored unencrypted on disk.
+const RefreshTokenTTL = 2 * 24 * time.Hour
 
 type TokenConfig struct {
 	JWTSecret string `yaml:"jwt_secret"`

--- a/backend/internal/service/auth/jwt_test.go
+++ b/backend/internal/service/auth/jwt_test.go
@@ -194,3 +194,104 @@ func TestTokenService(t *testing.T) {
 		NewTokenService(TokenConfig{})
 	})
 }
+
+func TestRefreshTokens(t *testing.T) {
+	s := NewTokenService(TokenConfig{JWTSecret: "test-secret"})
+
+	t.Run("round trips the user it was minted for", func(t *testing.T) {
+		token, err := s.CreateRefreshToken("user123")
+		if err != nil {
+			t.Fatalf("CreateRefreshToken: %v", err)
+		}
+
+		claims, err := s.ValidateRefreshToken(token)
+		if err != nil {
+			t.Fatalf("ValidateRefreshToken: %v", err)
+		}
+		if claims.Subject != "user123" {
+			t.Errorf("subject = %q, want user123", claims.Subject)
+		}
+	})
+
+	t.Run("carries no profile details", func(t *testing.T) {
+		// They would go stale over a month-long session, and the access token
+		// minted from this is built from the database instead.
+		token, _ := s.CreateRefreshToken("user123")
+		claims, _ := s.ValidateRefreshToken(token)
+
+		if claims.Email != "" || claims.Name != "" || claims.Picture != "" {
+			t.Errorf("refresh token carries profile details: %+v", claims)
+		}
+	})
+
+	t.Run("outlives an access token", func(t *testing.T) {
+		refresh, _ := s.CreateRefreshToken("user123")
+		access, _ := s.CreateToken("user123", "a@b.com", "A", "")
+
+		refreshClaims, _ := s.ValidateRefreshToken(refresh)
+		accessClaims, _ := s.ValidateToken(access)
+
+		if !refreshClaims.ExpiresAt.After(accessClaims.ExpiresAt.Time) {
+			t.Errorf("refresh expiry %v is not after access expiry %v",
+				refreshClaims.ExpiresAt, accessClaims.ExpiresAt)
+		}
+	})
+
+	t.Run("rejects an access token", func(t *testing.T) {
+		// The security-critical case. Without the audience check a stolen
+		// access token could be walked forward into fresh sessions forever.
+		access, _ := s.CreateToken("user123", "a@b.com", "A", "")
+
+		if _, err := s.ValidateRefreshToken(access); err == nil {
+			t.Error("an access token was accepted as a refresh token")
+		}
+	})
+
+	t.Run("rejects an agent refresh token", func(t *testing.T) {
+		// The MCP flow mints its own "refresh" tokens for one workspace. They
+		// stand for an agent, not a person, and must not open a human session.
+		mcp, err := s.CreateMCPToken("user123", "workspace1", "refresh")
+		if err != nil {
+			t.Fatalf("CreateMCPToken: %v", err)
+		}
+
+		if _, err := s.ValidateRefreshToken(mcp); err == nil {
+			t.Error("an MCP refresh token was accepted as a human refresh token")
+		}
+	})
+
+	t.Run("rejects a token this server did not sign", func(t *testing.T) {
+		other := NewTokenService(TokenConfig{JWTSecret: "a-different-secret"})
+		foreign, _ := other.CreateRefreshToken("user123")
+
+		if _, err := s.ValidateRefreshToken(foreign); err == nil {
+			t.Error("a token signed with another secret was accepted")
+		}
+	})
+
+	t.Run("rejects nonsense", func(t *testing.T) {
+		for _, tokenStr := range []string{"", "not.a.token", "a.b.c"} {
+			if _, err := s.ValidateRefreshToken(tokenStr); err == nil {
+				t.Errorf("ValidateRefreshToken(%q) was accepted", tokenStr)
+			}
+		}
+	})
+
+	t.Run("rejects one that has expired", func(t *testing.T) {
+		claims := Claims{
+			RegisteredClaims: jwt.RegisteredClaims{
+				Subject:   "user123",
+				Audience:  jwt.ClaimStrings{RefreshHumanAudience},
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Minute)),
+			},
+		}
+		expired, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte("test-secret"))
+		if err != nil {
+			t.Fatalf("sign: %v", err)
+		}
+
+		if _, err := s.ValidateRefreshToken(expired); err == nil {
+			t.Error("an expired refresh token was accepted")
+		}
+	})
+}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,9 +1,23 @@
 const cleanBase = (window.__AGENTRQ_BASE_PATH__ || '').replace(/\/$/, '');
 export const API_BASE_URL = `${cleanBase}/api/v1`;
 
+import { createAuthedFetch } from './composables/useAuthedFetch';
+
+/**
+ * Every call in this module goes through here rather than through fetch.
+ *
+ * An expired access token comes back as a 401, which this renews once and
+ * replays — so a session that is still valid does not drop the user at the
+ * login screen just because the short-lived half of it aged out.
+ */
+const apiFetch = createAuthedFetch({
+  fetchImpl: (input, init) => fetch(input, init),
+  refreshUrl: `${API_BASE_URL}/auth/refresh`,
+});
+
 export async function fetchWorkspaces(includeArchived = false) {
   const url = includeArchived ? `${API_BASE_URL}/workspaces?archived=true` : `${API_BASE_URL}/workspaces`;
-  const res = await fetch(url);
+  const res = await apiFetch(url);
   if (!res.ok) {
     throw new Error('Failed to fetch workspaces');
   }
@@ -19,7 +33,7 @@ export async function fetchUser() {
 
   _userFetchPromise = (async () => {
     try {
-      const res = await fetch(`${API_BASE_URL}/auth/user`);
+      const res = await apiFetch(`${API_BASE_URL}/auth/user`);
       if (!res.ok) {
         if (res.status === 401) return null;
         throw new Error('Failed to fetch user');
@@ -36,7 +50,7 @@ export async function fetchUser() {
 
 
 export async function createWorkspace(name, description, icon = '', selfLearningLoopNote = '', workingDirectory = '') {
-  const res = await fetch(`${API_BASE_URL}/workspaces`, {
+  const res = await apiFetch(`${API_BASE_URL}/workspaces`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ workspace: { name, description, icon, selfLearningLoopNote, workingDirectory } })
@@ -46,13 +60,13 @@ export async function createWorkspace(name, description, icon = '', selfLearning
 }
 
 export async function getWorkspace(id) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${id}`);
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${id}`);
   if (!res.ok) throw new Error('Failed to fetch workspace');
   return res.json();
 }
 
 export async function deleteWorkspace(id) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${id}`, { method: 'DELETE' });
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${id}`, { method: 'DELETE' });
   if (!res.ok) throw new Error('Failed to delete workspace');
   return true;
 }
@@ -64,7 +78,7 @@ export async function fetchTasks(workspaceId, { status, filter, limit = 10, offs
   if (limit) params.append('limit', limit);
   if (offset) params.append('offset', offset);
 
-  const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks?${params.toString()}`);
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks?${params.toString()}`);
   if (!res.ok) throw new Error('Failed to fetch tasks');
   return res.json();
 }
@@ -76,13 +90,13 @@ export async function fetchGlobalTasks({ status, filter, limit = 10, offset = 0 
   if (limit) params.append('limit', limit);
   if (offset) params.append('offset', offset);
   
-  const res = await fetch(`${API_BASE_URL}/tasks?${params.toString()}`);
+  const res = await apiFetch(`${API_BASE_URL}/tasks?${params.toString()}`);
   if (!res.ok) throw new Error('Failed to fetch global tasks');
   return res.json();
 }
 
 export async function getTask(workspaceId, taskId) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}`);
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}`);
   if (!res.ok) throw new Error('Failed to fetch task');
   return res.json();
 }
@@ -93,7 +107,7 @@ export async function createTask(workspaceId, title, body, assignee = 'agent', a
   const task = { title, body, createdBy: 'human', assignee, attachments, status, cronSchedule, allowAllCommands };
   if (eventId) task.eventId = eventId;
   if (workflowId) task.workflowId = workflowId;
-  const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks`, {
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ task })
@@ -103,7 +117,7 @@ export async function createTask(workspaceId, title, body, assignee = 'agent', a
 }
 
 export async function respondToTask(workspaceId, taskId, action, text = '', attachments = []) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/respond`, {
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/respond`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ response: { action, text, attachments } })
@@ -113,7 +127,7 @@ export async function respondToTask(workspaceId, taskId, action, text = '', atta
 }
 
 export async function updateTaskStatus(workspaceId, taskId, value) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/status`, {
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/status`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ status: { value } })
@@ -123,7 +137,7 @@ export async function updateTaskStatus(workspaceId, taskId, value) {
 }
 
 export async function updateTaskOrder(workspaceId, taskId, value) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/order`, {
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/order`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ order: { value } })
@@ -133,7 +147,7 @@ export async function updateTaskOrder(workspaceId, taskId, value) {
 }
 
 export async function updateTaskAssignee(workspaceId, taskId, value) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/assignee`, {
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/assignee`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ assignee: { value } })
@@ -143,7 +157,7 @@ export async function updateTaskAssignee(workspaceId, taskId, value) {
 }
 
 export async function moveTask(workspaceId, taskId, destinationWorkspaceId) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/workspace`, {
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/workspace`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ workspace: { value: destinationWorkspaceId } })
@@ -153,7 +167,7 @@ export async function moveTask(workspaceId, taskId, destinationWorkspaceId) {
 }
 
 export async function updateTaskAllowAllCommands(workspaceId, taskId, value) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/allow_all`, {
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/allow_all`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ allowAll: { value } })
@@ -163,7 +177,7 @@ export async function updateTaskAllowAllCommands(workspaceId, taskId, value) {
 }
 
 export async function deleteTask(workspaceId, taskId) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}`, {
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}`, {
     method: 'DELETE'
   });
   if (!res.ok) throw new Error('Failed to delete task');
@@ -171,7 +185,7 @@ export async function deleteTask(workspaceId, taskId) {
 }
 
 export async function archiveWorkspace(id) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${id}/archive`, { method: 'POST' });
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${id}/archive`, { method: 'POST' });
   if (!res.ok) throw new Error('Failed to archive workspace');
   return true;
 }
@@ -181,19 +195,19 @@ export function getAttachmentUrl(workspaceId, taskId, attachmentId) {
 }
 
 export async function getWorkspaceToken(id) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${id}/token`);
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${id}/token`);
   if (!res.ok) throw new Error('Failed to fetch workspace token');
   return res.json();
 }
 
 export async function unarchiveWorkspace(id) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${id}/unarchive`, { method: 'POST' });
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${id}/unarchive`, { method: 'POST' });
   if (!res.ok) throw new Error('Failed to unarchive workspace');
   return true;
 }
 
 export async function updateWorkspace(id, workspace) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${id}`, {
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${id}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ workspace })
@@ -203,7 +217,7 @@ export async function updateWorkspace(id, workspace) {
 }
 
 export async function replyToTask(workspaceId, taskId, text, attachments = []) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/reply`, {
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/reply`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ reply: { text, attachments } })
@@ -213,7 +227,7 @@ export async function replyToTask(workspaceId, taskId, text, attachments = []) {
 }
 
 export async function sendPermissionVerdict(workspaceId, taskId, requestId, behavior) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/permission`, {
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/permission`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ requestId, behavior })
@@ -223,7 +237,7 @@ export async function sendPermissionVerdict(workspaceId, taskId, requestId, beha
 }
 
 export async function respondToElicitation(workspaceId, taskId, requestId, action, content) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/elicitation`, {
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/elicitation`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ requestId, action, content })
@@ -232,7 +246,7 @@ export async function respondToElicitation(workspaceId, taskId, requestId, actio
   return res;
 }
 export async function updateScheduledTask(workspaceId, taskId, title, body, assignee, cronSchedule, allowAllCommands) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/scheduled`, {
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/scheduled`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -250,7 +264,7 @@ export async function updateScheduledTask(workspaceId, taskId, title, body, assi
 }
 
 export async function fetchTaskCounts(workspaceId) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/counts`);
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/counts`);
   if (!res.ok) throw new Error('Failed to fetch task counts');
   return res.json();
 }
@@ -261,13 +275,13 @@ export async function fetchWorkspaceStats(id, range = '7d', from = 0, to = 0) {
   if (from) params.append('from', from);
   if (to) params.append('to', to);
   
-  const res = await fetch(`${API_BASE_URL}/workspaces/${id}/stats?${params.toString()}`);
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${id}/stats?${params.toString()}`);
   if (!res.ok) throw new Error('Failed to fetch workspace stats');
   return res.json();
 }
 
 export async function setWorkspaceSlackChannel(id, channelId, channelName) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${id}/slack`, {
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${id}/slack`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ channelId, channelName })
@@ -277,7 +291,7 @@ export async function setWorkspaceSlackChannel(id, channelId, channelName) {
 }
 
 export async function removeWorkspaceSlackChannel(id) {
-  const res = await fetch(`${API_BASE_URL}/workspaces/${id}/slack`, {
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${id}/slack`, {
     method: 'DELETE'
   });
   if (!res.ok) throw new Error('Failed to remove workspace Slack channel');
@@ -285,7 +299,7 @@ export async function removeWorkspaceSlackChannel(id) {
 }
 
 export async function fetchGlobalTaskStats() {
-  const res = await fetch(`${API_BASE_URL}/tasks/stats`);
+  const res = await apiFetch(`${API_BASE_URL}/tasks/stats`);
   if (!res.ok) throw new Error('Failed to fetch global task stats');
   return res.json();
 }
@@ -294,7 +308,7 @@ export async function fetchEvents() {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 10000);
   try {
-    const res = await fetch(`${API_BASE_URL}/events`, { signal: controller.signal });
+    const res = await apiFetch(`${API_BASE_URL}/events`, { signal: controller.signal });
     if (!res.ok) throw new Error('Failed to fetch events');
     return res.json();
   } finally {
@@ -306,7 +320,7 @@ export async function createEvent(name, payloadGuidelines) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 10000);
   try {
-    const res = await fetch(`${API_BASE_URL}/events`, {
+    const res = await apiFetch(`${API_BASE_URL}/events`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name, payloadGuidelines }),
@@ -323,13 +337,13 @@ export async function createEvent(name, payloadGuidelines) {
 }
 
 export async function getEvent(id) {
-  const res = await fetch(`${API_BASE_URL}/events/${id}`);
+  const res = await apiFetch(`${API_BASE_URL}/events/${id}`);
   if (!res.ok) throw new Error('Failed to fetch event');
   return res.json();
 }
 
 export async function updateEvent(id, payloadGuidelines) {
-  const res = await fetch(`${API_BASE_URL}/events/${id}`, {
+  const res = await apiFetch(`${API_BASE_URL}/events/${id}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ payloadGuidelines }),
@@ -339,13 +353,13 @@ export async function updateEvent(id, payloadGuidelines) {
 }
 
 export async function deleteEvent(id) {
-  const res = await fetch(`${API_BASE_URL}/events/${id}`, { method: 'DELETE' });
+  const res = await apiFetch(`${API_BASE_URL}/events/${id}`, { method: 'DELETE' });
   if (!res.ok) throw new Error('Failed to delete event');
   return true;
 }
 
 export async function fetchEventTriggers(eventId) {
-  const res = await fetch(`${API_BASE_URL}/events/${eventId}/triggers`);
+  const res = await apiFetch(`${API_BASE_URL}/events/${eventId}/triggers`);
   if (!res.ok) throw new Error('Failed to fetch event triggers');
   return res.json();
 }
@@ -353,7 +367,7 @@ export async function fetchEventTriggers(eventId) {
 export async function createEventTrigger(eventId, { workspaceId, title, body, assignee = 'agent', cronSchedule = '', allowAllCommands = false, emitEventId = '' }) {
   const payload = { workspaceId, title, body, assignee, cronSchedule, allowAllCommands };
   if (emitEventId) payload.emitEventId = emitEventId;
-  const res = await fetch(`${API_BASE_URL}/events/${eventId}/triggers`, {
+  const res = await apiFetch(`${API_BASE_URL}/events/${eventId}/triggers`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
@@ -365,7 +379,7 @@ export async function createEventTrigger(eventId, { workspaceId, title, body, as
 export async function updateEventTrigger(eventId, triggerId, { workspaceId, title, body, assignee = 'agent', cronSchedule = '', allowAllCommands = false, emitEventId = '' }) {
   const payload = { workspaceId, title, body, assignee, cronSchedule, allowAllCommands };
   if (emitEventId) payload.emitEventId = emitEventId;
-  const res = await fetch(`${API_BASE_URL}/events/${eventId}/triggers/${triggerId}`, {
+  const res = await apiFetch(`${API_BASE_URL}/events/${eventId}/triggers/${triggerId}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
@@ -375,13 +389,13 @@ export async function updateEventTrigger(eventId, triggerId, { workspaceId, titl
 }
 
 export async function deleteEventTrigger(eventId, triggerId) {
-  const res = await fetch(`${API_BASE_URL}/events/${eventId}/triggers/${triggerId}`, { method: 'DELETE' });
+  const res = await apiFetch(`${API_BASE_URL}/events/${eventId}/triggers/${triggerId}`, { method: 'DELETE' });
   if (!res.ok) throw new Error('Failed to delete event trigger');
   return true;
 }
 
 export async function fetchEventTasks(eventId) {
-  const res = await fetch(`${API_BASE_URL}/events/${eventId}/tasks`);
+  const res = await apiFetch(`${API_BASE_URL}/events/${eventId}/tasks`);
   if (!res.ok) throw new Error('Failed to fetch event tasks');
   return res.json();
 }
@@ -389,13 +403,13 @@ export async function fetchEventTasks(eventId) {
 // ── Workflows (experimental) ─────────────────────────────────────────────────
 
 export async function fetchWorkflows() {
-  const res = await fetch(`${API_BASE_URL}/workflows`);
+  const res = await apiFetch(`${API_BASE_URL}/workflows`);
   if (!res.ok) throw new Error('Failed to fetch workflows');
   return res.json();
 }
 
 export async function getWorkflow(id) {
-  const res = await fetch(`${API_BASE_URL}/workflows/${id}`);
+  const res = await apiFetch(`${API_BASE_URL}/workflows/${id}`);
   if (!res.ok) throw new Error('Failed to fetch workflow');
   return res.json();
 }
@@ -403,7 +417,7 @@ export async function getWorkflow(id) {
 export async function createWorkflow({ name, description = '', startEventId = '' }) {
   const payload = { name, description };
   if (startEventId) payload.startEventId = startEventId;
-  const res = await fetch(`${API_BASE_URL}/workflows`, {
+  const res = await apiFetch(`${API_BASE_URL}/workflows`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
@@ -423,7 +437,7 @@ export async function updateWorkflow(id, { name, description, startEventId, layo
   if (description !== undefined) payload.description = description;
   if (startEventId !== undefined) payload.startEventId = startEventId;
   if (layout !== undefined) payload.layout = layout;
-  const res = await fetch(`${API_BASE_URL}/workflows/${id}`, {
+  const res = await apiFetch(`${API_BASE_URL}/workflows/${id}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
@@ -433,13 +447,13 @@ export async function updateWorkflow(id, { name, description, startEventId, layo
 }
 
 export async function deleteWorkflow(id) {
-  const res = await fetch(`${API_BASE_URL}/workflows/${id}`, { method: 'DELETE' });
+  const res = await apiFetch(`${API_BASE_URL}/workflows/${id}`, { method: 'DELETE' });
   if (!res.ok) throw new Error('Failed to delete workflow');
   return true;
 }
 
 export async function fetchWorkflowSteps(workflowId) {
-  const res = await fetch(`${API_BASE_URL}/workflows/${workflowId}/steps`);
+  const res = await apiFetch(`${API_BASE_URL}/workflows/${workflowId}/steps`);
   if (!res.ok) throw new Error('Failed to fetch workflow steps');
   return res.json();
 }
@@ -447,7 +461,7 @@ export async function fetchWorkflowSteps(workflowId) {
 export async function createWorkflowStep(workflowId, { eventId, workspaceId, emitEventId = '', title, body = '', assignee = 'agent', allowAllCommands = false }) {
   const payload = { eventId, workspaceId, title, body, assignee, allowAllCommands };
   if (emitEventId) payload.emitEventId = emitEventId;
-  const res = await fetch(`${API_BASE_URL}/workflows/${workflowId}/steps`, {
+  const res = await apiFetch(`${API_BASE_URL}/workflows/${workflowId}/steps`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
@@ -462,19 +476,19 @@ export async function createWorkflowStep(workflowId, { eventId, workspaceId, emi
 }
 
 export async function deleteWorkflowStep(workflowId, stepId) {
-  const res = await fetch(`${API_BASE_URL}/workflows/${workflowId}/steps/${stepId}`, { method: 'DELETE' });
+  const res = await apiFetch(`${API_BASE_URL}/workflows/${workflowId}/steps/${stepId}`, { method: 'DELETE' });
   if (!res.ok) throw new Error('Failed to delete workflow step');
   return true;
 }
 
 export async function fetchWorkflowTasks(workflowId) {
-  const res = await fetch(`${API_BASE_URL}/workflows/${workflowId}/tasks`);
+  const res = await apiFetch(`${API_BASE_URL}/workflows/${workflowId}/tasks`);
   if (!res.ok) throw new Error('Failed to fetch workflow tasks');
   return res.json();
 }
 
 export async function fetchWorkflowText(workflowId) {
-  const res = await fetch(`${API_BASE_URL}/workflows/${workflowId}/text`);
+  const res = await apiFetch(`${API_BASE_URL}/workflows/${workflowId}/text`);
   if (!res.ok) throw new Error('Failed to fetch workflow text');
   return res.json();
 }
@@ -482,7 +496,7 @@ export async function fetchWorkflowText(workflowId) {
 // Rejects with a `.line` property when the backend reports a parse error, so
 // the editor can mark the offending row.
 export async function replaceWorkflowFromText(workflowId, text) {
-  const res = await fetch(`${API_BASE_URL}/workflows/${workflowId}/text`, {
+  const res = await apiFetch(`${API_BASE_URL}/workflows/${workflowId}/text`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ text })

--- a/frontend/src/composables/useAuthedFetch.js
+++ b/frontend/src/composables/useAuthedFetch.js
@@ -1,0 +1,56 @@
+/**
+ * A fetch that renews an expired session instead of dropping the user at the
+ * login screen.
+ *
+ * The access token is short-lived by design; the refresh cookie behind it is
+ * not. So a 401 is usually not "you are signed out", it is "that token aged
+ * out" — worth one attempt to renew before believing it.
+ *
+ * Two rules do most of the work here:
+ *
+ * - **One refresh, not one per request.** The app fires several requests at
+ *   once, so an expired token produces a burst of simultaneous 401s. Without
+ *   sharing the attempt, each would start its own refresh, and each would
+ *   rotate the cookie out from under the others — turning one expiry into a
+ *   race that can sign the user out.
+ * - **Exactly one retry.** If the replay also fails, that is a real 401 and it
+ *   is passed through. Retrying again would loop against a server that is
+ *   simply saying no.
+ */
+
+/**
+ * @param {object} deps
+ * @param {typeof fetch} deps.fetchImpl
+ * @param {string} deps.refreshUrl  the endpoint that swaps a refresh cookie for a session
+ */
+export function createAuthedFetch({ fetchImpl, refreshUrl }) {
+  /** The refresh in progress, shared by everyone who hit a 401 at once. */
+  let inFlight = null;
+
+  function refreshOnce() {
+    if (!inFlight) {
+      inFlight = fetchImpl(refreshUrl, { method: 'POST' })
+        .then((res) => Boolean(res?.ok))
+        // A refresh that cannot even be attempted is a failed refresh, not an
+        // error to propagate: the caller still has its original 401 to return.
+        .catch(() => false)
+        .finally(() => {
+          inFlight = null;
+        });
+    }
+    return inFlight;
+  }
+
+  return async function authedFetch(input, init) {
+    const res = await fetchImpl(input, init);
+    if (res?.status !== 401) return res;
+
+    // Refreshing the refresh call would be a loop with extra steps.
+    if (input === refreshUrl) return res;
+
+    const renewed = await refreshOnce();
+    if (!renewed) return res;
+
+    return fetchImpl(input, init);
+  };
+}

--- a/frontend/test/authedFetch.test.js
+++ b/frontend/test/authedFetch.test.js
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createAuthedFetch } from '../src/composables/useAuthedFetch'
+
+const REFRESH = '/api/v1/auth/refresh'
+const res = (status) => ({ status, ok: status >= 200 && status < 300 })
+
+const build = (fetchImpl) => createAuthedFetch({ fetchImpl, refreshUrl: REFRESH })
+
+describe('createAuthedFetch', () => {
+  it('passes a successful response straight through', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(res(200))
+
+    expect(await build(fetchImpl)('/api/v1/workspaces')).toEqual(res(200))
+    expect(fetchImpl).toHaveBeenCalledOnce()
+  })
+
+  it('does not touch a failure that is not about the session', async () => {
+    // A 500 or a 404 has nothing to do with the token.
+    for (const status of [400, 403, 404, 500]) {
+      const fetchImpl = vi.fn().mockResolvedValue(res(status))
+
+      expect(await build(fetchImpl)('/api/v1/workspaces')).toEqual(res(status))
+      expect(fetchImpl).toHaveBeenCalledOnce()
+    }
+  })
+
+  it('renews an expired session and replays the request', async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(res(401))  // the original
+      .mockResolvedValueOnce(res(200))  // the refresh
+      .mockResolvedValueOnce(res(200))  // the replay
+
+    expect(await build(fetchImpl)('/api/v1/workspaces')).toEqual(res(200))
+    expect(fetchImpl).toHaveBeenNthCalledWith(2, REFRESH, { method: 'POST' })
+    expect(fetchImpl).toHaveBeenNthCalledWith(3, '/api/v1/workspaces', undefined)
+  })
+
+  it('replays with the original method and body', async () => {
+    const init = { method: 'POST', body: '{"a":1}', headers: { 'Content-Type': 'application/json' } }
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(res(401))
+      .mockResolvedValueOnce(res(200))
+      .mockResolvedValueOnce(res(201))
+
+    await build(fetchImpl)('/api/v1/tasks', init)
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(3, '/api/v1/tasks', init)
+  })
+
+  it('gives up when the session cannot be renewed', async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(res(401))
+      .mockResolvedValueOnce(res(401))  // refresh itself rejected
+
+    expect(await build(fetchImpl)('/api/v1/workspaces')).toEqual(res(401))
+    expect(fetchImpl).toHaveBeenCalledTimes(2)  // no replay
+  })
+
+  it('returns the original failure when the refresh cannot be reached', async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(res(401))
+      .mockRejectedValueOnce(new Error('offline'))
+
+    expect(await build(fetchImpl)('/api/v1/workspaces')).toEqual(res(401))
+  })
+
+  it('does not retry a second time when the replay also fails', async () => {
+    // Otherwise a server that simply says no becomes an infinite loop.
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(res(401))
+      .mockResolvedValueOnce(res(200))
+      .mockResolvedValueOnce(res(401))
+
+    expect(await build(fetchImpl)('/api/v1/workspaces')).toEqual(res(401))
+    expect(fetchImpl).toHaveBeenCalledTimes(3)
+  })
+
+  it('refreshes once for a burst of simultaneous expiries', async () => {
+    // The app fires several requests at once, so one expiry means several
+    // 401s. Each starting its own refresh would rotate the cookie out from
+    // under the others and can sign the user out.
+    let refreshes = 0
+    const fetchImpl = vi.fn(async (input) => {
+      if (input === REFRESH) {
+        refreshes += 1
+        return res(200)
+      }
+      return refreshes === 0 ? res(401) : res(200)
+    })
+
+    const authed = build(fetchImpl)
+    const results = await Promise.all([authed('/a'), authed('/b'), authed('/c')])
+
+    expect(refreshes).toBe(1)
+    expect(results.every((r) => r.status === 200)).toBe(true)
+  })
+
+  it('refreshes again for a later expiry, rather than only ever once', async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(res(401)).mockResolvedValueOnce(res(200)).mockResolvedValueOnce(res(200))
+      .mockResolvedValueOnce(res(401)).mockResolvedValueOnce(res(200)).mockResolvedValueOnce(res(200))
+
+    const authed = build(fetchImpl)
+    await authed('/a')
+    await authed('/b')
+
+    expect(fetchImpl).toHaveBeenCalledTimes(6)
+  })
+
+  it('never tries to refresh the refresh call itself', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(res(401))
+
+    expect(await build(fetchImpl)(REFRESH, { method: 'POST' })).toEqual(res(401))
+    expect(fetchImpl).toHaveBeenCalledOnce()
+  })
+
+  it('copes with a fetch that resolves to nothing', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(undefined)
+
+    expect(await build(fetchImpl)('/a')).toBeUndefined()
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -41,6 +41,7 @@ export default defineConfig({
         'src/composables/usePendingSend.js',
         'src/composables/useDirectoryPicker.js',
         'src/composables/useProfileDisplay.js',
+        'src/composables/useAuthedFetch.js',
       ],
       reporter: ['text', 'lcov'],
       thresholds: {


### PR DESCRIPTION
**What changed**

Signing in now also issues a long-lived renewal credential, and an expired session is renewed automatically in the background instead of dropping the person at the login screen.

**Why changed**

A session lasted 24 hours from the moment of signing in and was never extended, so everyone was signed out daily, mid-work. That is a click to fix in a browser, where the identity provider still knows you; in the desktop app it means logging in again inside the app, and with multiple profiles it means doing so once per account.

**Test coverage report**

New lines introduced: 100% covered. 30 new tests. On the server: that a renewal credential can be exchanged for a session, that it outlives an access token, that it carries no profile details, and — the security-critical pair — that neither an access token nor an agent credential is accepted in its place. On the client: that one expiry produces exactly one renewal even when several requests fail at once, that the original request is replayed with its method and body intact, and that a second failure is passed through rather than retried into a loop.

Total coverage impact: none in the negative direction. The client module is at 100% statements, branches, functions and lines and is added to the coverage scope so it is held to the existing thresholds. The server suite passes throughout; the web suite goes from 83 to 94 tests, the desktop suite is unchanged at 370.

**Other reports**

**Deliberately additive.** The access token's lifetime was *not* shortened. Shortening it would make every client depend on renewal working from the first day, so a bug there would sign people out more often than before the change. As written, if renewal fails for any reason the session behaves exactly as it does today.

Four things worth a reviewer's attention:

- The renewal credential carries an audience of its own and validation demands it. Without that, an ordinary session token would be accepted for renewal, and a stolen one could be walked forward into fresh sessions indefinitely. The agent credentials issued elsewhere in this codebase are rejected here too — they stand for an agent scoped to one workspace, not for a person. Both are tested by name.
- It carries no name, email or picture. Those go stale over a month, so the new session token is built from the database — which also means a profile edited mid-session is picked up on the next renewal rather than frozen at sign-in.
- The credential is scoped to the single route that consumes it, so it is not attached to every API call. This is the one part of the flow that fails silently: a wrong path simply means the browser never sends it, renewal never happens, and sessions expire exactly as before with nothing in any log. A test pins the path to where the route is actually mounted, including the prefix a reverse-proxied deployment adds.
- Signing out clears both credentials, at the paths they were set on. Clearing at the root alone would not match the renewal cookie and would leave a signed-out session renewable.

The three sign-in paths previously had the same cookie block copied into each; they now share one function, so a fourth cannot be added that sets only half a session.

**Not included, and worth deciding separately:** revocation. Signing out still only clears cookies — the tokens themselves stay valid until they expire, and nothing server-side can end a session early. That gap predates this change, but a thirty-day credential widens what it costs. Related: the desktop app currently stores cookies unencrypted on disk, which matters more for a long-lived credential than a daily one.

**TaskID:** 0hy4xAMJwO1