### PR TITLE
fix(desktop): give the window something to be dragged by on macOS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Consequences worth knowing before changing anything here:
   bridge in `desktop/src/preload/`. Components branch on `usePlatformStore()`,
   never on user-agent sniffing or probing for `window.agentrq`.
 
-### Two traps that are invisible in source
+### Three traps that are invisible in source
 
 - **Tailwind scans from the build root.** The desktop build's Vite root is
   `desktop/src/renderer`, so a class used only in a file under `desktop/` is
@@ -45,6 +45,13 @@ Consequences worth knowing before changing anything here:
   unstyled. `frontend/src/style.css` declares `@source './'` to fix this, and
   desktop-only *views* live in `frontend/src/desktop/` for the same reason.
   Moving them into `desktop/` breaks their styling with no error.
+- **macOS hides the title bar, so the page owns the window.** The window is
+  created with `titleBarStyle: 'hiddenInset'`, and a window with no title bar
+  cannot be dragged until the page declares a region with `-webkit-app-region:
+  drag` — the `.app-drag` class. The traffic lights are also drawn over the
+  top-left of the page, so that same strip reserves their space. Both are gated
+  on `platformStore.isMacDesktop`; making page content draggable on Windows or
+  Linux would only remove text selection.
 - **macOS only routes a URL scheme an app declares in its bundle.** Calling
   `app.setAsDefaultProtocolClient()` is enough for Windows and Linux, but the
   `protocols` entry in `desktop/electron-builder.yml` is what makes

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -157,6 +157,26 @@ other, which signs that user out once on upgrade. That was a deliberate trade:
 the session is only valid for 24 hours anyway, and the alternative is one
 profile permanently special-cased wherever a session is resolved.
 
+## The title bar, and who owns the window
+
+On macOS the window is created with `titleBarStyle: 'hiddenInset'` so the app
+fills it. Two things follow, and neither is visible from that line:
+
+- **A window with no title bar has no handle.** It cannot be moved at all until
+  the page declares one with `-webkit-app-region: drag`. That is the `.app-drag`
+  class in `frontend/src/style.css`, applied to a strip across the top of both
+  `App.vue` and the connection screen. A dragging region also swallows clicks,
+  so anything interactive placed inside one needs `.app-no-drag`.
+- **The traffic lights are drawn over the page.** They sit in the top-left,
+  which is where the sidebar starts, so the same strip reserves the space for
+  them. Without it the close, minimise and zoom buttons land on the logo.
+
+Both are macOS-only: Windows and Linux use `'default'` and keep a real title
+bar, where making page content draggable would take away text selection for
+nothing. The renderer decides with `platformStore.isMacDesktop`, which is why
+the shell passes `os` into `createAgentRQApp` — the connection screen takes it
+as a prop instead, since it is mounted before pinia exists.
+
 ## The native shell
 
 Everything the browser cannot offer lives in the main process and reaches the

--- a/desktop/scripts/verify-connection.mjs
+++ b/desktop/scripts/verify-connection.mjs
@@ -74,6 +74,16 @@ const CHECKS = `(async () => {
     document.querySelector('button[type=button]') === null,
     (document.querySelector('button[type=button]')?.textContent ?? 'none').trim());
 
+  // macOS hides the title bar, so this screen has to declare the window's drag
+  // handle itself — without one the window cannot be moved at all. Elsewhere
+  // there is a real title bar and the page must not claim page content as a
+  // handle.
+  const drag = document.querySelector('.app-drag');
+  const region = drag ? getComputedStyle(drag).webkitAppRegion : 'none';
+  record('the window can be dragged where it has no title bar',
+    ${process.platform === 'darwin'} ? region === 'drag' : drag === null,
+    'region ' + region);
+
   // The screen is styled, not just present. Tailwind's source detection is
   // rooted at the build, and a misconfigured root silently drops every
   // utility — which looks fine in the DOM and broken on screen.

--- a/desktop/src/renderer/main.js
+++ b/desktop/src/renderer/main.js
@@ -38,6 +38,9 @@ if (connection.configured) {
   const { app, router } = createAgentRQApp({
     history: createWebHistory('/'),
     platform: 'desktop',
+    // macOS hides the title bar, which leaves the page to draw the window's
+    // drag handle and to keep its own chrome clear of the traffic lights.
+    os: window.agentrq.platform,
   })
 
   // Every "go here" from the shell arrives on one channel: notification
@@ -97,5 +100,8 @@ if (connection.configured) {
     // A profile added and not yet connected can be abandoned; a first run has
     // nothing to go back to. The shell knows which this is.
     canCancel: Boolean(connection.canCancel),
+    // Passed rather than read from the platform store: this view is mounted on
+    // its own, before the application and its pinia exist.
+    isMac: window.agentrq.platform === 'darwin',
   }).mount('#app')
 }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,10 +1,23 @@
 <template>
-  <div id="app" class="flex flex-col md:flex-row h-[100dvh] bg-zinc-100 dark:bg-zinc-950 font-inter overflow-hidden">
+  <div id="app"
+       :class="[
+         'flex flex-col md:flex-row h-[100dvh] bg-zinc-100 dark:bg-zinc-950 font-inter overflow-hidden',
+         isMacDesktop ? 'pt-10' : ''
+       ]">
+
+    <!-- The window's drag handle, and the space the traffic lights sit in.
+         macOS desktop only: the shell hides the title bar there, so without
+         this the window cannot be moved and the close, minimise and zoom
+         buttons are drawn on top of the sidebar. -->
+    <div v-if="isMacDesktop" class="app-drag fixed top-0 inset-x-0 h-10 z-[150]" aria-hidden="true"></div>
 
     <!-- PWA Update Banner -->
     <Transition name="slide-down">
       <div v-if="needRefresh && !isUpdating"
-           class="fixed top-0 inset-x-0 z-[200] flex items-center justify-between gap-3 px-4 py-2.5 bg-black text-white text-xs font-medium shadow-lg">
+           :class="[
+             'fixed inset-x-0 z-[200] flex items-center justify-between gap-3 px-4 py-2.5 bg-black text-white text-xs font-medium shadow-lg',
+             isMacDesktop ? 'top-10' : 'top-0'
+           ]">
         <div class="flex items-center gap-2">
           <svg class="w-3.5 h-3.5 shrink-0 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
@@ -402,6 +415,9 @@ const platformStore = usePlatformStore()
 const profiles = ref([])
 const switchingProfile = ref(false)
 const showProfiles = computed(() => platformStore.isDesktop && profiles.value.length > 0)
+
+/** Whether this build has to draw its own window chrome. See style.css. */
+const isMacDesktop = computed(() => platformStore.isMacDesktop)
 const activeProfile = computed(() => profiles.value.find((p) => p.active) ?? null)
 const otherProfiles = computed(() => profiles.value.filter((p) => !p.active))
 

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -102,10 +102,14 @@ export function createAuthGuard(fetchUserFn = fetchUser) {
  * @param {'web'|'desktop'} [options.platform]
  *        Recorded in the platform store, which is the seam components use to
  *        offer a desktop-only affordance without forking.
+ * @param {string} [options.os]
+ *        `process.platform` from the desktop shell. Only macOS behaves
+ *        differently — it hides the title bar, leaving the page to draw the
+ *        window's drag handle — and the browser has no use for it at all.
  * @returns {{ app: import('vue').App, router: import('vue-router').Router, pinia: import('pinia').Pinia }}
  *          Unmounted, so the caller can do platform-specific setup first.
  */
-export function createAgentRQApp({ history, platform = 'web' } = {}) {
+export function createAgentRQApp({ history, platform = 'web', os = '' } = {}) {
   const router = createRouter({ history, routes })
   router.beforeEach(createAuthGuard())
 
@@ -118,7 +122,7 @@ export function createAgentRQApp({ history, platform = 'web' } = {}) {
 
   // Passing the pinia instance explicitly: this runs before mount, so there is
   // no active instance for the store to infer.
-  usePlatformStore(pinia).setPlatform(platform)
+  usePlatformStore(pinia).setPlatform(platform, os)
 
   return { app, router, pinia }
 }

--- a/frontend/src/desktop/ConnectionView.vue
+++ b/frontend/src/desktop/ConnectionView.vue
@@ -1,4 +1,10 @@
 <template>
+  <!-- The window's drag handle. This screen is the first thing a macOS user
+       sees, and with the title bar hidden there is otherwise nothing on the
+       window to grab. A sibling of the dialog rather than a child: it is part
+       of the window, not part of the dialog. -->
+  <div v-if="isMac" class="app-drag fixed top-0 inset-x-0 h-10 z-[60]" aria-hidden="true"></div>
+
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-gray-50/80 dark:bg-zinc-950/80 backdrop-blur-sm" aria-modal="true" role="dialog">
     <div class="w-full max-w-md p-8 bg-white dark:bg-zinc-900 rounded-3xl shadow-2xl border border-gray-100 dark:border-zinc-800">
       <div class="mb-10 text-center">
@@ -95,6 +101,12 @@ const props = defineProps({
    * shell decides, and this says which of the two it is.
    */
   canCancel: { type: Boolean, default: false },
+  /**
+   * Whether the shell hid the title bar, which it does only on macOS. The
+   * card is centred, so nothing here collides with the traffic lights — the
+   * window just needs somewhere to be grabbed by.
+   */
+  isMac: { type: Boolean, default: false },
 })
 
 const serverUrl = ref(props.initialUrl || 'https://app.agentrq.com')

--- a/frontend/src/stores/platformStore.js
+++ b/frontend/src/stores/platformStore.js
@@ -4,6 +4,15 @@ import { defineStore } from 'pinia'
 const KNOWN_PLATFORMS = ['web', 'desktop']
 
 /**
+ * What `process.platform` calls macOS.
+ *
+ * The desktop shell hides the title bar there, which is the one case where the
+ * page has to draw its own window chrome — so the app needs to know the OS, not
+ * only that it is the desktop build.
+ */
+const MACOS = 'darwin'
+
+/**
  * Which shell the app is running inside.
  *
  * The desktop build renders the very same components as the browser build, so
@@ -17,16 +26,27 @@ const KNOWN_PLATFORMS = ['web', 'desktop']
 export const usePlatformStore = defineStore('platform', {
   state: () => ({
     platform: 'web',
+    /** `process.platform` from the shell; '' in the browser, where it has no meaning. */
+    os: '',
   }),
   getters: {
     isDesktop: (state) => state.platform === 'desktop',
     isWeb: (state) => state.platform === 'web',
+    /**
+     * The one combination that changes how the app is laid out: on macOS the
+     * shell hides the title bar, so the page owns the window's drag handle and
+     * has to keep its own chrome clear of the traffic lights.
+     */
+    isMacDesktop: (state) => state.platform === 'desktop' && state.os === MACOS,
   },
   actions: {
-    setPlatform(next) {
+    setPlatform(next, os = '') {
       // An unrecognised value falls back to 'web': the browser build is the
       // one with no extra capabilities, so it is the safe assumption.
       this.platform = KNOWN_PLATFORMS.includes(next) ? next : 'web'
+      // Never remembered for the browser, where a page drawing window chrome
+      // would be drawing chrome for a window it does not own.
+      this.os = this.platform === 'desktop' && typeof os === 'string' ? os : ''
     },
   },
 })

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -16,6 +16,25 @@
 @custom-variant dark (&:where(.dark, .dark *));
 @import '@fontsource-variable/inter';
 
+/*
+ * Window dragging, for the desktop app on macOS.
+ *
+ * The shell hides the title bar there so the app can fill the window, and a
+ * window with no title bar has no handle: it cannot be moved at all until the
+ * page says which part of itself is the handle. That is what this is.
+ *
+ * A dragging region swallows clicks, so anything interactive inside one needs
+ * `app-no-drag` to get them back. Both properties are inert in a browser, where
+ * the page does not own the window.
+ */
+.app-drag {
+  -webkit-app-region: drag;
+}
+
+.app-no-drag {
+  -webkit-app-region: no-drag;
+}
+
 :root {
   --accent: #000000;
   --accent-bg: rgba(0, 0, 0, 0.05);

--- a/frontend/test/app.test.js
+++ b/frontend/test/app.test.js
@@ -205,6 +205,22 @@ describe('createAgentRQApp', () => {
     expect(usePlatformStore(pinia).isWeb).toBe(true)
   })
 
+  it('carries the shell OS through, so the app knows it owns the window chrome', () => {
+    const { pinia } = createAgentRQApp({
+      history: createMemoryHistory(),
+      platform: 'desktop',
+      os: 'darwin',
+    })
+
+    expect(usePlatformStore(pinia).isMacDesktop).toBe(true)
+  })
+
+  it('records no OS when none is given', () => {
+    const { pinia } = createAgentRQApp({ history: createMemoryHistory(), platform: 'desktop' })
+
+    expect(usePlatformStore(pinia).os).toBe('')
+  })
+
   it('registers the click-outside directive globally', () => {
     const { app } = createAgentRQApp({ history: createMemoryHistory() })
 

--- a/frontend/test/platformStore.test.js
+++ b/frontend/test/platformStore.test.js
@@ -33,6 +33,43 @@ describe('platformStore', () => {
     expect(store.isWeb).toBe(true)
   })
 
+  it('knows the desktop build on macOS, which draws its own window chrome', () => {
+    const store = usePlatformStore()
+    store.setPlatform('desktop', 'darwin')
+
+    expect(store.os).toBe('darwin')
+    expect(store.isMacDesktop).toBe(true)
+  })
+
+  it('is not macOS chrome on another desktop OS', () => {
+    // Windows and Linux keep a real title bar, so the page must not start
+    // reserving space for buttons that are not there.
+    const store = usePlatformStore()
+    store.setPlatform('desktop', 'win32')
+
+    expect(store.isMacDesktop).toBe(false)
+  })
+
+  it('never remembers an OS for the browser', () => {
+    // A page drawing window chrome in a browser tab would be drawing chrome
+    // for a window it does not own.
+    const store = usePlatformStore()
+    store.setPlatform('web', 'darwin')
+
+    expect(store.os).toBe('')
+    expect(store.isMacDesktop).toBe(false)
+  })
+
+  it('records no OS when the shell does not name one', () => {
+    const store = usePlatformStore()
+
+    for (const value of [undefined, null, 42]) {
+      store.setPlatform('desktop', value)
+      expect(store.os).toBe('')
+      expect(store.isMacDesktop).toBe(false)
+    }
+  })
+
   it('falls back to web for anything unrecognised', () => {
     // Guessing 'desktop' from an unknown value would hand a browser build
     // affordances it cannot deliver, so the safe direction is the other one.


### PR DESCRIPTION
## What changed

The desktop window can be moved again: there is now a strip across the top of the app that acts as the window's drag handle, and the app sits below it so the close, minimise and zoom buttons no longer land on the sidebar logo.

## Why changed

The window is created with the title bar hidden so the app can fill it, and a window with no title bar has no handle at all until the page declares one — so there was nowhere on the window to grab. macOS also draws its window buttons over the top-left of the page, which is where the sidebar starts, so the same strip reserves that space.

macOS only. Windows and Linux keep a real title bar, where claiming page content as a drag handle would take away text selection and give nothing back.

## Test coverage report

- **New lines: 100%.** The platform decision and the factory that carries it are both covered.
- Frontend suite 100 → 106 (6 new tests); gate holds at 100% statements, branches, functions and lines across every gated file.
- Desktop suite 380, unchanged and green. Both builds compile.

## Other reports

`npm run verify:connection` gained a check for the drag region and passes all 13:

```
✓ the window can be dragged where it has no title bar — region drag
✓ styles are applied — card border-radius 24px
```

Writing that check caught a regression in the same change: the strip had been added as the first child of the connection dialog, which is what the existing "styles are applied" canary selects, so that check started measuring the strip instead of the card. The strip is a sibling of the dialog now — it is part of the window, not part of the dialog.

Measured in the running app before and after, via the real renderer:

| | before | after |
|---|---|---|
| sidebar top | y = 0 | y = 40 |
| logo box | y = 20–52 (under the traffic lights) | y = 60–92 |
| drag region | none | `drag`, full width, 40px |

## TaskID

0i4YQ8upHM1