### PR TITLE
chore: bump patch version to v0.4.15

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.4.14"
+	_appVersion   = "v0.4.15"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.4.14" {
-			t.Errorf("Expected version v0.4.14, got %s", s.Version())
+		if s.Version() != "v0.4.15" {
+			t.Errorf("Expected version v0.4.15, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.4.14",
+      "version": "0.4.15",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.4.14",
+      "version": "0.4.15",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.4.14",
+  "version": "0.4.15",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
**What changed**

The project's version number moves from 0.4.14 to 0.4.15, everywhere it is declared.

**Why changed**

To cut a release carrying the three changes merged since the last one: the dashboard's Stop button for a running task, a permission decision no longer being lost when the agent reconnects, and a macOS desktop window that can be dragged again.

**Test coverage report**

- New lines introduced: none — this changes only version strings, and the one test that asserts the version was updated alongside it.
- Total coverage impact: none. The config package's test passes, both version-sync checks pass (plain and as CI runs it on a tag), and `npm ci` still succeeds against both lockfiles with no dependency drift.

**Other reports**

Changes in this release:

- feat: let a human stop a task from the dashboard (#393)
- fix: do not lose a permission decision when the agent reconnects (#392)
- fix(desktop): give the window something to be dragged by on macOS (#391)

Lockfile version fields were edited by hand rather than regenerated, so no unrelated dependency entries move underneath the release.

After merge, the release is cut by tagging `main` with `v0.4.15` and pushing the tag — merging alone publishes nothing.

TaskID: 0i7pc5gRWgj

Generated with [AgentRQ](https://agentrq.com)
