### PR TITLE
feat: let a human stop a task from the dashboard

### DIFF
--- a/backend/internal/controller/mcp/manager.go
+++ b/backend/internal/controller/mcp/manager.go
@@ -78,6 +78,19 @@ func (m *Manager) SendPermissionVerdict(ctx context.Context, workspaceID int64, 
 	return srv.SendPermissionVerdict(ctx, taskID, requestID, behavior)
 }
 
+// SupportsStop reports whether anything connected to the workspace can be asked
+// to stop a task. False for a workspace with no server running: there is
+// nothing connected to it, so there is nothing to ask.
+func (m *Manager) SupportsStop(workspaceID int64) bool {
+	m.mu.RLock()
+	srv, ok := m.servers[workspaceID]
+	m.mu.RUnlock()
+	if !ok || srv == nil {
+		return false
+	}
+	return srv.SupportsStop()
+}
+
 // SendChannelNotification forwards a channel notification to the appropriate WorkspaceServer.
 func (m *Manager) SendChannelNotification(ctx context.Context, workspaceID int64, userID string, taskID int64, content string) {
 	m.mu.RLock()

--- a/backend/internal/controller/mcp/manager_test.go
+++ b/backend/internal/controller/mcp/manager_test.go
@@ -72,3 +72,22 @@ func TestManager(t *testing.T) {
 		t.Errorf("expected newFn to be called three times, got %d", newCount)
 	}
 }
+
+// A workspace nothing is connected to cannot be asked to stop anything.
+func TestManager_SupportsStop(t *testing.T) {
+	m := NewManager(func(workspaceID int64, userID string) *WorkspaceServer {
+		return &WorkspaceServer{workspaceID: workspaceID, userID: userID}
+	})
+
+	if m.SupportsStop(1) {
+		t.Error("expected false for a workspace with no server running")
+	}
+
+	srv := m.Get(1, "user1")
+	if m.SupportsStop(1) {
+		t.Error("expected false with nothing connected to the server")
+	}
+	if srv == nil {
+		t.Fatal("expected a server")
+	}
+}

--- a/backend/internal/controller/mcp/permission_rebind_test.go
+++ b/backend/internal/controller/mcp/permission_rebind_test.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
 
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
@@ -186,15 +188,16 @@ func TestNotifySession_NoServer(t *testing.T) {
 }
 
 // connectedServer attaches a real MCP server with one live client session, so
-// that delivering a verdict actually goes somewhere. Returns the session id and
-// a channel of the notification methods the client receives.
-func connectedServer(t *testing.T, ps *WorkspaceServer) string {
+// that delivering a verdict actually goes somewhere. The client introduces
+// itself under clientName, which is what decides whether it can be stopped.
+// Returns the session id.
+func connectedServer(t *testing.T, ps *WorkspaceServer, clientName string) string {
 	t.Helper()
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
 	ps.mcpServer = server
 
-	client := mcp.NewClient(&mcp.Implementation{Name: "agent", Version: "0"}, &mcp.ClientOptions{
+	client := mcp.NewClient(&mcp.Implementation{Name: clientName, Version: "0"}, &mcp.ClientOptions{
 		KeepAlive: 0,
 	})
 
@@ -220,7 +223,7 @@ func connectedServer(t *testing.T, ps *WorkspaceServer) string {
 func TestSendPermissionVerdict_DeliversToALiveSession(t *testing.T) {
 	replies := 0
 	ps := permissionServer(t, &replies)
-	sessID := connectedServer(t, ps)
+	sessID := connectedServer(t, ps, "agent")
 
 	ps.permissionRequests["req-1"] = sessID
 	ps.permissionResponses["req-1"] = 700
@@ -238,5 +241,240 @@ func TestSendPermissionVerdict_DeliversToALiveSession(t *testing.T) {
 	}
 	if _, ok := ps.undeliveredVerdicts["req-1"]; ok {
 		t.Fatal("a delivered verdict must not be held")
+	}
+}
+
+// A stop request reaches whatever stop-capable agents are connected, without
+// needing to know which connection started the task.
+func TestSendCancelNotification_ReachesConnectedAgents(t *testing.T) {
+	replies := 0
+	ps := permissionServer(t, &replies)
+	connectedServer(t, ps, "acp-gateway")
+
+	if !ps.SendCancelNotification(context.Background(), 42).Stopped {
+		t.Fatal("expected the stop to reach the connected gateway")
+	}
+}
+
+// Stopping a task closes the approval it was waiting on, so the question does
+// not sit in the task forever.
+func TestSendCancelNotification_ClosesTheOutstandingApproval(t *testing.T) {
+	replies := 0
+	ps := permissionServer(t, &replies)
+	connectedServer(t, ps, "acp-gateway")
+
+	var marked map[string]any
+	ps.updateMessageMetadata = func(ctx context.Context, taskID int64, messageID int64, metadata any) error {
+		marked, _ = metadata.(map[string]any)
+		return nil
+	}
+	var toolCallStatus string
+	ps.updateToolCallStatus = func(ctx context.Context, id int64, status string) error {
+		toolCallStatus = status
+		return nil
+	}
+
+	ps.requestTaskIDs["req-1"] = 42
+	ps.permissionResponses["req-1"] = 700
+	ps.toolCallIDs["req-1"] = 900
+	// Another task's outstanding request must be left alone.
+	ps.requestTaskIDs["req-other"] = 43
+	ps.permissionResponses["req-other"] = 701
+
+	if !ps.SendCancelNotification(context.Background(), 42).Stopped {
+		t.Fatal("expected the stop to be delivered")
+	}
+
+	if marked == nil || marked["status"] != "cancelled" {
+		t.Fatalf("expected the approval marked cancelled, got %v", marked)
+	}
+	if toolCallStatus != "cancelled" {
+		t.Fatalf("expected the tool call marked cancelled, got %q", toolCallStatus)
+	}
+	if _, ok := ps.permissionResponses["req-1"]; ok {
+		t.Fatal("expected the stopped request to be forgotten")
+	}
+	if _, ok := ps.permissionResponses["req-other"]; !ok {
+		t.Fatal("stopping one task must not close another task's request")
+	}
+}
+
+// A tool call that will not take its new status is logged and stepped over:
+// the rest of the stop still has to happen.
+func TestSendCancelNotification_SurvivesAToolCallThatWillNotClose(t *testing.T) {
+	replies := 0
+	ps := permissionServer(t, &replies)
+	connectedServer(t, ps, "acp-gateway")
+
+	ps.updateMessageMetadata = func(ctx context.Context, taskID int64, messageID int64, metadata any) error {
+		return nil
+	}
+	ps.updateToolCallStatus = func(ctx context.Context, id int64, status string) error {
+		return errors.New("write failed")
+	}
+
+	ps.requestTaskIDs["req-1"] = 42
+	ps.permissionResponses["req-1"] = 700
+	ps.toolCallIDs["req-1"] = 900
+
+	if !ps.SendCancelNotification(context.Background(), 42).Stopped {
+		t.Fatal("expected the stop to be delivered")
+	}
+	if _, ok := ps.permissionResponses["req-1"]; ok {
+		t.Fatal("expected the stopped request to be forgotten regardless")
+	}
+}
+
+// A client with no stop in what it speaks cannot have its turn ended, but the
+// command it is standing at can still be refused — and refused for real, with a
+// verdict the agent receives rather than a request quietly closed behind it.
+func TestSendCancelNotification_RefusesWhatAClientThatCannotStopIsWaitingOn(t *testing.T) {
+	replies := 0
+	ps := permissionServer(t, &replies)
+	sessID := connectedServer(t, ps, "claude-code")
+
+	var marked map[string]any
+	ps.updateMessageMetadata = func(ctx context.Context, taskID int64, messageID int64, metadata any) error {
+		marked, _ = metadata.(map[string]any)
+		return nil
+	}
+	ps.permissionRequests["req-1"] = sessID
+	ps.requestTaskIDs["req-1"] = 42
+	ps.permissionResponses["req-1"] = 700
+	// Another task's outstanding request must be left alone.
+	ps.permissionRequests["req-other"] = sessID
+	ps.requestTaskIDs["req-other"] = 43
+	ps.permissionResponses["req-other"] = 701
+
+	outcome := ps.SendCancelNotification(context.Background(), 42)
+
+	if outcome.Stopped {
+		t.Fatal("a client that cannot stop must not be reported as stopped")
+	}
+	if outcome.ApprovalsDenied != 1 {
+		t.Fatalf("expected one approval refused, got %d", outcome.ApprovalsDenied)
+	}
+	if marked == nil || marked["status"] != "deny" {
+		t.Fatalf("expected the approval marked denied, got %v", marked)
+	}
+	if _, ok := ps.permissionResponses["req-other"]; !ok {
+		t.Fatal("stopping one task must not refuse another task's request")
+	}
+}
+
+// Nothing to stop and nothing being waited on: the stop achieved nothing, and
+// says so.
+func TestSendCancelNotification_NothingToActOn(t *testing.T) {
+	replies := 0
+	ps := permissionServer(t, &replies)
+	connectedServer(t, ps, "claude-code")
+
+	if outcome := ps.SendCancelNotification(context.Background(), 42); outcome.Acted() {
+		t.Fatalf("expected nothing to act on, got %+v", outcome)
+	}
+}
+
+// An approval whose session has gone is reported as not refused rather than
+// counted as one.
+func TestSendCancelNotification_ApprovalThatCannotBeRefused(t *testing.T) {
+	replies := 0
+	ps := permissionServer(t, &replies)
+	connectedServer(t, ps, "claude-code")
+
+	// No entry in permissionRequests, so the verdict has nowhere to go.
+	ps.requestTaskIDs["req-1"] = 42
+	ps.permissionResponses["req-1"] = 700
+
+	if outcome := ps.SendCancelNotification(context.Background(), 42); outcome.Acted() {
+		t.Fatalf("expected the refusal to fail, got %+v", outcome)
+	}
+}
+
+// With no agents connected there is simply nothing to tell.
+func TestSendCancelNotification_NoAgents(t *testing.T) {
+	replies := 0
+	ps := permissionServer(t, &replies)
+	ps.mcpServer = mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+
+	if outcome := ps.SendCancelNotification(context.Background(), 42); outcome.Acted() {
+		t.Fatalf("expected nothing to happen with nothing connected, got %+v", outcome)
+	}
+}
+
+// The dashboard only offers a Stop button when something connected would act on
+// it.
+func TestSupportsStop(t *testing.T) {
+	t.Run("nothing connected", func(t *testing.T) {
+		replies := 0
+		ps := permissionServer(t, &replies)
+		ps.mcpServer = mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+		if ps.SupportsStop() {
+			t.Fatal("expected false with no sessions")
+		}
+	})
+
+	t.Run("no MCP server at all", func(t *testing.T) {
+		replies := 0
+		ps := permissionServer(t, &replies)
+		if ps.SupportsStop() {
+			t.Fatal("expected false without an MCP server")
+		}
+	})
+
+	t.Run("a client that cannot stop", func(t *testing.T) {
+		replies := 0
+		ps := permissionServer(t, &replies)
+		connectedServer(t, ps, "claude-code")
+		if ps.SupportsStop() {
+			t.Fatal("expected false for a client with no stop")
+		}
+	})
+
+	t.Run("the ACP gateway", func(t *testing.T) {
+		replies := 0
+		ps := permissionServer(t, &replies)
+		connectedServer(t, ps, "acp-gateway")
+		if !ps.SupportsStop() {
+			t.Fatal("expected true for the ACP gateway")
+		}
+	})
+}
+
+// Client names arrive as the client chose to write them.
+func TestClientSupportsStop_NameHandling(t *testing.T) {
+	if clientSupportsStop(nil) {
+		t.Fatal("a missing session cannot be stopped")
+	}
+
+	cases := map[string]bool{
+		"acp-gateway":   true,
+		"ACP-Gateway":   true,
+		" acp-gateway ": true,
+		"claude-code":   false,
+		"":              false,
+	}
+	for name, want := range cases {
+		if got := stopCapableClients[strings.ToLower(strings.TrimSpace(name))]; got != want {
+			t.Errorf("client %q: expected stop support %v, got %v", name, want, got)
+		}
+	}
+}
+
+// A session that never completed the handshake carries no client name.
+func TestClientSupportsStop_NoClientInfo(t *testing.T) {
+	replies := 0
+	ps := permissionServer(t, &replies)
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+	ps.mcpServer = server
+
+	serverTransport, _ := mcp.NewInMemoryTransports()
+	sess, err := server.Connect(context.Background(), serverTransport, nil)
+	if err != nil {
+		t.Fatalf("connect server: %v", err)
+	}
+	t.Cleanup(func() { _ = sess.Close() })
+
+	if clientSupportsStop(sess) {
+		t.Fatal("a session with no client info cannot be stopped")
 	}
 }

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -566,6 +566,160 @@ func (ps *WorkspaceServer) SendChannelNotification(ctx context.Context, taskID i
 	zlog.Debug().Int("sessions", sessionCount).Msg("MCP notification sent")
 }
 
+// stopCapableClients names the MCP clients known to act on a stop request,
+// keyed by the lowercased client name from the initialize handshake.
+//
+// Stopping is not something MCP has: the notification below is this server's
+// own invention, and a client not written to listen for it drops it in
+// silence. Claude Code connected directly is such a client — there is no stop
+// in what it speaks — so a Stop button in front of it would report success and
+// change nothing. Only the ACP gateway acts on it, cancelling the turn of the
+// agent behind it.
+var stopCapableClients = map[string]bool{
+	"acp-gateway": true,
+}
+
+// clientSupportsStop reports whether a session's client acts on a stop request.
+func clientSupportsStop(sess *mcp.ServerSession) bool {
+	if sess == nil {
+		return false
+	}
+	p := sess.InitializeParams()
+	if p == nil || p.ClientInfo == nil {
+		return false
+	}
+	return stopCapableClients[strings.ToLower(strings.TrimSpace(p.ClientInfo.Name))]
+}
+
+// stopCapableSessions lists the connected sessions worth sending a stop to.
+func (ps *WorkspaceServer) stopCapableSessions() []string {
+	if ps.mcpServer == nil {
+		return nil
+	}
+	var ids []string
+	for sess := range ps.mcpServer.Sessions() {
+		if clientSupportsStop(sess) {
+			ids = append(ids, sess.ID())
+		}
+	}
+	return ids
+}
+
+// SupportsStop reports whether anything currently connected can be asked to
+// stop, so the dashboard only offers a Stop button that would do something.
+func (ps *WorkspaceServer) SupportsStop() bool {
+	return len(ps.stopCapableSessions()) > 0
+}
+
+// StopOutcome reports how much of a stop request could actually be carried out.
+type StopOutcome struct {
+	// Stopped is true when a connected agent was asked to stop its turn.
+	Stopped bool
+	// ApprovalsDenied counts the approvals refused on the human's behalf when
+	// the agent itself could not be stopped.
+	ApprovalsDenied int
+}
+
+// Acted reports whether the stop request changed anything at all.
+func (o StopOutcome) Acted() bool { return o.Stopped || o.ApprovalsDenied > 0 }
+
+// SendCancelNotification asks whatever is working on a task to stop, reporting
+// how far it got.
+//
+// Broadcast to every stop-capable session rather than addressed to one: the
+// agent may have reconnected since it started the task, and the point of a stop
+// button is that it works. An agent with nothing running for that task ignores
+// it.
+//
+// A client that cannot stop is passed over rather than told. That is not the
+// end of it: an agent whose turn cannot be ended can still be refused the
+// command it is standing at, which is the nearest thing to a stop it can be
+// given, so the approvals the task is waiting on are denied instead.
+func (ps *WorkspaceServer) SendCancelNotification(ctx context.Context, taskID int64) StopOutcome {
+	params := map[string]any{"task_id": monoflake.ID(taskID).String()}
+
+	sent := 0
+	for _, sessID := range ps.stopCapableSessions() {
+		if ps.notifySession(ctx, sessID, "notifications/claude/channel/cancel", params) {
+			sent++
+		}
+	}
+	if sent == 0 {
+		denied := ps.denyOutstandingRequests(ctx, taskID)
+		zlog.Info().Int64("workspace_id", ps.workspaceID).Int64("task_id", taskID).Int("approvals_denied", denied).
+			Msg("nothing connected can stop a task; refused what it was waiting on instead")
+		return StopOutcome{ApprovalsDenied: denied}
+	}
+	zlog.Info().Int64("workspace_id", ps.workspaceID).Int64("task_id", taskID).Int("sessions", sent).
+		Msg("asked connected agents to stop a task")
+
+	ps.closeOutstandingRequests(ctx, taskID)
+	return StopOutcome{Stopped: true}
+}
+
+// outstandingRequestIDs lists the approval requests a task is waiting on.
+func (ps *WorkspaceServer) outstandingRequestIDs(taskID int64) []string {
+	ps.requestTaskIDsMu.RLock()
+	defer ps.requestTaskIDsMu.RUnlock()
+
+	var requestIDs []string
+	for requestID, id := range ps.requestTaskIDs {
+		if id == taskID {
+			requestIDs = append(requestIDs, requestID)
+		}
+	}
+	return requestIDs
+}
+
+// denyOutstandingRequests refuses, on the human's behalf, every approval a task
+// is waiting on.
+//
+// For an agent that cannot be stopped this is what a Stop can still do: the
+// command it was about to run does not run. Unlike closing the request, the
+// verdict is genuinely delivered, so the agent is answered rather than left
+// holding a question whose reply would never arrive.
+func (ps *WorkspaceServer) denyOutstandingRequests(ctx context.Context, taskID int64) int {
+	denied := 0
+	for _, requestID := range ps.outstandingRequestIDs(taskID) {
+		if err := ps.SendPermissionVerdict(ctx, taskID, requestID, "deny"); err != nil {
+			zlog.Warn().Err(err).Str("request_id", requestID).Int64("task_id", taskID).
+				Msg("could not refuse the approval a task was waiting on")
+			continue
+		}
+		denied++
+	}
+	return denied
+}
+
+// closeOutstandingRequests marks a stopped task's approval requests as no
+// longer answerable.
+//
+// The agent answers them its own way when it stops, so nothing will ever come
+// back for them here. Left alone they would sit in the task as pending
+// questions for the rest of the workspace's life, and the task would keep
+// showing as waiting on someone.
+func (ps *WorkspaceServer) closeOutstandingRequests(ctx context.Context, taskID int64) {
+	for _, requestID := range ps.outstandingRequestIDs(taskID) {
+		ps.permissionResponsesMu.RLock()
+		msgID, hasMsg := ps.permissionResponses[requestID]
+		ps.permissionResponsesMu.RUnlock()
+		if hasMsg && ps.updateMessageMetadata != nil {
+			_ = ps.updateMessageMetadata(ctx, taskID, msgID, map[string]any{"status": "cancelled"})
+		}
+
+		ps.toolCallIDsMu.RLock()
+		tcID, hasToolCall := ps.toolCallIDs[requestID]
+		ps.toolCallIDsMu.RUnlock()
+		if hasToolCall && ps.updateToolCallStatus != nil {
+			if err := ps.updateToolCallStatus(ctx, tcID, "cancelled"); err != nil {
+				zlog.Error().Err(err).Int64("tool_call_id", tcID).Msg("failed to mark tool call cancelled")
+			}
+		}
+
+		ps.cleanupRequest(requestID)
+	}
+}
+
 // StartPing pings all connected MCP client sessions every minute to keep connections alive.
 // If a session's underlying stream is already closed or times out, it is explicitly closed
 // so the SDK removes it from its session registry, preventing repeated errors.

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -30,6 +30,7 @@ type (
 		Icon                  string
 		NotificationSettings  *NotificationSettings
 		AgentConnected        bool
+		AgentSupportsStop     bool
 		AutoAllowedTools      []string
 		AllowAllCommands      bool
 		SelfLearningLoopNote  string

--- a/backend/internal/data/view/api/view.go
+++ b/backend/internal/data/view/api/view.go
@@ -18,6 +18,7 @@ type (
 		Icon                  string                `json:"icon,omitempty"`
 		NotificationSettings  *NotificationSettings `json:"notificationSettings,omitempty"`
 		AgentConnected        bool                  `json:"agentConnected"`
+		AgentSupportsStop     bool                  `json:"agentSupportsStop"`
 		MCPURL                string                `json:"mcpUrl"`
 		MCPToken              string                `json:"mcpToken,omitempty"`
 		AutoAllowedTools      []string              `json:"autoAllowedTools,omitempty"`

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -611,6 +611,7 @@ func (h *handler) createWorkspace() fiber.Handler {
 			return c.Send(e)
 		}
 		rs.Workspace.AgentConnected = h.mcpManager.IsAgentConnected(rs.Workspace.ID)
+		rs.Workspace.AgentSupportsStop = h.mcpManager.SupportsStop(rs.Workspace.ID)
 		h.enrichWorkspaceSlack(ctx, &rs.Workspace)
 
 		c.Status(http.StatusCreated)
@@ -638,6 +639,7 @@ func (h *handler) getWorkspace() fiber.Handler {
 			return c.Send(e)
 		}
 		rs.Workspace.AgentConnected = h.mcpManager.IsAgentConnected(rs.Workspace.ID)
+		rs.Workspace.AgentSupportsStop = h.mcpManager.SupportsStop(rs.Workspace.ID)
 		h.enrichWorkspaceSlack(ctx, &rs.Workspace)
 
 		c.Status(http.StatusOK)
@@ -664,6 +666,7 @@ func (h *handler) listWorkspaces() fiber.Handler {
 		}
 		for i := range rs.Workspaces {
 			rs.Workspaces[i].AgentConnected = h.mcpManager.IsAgentConnected(rs.Workspaces[i].ID)
+			rs.Workspaces[i].AgentSupportsStop = h.mcpManager.SupportsStop(rs.Workspaces[i].ID)
 			h.enrichWorkspaceSlack(ctx, &rs.Workspaces[i])
 		}
 
@@ -770,6 +773,7 @@ func (h *handler) updateWorkspace() fiber.Handler {
 			srv.UpdateAutoAllowedTools(rs.Workspace.AutoAllowedTools)
 		}
 		rs.Workspace.AgentConnected = h.mcpManager.IsAgentConnected(rq.Workspace.ID)
+		rs.Workspace.AgentSupportsStop = h.mcpManager.SupportsStop(rq.Workspace.ID)
 		h.enrichWorkspaceSlack(ctx, &rs.Workspace)
 
 		c.Status(http.StatusOK)

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/agentrq/agentrq/backend/internal/controller/crud"
+	mcpctrl "github.com/agentrq/agentrq/backend/internal/controller/mcp"
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	"github.com/agentrq/agentrq/backend/internal/repository/base"
 	"github.com/agentrq/agentrq/backend/internal/service/auth"
@@ -375,6 +376,143 @@ func TestSendPermissionVerdict_RequiresWorkspaceAccess(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected status 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestStopTask_RequiresWorkspaceAccess(t *testing.T) {
+	app := fiber.New()
+	crudCtrl := &mockCrudWorkspaceAccess{}
+
+	// Intentionally no MCPManager: an unauthorized request must be refused
+	// before anything reaches a workspace server.
+	h := &handler{crud: crudCtrl}
+
+	workspaceID := monoflake.ID(1).String()
+	taskID := monoflake.ID(2).String()
+	userID := monoflake.ID(100).String()
+
+	app.Post("/api/v1/workspaces/:id/tasks/:taskID/stop", func(c *fiber.Ctx) error {
+		c.Locals("user_id", userID)
+		return h.stopTask()(c)
+	})
+
+	crudCtrl.checkWorkspaceAccessFunc = func(ctx context.Context, id int64, gotUserID string) (bool, error) {
+		return false, nil
+	}
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/workspaces/"+workspaceID+"/tasks/"+taskID+"/stop",
+		nil,
+	)
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestStopTask_RejectsATaskIDThatIsNotOne(t *testing.T) {
+	app := fiber.New()
+	crudCtrl := &mockCrudWorkspaceAccess{
+		checkWorkspaceAccessFunc: func(ctx context.Context, id int64, userID string) (bool, error) {
+			return true, nil
+		},
+	}
+	h := &handler{crud: crudCtrl}
+
+	app.Post("/api/v1/workspaces/:id/tasks/:taskID/stop", func(c *fiber.Ctx) error {
+		c.Locals("user_id", monoflake.ID(100).String())
+		return h.stopTask()(c)
+	})
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/workspaces/"+monoflake.ID(1).String()+"/tasks/0/stop",
+		nil,
+	)
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+// Nothing connected can be stopped, so the request is refused rather than
+// answered with a success the human would read as "the task stopped".
+func TestStopTask_RefusesWhenTheAgentCannotBeStopped(t *testing.T) {
+	app := fiber.New()
+	crudCtrl := &mockCrudWorkspaceAccess{
+		checkWorkspaceAccessFunc: func(ctx context.Context, id int64, userID string) (bool, error) {
+			return true, nil
+		},
+	}
+	h := &handler{
+		crud: crudCtrl,
+		mcpManager: mcpctrl.NewManager(func(workspaceID int64, userID string) *mcpctrl.WorkspaceServer {
+			// A workspace server with nothing connected to it.
+			return &mcpctrl.WorkspaceServer{}
+		}),
+	}
+
+	app.Post("/api/v1/workspaces/:id/tasks/:taskID/stop", func(c *fiber.Ctx) error {
+		c.Locals("user_id", monoflake.ID(100).String())
+		return h.stopTask()(c)
+	})
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/workspaces/"+monoflake.ID(1).String()+"/tasks/"+monoflake.ID(2).String()+"/stop",
+		nil,
+	)
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusConflict {
+		t.Errorf("expected 409, got %d", resp.StatusCode)
+	}
+}
+
+// No server for the workspace at all: there is nothing even to ask.
+func TestStopTask_WithoutAWorkspaceServer(t *testing.T) {
+	app := fiber.New()
+	crudCtrl := &mockCrudWorkspaceAccess{
+		checkWorkspaceAccessFunc: func(ctx context.Context, id int64, userID string) (bool, error) {
+			return true, nil
+		},
+	}
+	h := &handler{
+		crud: crudCtrl,
+		mcpManager: mcpctrl.NewManager(func(workspaceID int64, userID string) *mcpctrl.WorkspaceServer {
+			return nil
+		}),
+	}
+
+	app.Post("/api/v1/workspaces/:id/tasks/:taskID/stop", func(c *fiber.Ctx) error {
+		c.Locals("user_id", monoflake.ID(100).String())
+		return h.stopTask()(c)
+	})
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/workspaces/"+monoflake.ID(1).String()+"/tasks/"+monoflake.ID(2).String()+"/stop",
+		nil,
+	)
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
 	}
 }
 

--- a/backend/internal/handler/api/task.go
+++ b/backend/internal/handler/api/task.go
@@ -32,6 +32,7 @@ const (
 	_routePathAllowAll    = "/workspaces/:id/tasks/:taskID/allow_all"
 	_routePathPermission  = "/workspaces/:id/tasks/:taskID/permission"
 	_routePathElicitation = "/workspaces/:id/tasks/:taskID/elicitation"
+	_routePathStop        = "/workspaces/:id/tasks/:taskID/stop"
 	_routePathEvents      = "/workspaces/:id/events"
 	_routePathAttachment  = "/workspaces/:id/tasks/:taskID/attachments/:attachmentID"
 	_routePathCounts      = "/workspaces/:id/tasks/counts"
@@ -54,6 +55,7 @@ func (h *handler) registerTaskRoutes() error {
 	h.router.Put(_routePathScheduled, h.updateScheduledTask())
 	h.router.Post(_routePathPermission, h.sendPermissionVerdict())
 	h.router.Post(_routePathElicitation, h.respondToElicitation())
+	h.router.Post(_routePathStop, h.stopTask())
 	h.router.Delete(_routePathTask, h.deleteTask())
 	h.router.Get(_routePathEvents, h.sseEvents())
 	h.router.Get(_routePathAttachment, h.getAttachment())
@@ -674,6 +676,54 @@ func (h *handler) sendPermissionVerdict() fiber.Handler {
 		}
 
 		return c.SendStatus(http.StatusOK)
+	}
+}
+
+// stopTask asks whatever agent is working on a task to stop.
+//
+// Nothing about the task itself changes: this is a message to the agent, and
+// the agent decides what its own state becomes.
+//
+// Only an agent that can actually be stopped is asked. Stopping travels over a
+// notification this server invents, and a client not built to listen for it —
+// Claude Code speaking MCP directly, for one — would drop it without a word.
+// Such an agent is instead refused the approval it is standing at, which is as
+// close to a stop as it can be brought.
+func (h *handler) stopTask() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		workspaceID := monoflake.IDFromBase62(c.Params("id")).Int64()
+		userID := c.Locals("user_id").(string)
+
+		ctx, cancel := newContext(c)
+		defer cancel()
+		if ok, err := h.crud.CheckWorkspaceAccess(ctx, workspaceID, userID); err != nil || !ok {
+			return c.Status(http.StatusForbidden).JSON(fiber.Map{"error": "forbidden"})
+		}
+
+		taskID := monoflake.IDFromBase62(c.Params("taskID")).Int64()
+		if taskID == 0 {
+			return c.Status(http.StatusBadRequest).JSON(fiber.Map{"error": "invalid task id"})
+		}
+
+		srv := h.mcpManager.Get(workspaceID, userID)
+		if srv == nil {
+			return c.Status(http.StatusNotFound).JSON(fiber.Map{"error": "mcp server not found"})
+		}
+
+		// How much of a stop was possible depends on what is connected, and
+		// the human is told which it was: reporting a plain success for an
+		// agent that never stopped would leave them believing a task had
+		// ended while it is still running.
+		outcome := srv.SendCancelNotification(c.Context(), taskID)
+		if !outcome.Acted() {
+			return c.Status(http.StatusConflict).JSON(fiber.Map{
+				"error": "the connected agent does not support being stopped",
+			})
+		}
+		return c.Status(http.StatusOK).JSON(fiber.Map{
+			"stopped":         outcome.Stopped,
+			"approvalsDenied": outcome.ApprovalsDenied,
+		})
 	}
 }
 

--- a/backend/internal/mapper/api/workspace.go
+++ b/backend/internal/mapper/api/workspace.go
@@ -151,6 +151,7 @@ func fromEntityWorkspaceToView(p entity.Workspace, mcpURL string) view.Workspace
 		ArchivedAt:            p.ArchivedAt,
 		NotificationSettings:  fromEntityNotificationSettingsToView(p.NotificationSettings),
 		AgentConnected:        p.AgentConnected,
+		AgentSupportsStop:     p.AgentSupportsStop,
 		MCPURL:                mcpURL,
 		AutoAllowedTools:      p.AutoAllowedTools,
 		AllowAllCommands:      p.AllowAllCommands,

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -236,6 +236,19 @@ export async function sendPermissionVerdict(workspaceId, taskId, requestId, beha
   return res;
 }
 
+export async function stopTask(workspaceId, taskId) {
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/stop`, {
+    method: 'POST'
+  });
+  if (!res.ok) {
+    // The server says why when it refuses — most usefully that whatever is
+    // connected has no stop — and that reason is worth more than "failed".
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.error || 'Failed to stop the task');
+  }
+  return res.json();
+}
+
 export async function respondToElicitation(workspaceId, taskId, requestId, action, content) {
   const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/elicitation`, {
     method: 'POST',

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -41,7 +41,19 @@
               </button>
             </div>
 
-
+            <!-- Stop: only while the agent is working, and only when what is
+                 connected can actually be stopped. Not every agent can be:
+                 stopping travels over a notification only the ACP gateway acts
+                 on, so offering it to Claude Code speaking MCP directly would
+                 be a button that reports success and changes nothing. -->
+            <button v-if="task.status === 'ongoing' && workspace?.agentSupportsStop"
+                    @click.stop="stopRunningTask"
+                    @mouseenter="tooltipStore.show($event, 'Stop the agent working on this task', 'bottom')"
+                    @mouseleave="tooltipStore.hide()"
+                    class="h-7 px-2 rounded-lg border border-gray-200 dark:border-zinc-700/50 bg-gray-100 dark:bg-zinc-800 text-gray-500 dark:text-zinc-400 hover:text-red-600 dark:hover:text-red-400 hover:border-red-300 dark:hover:border-red-800 transition-all flex items-center gap-1 text-[8px] font-black uppercase tracking-tighter">
+              <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="1"></rect></svg>
+              <span class="hidden sm:inline">Stop</span>
+            </button>
 
             <!-- Status Selector -->
             <div class="relative">
@@ -251,7 +263,7 @@
                        </span>
                        <span class="text-[9px] font-semibold shrink-0"
                              :class="m.metadata.status === 'allow' || m.metadata.status === 'allow_always' ? 'text-gray-500 dark:text-zinc-400' : 'text-red-600 dark:text-red-500'">
-                         {{ m.metadata.status === 'deny' ? 'Denied' : m.metadata.status === 'allow_always' ? 'Always' : 'Allowed' }}
+                         {{ m.metadata.status === 'deny' ? 'Denied' : m.metadata.status === 'cancelled' ? 'Stopped' : m.metadata.status === 'allow_always' ? 'Always' : 'Allowed' }}
                        </span>
                        <svg class="w-3 h-3 text-gray-500 shrink-0 transition-transform duration-200" :class="m._detailsExpanded ? 'rotate-180' : ''" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
                      </div>
@@ -649,7 +661,7 @@
 <script setup>
 import { ref, onMounted, computed, onUnmounted, watch, nextTick } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { getWorkspace, fetchTasks, archiveWorkspace, unarchiveWorkspace, updateWorkspace, getWorkspaceToken, getTask, updateTaskStatus, respondToTask, updateTaskAssignee, getAttachmentUrl, sendPermissionVerdict, respondToElicitation, updateTaskAllowAllCommands, fetchUser } from '../api';
+import { getWorkspace, fetchTasks, archiveWorkspace, unarchiveWorkspace, updateWorkspace, getWorkspaceToken, getTask, updateTaskStatus, respondToTask, updateTaskAssignee, getAttachmentUrl, sendPermissionVerdict, respondToElicitation, stopTask, updateTaskAllowAllCommands, fetchUser } from '../api';
 import { useTooltipStore } from '../stores/tooltipStore';
 import { useToasts } from '../composables/useToasts';
 import { useViewport } from '../composables/useViewport';
@@ -1037,6 +1049,25 @@ const updateAssignee = async (newAssignee) => {
     notifySuccess(`Task reassigned to ${newAssignee}`);
   } catch (err) {
     notifyError("Failed to reassign task: " + err.message);
+  }
+};
+
+// Asks the agent to stop what it is doing. The task's own status is left
+// alone: this is a message to the agent, and what it does next is its to say.
+//
+// An agent whose turn cannot be ended is refused the command it was standing
+// at instead, which is a different thing to have happened and is said so.
+const stopRunningTask = async () => {
+  if (!task.value) return;
+  try {
+    const result = await stopTask(workspaceId.value, taskId.value);
+    if (result?.stopped) {
+      notifySuccess("Asked the agent to stop this task.");
+    } else {
+      notifySuccess("This agent cannot be stopped, so the command it was waiting on was refused.");
+    }
+  } catch (err) {
+    notifyError("Failed to stop the task: " + err.message);
   }
 };
 

--- a/frontend/test/stopTask.test.js
+++ b/frontend/test/stopTask.test.js
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { stopTask } from '../src/api'
+
+describe('stopTask', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('asks the server to stop the task, and reports what happened', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ stopped: true, approvalsDenied: 0 }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    expect(await stopTask('ws1', 'task1')).toEqual({ stopped: true, approvalsDenied: 0 })
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/workspaces/ws1/tasks/task1/stop',
+      { method: 'POST' },
+    )
+  })
+
+  // An agent that could not be stopped had its pending command refused
+  // instead — a different outcome, and the caller has to be able to tell.
+  it('distinguishes a refused approval from an actual stop', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ stopped: false, approvalsDenied: 1 }),
+    }))
+
+    expect(await stopTask('ws1', 'task1')).toEqual({ stopped: false, approvalsDenied: 1 })
+  })
+
+  // Being told the agent has no stop is the whole point of the refusal; a bare
+  // "failed" would leave the human guessing at a task that is still running.
+  it('reports the reason the server refused', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({ error: 'the connected agent does not support being stopped' }),
+    }))
+
+    await expect(stopTask('ws1', 'task1')).rejects.toThrow(
+      'the connected agent does not support being stopped',
+    )
+  })
+
+  it('still says something when the refusal carries no reason', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => { throw new Error('not json') },
+    }))
+
+    await expect(stopTask('ws1', 'task1')).rejects.toThrow('Failed to stop the task')
+  })
+})


### PR DESCRIPTION
The gateway half is agentrq/acp-gateway#45.

**What changed**

An ongoing task gets a Stop button, which asks whatever agent is working on it to stop, and closes the approval that task was waiting on. An agent that cannot be stopped is instead refused the command it was standing at, and the dashboard says which of the two happened.

**Why changed**

There was no way to stop an agent mid-task. The assignee toggle is labelled "Stop Agent" but only changes a field — nothing is actually told to stop, so a task that had gone wrong ran to its own conclusion, holding one of the gateway's concurrency slots while it did.

Not every agent can be stopped, though. Stopping travels over a notification this server invents, and a client not written to listen for it drops it in silence — Claude Code speaking MCP directly is such a client, so a Stop button in front of it would have reported success and changed nothing. Only agents reached through the ACP gateway act on it, and the gateway introduces itself by name at the MCP handshake, which is what the workspace now reports to the dashboard so the button is only offered where it would do something.

That is not the end of it for an agent with no stop. Its turn cannot be ended, but the command it is standing at can still be refused, so that is what a stop does for one — and refused for real, with a verdict the agent receives, rather than the request quietly closed behind it. Closing it silently would strand the agent holding a question whose reply could never arrive.

When the agent does stop, closing the outstanding approval matters as much as the stop itself. The agent answers that request its own way when it stops, so nothing was ever coming back for it here; left alone it sat in the task as a question nobody could answer, and the task kept showing as waiting on a person.

The task's own status is deliberately untouched. This is a message to the agent, and what the agent's state becomes afterwards is the agent's to report.

It is a new kind of message rather than a new approval outcome: the gateway reads any outcome that is not "allow" as a refusal, and a refusal lets the turn carry on rather than ending it.

**Test coverage report**

- New lines introduced: 100% of the new backend logic, with one exception noted below — the capability check, the broadcast that skips clients with no stop, refusing what such a client is waiting on (including an approval that can no longer be delivered), closing a stopped task's approvals without touching another task's, and the endpoint's access, identifier, missing-server and refusal paths. The single uncovered statement is the endpoint's success return, which needs a live stop-capable MCP session inside a workspace server whose fields are package-private; the delivery it guards is covered at the controller layer.
- Total coverage impact: the MCP controller package goes from 62.3% on main to 64.8%, the API handler package from 27.6% to 28.3%. Whole backend suite passes, frontend suite passes (110 tests, 4 new), frontend builds, `gofmt` clean on changed files.
- Verified end to end against this backend running locally with a real ACP agent (`antigravity-acp`) connected through the gateway: created a task, let the agent reach a command that needs approval, then pressed Stop through this endpoint. The agent stopped (`Antigravity SDK prompt cancelled`), the task recorded that the turn was cut short, and the approval card and its tool call both came back marked `cancelled` rather than staying pending.

**Other reports**

Rebased onto latest main to clear the conflicts: this branch was stacked on #392, which has since been squash-merged, so the branch carried a second copy of that change and git saw two versions of the same work. It is now a single commit on top of main.

That earlier live run is also what caught the pending-approval problem: the first pass stopped the agent correctly but left the card saying "pending" forever, which the interface would then have rendered as "Allowed" once resolved. Both are fixed here.

TaskID: 0i7lpev5MnZ (fixes) — originally 0i4izEeJzdp

Generated with [AgentRQ](https://agentrq.com)
