### PR TITLE
chore: bump patch version to v0.4.14

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.4.13"
+	_appVersion   = "v0.4.14"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.4.13" {
-			t.Errorf("Expected version v0.4.13, got %s", s.Version())
+		if s.Version() != "v0.4.14" {
+			t.Errorf("Expected version v0.4.14, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.4.13",
+      "version": "0.4.14",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.4.13",
+      "version": "0.4.14",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
## What changed

The project version moves from 0.4.13 to 0.4.14 everywhere it is declared — the desktop app, the web frontend and the backend.

## Why changed

Cutting a release. The tag build refuses to package a tree whose versions disagree, and electron-updater compares the desktop version against the published release, so all six declarations move together.

## Test coverage report

No new lines — this is a version change only, so coverage is unaffected. The backend config test asserting the version was updated alongside it and passes.

## Other reports

Version sync verified in both forms, including the one CI runs on a tag build:

```
✓ desktop, frontend and backend are all at 0.4.14
✓ tag v0.4.14 matches version 0.4.14
```

`npm ci` still succeeds in both `desktop/` and `frontend/` — the lockfile version fields were edited by hand rather than regenerated, so no dependency resolution shifted underneath the release.

### Shipping in this version

- **fix(desktop):** a way out of the connection screen when adding a profile (#389) — Cancel and Escape now work whenever there is another profile to go back to, discarding the half-made profile and returning to the account it was added from.

## TaskID

0i4SgoXA481