### PR TITLE
chore: bump patch version to v0.4.13

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.4.12"
+	_appVersion   = "v0.4.13"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.4.12" {
-			t.Errorf("Expected version v0.4.12, got %s", s.Version())
+		if s.Version() != "v0.4.13" {
+			t.Errorf("Expected version v0.4.13, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.4.12",
+      "version": "0.4.13",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.4.12",
+      "version": "0.4.13",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.4.12",
+  "version": "0.4.13",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
**What changed**

The project version moves from 0.4.12 to 0.4.13 everywhere it is declared — the desktop and web packages with their lockfiles, and the server's application version constant with the test asserting it.

**Why changed**

To cut the release carrying the two changes merged since the last one: multiple signed-in profiles in the desktop app, and refresh tokens so people are no longer signed out once a day.

**What ships since v0.4.12**

- feat: several accounts can be signed in at once in the desktop app and switched from the sidebar, each with its own session, server and notification settings, and each showing which account it belongs to (#386)
- feat: sessions are renewed in the background instead of ending after a day, with a two-day idle window that resets on use (#387)

**Test coverage report**

No executable code was added, so no new lines require coverage and total coverage is unaffected. The two changed assertions are the existing version test updated to the new value. All three suites pass: the server suite, 94 on the web front end, 370 in the desktop shell, with both 100% coverage gates holding.

**Other reports**

The version-sync guard was exercised as CI runs it: `GITHUB_REF=refs/tags/v0.4.13` reports both that the sources agree and that the tag matches the tree.

Both lockfiles were edited in place rather than regenerated, so this changes the version and nothing about dependency resolution.

Worth knowing before release: this is the first version carrying the refresh-token flow, so the thing to watch after tagging is that people stop being signed out daily. Two items remain open and are unchanged by this release — sessions still cannot be revoked server-side, and the desktop app still stores its cookies unencrypted on disk, which matters more now that one of them outlives a single day.

**TaskID:** 0hyDK7SK0DR