### PR TITLE
chore: bump patch version to v0.4.16

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.4.15"
+	_appVersion   = "v0.4.16"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.4.15" {
-			t.Errorf("Expected version v0.4.15, got %s", s.Version())
+		if s.Version() != "v0.4.16" {
+			t.Errorf("Expected version v0.4.16, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.4.15",
+      "version": "0.4.16",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.4.15",
+  "version": "0.4.16",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.4.15",
+      "version": "0.4.16",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.4.15",
+  "version": "0.4.16",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
**What changed**

The project's version number moves from 0.4.15 to 0.4.16, everywhere it is declared.

**Why changed**

To cut a release carrying the four changes merged since the last one: the agent's reasoning, plan and usage now shown in the task chat; the stop button moved down beside the composer's send button; an error that was logged every time someone opened a page; and the backend's test suite finally running in CI.

**Test coverage report**

- New lines introduced: none — this changes only version strings, and the one test that asserts the version was updated alongside it.
- Total coverage impact: none. The config package's test passes, both version-sync checks pass (plain, and in the form CI runs on a tag build), and `npm ci` still succeeds against both lockfiles with no dependency drift.

**Other reports**

Changes in this release:

- feat(telemetry): show the agent's reasoning, plan and usage in the task chat (#398)
- feat: move the stop button next to send (#397)
- fix: stop logging an error for every page a user opens (#395)
- ci: run the backend Go tests (#396)

Lockfile version fields were edited by hand rather than regenerated, so no unrelated dependency entries move underneath the release. One `0.4.15` deliberately left alone in the frontend lockfile: it is the version of a Babel polyfill plugin that happens to match, not a declaration of this project's version.

This is also the first bump since #396, so the backend suite now runs on it — the version constant and its assertion live in Go, and until now nothing in CI would have caught them disagreeing.

After merge, the release is cut by tagging `main` with `v0.4.16` and pushing the tag; merging alone publishes nothing.

TaskID: 0i7pc5gRWgj

Generated with [AgentRQ](https://agentrq.com)
