### PR TITLE
feat(telemetry): show the agent's reasoning, plan and usage in the task chat

### DIFF
--- a/backend/internal/controller/mcp/agent_telemetry.go
+++ b/backend/internal/controller/mcp/agent_telemetry.go
@@ -1,0 +1,180 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	zlog "github.com/rs/zerolog/log"
+
+	"github.com/mustafaturan/monoflake"
+)
+
+// AgentTelemetryNotificationMethod is the channel notification carrying the
+// parts of an agent's turn that are not its answer: the reasoning behind it,
+// the plan it is working to, and what the turn is costing.
+//
+// Named "agent telemetry" throughout to keep it apart from emitTelemetry, which
+// is this product's own usage analytics and has nothing to do with it.
+const AgentTelemetryNotificationMethod = "notifications/claude/channel/telemetry"
+
+// The kinds of telemetry a gateway sends.
+const (
+	agentTelemetryKindThought = "thought"
+	agentTelemetryKindPlan    = "plan"
+	agentTelemetryKindUsage   = "usage"
+)
+
+// The message metadata types the frontend renders these as.
+const (
+	MessageTypeAgentThought = "agent_thought"
+	MessageTypeAgentPlan    = "agent_plan"
+	MessageTypeAgentUsage   = "agent_usage"
+)
+
+// AgentTelemetryParams is the payload of an agent telemetry notification.
+//
+// Text is a rendered, ready-to-show form of the same thing Data holds
+// structurally, so a client that does not understand a given kind still has
+// something to show.
+type AgentTelemetryParams struct {
+	TaskID    string         `json:"task_id"`
+	SessionID string         `json:"session_id"`
+	Kind      string         `json:"kind"`
+	Text      string         `json:"text"`
+	Data      map[string]any `json:"data"`
+}
+
+// planID is the plan a payload refers to, or "" if it names none.
+func (p AgentTelemetryParams) planID() string {
+	id, _ := p.Data["planId"].(string)
+	return id
+}
+
+// removed reports whether the agent withdrew the plan this payload names.
+func (p AgentTelemetryParams) removed() bool {
+	gone, _ := p.Data["removed"].(bool)
+	return gone
+}
+
+// agentTelemetryMessageKey identifies the one chat message that stands for a
+// plan, or for a task's usage counters — the things that are revised in place
+// rather than appended to.
+func agentTelemetryMessageKey(taskID int64, kind, planID string) string {
+	if kind == agentTelemetryKindPlan {
+		return fmt.Sprintf("%d:plan:%s", taskID, planID)
+	}
+	return fmt.Sprintf("%d:%s", taskID, kind)
+}
+
+// HandleAgentTelemetry relays one piece of agent telemetry into a task's chat.
+//
+// Reasoning is appended: each block explains a different moment of the turn.
+// Plans and usage counters are revised in place, because a new message every
+// time a checkbox ticks or a token counter moves buries the conversation.
+func (ps *WorkspaceServer) HandleAgentTelemetry(ctx context.Context, sessionID string, p AgentTelemetryParams) {
+	taskID, ok := ps.resolveTaskID(ctx, sessionID, p.TaskID)
+	if !ok {
+		zlog.Warn().Str("session_id", sessionID).Str("kind", p.Kind).
+			Msg("could not relay agent telemetry: no active task")
+		return
+	}
+
+	switch p.Kind {
+	case agentTelemetryKindThought:
+		if strings.TrimSpace(p.Text) == "" {
+			return
+		}
+		ps.postAgentTelemetryMessage(ctx, taskID, p.Text, agentTelemetryMetadata(MessageTypeAgentThought, p))
+	case agentTelemetryKindPlan:
+		ps.reviseAgentTelemetryMessage(ctx, taskID, p, MessageTypeAgentPlan)
+	case agentTelemetryKindUsage:
+		ps.reviseAgentTelemetryMessage(ctx, taskID, p, MessageTypeAgentUsage)
+	default:
+		zlog.Debug().Str("kind", p.Kind).Int64("task_id", taskID).
+			Msg("ignoring agent telemetry of an unrecognised kind")
+	}
+}
+
+// agentTelemetryMetadata builds the message metadata a client renders from.
+//
+// Text is carried in the metadata as well as in the message body: the body is
+// written once and a revised plan or usage line would otherwise go stale, so
+// the metadata is what a client should prefer.
+func agentTelemetryMetadata(messageType string, p AgentTelemetryParams) map[string]any {
+	metadata := map[string]any{"type": messageType, "text": p.Text}
+	for k, v := range p.Data {
+		// The payload describes the telemetry; it does not get to say what
+		// kind of message this is or to replace the rendered text.
+		if k == "type" || k == "text" {
+			continue
+		}
+		metadata[k] = v
+	}
+	return metadata
+}
+
+// postAgentTelemetryMessage appends a new chat message and returns its ID, or
+// 0 if it could not be delivered.
+func (ps *WorkspaceServer) postAgentTelemetryMessage(ctx context.Context, taskID int64, text string, metadata map[string]any) int64 {
+	msgID, err := ps.reply(ctx, monoflake.ID(taskID).String(), text, nil, metadata)
+	if err != nil {
+		zlog.Error().Err(err).Int64("task_id", taskID).
+			Msg("failed to relay agent telemetry")
+		return 0
+	}
+	return msgID
+}
+
+// reviseAgentTelemetryMessage updates the message already standing for this
+// plan or usage counter, and posts a new one only when there is none.
+func (ps *WorkspaceServer) reviseAgentTelemetryMessage(ctx context.Context, taskID int64, p AgentTelemetryParams, messageType string) {
+	key := agentTelemetryMessageKey(taskID, p.Kind, p.planID())
+	metadata := agentTelemetryMetadata(messageType, p)
+
+	ps.agentTelemetryMessagesMu.RLock()
+	msgID, known := ps.agentTelemetryMessages[key]
+	ps.agentTelemetryMessagesMu.RUnlock()
+
+	revised := false
+	if known && ps.updateMessageMetadata != nil {
+		if err := ps.updateMessageMetadata(ctx, taskID, msgID, metadata); err != nil {
+			// The message is gone, or was never written: fall through and post
+			// a fresh one rather than lose the update.
+			zlog.Warn().Err(err).Int64("task_id", taskID).Int64("message_id", msgID).
+				Msg("could not revise agent telemetry message; posting a new one")
+		} else {
+			revised = true
+		}
+	}
+
+	if revised {
+		ps.forgetRemovedPlan(key, p)
+		return
+	}
+
+	// A withdrawal notice for a plan that was never shown says nothing to the
+	// human, and posting one would put an orphaned card in the conversation.
+	if p.removed() {
+		return
+	}
+
+	if msgID = ps.postAgentTelemetryMessage(ctx, taskID, p.Text, metadata); msgID == 0 {
+		return
+	}
+	ps.agentTelemetryMessagesMu.Lock()
+	ps.agentTelemetryMessages[key] = msgID
+	ps.agentTelemetryMessagesMu.Unlock()
+}
+
+// forgetRemovedPlan releases a withdrawn plan's message, so that an agent
+// reusing the same plan ID later starts a new card rather than reviving the
+// one marked withdrawn.
+func (ps *WorkspaceServer) forgetRemovedPlan(key string, p AgentTelemetryParams) {
+	if !p.removed() {
+		return
+	}
+	ps.agentTelemetryMessagesMu.Lock()
+	delete(ps.agentTelemetryMessages, key)
+	ps.agentTelemetryMessagesMu.Unlock()
+}

--- a/backend/internal/controller/mcp/agent_telemetry_test.go
+++ b/backend/internal/controller/mcp/agent_telemetry_test.go
@@ -1,0 +1,424 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	mock_pubsub "github.com/agentrq/agentrq/backend/internal/service/mocks/pubsub"
+	"github.com/golang/mock/gomock"
+)
+
+// postedMessage is one chat message the workspace server delivered.
+type postedMessage struct {
+	chatID   string
+	text     string
+	metadata map[string]any
+}
+
+// metadataRevision is one in-place update to an already-posted message.
+type metadataRevision struct {
+	messageID int64
+	metadata  map[string]any
+}
+
+// telemetryRecorder is a workspace server wired up just enough to take agent
+// telemetry, plus a record of everything it wrote to the task.
+type telemetryRecorder struct {
+	ps        *WorkspaceServer
+	posted    []postedMessage
+	revisions []metadataRevision
+	// replyErr, when set, makes every delivery attempt fail.
+	replyErr error
+	// updateErr, when set, makes every in-place revision fail.
+	updateErr error
+}
+
+// asMap re-reads metadata the way a client would: as JSON, not as whatever
+// concrete map the handler happened to build.
+func asMap(t *testing.T, metadata any) map[string]any {
+	t.Helper()
+	b, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatalf("metadata is not serialisable: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("metadata did not round-trip: %v", err)
+	}
+	return out
+}
+
+func newTelemetryRecorder(t *testing.T) *telemetryRecorder {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	pubsubMock := mock_pubsub.NewMockService(ctrl)
+	pubsubMock.EXPECT().Publish(gomock.Any(), gomock.Any()).AnyTimes()
+
+	rec := &telemetryRecorder{}
+	rec.ps = &WorkspaceServer{
+		workspaceID:            100,
+		pubsub:                 pubsubMock,
+		sessionTasks:           map[string]int64{"sess-1": 42},
+		agentTelemetryMessages: make(map[string]int64),
+		getTask: func(ctx context.Context, taskID int64) (model.Task, error) {
+			return model.Task{ID: taskID}, nil
+		},
+		listTasks: func(ctx context.Context, filter ListTasksFilter) ([]model.Task, error) {
+			return nil, errors.New("no ongoing task")
+		},
+		reply: func(ctx context.Context, chatID, text string, a []entity.Attachment, metadata any) (int64, error) {
+			if rec.replyErr != nil {
+				return 0, rec.replyErr
+			}
+			rec.posted = append(rec.posted, postedMessage{chatID: chatID, text: text, metadata: asMap(t, metadata)})
+			return int64(700 + len(rec.posted)), nil
+		},
+		updateMessageMetadata: func(ctx context.Context, taskID, messageID int64, metadata any) error {
+			if rec.updateErr != nil {
+				return rec.updateErr
+			}
+			rec.revisions = append(rec.revisions, metadataRevision{messageID: messageID, metadata: asMap(t, metadata)})
+			return nil
+		},
+	}
+	return rec
+}
+
+func thoughtParams(text string) AgentTelemetryParams {
+	return AgentTelemetryParams{SessionID: "sess-1", Kind: "thought", Text: text, Data: map[string]any{}}
+}
+
+func planParams(planID, text string, data map[string]any) AgentTelemetryParams {
+	full := map[string]any{"planId": planID, "planType": "items"}
+	for k, v := range data {
+		full[k] = v
+	}
+	return AgentTelemetryParams{SessionID: "sess-1", Kind: "plan", Text: text, Data: full}
+}
+
+// Reasoning is appended: each block explains a different moment of the turn.
+func TestHandleAgentTelemetry_ThoughtIsPostedAsItsOwnMessage(t *testing.T) {
+	rec := newTelemetryRecorder(t)
+
+	rec.ps.HandleAgentTelemetry(context.Background(), "sess-1", thoughtParams("Checking the config first."))
+	rec.ps.HandleAgentTelemetry(context.Background(), "sess-1", thoughtParams("Now running the tests."))
+
+	if len(rec.posted) != 2 {
+		t.Fatalf("expected each reasoning block to be its own message, got %d", len(rec.posted))
+	}
+	if rec.posted[0].text != "Checking the config first." {
+		t.Errorf("reasoning text was not delivered: %q", rec.posted[0].text)
+	}
+	if got := rec.posted[0].metadata["type"]; got != MessageTypeAgentThought {
+		t.Errorf("metadata type = %v, want %v", got, MessageTypeAgentThought)
+	}
+	if got := rec.posted[0].metadata["text"]; got != "Checking the config first." {
+		t.Errorf("metadata text = %v, want the reasoning itself", got)
+	}
+	if len(rec.revisions) != 0 {
+		t.Errorf("reasoning must never overwrite an earlier block, got %d revisions", len(rec.revisions))
+	}
+}
+
+// An agent that emits an empty reasoning block has said nothing worth showing.
+func TestHandleAgentTelemetry_BlankThoughtIsDropped(t *testing.T) {
+	rec := newTelemetryRecorder(t)
+
+	rec.ps.HandleAgentTelemetry(context.Background(), "sess-1", thoughtParams("   \n\t "))
+
+	if len(rec.posted) != 0 {
+		t.Fatalf("expected nothing to be posted, got %d messages", len(rec.posted))
+	}
+}
+
+// A plan card is written once and revised thereafter: a new message per ticked
+// checkbox would bury the conversation.
+func TestHandleAgentTelemetry_PlanIsRevisedInPlace(t *testing.T) {
+	rec := newTelemetryRecorder(t)
+	ctx := context.Background()
+
+	rec.ps.HandleAgentTelemetry(ctx, "sess-1", planParams("default", "- ⬜ Add tests", map[string]any{
+		"entries": []any{map[string]any{"content": "Add tests", "status": "pending"}},
+	}))
+	rec.ps.HandleAgentTelemetry(ctx, "sess-1", planParams("default", "- ✅ Add tests", map[string]any{
+		"entries": []any{map[string]any{"content": "Add tests", "status": "completed"}},
+	}))
+
+	if len(rec.posted) != 1 {
+		t.Fatalf("expected one plan message, got %d", len(rec.posted))
+	}
+	if len(rec.revisions) != 1 {
+		t.Fatalf("expected the second update to revise the first, got %d revisions", len(rec.revisions))
+	}
+	if rec.revisions[0].messageID != 701 {
+		t.Errorf("revised message %d, want the one that was posted", rec.revisions[0].messageID)
+	}
+	// The body was written once, so the metadata is what has to stay current.
+	if got := rec.revisions[0].metadata["text"]; got != "- ✅ Add tests" {
+		t.Errorf("revised text = %v, want the latest rendering", got)
+	}
+}
+
+// Plans are told apart by their ID, so an agent running two at once gets two
+// cards rather than one that flickers between them.
+func TestHandleAgentTelemetry_DistinctPlansGetDistinctMessages(t *testing.T) {
+	rec := newTelemetryRecorder(t)
+	ctx := context.Background()
+
+	rec.ps.HandleAgentTelemetry(ctx, "sess-1", planParams("plan-a", "- ⬜ A", nil))
+	rec.ps.HandleAgentTelemetry(ctx, "sess-1", planParams("plan-b", "- ⬜ B", nil))
+
+	if len(rec.posted) != 2 {
+		t.Fatalf("expected a message per plan, got %d", len(rec.posted))
+	}
+	if len(rec.revisions) != 0 {
+		t.Errorf("one plan must not overwrite another, got %d revisions", len(rec.revisions))
+	}
+}
+
+// Usage counters are cumulative, so one card per task is revised as the turn
+// goes on.
+func TestHandleAgentTelemetry_UsageIsRevisedInPlace(t *testing.T) {
+	rec := newTelemetryRecorder(t)
+	ctx := context.Background()
+	usage := func(text string, used float64) AgentTelemetryParams {
+		return AgentTelemetryParams{
+			SessionID: "sess-1",
+			Kind:      "usage",
+			Text:      text,
+			Data:      map[string]any{"used": used, "size": 200000.0},
+		}
+	}
+
+	rec.ps.HandleAgentTelemetry(ctx, "sess-1", usage("Context 100 / 200,000 tokens (0%)", 100))
+	rec.ps.HandleAgentTelemetry(ctx, "sess-1", usage("Context 50,000 / 200,000 tokens (25%)", 50000))
+
+	if len(rec.posted) != 1 {
+		t.Fatalf("expected one usage message, got %d", len(rec.posted))
+	}
+	if len(rec.revisions) != 1 {
+		t.Fatalf("expected the later snapshot to revise the first, got %d", len(rec.revisions))
+	}
+	if got := rec.revisions[0].metadata["used"]; got != 50000.0 {
+		t.Errorf("revised used = %v, want the later snapshot", got)
+	}
+	if got := rec.posted[0].metadata["type"]; got != MessageTypeAgentUsage {
+		t.Errorf("metadata type = %v, want %v", got, MessageTypeAgentUsage)
+	}
+}
+
+// Withdrawing a plan marks the card the human is already looking at.
+func TestHandleAgentTelemetry_WithdrawnPlanMarksTheExistingCard(t *testing.T) {
+	rec := newTelemetryRecorder(t)
+	ctx := context.Background()
+
+	rec.ps.HandleAgentTelemetry(ctx, "sess-1", planParams("plan-a", "- ⬜ A", nil))
+	rec.ps.HandleAgentTelemetry(ctx, "sess-1", planParams("plan-a", "Plan withdrawn.", map[string]any{"removed": true}))
+
+	if len(rec.revisions) != 1 {
+		t.Fatalf("expected the withdrawal to revise the plan card, got %d", len(rec.revisions))
+	}
+	if got := rec.revisions[0].metadata["removed"]; got != true {
+		t.Errorf("revised metadata removed = %v, want true", got)
+	}
+
+	// The card is released, so an agent reusing the ID starts a fresh one
+	// rather than reviving a card marked withdrawn.
+	rec.ps.HandleAgentTelemetry(ctx, "sess-1", planParams("plan-a", "- ⬜ A again", nil))
+	if len(rec.posted) != 2 {
+		t.Fatalf("expected a fresh card after a withdrawal, got %d messages", len(rec.posted))
+	}
+}
+
+// A withdrawal for a plan the human never saw would leave an orphaned card.
+func TestHandleAgentTelemetry_WithdrawnUnknownPlanPostsNothing(t *testing.T) {
+	rec := newTelemetryRecorder(t)
+
+	rec.ps.HandleAgentTelemetry(context.Background(), "sess-1",
+		planParams("plan-never-shown", "Plan withdrawn.", map[string]any{"removed": true}))
+
+	if len(rec.posted) != 0 {
+		t.Fatalf("expected nothing to be posted, got %d messages", len(rec.posted))
+	}
+}
+
+// If the message a plan was written to is gone, the update must not be lost.
+func TestHandleAgentTelemetry_UnrevisableMessageIsRewritten(t *testing.T) {
+	rec := newTelemetryRecorder(t)
+	ctx := context.Background()
+
+	rec.ps.HandleAgentTelemetry(ctx, "sess-1", planParams("plan-a", "- ⬜ A", nil))
+	rec.updateErr = errors.New("message not found")
+	rec.ps.HandleAgentTelemetry(ctx, "sess-1", planParams("plan-a", "- ✅ A", nil))
+
+	if len(rec.posted) != 2 {
+		t.Fatalf("expected the update to be posted afresh, got %d messages", len(rec.posted))
+	}
+	if rec.posted[1].text != "- ✅ A" {
+		t.Errorf("rewritten message = %q, want the latest rendering", rec.posted[1].text)
+	}
+
+	// And the plan now tracks the message it was actually written to.
+	rec.updateErr = nil
+	rec.ps.HandleAgentTelemetry(ctx, "sess-1", planParams("plan-a", "- ✅ A done", nil))
+	if len(rec.revisions) != 1 || rec.revisions[0].messageID != 702 {
+		t.Fatalf("expected the next update to revise message 702, got %+v", rec.revisions)
+	}
+}
+
+// A plan that could not be delivered must not be recorded as delivered, or the
+// next update would try to revise a message that does not exist.
+func TestHandleAgentTelemetry_UndeliverablePlanIsNotRemembered(t *testing.T) {
+	rec := newTelemetryRecorder(t)
+	ctx := context.Background()
+	rec.replyErr = errors.New("workspace is archived")
+
+	rec.ps.HandleAgentTelemetry(ctx, "sess-1", planParams("plan-a", "- ⬜ A", nil))
+
+	if len(rec.ps.agentTelemetryMessages) != 0 {
+		t.Fatalf("a failed delivery must not be tracked, got %v", rec.ps.agentTelemetryMessages)
+	}
+
+	rec.replyErr = nil
+	rec.ps.HandleAgentTelemetry(ctx, "sess-1", planParams("plan-a", "- ✅ A", nil))
+	if len(rec.posted) != 1 || len(rec.revisions) != 0 {
+		t.Fatalf("expected a fresh post rather than a revision, got %d posts / %d revisions",
+			len(rec.posted), len(rec.revisions))
+	}
+}
+
+// The payload describes the telemetry; it does not get to relabel the message.
+func TestAgentTelemetryMetadata_PayloadCannotOverrideTypeOrText(t *testing.T) {
+	metadata := agentTelemetryMetadata(MessageTypeAgentPlan, AgentTelemetryParams{
+		Text: "the real rendering",
+		Data: map[string]any{
+			"type":    "permission_request",
+			"text":    "something else",
+			"planId":  "plan-a",
+			"entries": []any{},
+		},
+	})
+
+	if metadata["type"] != MessageTypeAgentPlan {
+		t.Errorf("type = %v, want %v", metadata["type"], MessageTypeAgentPlan)
+	}
+	if metadata["text"] != "the real rendering" {
+		t.Errorf("text = %v, want the rendering the gateway produced", metadata["text"])
+	}
+	if metadata["planId"] != "plan-a" {
+		t.Errorf("planId = %v, want it carried through", metadata["planId"])
+	}
+}
+
+// Telemetry that belongs to no task has nowhere to go.
+func TestHandleAgentTelemetry_NoTaskPostsNothing(t *testing.T) {
+	rec := newTelemetryRecorder(t)
+
+	rec.ps.HandleAgentTelemetry(context.Background(), "sess-unknown", thoughtParams("Nowhere to put this."))
+
+	if len(rec.posted) != 0 {
+		t.Fatalf("expected nothing to be posted, got %d messages", len(rec.posted))
+	}
+}
+
+// A newer gateway may send kinds this build does not know; they are ignored
+// rather than shown as an empty message.
+func TestHandleAgentTelemetry_UnknownKindIsIgnored(t *testing.T) {
+	rec := newTelemetryRecorder(t)
+
+	rec.ps.HandleAgentTelemetry(context.Background(), "sess-1", AgentTelemetryParams{
+		SessionID: "sess-1", Kind: "something_new", Text: "…",
+	})
+
+	if len(rec.posted) != 0 {
+		t.Fatalf("expected nothing to be posted, got %d messages", len(rec.posted))
+	}
+}
+
+// The payload's own task ID wins over the session mapping, so telemetry from a
+// gateway juggling several tasks lands on the right one.
+func TestHandleAgentTelemetry_PayloadTaskIDIsHonoured(t *testing.T) {
+	rec := newTelemetryRecorder(t)
+	p := thoughtParams("For another task.")
+	p.TaskID = "0an2BXTfpGj"
+
+	rec.ps.HandleAgentTelemetry(context.Background(), "sess-1", p)
+
+	if len(rec.posted) != 1 {
+		t.Fatalf("expected one message, got %d", len(rec.posted))
+	}
+	if rec.posted[0].chatID != "0an2BXTfpGj" {
+		t.Errorf("posted to %q, want the task the payload named", rec.posted[0].chatID)
+	}
+}
+
+// The SDK rejects this notification method, so it arrives as a raw body the
+// handler recognises and forwards here.
+func TestHandleCustomNotification_RoutesAgentTelemetry(t *testing.T) {
+	rec := newTelemetryRecorder(t)
+	body, _ := json.Marshal(map[string]any{
+		"method": AgentTelemetryNotificationMethod,
+		"params": map[string]any{
+			"task_id":    "",
+			"session_id": "sess-1",
+			"kind":       "thought",
+			"text":       "Reasoning from the wire.",
+			"data":       map[string]any{},
+		},
+	})
+
+	rec.ps.HandleCustomNotification(context.Background(), "sess-1", body)
+
+	if len(rec.posted) != 1 {
+		t.Fatalf("expected the notification to be relayed, got %d messages", len(rec.posted))
+	}
+	if rec.posted[0].text != "Reasoning from the wire." {
+		t.Errorf("relayed text = %q", rec.posted[0].text)
+	}
+}
+
+// A telemetry body the shared notification envelope accepts but the telemetry
+// payload does not is dropped rather than half-read.
+func TestHandleCustomNotification_MalformedAgentTelemetryIsDropped(t *testing.T) {
+	rec := newTelemetryRecorder(t)
+	// `kind` as a number: the permission envelope this shares a decode with
+	// ignores the field, so only the telemetry decode rejects it.
+	body := []byte(`{"method":"` + AgentTelemetryNotificationMethod +
+		`","params":{"session_id":"sess-1","kind":123,"text":"…"}}`)
+
+	rec.ps.HandleCustomNotification(context.Background(), "sess-1", body)
+
+	if len(rec.posted) != 0 {
+		t.Fatalf("expected nothing to be posted, got %d messages", len(rec.posted))
+	}
+}
+
+// Plans are keyed per plan; usage is keyed per task.
+func TestAgentTelemetryMessageKey(t *testing.T) {
+	if got, want := agentTelemetryMessageKey(42, agentTelemetryKindPlan, "plan-a"), "42:plan:plan-a"; got != want {
+		t.Errorf("plan key = %q, want %q", got, want)
+	}
+	if got, want := agentTelemetryMessageKey(42, agentTelemetryKindUsage, ""), "42:usage"; got != want {
+		t.Errorf("usage key = %q, want %q", got, want)
+	}
+}
+
+// A build without the in-place update wired up still shows the telemetry; it
+// just appends instead of revising.
+func TestHandleAgentTelemetry_WithoutInPlaceUpdatesPlansAreAppended(t *testing.T) {
+	rec := newTelemetryRecorder(t)
+	rec.ps.updateMessageMetadata = nil
+	ctx := context.Background()
+
+	rec.ps.HandleAgentTelemetry(ctx, "sess-1", planParams("plan-a", "- ⬜ A", nil))
+	rec.ps.HandleAgentTelemetry(ctx, "sess-1", planParams("plan-a", "- ✅ A", nil))
+
+	if len(rec.posted) != 2 {
+		t.Fatalf("expected both plans to be posted, got %d", len(rec.posted))
+	}
+}

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -124,15 +124,19 @@ type WorkspaceServer struct {
 	undeliveredVerdicts   map[string]string // requestID -> verdict the agent never received
 	toolCallIDsMu         sync.RWMutex
 	toolCallIDs           map[string]int64 // requestID -> ToolCall row ID (manual requests only, until resolved)
-	elicitationsMu        sync.Mutex
-	elicitations          map[string]chan elicitationResponse // requestID -> channel the waiting elicit tool call blocks on
-	metadataMu            sync.RWMutex
-	icon                  string
-	name                  string
-	description           string
-	archivedAt            *time.Time
-	lastUpdateCheckAt     time.Time
-	agentConnections      atomic.Int32
+	// The chat message standing for a plan or for a task's usage counters, so
+	// each revision rewrites that message instead of appending another one.
+	agentTelemetryMessagesMu sync.RWMutex
+	agentTelemetryMessages   map[string]int64 // taskID:kind[:planID] -> messageID
+	elicitationsMu           sync.Mutex
+	elicitations             map[string]chan elicitationResponse // requestID -> channel the waiting elicit tool call blocks on
+	metadataMu               sync.RWMutex
+	icon                     string
+	name                     string
+	description              string
+	archivedAt               *time.Time
+	lastUpdateCheckAt        time.Time
+	agentConnections         atomic.Int32
 
 	// done is closed by Close to stop the StartPing/StartPoller ticker goroutines, so a
 	// removed workspace server does not leak them for the lifetime of the process.
@@ -325,40 +329,41 @@ func NewWorkspaceServer(
 ) *WorkspaceServer {
 	zlog.Info().Int64("workspace_id", workspaceID).Msg("new workspace server created")
 	ps := &WorkspaceServer{
-		workspaceID:           workspaceID,
-		userID:                userID,
-		done:                  make(chan struct{}),
-		createTask:            createTask,
-		updateStatus:          updateStatus,
-		getTask:               getTask,
-		listTasks:             listTasks,
-		getNextTask:           getNextTask,
-		reply:                 reply,
-		updateMessageMetadata: updateMessageMetadata,
-		updateAutoAllowed:     updateAutoAllowed,
-		publishEvent:          publishEvent,
-		recordToolCall:        recordToolCall,
-		updateToolCallStatus:  updateToolCallStatus,
-		bus:                   bus,
-		idgen:                 ids,
-		storage:               store,
-		tokenSvc:              tokenSvc,
-		autoAllowedTools:      autoAllowedTools,
-		permissionRequests:    make(map[string]string),
-		requestTools:          make(map[string]string),
-		requestParams:         make(map[string]*PermissionRequestParams),
-		sessionTasks:          make(map[string]int64),
-		requestTaskIDs:        make(map[string]int64),
-		permissionResponses:   make(map[string]int64),
-		undeliveredVerdicts:   make(map[string]string),
-		toolCallIDs:           make(map[string]int64),
-		elicitations:          make(map[string]chan elicitationResponse),
-		icon:                  icon,
-		name:                  name,
-		description:           description,
-		archivedAt:            archivedAt,
-		pubsub:                pubsub,
-		lastUpdateCheckAt:     time.Now(), // defer first status check by a full hour
+		workspaceID:            workspaceID,
+		userID:                 userID,
+		done:                   make(chan struct{}),
+		createTask:             createTask,
+		updateStatus:           updateStatus,
+		getTask:                getTask,
+		listTasks:              listTasks,
+		getNextTask:            getNextTask,
+		reply:                  reply,
+		updateMessageMetadata:  updateMessageMetadata,
+		updateAutoAllowed:      updateAutoAllowed,
+		publishEvent:           publishEvent,
+		recordToolCall:         recordToolCall,
+		updateToolCallStatus:   updateToolCallStatus,
+		bus:                    bus,
+		idgen:                  ids,
+		storage:                store,
+		tokenSvc:               tokenSvc,
+		autoAllowedTools:       autoAllowedTools,
+		permissionRequests:     make(map[string]string),
+		requestTools:           make(map[string]string),
+		requestParams:          make(map[string]*PermissionRequestParams),
+		sessionTasks:           make(map[string]int64),
+		requestTaskIDs:         make(map[string]int64),
+		permissionResponses:    make(map[string]int64),
+		undeliveredVerdicts:    make(map[string]string),
+		toolCallIDs:            make(map[string]int64),
+		agentTelemetryMessages: make(map[string]int64),
+		elicitations:           make(map[string]chan elicitationResponse),
+		icon:                   icon,
+		name:                   name,
+		description:            description,
+		archivedAt:             archivedAt,
+		pubsub:                 pubsub,
+		lastUpdateCheckAt:      time.Now(), // defer first status check by a full hour
 	}
 
 	workspaceIDStr := monoflake.ID(workspaceID).String()
@@ -2045,6 +2050,18 @@ func (ps *WorkspaceServer) HandleCustomNotification(ctx context.Context, session
 	}
 
 	zlog.Debug().Str("method", msg.Method).Str("session_id", sessionID).Msg("HandleCustomNotification received method")
+
+	if msg.Method == AgentTelemetryNotificationMethod {
+		var telemetry struct {
+			Params AgentTelemetryParams `json:"params"`
+		}
+		if err := json.Unmarshal(data, &telemetry); err != nil {
+			zlog.Error().Err(err).Str("session_id", sessionID).Msg("Failed to unmarshal agent telemetry notification")
+			return
+		}
+		ps.HandleAgentTelemetry(ctx, sessionID, telemetry.Params)
+		return
+	}
 
 	if msg.Method == "notifications/claude/channel/permission_request" {
 		p := msg.Params

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -25,6 +25,14 @@ import (
 	"github.com/mustafaturan/monoflake"
 )
 
+// customNotificationMethods are the channel notifications the MCP SDK rejects
+// as unsupported methods, so they are recognised here and handed to the
+// workspace server directly instead of reaching its middleware.
+var customNotificationMethods = []string{
+	"notifications/claude/channel/permission_request",
+	mcpctrl.AgentTelemetryNotificationMethod,
+}
+
 type Params struct {
 	MCPManager *mcpctrl.Manager
 	Crud       crud.Controller
@@ -359,14 +367,17 @@ func (h *handler) streamableHandler() http.Handler {
 		}
 
 		if r.Method == "POST" {
-			// Custom handling for notifications/claude/channel/permission_request
-			// because mcp-go (SDK) rejects them as unsupported methods.
-			if strings.Contains(string(body), "notifications/claude/channel/permission_request") {
-				zlog.Debug().Str("session_id", sessionID).Msg("Handling custom permission notification")
-				srv.HandleCustomNotification(ctx, sessionID, body)
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				return
+			// Custom handling for the channel notifications the SDK does not
+			// know about, because mcp-go (SDK) rejects them as unsupported
+			// methods before any middleware sees them.
+			for _, method := range customNotificationMethods {
+				if strings.Contains(string(body), method) {
+					zlog.Debug().Str("session_id", sessionID).Str("method", method).Msg("Handling custom channel notification")
+					srv.HandleCustomNotification(ctx, sessionID, body)
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					return
+				}
 			}
 		}
 		srv.Handler().ServeHTTP(w, r.WithContext(ctx))

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -361,11 +361,13 @@
     </main>
 
     <!-- Global Tooltip -->
+    <!-- whitespace-pre, not nowrap: a tooltip may carry more than one line
+         (the context gauge shows tokens and cost on separate lines), and
+         neither should wrap. The interpolation sits tight against the tags so
+         the preserved whitespace is only what the text itself holds. -->
     <div v-if="tooltipStore.visible"
-      class="fixed z-[100] px-3 py-1.5 text-xs font-semibold text-black dark:text-white bg-white dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 rounded-sm shadow-lg pointer-events-none whitespace-nowrap"
-      :style="tooltipStore.style">
-      {{ tooltipStore.text }}
-    </div>
+      class="fixed z-[100] px-3 py-1.5 text-xs font-semibold text-black dark:text-white bg-white dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 rounded-sm shadow-lg pointer-events-none whitespace-pre"
+      :style="tooltipStore.style">{{ tooltipStore.text }}</div>
 
     <!-- Global Toasts -->
     <Toast />

--- a/frontend/src/composables/useAgentTelemetry.js
+++ b/frontend/src/composables/useAgentTelemetry.js
@@ -1,0 +1,156 @@
+/**
+ * Reading the telemetry an agent streams alongside its answer: the reasoning
+ * behind it, the plan it is working to, and what the turn is costing.
+ *
+ * These arrive as ordinary agent messages carrying a metadata type. The
+ * metadata is the source of truth, not the message body: a plan card and a
+ * usage line are revised in place as the turn goes on, and only the metadata
+ * is rewritten — the body keeps whatever it was first written with.
+ *
+ * Extracted from TaskDetailView so it can be tested: the view is a large
+ * component wired to a router, a store and network calls, and the project has
+ * no component-test harness.
+ */
+
+/** The message metadata types the backend writes agent telemetry as. */
+export const AGENT_TELEMETRY_MESSAGE_TYPES = {
+  agent_thought: 'thought',
+  agent_plan: 'plan',
+  agent_usage: 'usage',
+};
+
+/**
+ * Which kind of telemetry a message is, or null if it is an ordinary message.
+ *
+ * @param {object} message
+ * @returns {'thought'|'plan'|'usage'|null}
+ */
+export function agentTelemetryKind(message) {
+  return AGENT_TELEMETRY_MESSAGE_TYPES[message?.metadata?.type] ?? null;
+}
+
+/** @param {object} message */
+export function isAgentTelemetry(message) {
+  return agentTelemetryKind(message) !== null;
+}
+
+/**
+ * The current rendering of a piece of telemetry.
+ *
+ * Prefers the metadata, which is rewritten on every revision, and falls back
+ * to the message body for anything written before the metadata carried it.
+ *
+ * @param {object} message
+ * @returns {string}
+ */
+export function telemetryText(message) {
+  const fromMetadata = message?.metadata?.text;
+  if (typeof fromMetadata === 'string' && fromMetadata !== '') return fromMetadata;
+  return message?.text ?? '';
+}
+
+/** Whether the agent has withdrawn the plan this message stands for. */
+export function planIsWithdrawn(message) {
+  return message?.metadata?.removed === true;
+}
+
+/**
+ * A plan in the form the card renders.
+ *
+ * Agents publish plans three ways — as entries, as a markdown document, or as
+ * a file they are keeping the plan in — so the card has to know which it has.
+ *
+ * @param {object} message
+ * @returns {{type: 'items', entries: Array<object>} |
+ *           {type: 'markdown', content: string} |
+ *           {type: 'file', uri: string} |
+ *           {type: 'text', text: string}}
+ */
+export function planContent(message) {
+  const metadata = message?.metadata ?? {};
+  if (Array.isArray(metadata.entries)) {
+    return { type: 'items', entries: metadata.entries.map(normalizePlanEntry) };
+  }
+  if (metadata.planType === 'markdown') {
+    return { type: 'markdown', content: metadata.content ?? '' };
+  }
+  if (metadata.planType === 'file') {
+    return { type: 'file', uri: metadata.uri ?? '' };
+  }
+  return { type: 'text', text: telemetryText(message) };
+}
+
+/** Fills in what an entry does not say, so the card never renders a blank row. */
+function normalizePlanEntry(entry) {
+  const status = entry?.status ?? 'pending';
+  return {
+    content: entry?.content ?? '',
+    priority: entry?.priority ?? 'medium',
+    status,
+    done: status === 'completed',
+    active: status === 'in_progress',
+  };
+}
+
+/**
+ * How far along an entry-based plan is, or null when there is nothing to
+ * count — a markdown plan, or one with no entries yet.
+ *
+ * @param {object} message
+ * @returns {{done: number, total: number}|null}
+ */
+export function planProgress(message) {
+  const plan = planContent(message);
+  if (plan.type !== 'items' || plan.entries.length === 0) return null;
+  return {
+    done: plan.entries.filter((entry) => entry.done).length,
+    total: plan.entries.length,
+  };
+}
+
+/**
+ * The context and cost counters, with the percentage worked out when the
+ * agent did not send one.
+ *
+ * @param {object} message
+ * @returns {{used: number|null, size: number|null, percent: number|null, text: string}}
+ */
+export function usageDetail(message) {
+  const metadata = message?.metadata ?? {};
+  const used = numberOrNull(metadata.used);
+  const size = numberOrNull(metadata.size);
+  let percent = numberOrNull(metadata.percent);
+  if (percent === null && used !== null && size !== null && size > 0) {
+    percent = Math.round((used / size) * 100);
+  }
+  return {
+    used,
+    size,
+    // A bar cannot be drawn outside its track, and an agent over its own
+    // reported window would otherwise overflow the card.
+    percent: percent === null ? null : Math.min(Math.max(percent, 0), 100),
+    text: telemetryText(message),
+  };
+}
+
+function numberOrNull(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * A one-line summary of a reasoning block, for the collapsed card.
+ *
+ * @param {object} message
+ * @param {number} [maxLength]
+ * @returns {string}
+ */
+export function thoughtPreview(message, maxLength = 90) {
+  const firstLine = telemetryText(message)
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line !== '');
+  if (!firstLine) return '';
+  const collapsed = firstLine.replace(/\s+/g, ' ');
+  if (collapsed.length <= maxLength) return collapsed;
+  return `${collapsed.slice(0, maxLength - 1).trimEnd()}…`;
+}

--- a/frontend/src/composables/useAgentTelemetry.js
+++ b/frontend/src/composables/useAgentTelemetry.js
@@ -35,6 +35,21 @@ export function isAgentTelemetry(message) {
 }
 
 /**
+ * Telemetry that belongs in the message thread, as opposed to the composer.
+ *
+ * Reasoning and plans are moments in a conversation and are read in sequence.
+ * The context counters are not: they describe the session as a whole, and only
+ * the current value means anything — so they live on the composer as a gauge
+ * rather than as a message that scrolls away.
+ *
+ * @param {object} message
+ */
+export function isThreadTelemetry(message) {
+  const kind = agentTelemetryKind(message);
+  return kind === 'thought' || kind === 'plan';
+}
+
+/**
  * The current rendering of a piece of telemetry.
  *
  * Prefers the metadata, which is rewritten on every revision, and falls back
@@ -135,6 +150,102 @@ export function usageDetail(message) {
 
 function numberOrNull(value) {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/** Where a filling context window stops being routine. */
+const CONTEXT_HIGH_PERCENT = 75;
+const CONTEXT_CRITICAL_PERCENT = 90;
+
+/**
+ * How much attention the current context level deserves.
+ *
+ * A number alone does not read at a glance; the gauge changes colour so that
+ * a session about to run out of room is noticeable without being read.
+ *
+ * @param {number|null} percent
+ * @returns {'normal'|'high'|'critical'}
+ */
+export function usageTone(percent) {
+  if (percent === null || percent === undefined) return 'normal';
+  if (percent >= CONTEXT_CRITICAL_PERCENT) return 'critical';
+  if (percent >= CONTEXT_HIGH_PERCENT) return 'high';
+  return 'normal';
+}
+
+/**
+ * The most recent context report in a thread, or null if there is none.
+ *
+ * Searched from the end: the counters are cumulative, so only the last one
+ * describes the session as it stands.
+ *
+ * @param {Array<object>} messages
+ * @returns {object|null}
+ */
+export function latestUsageMessage(messages) {
+  const list = Array.isArray(messages) ? messages : [];
+  for (let i = list.length - 1; i >= 0; i -= 1) {
+    if (agentTelemetryKind(list[i]) === 'usage') return list[i];
+  }
+  return null;
+}
+
+/** Thousands-separated, so six-figure token counts stay readable. */
+function formatTokens(tokens) {
+  return tokens.toLocaleString('en-US');
+}
+
+/**
+ * A cost with enough precision to be worth showing. Turns routinely cost
+ * fractions of a cent, and "0.00 USD" says nothing.
+ */
+function formatCost(cost) {
+  const amount =
+    cost.amount !== 0 && Math.abs(cost.amount) < 0.01
+      ? cost.amount.toFixed(4)
+      : cost.amount.toFixed(2);
+  return `${amount} ${cost.currency ?? ''}`.trim();
+}
+
+/** The lines the gauge's tooltip shows on hover. */
+function usageTooltip(message, detail) {
+  const lines = [];
+  if (detail.used !== null && detail.size !== null) {
+    const share = detail.percent === null ? '' : ` (${detail.percent}%)`;
+    lines.push(`Context ${formatTokens(detail.used)} / ${formatTokens(detail.size)} tokens${share}`);
+  }
+  const cost = message?.metadata?.cost;
+  if (cost && numberOrNull(cost.amount) !== null) {
+    lines.push(`Session cost ${formatCost(cost)}`);
+  }
+  // Nothing structured to work from: fall back to whatever the agent rendered.
+  return lines.length > 0 ? lines.join('\n') : detail.text;
+}
+
+/**
+ * Everything the context ring needs, or null when nothing has been reported.
+ *
+ * The ring is drawn as a stroked circle whose dash gap is the unused part, so
+ * the geometry is worked out here rather than in the template.
+ *
+ * @param {object} message  a usage telemetry message
+ * @param {number} [radius] the ring's radius in the SVG's own units
+ * @returns {{percent: number|null, dashArray: number, dashOffset: number,
+ *            tone: string, tooltip: string}|null}
+ */
+export function contextGauge(message, radius = 8) {
+  if (agentTelemetryKind(message) !== 'usage') return null;
+  const detail = usageDetail(message);
+  const circumference = 2 * Math.PI * radius;
+  return {
+    percent: detail.percent,
+    dashArray: circumference,
+    // An agent that reported no window size still gets a ring, drawn empty:
+    // the tooltip carries the numbers, and hiding the ring would hide those
+    // too.
+    dashOffset: circumference * (1 - (detail.percent ?? 0) / 100),
+    tone: usageTone(detail.percent),
+    tooltip: usageTooltip(message, detail),
+  };
 }
 
 /**

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -161,8 +161,78 @@
       <!-- Messages -->
       <template v-for="m in displayMessages" :key="m.id">
 
+        <!-- Agent telemetry — the reasoning, plan and counters an ACP gateway
+             streams alongside the answer. Muted and indented under the agent's
+             avatar: this is how the answer came about, not the answer. -->
+        <div v-if="isAgentTelemetry(m)" class="flex gap-3 animate-in fade-in slide-in-from-bottom-2 duration-300 max-w-full md:max-w-[90%] w-full">
+          <div class="w-8 shrink-0"></div>
+          <div class="flex flex-col items-start min-w-0 w-full">
+
+            <!-- Reasoning: collapsed to a single line until asked for -->
+            <div v-if="agentTelemetryKind(m) === 'thought'"
+                 @click="toggleTelemetry(m.id)"
+                 class="w-full border border-dashed border-gray-200 dark:border-zinc-700 rounded-sm bg-gray-50/70 dark:bg-zinc-900/40 px-3 py-2 cursor-pointer select-none hover:border-gray-300 dark:hover:border-zinc-600 transition-colors">
+              <div class="flex items-center gap-2 min-w-0">
+                <svg class="w-3 h-3 shrink-0 text-gray-400 dark:text-zinc-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" /></svg>
+                <span class="text-[9px] font-semibold uppercase tracking-wider text-gray-400 dark:text-zinc-500 shrink-0">Thinking</span>
+                <span v-if="!expandedTelemetry.has(m.id)" class="text-[11px] italic text-gray-500 dark:text-zinc-400 truncate min-w-0">{{ thoughtPreview(m) }}</span>
+                <span class="flex-1"></span>
+                <span class="text-[8px] font-semibold text-gray-400 dark:text-zinc-600 shrink-0 hidden sm:block">{{ formatDateTime(m.createdAt) }}</span>
+                <svg class="w-3 h-3 shrink-0 text-gray-400 dark:text-zinc-500 transition-transform duration-200" :class="expandedTelemetry.has(m.id) ? 'rotate-180' : ''" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
+              </div>
+              <div v-if="expandedTelemetry.has(m.id)"
+                   class="md-body mt-2 pt-2 border-t border-dashed border-gray-200 dark:border-zinc-700 text-[12px] italic text-gray-600 dark:text-zinc-400"
+                   v-html="renderMarkdown(telemetryText(m))"></div>
+            </div>
+
+            <!-- Plan: one card per plan, rewritten in place as the agent works -->
+            <div v-else-if="agentTelemetryKind(m) === 'plan'"
+                 class="w-full border border-gray-200 dark:border-zinc-700 rounded-sm bg-white dark:bg-zinc-900 overflow-hidden shadow-sm"
+                 :class="planIsWithdrawn(m) ? 'opacity-60' : ''">
+              <div class="bg-gray-50 dark:bg-zinc-800/80 border-b border-gray-200 dark:border-zinc-700 px-3 py-2 flex items-center gap-2">
+                <svg class="w-3.5 h-3.5 shrink-0 text-gray-500 dark:text-zinc-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" /></svg>
+                <span class="text-[10px] font-semibold text-gray-800 dark:text-zinc-200">Plan</span>
+                <span v-if="planIsWithdrawn(m)" class="text-[8px] font-bold uppercase tracking-wider text-gray-400 dark:text-zinc-500">Withdrawn</span>
+                <span class="flex-1"></span>
+                <span v-if="planProgress(m)" class="text-[9px] font-semibold text-gray-500 dark:text-zinc-400 shrink-0">{{ planProgress(m).done }} / {{ planProgress(m).total }}</span>
+              </div>
+              <div class="p-3 min-w-0">
+                <ul v-if="planContent(m).type === 'items' && planContent(m).entries.length" class="flex flex-col gap-1.5">
+                  <li v-for="(entry, i) in planContent(m).entries" :key="i" class="flex items-start gap-2 text-[11px] min-w-0">
+                    <span class="mt-[3px] w-3 h-3 shrink-0 rounded-[3px] border flex items-center justify-center"
+                          :class="entry.done ? 'bg-gray-900 dark:bg-white border-gray-900 dark:border-white'
+                                  : entry.active ? 'border-gray-900 dark:border-white'
+                                  : 'border-gray-300 dark:border-zinc-600'">
+                      <svg v-if="entry.done" class="w-2 h-2 text-white dark:text-black" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="4"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
+                      <span v-else-if="entry.active" class="w-1.5 h-1.5 rounded-full bg-gray-900 dark:bg-white animate-pulse"></span>
+                    </span>
+                    <span class="min-w-0 break-words"
+                          :class="entry.done ? 'line-through text-gray-400 dark:text-zinc-500'
+                                  : entry.active ? 'font-semibold text-gray-900 dark:text-zinc-100'
+                                  : 'text-gray-600 dark:text-zinc-400'">{{ entry.content }}</span>
+                    <span v-if="entry.priority === 'high' && !entry.done" class="ml-auto shrink-0 text-[8px] font-bold uppercase tracking-wider text-amber-600 dark:text-amber-500">High</span>
+                  </li>
+                </ul>
+                <a v-else-if="planContent(m).type === 'file'" :href="planContent(m).uri" target="_blank" rel="noopener noreferrer"
+                   class="text-[11px] font-medium text-gray-700 dark:text-zinc-300 underline break-all">{{ planContent(m).uri }}</a>
+                <div v-else class="md-body text-[12px] text-gray-600 dark:text-zinc-400"
+                     v-html="renderMarkdown(planContent(m).type === 'markdown' ? planContent(m).content : telemetryText(m))"></div>
+              </div>
+            </div>
+
+            <!-- Context and cost: one line per task, rewritten as the turn goes on -->
+            <div v-else class="w-full flex items-center gap-2.5 px-3 py-1.5 rounded-sm bg-gray-50/70 dark:bg-zinc-900/40 border border-gray-100 dark:border-zinc-800">
+              <svg class="w-3 h-3 shrink-0 text-gray-400 dark:text-zinc-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" /></svg>
+              <span class="text-[10px] font-medium text-gray-500 dark:text-zinc-400 whitespace-nowrap">{{ usageDetail(m).text }}</span>
+              <div v-if="usageDetail(m).percent !== null" class="flex-1 min-w-[40px] h-1 rounded-full bg-gray-200 dark:bg-zinc-700 overflow-hidden">
+                <div class="h-full rounded-full bg-gray-600 dark:bg-zinc-300 transition-all duration-500" :style="{ width: usageDetail(m).percent + '%' }"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <!-- Agent message — left aligned -->
-        <div v-if="m.sender === 'agent'" class="group flex gap-3 animate-in fade-in slide-in-from-bottom-2 duration-300 max-w-full md:max-w-[90%]">
+        <div v-else-if="m.sender === 'agent'" class="group flex gap-3 animate-in fade-in slide-in-from-bottom-2 duration-300 max-w-full md:max-w-[90%]">
           <div class="w-8 h-8 rounded-full bg-gray-100 dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 flex items-center justify-center shrink-0 mt-0.5">
             <svg class="w-4 h-4 text-gray-700 dark:text-zinc-100" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"></path><rect width="16" height="12" x="4" y="8" rx="2"></rect><path d="M2 14h2"></path><path d="M20 14h2"></path><path d="M15 13v2"></path><path d="M9 13v2"></path></svg>
           </div>
@@ -681,6 +751,16 @@ import { usePendingSend } from '../composables/usePendingSend';
 import { scrollToBottom as scrollContainerToBottom, shouldScrollOnViewChange } from '../composables/useChatScroll';
 import { useEventBus } from '../useEventBus';
 import { renderMarkdown } from '../utils/markdown';
+import {
+  agentTelemetryKind,
+  isAgentTelemetry,
+  planContent,
+  planIsWithdrawn,
+  planProgress,
+  telemetryText,
+  thoughtPreview,
+  usageDetail,
+} from '../composables/useAgentTelemetry';
 import TrajectoryPanel from '../components/TrajectoryPanel.vue';
 
 const { notifyError, notifySuccess } = useToasts();
@@ -741,6 +821,15 @@ function toggleMessageRender(id) {
   s.has(id) ? s.delete(id) : s.add(id);
   rawMessages.value = s;
 }
+// Reasoning blocks are collapsed by default: they explain the answer, they are
+// not the answer, and a turn can produce a great many of them.
+const expandedTelemetry = ref(new Set());
+function toggleTelemetry(id) {
+  const s = new Set(expandedTelemetry.value);
+  s.has(id) ? s.delete(id) : s.add(id);
+  expandedTelemetry.value = s;
+}
+
 const copiedMessages = ref(new Set());
 async function copyMessageText(id, text) {
   await navigator.clipboard.writeText(text || '');

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -164,7 +164,7 @@
         <!-- Agent telemetry — the reasoning, plan and counters an ACP gateway
              streams alongside the answer. Muted and indented under the agent's
              avatar: this is how the answer came about, not the answer. -->
-        <div v-if="isAgentTelemetry(m)" class="flex gap-3 animate-in fade-in slide-in-from-bottom-2 duration-300 max-w-full md:max-w-[90%] w-full">
+        <div v-if="isThreadTelemetry(m)" class="flex gap-3 animate-in fade-in slide-in-from-bottom-2 duration-300 max-w-full md:max-w-[90%] w-full">
           <div class="w-8 shrink-0"></div>
           <div class="flex flex-col items-start min-w-0 w-full">
 
@@ -186,7 +186,7 @@
             </div>
 
             <!-- Plan: one card per plan, rewritten in place as the agent works -->
-            <div v-else-if="agentTelemetryKind(m) === 'plan'"
+            <div v-else
                  class="w-full border border-gray-200 dark:border-zinc-700 rounded-sm bg-white dark:bg-zinc-900 overflow-hidden shadow-sm"
                  :class="planIsWithdrawn(m) ? 'opacity-60' : ''">
               <div class="bg-gray-50 dark:bg-zinc-800/80 border-b border-gray-200 dark:border-zinc-700 px-3 py-2 flex items-center gap-2">
@@ -217,15 +217,6 @@
                    class="text-[11px] font-medium text-gray-700 dark:text-zinc-300 underline break-all">{{ planContent(m).uri }}</a>
                 <div v-else class="md-body text-[12px] text-gray-600 dark:text-zinc-400"
                      v-html="renderMarkdown(planContent(m).type === 'markdown' ? planContent(m).content : telemetryText(m))"></div>
-              </div>
-            </div>
-
-            <!-- Context and cost: one line per task, rewritten as the turn goes on -->
-            <div v-else class="w-full flex items-center gap-2.5 px-3 py-1.5 rounded-sm bg-gray-50/70 dark:bg-zinc-900/40 border border-gray-100 dark:border-zinc-800">
-              <svg class="w-3 h-3 shrink-0 text-gray-400 dark:text-zinc-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" /></svg>
-              <span class="text-[10px] font-medium text-gray-500 dark:text-zinc-400 whitespace-nowrap">{{ usageDetail(m).text }}</span>
-              <div v-if="usageDetail(m).percent !== null" class="flex-1 min-w-[40px] h-1 rounded-full bg-gray-200 dark:bg-zinc-700 overflow-hidden">
-                <div class="h-full rounded-full bg-gray-600 dark:bg-zinc-300 transition-all duration-500" :style="{ width: usageDetail(m).percent + '%' }"></div>
               </div>
             </div>
           </div>
@@ -633,6 +624,28 @@
                 <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M17.657 18.657A8 8 0 016.343 7.343S7 9 9 10c0-2 .5-5 2.986-7C14 5 16.09 5.777 17.656 7.343A7.99 7.99 0 0120 13a7.98 7.98 0 01-2.343 5.657z" /><path stroke-linecap="round" stroke-linejoin="round" d="M9.879 16.121A3 3 0 1012.015 11L11 14l2.015-2.879z" /></svg>
                 YOLO
               </button>
+              <!-- Context window. Not a message: the counters describe the
+                   session as a whole and only the current value means
+                   anything, so they sit here where they stay in view rather
+                   than scrolling away up the thread. -->
+              <div v-if="contextUsage" role="img" tabindex="0"
+                   :aria-label="contextUsage.tooltip"
+                   @mouseenter="tooltipStore.show($event, contextUsage.tooltip, 'top')"
+                   @mouseleave="tooltipStore.hide()"
+                   @focus="tooltipStore.show($event, contextUsage.tooltip, 'top')"
+                   @blur="tooltipStore.hide()"
+                   class="h-6 w-6 rounded-sm bg-gray-105 dark:bg-zinc-700/50 flex items-center justify-center cursor-default focus:outline-none focus-visible:ring-1 focus-visible:ring-gray-400 dark:focus-visible:ring-zinc-500">
+                <svg class="w-3.5 h-3.5 -rotate-90" viewBox="0 0 20 20" aria-hidden="true">
+                  <circle cx="10" cy="10" r="8" fill="none" stroke-width="3.5" stroke="currentColor" class="text-gray-300 dark:text-zinc-600" />
+                  <circle cx="10" cy="10" r="8" fill="none" stroke-width="3.5" stroke-linecap="round" stroke="currentColor"
+                          :stroke-dasharray="contextUsage.dashArray"
+                          :stroke-dashoffset="contextUsage.dashOffset"
+                          :class="contextUsage.tone === 'critical' ? 'text-red-500'
+                                  : contextUsage.tone === 'high' ? 'text-amber-500'
+                                  : 'text-gray-500 dark:text-zinc-300'"
+                          class="transition-all duration-500" />
+                </svg>
+              </div>
             </div>
 
             <!-- Right actions: stop, then send -->
@@ -753,13 +766,14 @@ import { useEventBus } from '../useEventBus';
 import { renderMarkdown } from '../utils/markdown';
 import {
   agentTelemetryKind,
-  isAgentTelemetry,
+  contextGauge,
+  isThreadTelemetry,
+  latestUsageMessage,
   planContent,
   planIsWithdrawn,
   planProgress,
   telemetryText,
   thoughtPreview,
-  usageDetail,
 } from '../composables/useAgentTelemetry';
 import TrajectoryPanel from '../components/TrajectoryPanel.vue';
 
@@ -949,12 +963,22 @@ const sortedMessages = computed(() => {
   return [...task.value.messages].sort((a,b) => new Date(a.createdAt) - new Date(b.createdAt));
 });
 
+// The context counters are telemetry, but they belong on the composer's gauge
+// rather than in the thread — see isThreadTelemetry.
+const threadMessages = computed(() =>
+  sortedMessages.value.filter((m) => agentTelemetryKind(m) !== 'usage')
+);
+
+// The session's context and cost as they stand, or null until an agent reports
+// them. Only a connected ACP gateway sends these.
+const contextUsage = computed(() => contextGauge(latestUsageMessage(sortedMessages.value)));
+
 // Appends a synthetic, not-yet-sent message bubble while a delayed send is
 // counting down, so the human can see and cancel exactly what's about to go
 // out instead of it disappearing into the composer footer.
 const displayMessages = computed(() => {
-  if (!pendingSend.value) return sortedMessages.value;
-  return [...sortedMessages.value, {
+  if (!pendingSend.value) return threadMessages.value;
+  return [...threadMessages.value, {
     id: '__pending-send__',
     sender: 'human',
     text: pendingSend.value.text,

--- a/frontend/test/agentTelemetry.test.js
+++ b/frontend/test/agentTelemetry.test.js
@@ -2,13 +2,17 @@ import { describe, it, expect } from 'vitest'
 
 import {
   agentTelemetryKind,
+  contextGauge,
   isAgentTelemetry,
+  isThreadTelemetry,
+  latestUsageMessage,
   planContent,
   planIsWithdrawn,
   planProgress,
   telemetryText,
   thoughtPreview,
   usageDetail,
+  usageTone,
 } from '../src/composables/useAgentTelemetry'
 
 const message = (metadata, text = '') => ({ id: 'm1', sender: 'agent', text, metadata })
@@ -217,5 +221,161 @@ describe('thoughtPreview', () => {
 
   it('has nothing to preview for an empty block', () => {
     expect(thoughtPreview(message({ type: 'agent_thought', text: '   \n  ' }))).toBe('')
+  })
+})
+
+describe('isThreadTelemetry', () => {
+  // Reasoning and plans are moments in a conversation. The context counters
+  // describe the session as a whole, so they live on the composer's gauge and
+  // must not also scroll past in the thread.
+  it('keeps reasoning and plans in the thread', () => {
+    expect(isThreadTelemetry(message({ type: 'agent_thought' }))).toBe(true)
+    expect(isThreadTelemetry(message({ type: 'agent_plan' }))).toBe(true)
+  })
+
+  it('keeps the context counters out of it', () => {
+    expect(isThreadTelemetry(message({ type: 'agent_usage' }))).toBe(false)
+  })
+
+  it('leaves ordinary messages alone', () => {
+    expect(isThreadTelemetry(message({ type: 'permission_request' }))).toBe(false)
+    expect(isThreadTelemetry(undefined)).toBe(false)
+  })
+})
+
+describe('usageTone', () => {
+  it('stays quiet while there is room to spare', () => {
+    expect(usageTone(0)).toBe('normal')
+    expect(usageTone(74)).toBe('normal')
+  })
+
+  it('speaks up as the window fills', () => {
+    expect(usageTone(75)).toBe('high')
+    expect(usageTone(89)).toBe('high')
+  })
+
+  it('escalates when the session is nearly out of room', () => {
+    expect(usageTone(90)).toBe('critical')
+    expect(usageTone(100)).toBe('critical')
+  })
+
+  it('says nothing is wrong when there is nothing to judge', () => {
+    expect(usageTone(null)).toBe('normal')
+    expect(usageTone(undefined)).toBe('normal')
+  })
+})
+
+describe('latestUsageMessage', () => {
+  // The counters are cumulative, so only the last report describes the
+  // session as it stands.
+  it('takes the last report, not the first', () => {
+    const older = message({ type: 'agent_usage', used: 100, size: 200000 })
+    const newer = message({ type: 'agent_usage', used: 50000, size: 200000 })
+
+    expect(latestUsageMessage([older, message({ type: 'agent_plan' }), newer])).toBe(newer)
+  })
+
+  it('has nothing to report before an agent has said anything', () => {
+    expect(latestUsageMessage([message({ type: 'agent_plan' }), message(undefined)])).toBeNull()
+    expect(latestUsageMessage([])).toBeNull()
+    expect(latestUsageMessage(undefined)).toBeNull()
+  })
+})
+
+describe('contextGauge', () => {
+  const usage = message({
+    type: 'agent_usage',
+    used: 50000,
+    size: 200000,
+    percent: 25,
+    cost: { amount: 0.38, currency: 'USD' },
+    text: 'Context 50,000 / 200,000 tokens (25%) · 0.38 USD',
+  })
+
+  it('draws a quarter of the ring for a quarter-full window', () => {
+    const gauge = contextGauge(usage, 8)
+    const circumference = 2 * Math.PI * 8
+
+    expect(gauge.dashArray).toBeCloseTo(circumference, 5)
+    expect(gauge.dashOffset).toBeCloseTo(circumference * 0.75, 5)
+    expect(gauge.percent).toBe(25)
+    expect(gauge.tone).toBe('normal')
+  })
+
+  it('scales the ring to whatever radius the icon uses', () => {
+    expect(contextGauge(usage, 20).dashArray).toBeCloseTo(2 * Math.PI * 20, 5)
+  })
+
+  it('closes the ring completely on a full window', () => {
+    const gauge = contextGauge(message({ type: 'agent_usage', used: 200000, size: 200000 }))
+
+    expect(gauge.dashOffset).toBeCloseTo(0, 5)
+    expect(gauge.tone).toBe('critical')
+  })
+
+  it('names the tokens and the cost on separate lines', () => {
+    expect(contextGauge(usage).tooltip).toBe(
+      'Context 50,000 / 200,000 tokens (25%)\nSession cost 0.38 USD'
+    )
+  })
+
+  it('leaves out the cost line when no cost was reported', () => {
+    const gauge = contextGauge(message({ type: 'agent_usage', used: 10, size: 100, percent: 10 }))
+
+    expect(gauge.tooltip).toBe('Context 10 / 100 tokens (10%)')
+  })
+
+  it('keeps sub-cent costs from rounding away to nothing', () => {
+    const gauge = contextGauge(
+      message({ type: 'agent_usage', used: 10, size: 100, cost: { amount: 0.0023, currency: 'USD' } })
+    )
+
+    expect(gauge.tooltip).toContain('Session cost 0.0023 USD')
+  })
+
+  it('renders a zero cost plainly rather than at four decimals', () => {
+    const gauge = contextGauge(
+      message({ type: 'agent_usage', used: 10, size: 100, cost: { amount: 0, currency: 'EUR' } })
+    )
+
+    expect(gauge.tooltip).toContain('Session cost 0.00 EUR')
+  })
+
+  it('names a cost whose currency the agent left off', () => {
+    const gauge = contextGauge(message({ type: 'agent_usage', used: 10, size: 100, cost: { amount: 2 } }))
+
+    expect(gauge.tooltip).toContain('Session cost 2.00')
+  })
+
+  it('ignores a cost that is not a number', () => {
+    const gauge = contextGauge(
+      message({ type: 'agent_usage', used: 10, size: 100, cost: { amount: 'lots', currency: 'USD' } })
+    )
+
+    expect(gauge.tooltip).toBe('Context 10 / 100 tokens (10%)')
+  })
+
+  // The tooltip is what carries the numbers, so an unreported window size
+  // draws an empty ring rather than hiding the gauge entirely.
+  it('draws an empty ring when the window size is unknown', () => {
+    const gauge = contextGauge(
+      message({ type: 'agent_usage', used: 4000, size: 0, text: 'Context 4,000 / 0 tokens' })
+    )
+
+    expect(gauge.percent).toBeNull()
+    expect(gauge.dashOffset).toBeCloseTo(gauge.dashArray, 5)
+    expect(gauge.tone).toBe('normal')
+    expect(gauge.tooltip).toBe('Context 4,000 / 0 tokens')
+  })
+
+  it('falls back to the agent\'s own rendering when nothing is structured', () => {
+    expect(contextGauge(message({ type: 'agent_usage', text: 'Context unknown' }, 'body')).tooltip).toBe(
+      'Context unknown'
+    )
+  })
+
+  it('has no gauge to draw for anything that is not a context report', () => {
+    expect(contextGauge(message({ type: 'agent_plan' }))).toBeNull()
+    expect(contextGauge(undefined)).toBeNull()
   })
 })

--- a/frontend/test/agentTelemetry.test.js
+++ b/frontend/test/agentTelemetry.test.js
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  agentTelemetryKind,
+  isAgentTelemetry,
+  planContent,
+  planIsWithdrawn,
+  planProgress,
+  telemetryText,
+  thoughtPreview,
+  usageDetail,
+} from '../src/composables/useAgentTelemetry'
+
+const message = (metadata, text = '') => ({ id: 'm1', sender: 'agent', text, metadata })
+
+describe('agentTelemetryKind', () => {
+  it('names the kind of each telemetry message', () => {
+    expect(agentTelemetryKind(message({ type: 'agent_thought' }))).toBe('thought')
+    expect(agentTelemetryKind(message({ type: 'agent_plan' }))).toBe('plan')
+    expect(agentTelemetryKind(message({ type: 'agent_usage' }))).toBe('usage')
+  })
+
+  it('leaves every other message alone', () => {
+    expect(agentTelemetryKind(message({ type: 'permission_request' }))).toBeNull()
+    expect(agentTelemetryKind(message(undefined))).toBeNull()
+    expect(agentTelemetryKind(undefined)).toBeNull()
+  })
+
+  it('answers the same question as isAgentTelemetry', () => {
+    expect(isAgentTelemetry(message({ type: 'agent_plan' }))).toBe(true)
+    expect(isAgentTelemetry(message({ type: 'permission_request' }))).toBe(false)
+  })
+})
+
+describe('telemetryText', () => {
+  // Plans and usage lines are revised in place and only their metadata is
+  // rewritten, so the body goes stale the moment the agent revises them.
+  it('prefers the metadata, which is the part that gets revised', () => {
+    expect(telemetryText(message({ type: 'agent_plan', text: 'current' }, 'as first written'))).toBe(
+      'current'
+    )
+  })
+
+  it('falls back to the body when the metadata carries no text', () => {
+    expect(telemetryText(message({ type: 'agent_plan' }, 'as first written'))).toBe('as first written')
+    expect(telemetryText(message({ type: 'agent_plan', text: '' }, 'as first written'))).toBe(
+      'as first written'
+    )
+  })
+
+  it('has nothing to show for a message with neither', () => {
+    expect(telemetryText(message({ type: 'agent_plan' }))).toBe('')
+    expect(telemetryText(undefined)).toBe('')
+  })
+})
+
+describe('planContent', () => {
+  it('reads an entry-based plan, filling in what an entry leaves out', () => {
+    const plan = planContent(
+      message({
+        type: 'agent_plan',
+        planType: 'items',
+        entries: [
+          { content: 'Read the config', priority: 'high', status: 'completed' },
+          { content: 'Wire it up', priority: 'medium', status: 'in_progress' },
+          { content: 'Add tests' },
+        ],
+      })
+    )
+
+    expect(plan.type).toBe('items')
+    expect(plan.entries).toEqual([
+      { content: 'Read the config', priority: 'high', status: 'completed', done: true, active: false },
+      { content: 'Wire it up', priority: 'medium', status: 'in_progress', done: false, active: true },
+      { content: 'Add tests', priority: 'medium', status: 'pending', done: false, active: false },
+    ])
+  })
+
+  it('renders an entry with nothing in it rather than dropping the row', () => {
+    const plan = planContent(message({ type: 'agent_plan', entries: [null] }))
+
+    expect(plan.entries).toEqual([
+      { content: '', priority: 'medium', status: 'pending', done: false, active: false },
+    ])
+  })
+
+  it('reads a markdown plan', () => {
+    expect(
+      planContent(message({ type: 'agent_plan', planType: 'markdown', content: '## Steps' }))
+    ).toEqual({ type: 'markdown', content: '## Steps' })
+  })
+
+  it('reads a file-backed plan', () => {
+    expect(
+      planContent(message({ type: 'agent_plan', planType: 'file', uri: 'file:///tmp/plan.md' }))
+    ).toEqual({ type: 'file', uri: 'file:///tmp/plan.md' })
+  })
+
+  it('shows an empty markdown or file plan as empty rather than undefined', () => {
+    expect(planContent(message({ type: 'agent_plan', planType: 'markdown' })).content).toBe('')
+    expect(planContent(message({ type: 'agent_plan', planType: 'file' })).uri).toBe('')
+  })
+
+  it('falls back to whatever text there is for a shape it does not know', () => {
+    expect(planContent(message({ type: 'agent_plan', text: 'Plan withdrawn.' }))).toEqual({
+      type: 'text',
+      text: 'Plan withdrawn.',
+    })
+    expect(planContent(undefined)).toEqual({ type: 'text', text: '' })
+  })
+})
+
+describe('planProgress', () => {
+  it('counts what is done against what there is', () => {
+    expect(
+      planProgress(
+        message({
+          type: 'agent_plan',
+          entries: [
+            { content: 'a', status: 'completed' },
+            { content: 'b', status: 'completed' },
+            { content: 'c', status: 'in_progress' },
+          ],
+        })
+      )
+    ).toEqual({ done: 2, total: 3 })
+  })
+
+  it('has nothing to count for an empty or non-entry plan', () => {
+    expect(planProgress(message({ type: 'agent_plan', entries: [] }))).toBeNull()
+    expect(planProgress(message({ type: 'agent_plan', planType: 'markdown', content: '#' }))).toBeNull()
+  })
+})
+
+describe('planIsWithdrawn', () => {
+  it('knows a plan the agent dropped', () => {
+    expect(planIsWithdrawn(message({ type: 'agent_plan', removed: true }))).toBe(true)
+    expect(planIsWithdrawn(message({ type: 'agent_plan' }))).toBe(false)
+    expect(planIsWithdrawn(undefined)).toBe(false)
+  })
+})
+
+describe('usageDetail', () => {
+  it('carries the counters through as the agent reported them', () => {
+    expect(
+      usageDetail(
+        message({
+          type: 'agent_usage',
+          used: 50000,
+          size: 200000,
+          percent: 25,
+          text: 'Context 50,000 / 200,000 tokens (25%)',
+        })
+      )
+    ).toEqual({
+      used: 50000,
+      size: 200000,
+      percent: 25,
+      text: 'Context 50,000 / 200,000 tokens (25%)',
+    })
+  })
+
+  it('works out the percentage when the agent did not send one', () => {
+    expect(usageDetail(message({ type: 'agent_usage', used: 25000, size: 200000 })).percent).toBe(13)
+  })
+
+  // A bar cannot be drawn outside its track.
+  it('keeps the percentage inside the range a bar can draw', () => {
+    expect(usageDetail(message({ type: 'agent_usage', percent: 140 })).percent).toBe(100)
+    expect(usageDetail(message({ type: 'agent_usage', percent: -5 })).percent).toBe(0)
+  })
+
+  it('has no percentage to show without a window size to divide by', () => {
+    expect(usageDetail(message({ type: 'agent_usage', used: 10, size: 0 })).percent).toBeNull()
+    expect(usageDetail(message({ type: 'agent_usage', used: 10 })).percent).toBeNull()
+  })
+
+  it('treats counters that are not real numbers as missing', () => {
+    const detail = usageDetail(message({ type: 'agent_usage', used: '50000', size: NaN }))
+
+    expect(detail).toEqual({ used: null, size: null, percent: null, text: '' })
+  })
+
+  it('has nothing to report for a message that is not there', () => {
+    expect(usageDetail(undefined)).toEqual({ used: null, size: null, percent: null, text: '' })
+  })
+})
+
+describe('thoughtPreview', () => {
+  it('summarises a block by its first line', () => {
+    expect(
+      thoughtPreview(message({ type: 'agent_thought', text: '\n  Checking the config.\nThen tests.' }))
+    ).toBe('Checking the config.')
+  })
+
+  it('collapses the whitespace inside that line', () => {
+    expect(thoughtPreview(message({ type: 'agent_thought', text: 'Checking\tthe   config.' }))).toBe(
+      'Checking the config.'
+    )
+  })
+
+  it('truncates a long line rather than letting it wrap the header', () => {
+    const preview = thoughtPreview(message({ type: 'agent_thought', text: 'x'.repeat(200) }), 10)
+
+    expect(preview).toBe(`${'x'.repeat(9)}…`)
+  })
+
+  it('does not truncate a line that already fits', () => {
+    expect(thoughtPreview(message({ type: 'agent_thought', text: 'Short.' }), 10)).toBe('Short.')
+  })
+
+  it('trims the trailing space a cut can leave behind', () => {
+    expect(thoughtPreview(message({ type: 'agent_thought', text: 'abcdefghi jklmn' }), 11)).toBe(
+      'abcdefghi…'
+    )
+  })
+
+  it('has nothing to preview for an empty block', () => {
+    expect(thoughtPreview(message({ type: 'agent_thought', text: '   \n  ' }))).toBe('')
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -38,6 +38,7 @@ export default defineConfig({
         'src/desktop/*.js',
         'src/composables/useChatScroll.js',
         'src/composables/useTaskGroups.js',
+        'src/composables/useAgentTelemetry.js',
         'src/composables/usePendingSend.js',
         'src/composables/useDirectoryPicker.js',
         'src/composables/useProfileDisplay.js',


### PR DESCRIPTION
## What changed

The workspace now shows the parts of an agent's turn that are not its answer. Reasoning appears in the thread as a muted aside collapsed to one line until you ask for it, and the execution plan as a card with per-step status and progress. The context window is not a message at all — it sits beside the YOLO toggle as a ring that fills as the session fills, the way Zed shows it, with the tokens and running cost on hover.

## Why

Watching a long agent run, a person could see what it finally said and which commands it asked to run, but nothing of how it got there. The protocol was already carrying the reasoning, the plan and the counters; nothing on this side was listening.

The counters in particular don't belong in a thread: they describe the session as a whole, only the current value means anything, and the moment you actually want them is while you're deciding what to send next — by which time a message has scrolled away.

## Test coverage report

- **New lines: 100%.** `backend/internal/controller/mcp/agent_telemetry.go` is at 100% on every function (17 new Go tests). `frontend/src/composables/useAgentTelemetry.js` is at 100% statements / branches / functions / lines (48 new tests) and is added to the frontend's enforced-100% coverage list.
- **Total coverage impact:** the frontend's covered set stays at 100% across the board, with one more file inside it. Backend: `go test ./...` passes unchanged; the new file adds fully-covered lines, so package coverage moves up rather than down.
- Suites: frontend 110 → 158 tests, backend `./internal/controller/mcp` +17, all passing.

## Other notes

- Named `AgentTelemetry` rather than `Telemetry` throughout: `WorkspaceServer` already has `emitTelemetry`, which is this product's own usage analytics and is unrelated.
- The MCP Go SDK rejects this notification method before any middleware runs — which is exactly why `permission_request` is already recognised from the raw POST body. That interception is generalised from one hard-coded string to a list, and telemetry joins it, rather than adding an unreachable middleware branch.
- Plans are revised in place rather than appended: a new chat message every time a checkbox ticks would bury the conversation. Only message *metadata* can be rewritten, so a revised plan's body keeps whatever it was first written with — the metadata therefore carries the current rendering as well, and the UI prefers it over the body.
- A withdrawn plan marks the card the person is looking at and then releases it, so an agent reusing that plan ID starts a fresh card rather than reviving one marked withdrawn.
- The ring turns amber past 75% and red past 90%, so a session about to run out of room is noticeable without being read. It is reachable by keyboard as well as hover.
- The shared tooltip now preserves newlines so it can carry the tokens and the cost on separate lines.
- Requires the matching gateway change: agentrq/acp-gateway#48.

TaskID: 0i81xtB9kQr

---
Generated with [AgentRQ](https://agentrq.com)