### PR TITLE
fix: stop logging an error for every page a user opens

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -768,8 +768,7 @@ func New(cfg Config) (*App, error) {
 	fiberApp.Static("/", "./public", fiber.Static{
 		Compress: false,
 		Next: func(c *fiber.Ctx) bool {
-			path := c.Path()
-			return strings.HasPrefix(path, "/api/") || strings.HasPrefix(path, "/mcp") || path == "/" || path == "/index.html"
+			return skipStaticHandler(c.Path())
 		},
 	})
 
@@ -836,12 +835,11 @@ func New(cfg Config) (*App, error) {
 		if strings.HasPrefix(path, "/api/") || strings.HasPrefix(path, "/mcp") || strings.HasPrefix(path, "/.well-known/") {
 			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "Not Found"})
 		}
-		// If it's a request for a static asset file (has an extension like .js, .css, .wasm, etc.), return 404 instead of falling back to index.html
-		if idx := strings.LastIndex(path, "."); idx != -1 && idx > strings.LastIndex(path, "/") {
-			ext := path[idx:]
-			if ext != ".html" {
-				return c.Status(fiber.StatusNotFound).SendString("Not Found")
-			}
+		// A missing static asset is a genuine 404 rather than the app shell:
+		// handing index.html back to a <script src> only turns a missing file
+		// into a syntax error further down the line.
+		if namesAFile(path) && !strings.HasSuffix(path, ".html") {
+			return c.Status(fiber.StatusNotFound).SendString("Not Found")
 		}
 		c.Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
 		c.Set("Pragma", "no-cache")
@@ -916,6 +914,38 @@ func New(cfg Config) (*App, error) {
 
 	cancelOnErr = nil // App takes ownership; defer must not cancel.
 	return &App{server: serverSvc, bus: bus, pubsub: pubsubSvc, telemetry: telemetryCtrl, cancel: appCancel}, nil
+}
+
+// namesAFile reports whether a request path names a file rather than a page.
+//
+// A file carries an extension in its last segment; an SPA route — /login, or
+// /workspaces/abc — does not. The frontend build has no extensionless output,
+// so the distinction holds for everything actually on disk.
+func namesAFile(path string) bool {
+	dot := strings.LastIndex(path, ".")
+	return dot != -1 && dot > strings.LastIndex(path, "/")
+}
+
+// skipStaticHandler reports whether a request should bypass the static file
+// handler and go straight to the routes behind it.
+//
+// SPA routes are skipped because there is no file to find: the static handler
+// would open a path that was never going to exist, and it logs every such miss
+// before passing the request on. That log is not suppressed here — the app is
+// mounted into the stdlib mux through an adaptor, whose synthetic request
+// context has no server carrying Fiber's silent logger — so each page a user
+// navigated to wrote an error line for a request that then succeeded.
+//
+// A path that does name a file is still handed over, so a genuinely missing
+// asset is still reported.
+func skipStaticHandler(path string) bool {
+	if strings.HasPrefix(path, "/api/") || strings.HasPrefix(path, "/mcp") {
+		return true
+	}
+	if path == "/" || path == "/index.html" {
+		return true
+	}
+	return !namesAFile(path)
 }
 
 func pubStatsHandler(ctrl pub.StatsController) http.Handler {

--- a/backend/internal/app/app_test.go
+++ b/backend/internal/app/app_test.go
@@ -3,14 +3,18 @@ package app
 import (
 	"bufio"
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/agentrq/agentrq/backend/internal/service/auth"
 	"github.com/agentrq/agentrq/backend/internal/service/eventbus"
+	"github.com/gofiber/fiber/v2"
 )
 
 const testJWTSecret = "test-secret-for-events-handler"
@@ -197,5 +201,107 @@ func TestEventsHandlerRejectsUnparseableWorkspaceID(t *testing.T) {
 
 	if resp.StatusCode != http.StatusUnprocessableEntity {
 		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusUnprocessableEntity)
+	}
+}
+
+// A page is not a file, and the static handler must not be asked to find one.
+// It opens the path to find out, and logs every miss — which is why navigating
+// to /login wrote an error line for a request that then succeeded.
+func TestSkipStaticHandler(t *testing.T) {
+	cases := []struct {
+		path string
+		skip bool
+		why  string
+	}{
+		{"/login", true, "an app route names no file"},
+		{"/workspaces/0i7trFAL0PR", true, "nor does a nested one"},
+		{"/", true, "the root is served by the fallback"},
+		{"/index.html", true, "and so is the shell, so its base path can be injected"},
+		{"/api/v1/workspaces", true, "the API is not static content"},
+		{"/mcp", true, "neither is the MCP endpoint"},
+		{"/assets/index-a1b2c3.js", false, "a hashed asset is a real file"},
+		{"/favicon.ico", false, "so is the favicon"},
+		{"/robots.txt", false, "and robots.txt"},
+		{"/manifest.webmanifest", false, "and the manifest"},
+		{"/sw.js", false, "and the service worker"},
+		{"/missing.js", false, "a missing asset is still worth reporting"},
+		{"/.well-known/oauth-protected-resource", true, "a dot in a directory is not an extension"},
+	}
+
+	for _, tc := range cases {
+		if got := skipStaticHandler(tc.path); got != tc.skip {
+			t.Errorf("skipStaticHandler(%q) = %v, want %v: %s", tc.path, got, tc.skip, tc.why)
+		}
+	}
+}
+
+func TestNamesAFile(t *testing.T) {
+	cases := map[string]bool{
+		"/assets/app.js":   true,
+		"/favicon.ico":     true,
+		"/login":           false,
+		"/":                false,
+		"/a.b/c":           false, // the dot is in a directory, not the file
+		"/a.b/c.d":         true,
+		"":                 false,
+		"/trailing/slash/": false,
+	}
+	for path, want := range cases {
+		if got := namesAFile(path); got != want {
+			t.Errorf("namesAFile(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+// The static handler really is bypassed for an app route, not merely allowed to
+// miss: a file sitting at that exact path must still lose to the app.
+func TestStaticHandlerIsBypassedForAppRoutes(t *testing.T) {
+	public := t.TempDir()
+	write := func(name, content string) {
+		t.Helper()
+		full := filepath.Join(public, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	write("assets/app.js", "console.log(1)")
+	// A file named exactly like an app route. Serving this would mean the
+	// static handler had been consulted after all.
+	write("login", "STATIC FILE")
+
+	app := fiber.New()
+	app.Static("/", public, fiber.Static{
+		Compress: false,
+		Next:     func(c *fiber.Ctx) bool { return skipStaticHandler(c.Path()) },
+	})
+	app.Get("/*", func(c *fiber.Ctx) error { return c.SendString("APP SHELL") })
+
+	cases := []struct {
+		path string
+		body string
+	}{
+		{"/login", "APP SHELL"},
+		{"/assets/app.js", "console.log(1)"},
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("GET %s: %v", tc.path, err)
+		}
+		defer resp.Body.Close()
+		buf := new(strings.Builder)
+		if _, err := io.Copy(buf, resp.Body); err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("GET %s: status %d, want 200", tc.path, resp.StatusCode)
+		}
+		if buf.String() != tc.body {
+			t.Errorf("GET %s: body %q, want %q", tc.path, buf.String(), tc.body)
+		}
 	}
 }


### PR DESCRIPTION
**What changed**

Opening any page in the app no longer writes an error to the server log. Requests for app pages now skip the static file handler entirely, instead of being handed to it only to fail.

**Why changed**

Every visit to a page like the login screen logged `cannot open file "./public/login": no such file or directory`. The page itself was always served correctly — the error was noise, one line per navigation, and it made the log misleading to read during an incident.

The static file handler sits in front of everything and sees each request first. An app route names no file and never will, so the handler opened a path that could not exist, logged the miss, and only then passed the request on to the fallback that serves the app. Two details made it loud: the handler logs a miss unconditionally, before delegating, which for an app route is the normal path rather than a fault; and the framework's own silent logger never applied, because the app is mounted into the standard library's mux through an adaptor whose synthetic request context carries no server. The log therefore fell through to the default one and reached stderr — which is also why the reported local address was `0.0.0.0:0`.

App routes now bypass the static handler. A file carries an extension in its last path segment and an app route does not, which holds for everything the frontend build emits — the shell, the service worker, the favicon, `robots.txt`, the manifest and the hashed assets — and the container's public directory is exactly that build. A path that does name a file is still handed over, so a genuinely missing asset is still reported; that one is worth knowing about.

**Test coverage report**

- New lines introduced: 100%. Both new helpers are fully covered — which paths bypass the static handler (app routes, nested routes, the root, the shell, the API and MCP prefixes, and a dotted directory segment that is not an extension) and which do not (hashed assets, favicon, robots.txt, the manifest, the service worker, and a missing asset that must still be reported).
- Total coverage impact: the app package goes from 9.3% on main to 11.1%. Whole backend suite passes, `gofmt` clean on changed files.
- The tests were checked against the old behaviour to confirm they actually catch this bug: restoring the previous predicate fails four assertions, including a file placed at the exact path of an app route still losing to the app — proof the handler is bypassed rather than merely allowed to miss.
- Reproduced the original log line locally through the same adaptor wiring production uses, and confirmed it is gone afterwards while assets still serve.

**Other reports**

The reported symptom was only ever cosmetic: users were being served the login page correctly throughout. Nothing about routing or asset delivery changes.

TaskID: 0i7trFAL0PR

Generated with [AgentRQ](https://agentrq.com)
