### PR TITLE
ci: run the backend Go tests

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,0 +1,61 @@
+name: Backend
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/**'
+      - 'Makefile'
+      - '.github/workflows/backend.yml'
+  # The Makefile is in scope because the mock generation the tests depend on
+  # lives there: a change to it can break the build without touching backend/.
+  pull_request:
+    paths:
+      - 'backend/**'
+      - 'Makefile'
+      - '.github/workflows/backend.yml'
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  test:
+    name: Test and build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          # Tracks the toolchain the module declares rather than a second copy
+          # of the version that would quietly drift from it.
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: Install mockgen
+        # The mock packages are generated and gitignored, so a fresh checkout
+        # cannot compile the tests that use them. The version is read from the
+        # module's own dependency on github.com/golang/mock, so the generator
+        # and the gomock runtime the tests link against cannot disagree.
+        run: |
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          go install "github.com/golang/mock/mockgen@$(go list -m -f '{{.Version}}' github.com/golang/mock)"
+        working-directory: backend
+
+      - name: Generate mocks
+        run: make mocks
+
+      - name: Build
+        run: go build ./...
+        working-directory: backend
+
+      - name: Test
+        run: go test ./internal/...
+        working-directory: backend


### PR DESCRIPTION
**What changed**

The backend's Go tests now run in CI, on pushes to main and on pull requests that touch backend code.

**Why changed**

There was no workflow that ran them. Everything in CI covered the frontend, the desktop app, the Docker images and the plugin bundle, and all of it is filtered to frontend and desktop paths — so a backend-only change triggered none of it. The recent static-file fix ran four checks, and the only Go-related one was security analysis rather than a test run. In practice the Go tests only ever ran on the machine of whoever remembered to run them, and a backend pull request could be merged with a suite that failed or did not compile without anything saying so.

Two details the workflow has to get right. The mock packages are generated and not committed, so a fresh checkout cannot even compile the tests that use them — they are generated before anything is built. And the generator's version is read from the module's own dependency rather than written down a second time, so it cannot drift from the runtime the tests link against. The Makefile is in the path filter for the same reason: the generation lives there, so a change to it can break the backend without touching a backend file.

**Test coverage report**

- New lines introduced: not applicable — this adds no application code, only CI configuration. It does, however, put the existing backend suite under CI for the first time: 28 packages that previously ran nowhere but a developer's laptop.
- Total coverage impact: none to the codebase's own coverage.
- Verified from a clean checkout with the mocks deleted, running the workflow's exact commands in order: install, generate, build, test — 28 packages pass. Then verified it is not passing vacuously, by adding a deliberately failing test and confirming the test step exits non-zero, and that removing it returns to zero.

**Other reports**

No `gofmt` check is included. Twelve files under `backend/internal` are already unformatted, so a blanket check would fail on its first run; reformatting them is worth doing but does not belong in the change that adds the tests. Worth raising separately.

On the path filter: this pull request touches only the workflow file, which is itself in the filter, so the workflow's appearance in these checks is the positive case. The negative case is already evidenced by the existing workflows — a Go-only change did not trigger the frontend or desktop ones — so the same filtering keeps this workflow off frontend-only changes.

TaskID: 0i7vrVxsX2X

Generated with [AgentRQ](https://agentrq.com)
