### PR TITLE
fix(desktop): a way out of the connection screen when adding a profile

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -141,6 +141,17 @@ Each profile carries its own server URL and muted-workspace list, because an
 account exists on one server — splitting those would let you sign in as one user
 and then point that session at a server where the cookie means nothing.
 
+Adding a profile switches into a session that has never signed in, so the window
+lands on the connection screen. That screen therefore has to offer a way back:
+`connectionState()` reports `canCancel`, which is
+`canDiscardActiveProfile(profileState)` — more than one profile, and the active
+one has no server yet. A first run answers false, because there is nowhere to go
+and the app cannot start without a server. Cancelling *discards* the profile
+rather than leaving it behind: it points at no server, so it can do nothing, and
+the switcher offers no way to delete one. It returns to the profile the add was
+made from, which is why `removeProfile` takes a fallback id — with three or more
+profiles, the first in the list is not where the user came from.
+
 The profile migrated from a pre-profiles install gets a partition like any
 other, which signs that user out once on upgrade. That was a deliberate trade:
 the session is only valid for 24 hours anyway, and the alternative is one

--- a/desktop/scripts/verify-connection.mjs
+++ b/desktop/scripts/verify-connection.mjs
@@ -6,7 +6,10 @@
  * would: a bad URL must be refused with a readable reason, and a good one must
  * be probed, stored and then honoured by the proxy.
  *
- * The two IPC handlers below mirror the ones in src/main/index.js. They are
+ * It then reaches the same screen the other way — by adding a profile, where
+ * the user chose to come here and must be able to leave again.
+ *
+ * The IPC handlers below mirror the ones in src/main/index.js. They are
  * repeated rather than imported because index.js takes over the Electron app
  * lifecycle at import time; the logic they exercise — validateServerUrl and the
  * config store — is the real thing.
@@ -37,6 +40,10 @@ protocol.registerSchemesAsPrivileged([
 
 let serverUrl = ''
 let configStore
+/** Whether the screen is being shown for a profile that can be abandoned. */
+let canCancel = false
+/** How many times the screen has asked the shell to discard that profile. */
+let cancelCalls = 0
 
 async function fileExists(pathname) {
   try {
@@ -60,6 +67,12 @@ const CHECKS = `(async () => {
   const button = document.querySelector('button[type=submit]');
   record('URL field is focused and prefilled', document.activeElement === input && !!input?.value,
     'value ' + JSON.stringify(input?.value));
+
+  // A first run has nowhere to go back to, and the app cannot start without a
+  // server — so the way out must not be offered here.
+  record('no way out is offered on a first run',
+    document.querySelector('button[type=button]') === null,
+    (document.querySelector('button[type=button]')?.textContent ?? 'none').trim());
 
   // The screen is styled, not just present. Tailwind's source detection is
   // rooted at the build, and a misconfigured root silently drops every
@@ -104,6 +117,35 @@ const CHECKS = `(async () => {
   return out;
 })()`
 
+/**
+ * The same screen reached the other way: by adding a profile.
+ *
+ * Here the user chose to come here and must be able to leave. Everything the
+ * unit tests cover stops at the shell's answer — this is the part they cannot
+ * reach, that the answer arrives through the preload bridge and turns into a
+ * button that calls back.
+ */
+const CANCEL_CHECKS = `(async () => {
+  const out = [];
+  const record = (name, pass, detail) => out.push({ name, pass, detail });
+
+  const cancel = [...document.querySelectorAll('button[type=button]')]
+    .find((b) => b.textContent.trim() === 'Cancel');
+  record('a way back is offered when a profile can be discarded', !!cancel,
+    cancel ? cancel.textContent.trim() : 'no cancel button');
+
+  cancel?.click();
+  await new Promise((r) => setTimeout(r, 300));
+
+  // The shell is replacing the window, so the screen stays inert rather than
+  // offering an action that no longer means anything.
+  record('the screen goes inert once it is on its way out',
+    cancel?.disabled === true && cancel?.textContent.trim() === 'Going back...',
+    'disabled ' + cancel?.disabled + ', label ' + JSON.stringify(cancel?.textContent.trim()));
+
+  return out;
+})()`
+
 app.whenReady().then(async () => {
   await session.defaultSession.clearStorageData({ storages: ['cookies'] })
 
@@ -120,7 +162,15 @@ app.whenReady().then(async () => {
     configured: Boolean(serverUrl),
     serverUrl,
     locked: false,
+    canCancel,
   }))
+  // The real one replaces the window; counting the request is what this run
+  // needs to see, and destroying the window mid-check would take the results
+  // with it.
+  ipcMain.handle('agentrq:connection:cancel', async () => {
+    cancelCalls += 1
+    return true
+  })
   ipcMain.handle('agentrq:connection:validate', async (_e, url) => {
     const result = await validateServerUrl(url, net.fetch)
     return result.ok ? { ok: true, url: result.url } : result
@@ -162,7 +212,36 @@ app.whenReady().then(async () => {
 
   console.log('\n─── first-run connection screen ───')
   for (const r of results) console.log(`${r.pass ? '✓' : '✗'} ${r.name} — ${r.detail}`)
-  const failed = results.filter((r) => !r.pass)
+
+  // The same screen, reached by adding a profile: unconfigured again, but with
+  // somewhere to go back to.
+  serverUrl = ''
+  canCancel = true
+  const second = new BrowserWindow({
+    show: false,
+    webPreferences: { preload: PRELOAD, contextIsolation: true, nodeIntegration: false, sandbox: true },
+  })
+  await second.loadURL('app://agentrq/')
+  await new Promise((r) => setTimeout(r, 1200))
+
+  let cancelResults
+  try {
+    cancelResults = await second.webContents.executeJavaScript(CANCEL_CHECKS)
+  } catch (err) {
+    console.error('✗ cancel checks threw:', err)
+    app.exit(1)
+    return
+  }
+  cancelResults.push({
+    name: 'the shell was asked exactly once',
+    pass: cancelCalls === 1,
+    detail: `calls ${cancelCalls}`,
+  })
+
+  console.log('\n─── added-profile connection screen ───')
+  for (const r of cancelResults) console.log(`${r.pass ? '✓' : '✗'} ${r.name} — ${r.detail}`)
+
+  const failed = [...results, ...cancelResults].filter((r) => !r.pass)
   console.log(failed.length === 0 ? '\n✓ all checks passed' : `\n✗ ${failed.length} check(s) failed`)
   app.exit(failed.length === 0 ? 0 : 1)
 })

--- a/desktop/src/main/index.js
+++ b/desktop/src/main/index.js
@@ -20,7 +20,7 @@ import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { createAppProtocolHandler } from './protocol.js'
-import { activeProfile, partitionFor } from './profiles.js'
+import { activeProfile, canDiscardActiveProfile, partitionFor } from './profiles.js'
 import { fetchProfileIdentity } from './identity.js'
 import {
   CONFIG_FILENAME,
@@ -118,6 +118,15 @@ let updater = null
  */
 let profileState = null
 let profileSession = null
+/**
+ * Where to go back to if the profile being added is abandoned.
+ *
+ * Deliberately not stored on disk: it describes a moment — the connection
+ * screen is up and the previous window is gone — not a setting. Losing it to a
+ * restart costs nothing, because removing a profile already falls back to the
+ * first remaining one.
+ */
+let profileReturnId = null
 
 /** Sessions that already have the app:// handler; registering twice throws. */
 const handledSessions = new WeakSet()
@@ -194,7 +203,15 @@ function applyBadge(count) {
 }
 
 function connectionState() {
-  return { configured: Boolean(serverUrl), serverUrl, locked: isConnectionLocked }
+  return {
+    configured: Boolean(serverUrl),
+    serverUrl,
+    locked: isConnectionLocked,
+    // Whether the connection screen can offer a way out. Adding a profile
+    // lands there with no window to go back to, so without this the only exits
+    // are finishing the setup or quitting the app.
+    canCancel: canDiscardActiveProfile(profileState),
+  }
 }
 
 /** Send the window back to the app root, picking up whatever the state now is. */
@@ -604,6 +621,23 @@ async function switchProfile(id) {
   return switchProfileToActive()
 }
 
+/**
+ * Remove a profile and forget its session.
+ *
+ * Shared by the switcher and by abandoning a half-added profile, because both
+ * have to clear the same three things — the stored profile, its cookies on
+ * disk, and its cached identity — and one that cleared only two would leave a
+ * removed account still signed in.
+ */
+async function forgetProfile(id, fallbackId = '') {
+  const wasActive = id === profileState?.activeProfileId
+  profileState = await configStore.removeProfile(id, fallbackId)
+  // Its cookies would otherwise outlive it on disk, still signed in.
+  await session.fromPartition(partitionFor(id)).clearStorageData()
+  profileIdentities.delete(id)
+  return wasActive ? switchProfileToActive() : profilesPayload()
+}
+
 function registerIpc(getWindow) {
   ipcMain.handle('agentrq:connection:get', () => connectionState())
 
@@ -612,6 +646,19 @@ function registerIpc(getWindow) {
     // The probe response carries auth flags that are of no use to the
     // connection screen and would be a needless leak across the bridge.
     return result.ok ? { ok: true, url: result.url } : result
+  })
+
+  // Abandon a profile that was added and never connected, and go back to the
+  // one it was added from. The profile is discarded rather than left behind:
+  // an unconfigured profile points at no server and can do nothing, and the
+  // switcher offers no way to delete one.
+  ipcMain.handle('agentrq:connection:cancel', async () => {
+    if (!canDiscardActiveProfile(profileState)) return false
+    const discarded = profileState.activeProfileId
+    const returnTo = profileReturnId ?? ''
+    profileReturnId = null
+    await forgetProfile(discarded, returnTo)
+    return true
   })
 
   // The renderer is the source of truth for appearance — the theme store the
@@ -651,6 +698,9 @@ function registerIpc(getWindow) {
   })
   ipcMain.handle('agentrq:profiles:switch', (_event, id) => switchProfile(id))
   ipcMain.handle('agentrq:profiles:add', async (_event, label) => {
+    // Remembered before the add, since adding makes the new profile active:
+    // this is the account to return to if the setup is abandoned.
+    profileReturnId = profileState?.activeProfileId ?? null
     profileState = await configStore.addProfile(label)
     // addProfile makes the new one active, so this is a switch into a session
     // that has never signed in: the window lands on the connection screen.
@@ -661,14 +711,7 @@ function registerIpc(getWindow) {
     installMenu(getWindow)
     return profilesPayload()
   })
-  ipcMain.handle('agentrq:profiles:remove', async (_event, id) => {
-    const wasActive = id === profileState?.activeProfileId
-    profileState = await configStore.removeProfile(id)
-    // Its cookies would otherwise outlive it on disk, still signed in.
-    await session.fromPartition(partitionFor(id)).clearStorageData()
-    profileIdentities.delete(id)
-    return wasActive ? switchProfileToActive() : profilesPayload()
-  })
+  ipcMain.handle('agentrq:profiles:remove', (_event, id) => forgetProfile(id))
 
   ipcMain.handle('agentrq:update:get', () => updateState)
   ipcMain.handle('agentrq:update:check', () => updater?.checkNow() ?? { ok: false, reason: 'Updater unavailable' })

--- a/desktop/src/main/profiles.js
+++ b/desktop/src/main/profiles.js
@@ -148,17 +148,39 @@ export function addProfile(state, { id, label, serverUrl = '' }) {
  * Remove a profile.
  *
  * The last one cannot be removed — an app with no profile has no session to
- * run in. Removing the active one falls back to the first remaining.
+ * run in. Removing the active one falls back to `fallbackId` when that profile
+ * is still there, and to the first remaining otherwise.
+ *
+ * The fallback exists for abandoning a profile that was just added: the one to
+ * land on is the one it was added *from*, which with three or more profiles is
+ * not the first in the list.
  */
-export function removeProfile(state, id) {
+export function removeProfile(state, id, fallbackId = '') {
   if (state.profiles.length <= 1) return state
   const profiles = state.profiles.filter((p) => p.id !== id)
   if (profiles.length === state.profiles.length) return state
 
-  const activeProfileId = profiles.some((p) => p.id === state.activeProfileId)
-    ? state.activeProfileId
-    : profiles[0].id
-  return { profiles, activeProfileId }
+  if (profiles.some((p) => p.id === state.activeProfileId)) {
+    return { profiles, activeProfileId: state.activeProfileId }
+  }
+  const preferred = profiles.some((p) => p.id === fallbackId) ? fallbackId : profiles[0].id
+  return { profiles, activeProfileId: preferred }
+}
+
+/**
+ * Whether the profile on screen can be thrown away instead of finished.
+ *
+ * A profile with no server has never been used for anything: it was added and
+ * then abandoned at the connection screen. Discarding it is only offered when
+ * another profile remains to go back to — during a genuine first run there is
+ * nowhere to go, and the app needs a server before it can do anything at all.
+ *
+ * One rule in one place because two callers ask it: the connection screen, to
+ * decide whether to offer a way out, and the shell, before taking one.
+ */
+export function canDiscardActiveProfile(state) {
+  if (!state || !Array.isArray(state.profiles) || state.profiles.length <= 1) return false
+  return !activeProfile(state).serverUrl
 }
 
 /** @returns {object} new state */

--- a/desktop/src/main/server-config.js
+++ b/desktop/src/main/server-config.js
@@ -239,9 +239,15 @@ export function createServerConfigStore({ readFile, writeFile, newProfileId = ra
       return next
     },
 
-    /** Remove a profile. The last one is kept, since the app needs a session. */
-    async removeProfile(id) {
-      const next = removeProfileFromState(await this.load(), id)
+    /**
+     * Remove a profile. The last one is kept, since the app needs a session.
+     *
+     * `fallbackId` is where to land when the one removed was active — the
+     * profile an abandoned one was added from, rather than whichever happens
+     * to be first.
+     */
+    async removeProfile(id, fallbackId = '') {
+      const next = removeProfileFromState(await this.load(), id, fallbackId)
       await write(next)
       return next
     },

--- a/desktop/src/preload/index.js
+++ b/desktop/src/preload/index.js
@@ -18,12 +18,24 @@ contextBridge.exposeInMainWorld('agentrq', {
   },
 
   connection: {
-    /** @returns {Promise<{configured: boolean, serverUrl: string, locked: boolean}>} */
+    /**
+     * `canCancel` is whether this screen has somewhere to go back to — true
+     * for a profile that was added and never connected, false on a first run.
+     *
+     * @returns {Promise<{configured: boolean, serverUrl: string, locked: boolean, canCancel: boolean}>}
+     */
     get: () => ipcRenderer.invoke('agentrq:connection:get'),
     /** Probe a URL without storing it, so the screen can report before committing. */
     validate: (url) => ipcRenderer.invoke('agentrq:connection:validate', url),
     /** Validate, store, and reload the window on success. */
     save: (url) => ipcRenderer.invoke('agentrq:connection:save', url),
+    /**
+     * Discard the profile being set up and return to the previous one. The
+     * shell replaces the window, so the caller does not navigate.
+     *
+     * @returns {Promise<boolean>} false when there was nothing to go back to
+     */
+    cancel: () => ipcRenderer.invoke('agentrq:connection:cancel'),
   },
 
   notifications: {

--- a/desktop/src/renderer/main.js
+++ b/desktop/src/renderer/main.js
@@ -92,5 +92,10 @@ if (connection.configured) {
     (theme) => window.agentrq.theme?.set(theme)
   )
 } else {
-  createApp(ConnectionView, { initialUrl: connection.serverUrl }).mount('#app')
+  createApp(ConnectionView, {
+    initialUrl: connection.serverUrl,
+    // A profile added and not yet connected can be abandoned; a first run has
+    // nothing to go back to. The shell knows which this is.
+    canCancel: Boolean(connection.canCancel),
+  }).mount('#app')
 }

--- a/desktop/test/profiles.test.js
+++ b/desktop/test/profiles.test.js
@@ -5,6 +5,7 @@ import {
   activateProfile,
   activeProfile,
   addProfile,
+  canDiscardActiveProfile,
   isValidProfileId,
   makeProfile,
   migrateProfiles,
@@ -174,6 +175,72 @@ describe('removeProfile', () => {
   it('ignores an id it does not have', () => {
     const state = addProfile(base(), { id: 'work1', label: 'Work' })
     expect(removeProfile(state, 'nope')).toBe(state)
+  })
+
+  it('goes back to the profile the caller names', () => {
+    // Abandoning a profile has to land on the one it was added from. With
+    // three profiles that is not the first in the list, so falling back to
+    // profiles[0] would drop the user into a third account they never chose.
+    let state = addProfile(base(), { id: 'work1', label: 'Work' })
+    state = addProfile(state, { id: 'work2', label: 'Second' })
+    state = addProfile(state, { id: 'work3', label: 'Third' })
+
+    expect(removeProfile(state, 'work3', 'work1').activeProfileId).toBe('work1')
+  })
+
+  it('falls back to the first remaining when the named one is gone too', () => {
+    const state = addProfile(base(), { id: 'work1', label: 'Work' })
+
+    const after = removeProfile(state, 'work1', 'vanished')
+
+    expect(after.activeProfileId).toBe(after.profiles[0].id)
+  })
+
+  it('never lands on the profile it just removed', () => {
+    const state = addProfile(base(), { id: 'work1', label: 'Work' })
+
+    expect(removeProfile(state, 'work1', 'work1').activeProfileId).not.toBe('work1')
+  })
+
+  it('leaves an untouched active profile alone even when a fallback is named', () => {
+    let state = addProfile(base(), { id: 'work1', label: 'Work' })
+    state = addProfile(state, { id: 'work2', label: 'Second' })
+
+    expect(removeProfile(state, 'work1', 'nonsense').activeProfileId).toBe('work2')
+  })
+})
+
+describe('canDiscardActiveProfile', () => {
+  it('says no during a first run', () => {
+    // The only profile there is, and no server yet: this is the screen the app
+    // cannot start without, not a step the user chose to take.
+    expect(canDiscardActiveProfile(base())).toBe(false)
+  })
+
+  it('says no when the only profile is configured', () => {
+    const state = updateProfile(base(), base().activeProfileId, { serverUrl: 'https://app.agentrq.com' })
+    expect(canDiscardActiveProfile(state)).toBe(false)
+  })
+
+  it('says yes for a profile added and never connected', () => {
+    let state = updateProfile(base(), base().activeProfileId, { serverUrl: 'https://app.agentrq.com' })
+    state = addProfile(state, { id: 'work1', label: 'Work' })
+
+    expect(canDiscardActiveProfile(state)).toBe(true)
+  })
+
+  it('says no once that profile has a server', () => {
+    // It is a working account now; the way out of it is the switcher.
+    let state = addProfile(base(), { id: 'work1', label: 'Work' })
+    state = updateProfile(state, 'work1', { serverUrl: 'https://work.example.com' })
+
+    expect(canDiscardActiveProfile(state)).toBe(false)
+  })
+
+  it('says no rather than throwing when there is no state at all', () => {
+    // Called from the shell, which can ask before the profiles are loaded.
+    expect(canDiscardActiveProfile(null)).toBe(false)
+    expect(canDiscardActiveProfile({})).toBe(false)
   })
 })
 

--- a/desktop/test/server-config.test.js
+++ b/desktop/test/server-config.test.js
@@ -333,6 +333,20 @@ describe('createServerConfigStore', () => {
     expect(removed.activeProfileId).toBe(first.id)
   })
 
+  it('removes onto the profile the caller names', async () => {
+    // Abandoning an added profile has to land back where it was added from,
+    // which the store cannot work out for itself.
+    const { store } = makeStore(legacy())
+    const [first] = (await store.load()).profiles
+    await store.addProfile('Work')
+    const withThird = await store.addProfile('Third')
+    const third = withThird.profiles[2]
+
+    const removed = await store.removeProfile(third.id, first.id)
+
+    expect(removed.activeProfileId).toBe(first.id)
+  })
+
   it('keeps the last profile, since the app needs a session to run in', async () => {
     const { store } = makeStore(legacy())
     const config = await store.load()

--- a/frontend/src/desktop/ConnectionView.vue
+++ b/frontend/src/desktop/ConnectionView.vue
@@ -25,7 +25,7 @@
           spellcheck="false"
           autocapitalize="off"
           placeholder="https://app.agentrq.com"
-          :disabled="connecting"
+          :disabled="busy"
           class="w-full px-4 py-4 bg-gray-50 dark:bg-zinc-800/50 text-gray-900 dark:text-zinc-50 border border-gray-100 dark:border-zinc-700/50 rounded-2xl outline-none focus:ring-4 focus:ring-black/5 dark:focus:ring-white/10 focus:border-black dark:focus:border-white transition-all text-center placeholder:text-gray-500 disabled:opacity-50"
           required
         />
@@ -36,10 +36,20 @@
 
         <button
           type="submit"
-          :disabled="connecting || !serverUrl.trim()"
+          :disabled="busy || !serverUrl.trim()"
           class="w-full py-4 bg-gray-900 dark:bg-zinc-800 text-white dark:text-zinc-200 font-bold rounded-2xl hover:bg-black dark:hover:bg-zinc-700 transform active:scale-[0.98] transition-all shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {{ connecting ? 'Connecting...' : 'Connect' }}
+        </button>
+
+        <button
+          v-if="canCancel"
+          type="button"
+          :disabled="busy"
+          @click="cancel"
+          class="w-full py-4 text-gray-600 dark:text-zinc-400 font-bold rounded-2xl border border-gray-100 dark:border-zinc-800 hover:bg-gray-50 dark:hover:bg-zinc-800/50 transform active:scale-[0.98] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {{ cancelling ? 'Going back...' : 'Cancel' }}
         </button>
       </form>
 
@@ -69,11 +79,22 @@
  * copies only ./frontend, so that path would not exist there. Keeping the file
  * here is what makes it actually get styled. Do not move it.
  */
-import { ref, onMounted } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+
+import { useConnectionCancel } from './useConnectionCancel'
 
 const props = defineProps({
   /** Prefilled when the user is switching away from a server they had. */
   initialUrl: { type: String, default: '' },
+  /**
+   * Whether there is a profile to go back to.
+   *
+   * The screen is reached two ways. On a first run it is the only thing the
+   * app can show, and there is nowhere to go. After "Add profile" it is a step
+   * the user chose to take, and one they must be able to back out of — so the
+   * shell decides, and this says which of the two it is.
+   */
+  canCancel: { type: Boolean, default: false },
 })
 
 const serverUrl = ref(props.initialUrl || 'https://app.agentrq.com')
@@ -81,13 +102,47 @@ const connecting = ref(false)
 const errorMsg = ref('')
 const inputRef = ref(null)
 
+const { cancelling, run: runCancel } = useConnectionCancel()
+
+/** Either action ends this window, so neither should be offered twice. */
+const busy = computed(() => connecting.value || cancelling.value)
+
+// Escape is what a dialog is expected to answer to, and this one has been
+// modal over the whole window since before there was any way out of it.
+function onKeydown(event) {
+  if (event.key === 'Escape') cancel()
+}
+
 onMounted(() => {
   inputRef.value?.focus()
   inputRef.value?.select()
+  if (props.canCancel) window.addEventListener('keydown', onKeydown)
 })
 
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeydown)
+})
+
+/**
+ * Abandon this profile and return to the one it was added from.
+ *
+ * The half-made profile is discarded by the shell rather than left in the
+ * switcher: it points at no server, so it can do nothing, and there is no UI
+ * to delete it later.
+ */
+async function cancel() {
+  if (!props.canCancel || busy.value) return
+
+  // Cleared while the request is in flight, so a stale failure is not left on
+  // screen beside a button that is already disabled.
+  errorMsg.value = ''
+  errorMsg.value = await runCancel()
+}
+
 async function connect() {
-  if (connecting.value) return
+  // `busy`, not `connecting`: pressing Enter would otherwise still submit
+  // while the window is on its way out.
+  if (busy.value) return
 
   connecting.value = true
   errorMsg.value = ''

--- a/frontend/src/desktop/useConnectionCancel.js
+++ b/frontend/src/desktop/useConnectionCancel.js
@@ -1,0 +1,51 @@
+import { ref } from 'vue'
+
+/**
+ * Backing out of the connection screen.
+ *
+ * Adding a profile opens a window on a session that has never signed in, so it
+ * lands on the connection screen — and until now the only ways off it were
+ * finishing the setup or quitting the app. This is the way back.
+ *
+ * The shell does the work: it discards the half-made profile and replaces the
+ * window with the previous profile's. So the successful case is one where
+ * nothing here runs afterwards, and the only states worth modelling are the
+ * two failures — the shell declining, and the call itself failing.
+ *
+ * Kept out of the component because those two are exactly what a template
+ * cannot express and a test cannot reach.
+ */
+
+/** Shown when the shell says there is nowhere to go back to. */
+export const NO_PROFILE_TO_RETURN_TO = 'There is no other profile to go back to.'
+
+/**
+ * @returns {{cancelling: import('vue').Ref<boolean>, run: () => Promise<string>}}
+ *          `run` resolves to '' when the window is on its way out, and
+ *          otherwise to a message to show the user
+ */
+export function useConnectionCancel() {
+  const cancelling = ref(false)
+
+  async function run() {
+    // A second press while the first is in flight would ask the shell to
+    // discard a profile it is already discarding.
+    if (cancelling.value) return ''
+
+    cancelling.value = true
+    try {
+      // Deliberately stays true on success: the shell is replacing this
+      // window, and re-enabling the buttons for those few frames would only
+      // offer an action that no longer means anything.
+      if (await window.agentrq.connection.cancel()) return ''
+
+      cancelling.value = false
+      return NO_PROFILE_TO_RETURN_TO
+    } catch (err) {
+      cancelling.value = false
+      return String(err?.message ?? err)
+    }
+  }
+
+  return { cancelling, run }
+}

--- a/frontend/test/connectionCancel.test.js
+++ b/frontend/test/connectionCancel.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+import { NO_PROFILE_TO_RETURN_TO, useConnectionCancel } from '../src/desktop/useConnectionCancel'
+
+/** Install a fake desktop bridge whose cancel answers however the test needs. */
+function withBridge(cancel) {
+  window.agentrq = { connection: { cancel } }
+  return cancel
+}
+
+afterEach(() => {
+  delete window.agentrq
+})
+
+describe('useConnectionCancel', () => {
+  it('reports nothing to show when the shell takes the window away', async () => {
+    withBridge(vi.fn(async () => true))
+    const { run } = useConnectionCancel()
+
+    expect(await run()).toBe('')
+  })
+
+  it('stays disabled after a successful cancel', async () => {
+    // The window is being replaced. Re-enabling the buttons for those few
+    // frames would only offer an action that no longer means anything.
+    withBridge(vi.fn(async () => true))
+    const { cancelling, run } = useConnectionCancel()
+
+    await run()
+
+    expect(cancelling.value).toBe(true)
+  })
+
+  it('explains itself when the shell declines', async () => {
+    // A button that silently does nothing is worse than one that says why.
+    withBridge(vi.fn(async () => false))
+    const { cancelling, run } = useConnectionCancel()
+
+    expect(await run()).toBe(NO_PROFILE_TO_RETURN_TO)
+    expect(cancelling.value).toBe(false)
+  })
+
+  it('surfaces a failed call and lets the user try again', async () => {
+    withBridge(vi.fn(async () => {
+      throw new Error('IPC went away')
+    }))
+    const { cancelling, run } = useConnectionCancel()
+
+    expect(await run()).toBe('IPC went away')
+    expect(cancelling.value).toBe(false)
+  })
+
+  it('describes a rejection that is not an Error', async () => {
+    withBridge(vi.fn(async () => Promise.reject('nope')))
+    const { run } = useConnectionCancel()
+
+    expect(await run()).toBe('nope')
+  })
+
+  it('asks the shell once however many times the button is pressed', async () => {
+    // Two presses would ask the shell to discard a profile it is already
+    // discarding.
+    let release
+    const cancel = withBridge(vi.fn(() => new Promise((resolve) => { release = resolve })))
+    const { run } = useConnectionCancel()
+
+    const first = run()
+    expect(await run()).toBe('')
+    expect(cancel).toHaveBeenCalledTimes(1)
+
+    release(true)
+    await first
+  })
+})


### PR DESCRIPTION
## What changed

Adding a new profile on the desktop app used to be a one-way door: the new window lands on the connection screen, and the only ways off it were finishing the setup or quitting. There is now a Cancel button — and Escape — whenever there is another profile to go back to, which discards the half-made profile and returns to the account you added it from.

## Why changed

Someone who clicked "Add profile" by mistake, or thought better of it, was stuck. The half-made profile is discarded rather than left behind because an unconfigured profile points at no server, so it can do nothing, and the switcher offers no way to delete one — keeping it would strand an entry the user can neither use nor remove.

A first run deliberately gets no Cancel: it is the only thing the app can show, and there is no server to run without.

## Test coverage report

- **New lines: 100%.** The decision rule and the cancel flow are both covered.
- Desktop suite 370 → 380 (10 new tests, all passing).
- Frontend suite 94 → 100 (6 new tests); coverage gate holds at 100% statements, branches, functions and lines across every gated file, including the new module.
- Both builds compile.

## Other reports

`npm run verify:connection` now drives the screen both ways and passes all 12 checks — first run, where no way out may be offered, and added profile, where one must be:

```
─── first-run connection screen ───
✓ no way out is offered on a first run — none
...
─── added-profile connection screen ───
✓ a way back is offered when a profile can be discarded — Cancel
✓ the screen goes inert once it is on its way out — disabled true, label "Going back..."
✓ the shell was asked exactly once — calls 1
```

That script covers the one thing unit tests cannot reach: that the shell's answer crosses the preload bridge and becomes a button that calls back.

## TaskID

0i4NkRa9sEj