### PR TITLE
fix(trajectory): stop a new message emptying the task's tool lane

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -721,13 +721,8 @@ func New(cfg Config) (*App, error) {
 				}
 
 				if taskID != 0 && eventType != "" {
-					t, err := repo.SystemGetTask(ctx, taskID)
+					t, err := taskEventPayload(ctx, repo, taskID)
 					if err == nil {
-						// Preload task messages
-						messages, err := repo.ListMessages(ctx, t.ID)
-						if err == nil {
-							t.Messages = messages
-						}
 						bus.Publish(ev.WorkspaceID, ownerID, eventbus.Event{
 							Type:    eventType,
 							Payload: mapper.FromModelTaskToView(t),
@@ -914,6 +909,33 @@ func New(cfg Config) (*App, error) {
 
 	cancelOnErr = nil // App takes ownership; defer must not cancel.
 	return &App{server: serverSvc, bus: bus, pubsub: pubsubSvc, telemetry: telemetryCtrl, cancel: appCancel}, nil
+}
+
+// taskEventPayload loads the task an SSE event is about, with the relations a
+// task view carries.
+//
+// A client replaces its whole task with this payload, so a relation missing
+// from it is a relation the client loses: publishing a task loaded without its
+// tool calls is what used to empty the trajectory's tool lane every time a new
+// message arrived. SystemGetTask preloads nothing — it is the system-scoped
+// lookup, used in plenty of places that want only the row — so the relations
+// are loaded here rather than widened for every caller.
+//
+// A relation that fails to load is left as it is instead of failing the
+// publish: an event that reports a status change late-but-complete is worth
+// more than no event at all.
+func taskEventPayload(ctx context.Context, repo base.Repository, taskID int64) (model.Task, error) {
+	t, err := repo.SystemGetTask(ctx, taskID)
+	if err != nil {
+		return model.Task{}, err
+	}
+	if messages, err := repo.ListMessages(ctx, t.ID); err == nil {
+		t.Messages = messages
+	}
+	if toolCalls, err := repo.ListToolCalls(ctx, t.ID); err == nil {
+		t.ToolCalls = toolCalls
+	}
+	return t, nil
 }
 
 // namesAFile reports whether a request path names a file rather than a page.

--- a/backend/internal/app/app_test.go
+++ b/backend/internal/app/app_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bufio"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -12,9 +13,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agentrq/agentrq/backend/internal/data/model"
 	"github.com/agentrq/agentrq/backend/internal/service/auth"
 	"github.com/agentrq/agentrq/backend/internal/service/eventbus"
+	mock_repository "github.com/agentrq/agentrq/backend/internal/service/mocks/repository"
 	"github.com/gofiber/fiber/v2"
+	"github.com/golang/mock/gomock"
 )
 
 const testJWTSecret = "test-secret-for-events-handler"
@@ -303,5 +307,78 @@ func TestStaticHandlerIsBypassedForAppRoutes(t *testing.T) {
 		if buf.String() != tc.body {
 			t.Errorf("GET %s: body %q, want %q", tc.path, buf.String(), tc.body)
 		}
+	}
+}
+
+// The SSE payload a client replaces its whole task with.
+//
+// The regression: it was built from SystemGetTask, which preloads nothing, and
+// only the messages were loaded back on — so every event carried a task that
+// had never called a tool, and the trajectory's tool lane emptied itself the
+// moment a new message arrived.
+func TestTaskEventPayloadCarriesTheTasksRelations(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	repo := mock_repository.NewMockRepository(ctrl)
+	ctx := context.Background()
+
+	repo.EXPECT().SystemGetTask(ctx, int64(7)).Return(model.Task{ID: 7, Title: "Ship it"}, nil)
+	repo.EXPECT().ListMessages(ctx, int64(7)).Return([]model.Message{{ID: 1}, {ID: 2}}, nil)
+	repo.EXPECT().ListToolCalls(ctx, int64(7)).Return([]model.ToolCall{{ID: 3, ToolName: "Read"}}, nil)
+
+	task, err := taskEventPayload(ctx, repo, 7)
+	if err != nil {
+		t.Fatalf("taskEventPayload: %v", err)
+	}
+	if len(task.Messages) != 2 {
+		t.Errorf("expected 2 messages, got %d", len(task.Messages))
+	}
+	if len(task.ToolCalls) != 1 {
+		t.Fatalf("expected the task's tool calls, got %d", len(task.ToolCalls))
+	}
+	if task.ToolCalls[0].ToolName != "Read" {
+		t.Errorf("unexpected tool call %q", task.ToolCalls[0].ToolName)
+	}
+}
+
+// A relation that cannot be loaded is worth less than the event itself: the
+// status change still reaches the client.
+func TestTaskEventPayloadStillPublishesWhenARelationFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	repo := mock_repository.NewMockRepository(ctrl)
+	ctx := context.Background()
+
+	repo.EXPECT().SystemGetTask(ctx, int64(7)).Return(model.Task{ID: 7, Status: "completed"}, nil)
+	repo.EXPECT().ListMessages(ctx, int64(7)).Return(nil, errors.New("messages unavailable"))
+	repo.EXPECT().ListToolCalls(ctx, int64(7)).Return(nil, errors.New("tool calls unavailable"))
+
+	task, err := taskEventPayload(ctx, repo, 7)
+	if err != nil {
+		t.Fatalf("taskEventPayload: %v", err)
+	}
+	if task.Status != "completed" {
+		t.Errorf("expected the task itself, got status %q", task.Status)
+	}
+	if task.Messages != nil || task.ToolCalls != nil {
+		t.Errorf("expected the failed relations to be left empty")
+	}
+}
+
+// No task, no event: a payload for a task that cannot be read would be worse
+// than silence, since the client would replace what it has with it.
+func TestTaskEventPayloadFailsWhenTheTaskCannotBeRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	repo := mock_repository.NewMockRepository(ctrl)
+	ctx := context.Background()
+
+	repo.EXPECT().SystemGetTask(ctx, int64(7)).Return(model.Task{}, errors.New("gone"))
+
+	if _, err := taskEventPayload(ctx, repo, 7); err == nil {
+		t.Fatal("expected an error when the task cannot be read")
 	}
 }

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -39,6 +39,7 @@ type Repository interface {
 
 	// ToolCall
 	CreateToolCall(ctx context.Context, tc model.ToolCall) (model.ToolCall, error)
+	ListToolCalls(ctx context.Context, taskID int64) ([]model.ToolCall, error)
 	UpdateToolCallStatus(ctx context.Context, id int64, status string) (model.ToolCall, error)
 	UpdateToolCallsWorkspaceID(ctx context.Context, taskID int64, workspaceID int64) error
 
@@ -390,6 +391,17 @@ func (r *repository) CreateToolCall(ctx context.Context, tc model.ToolCall) (mod
 		return model.ToolCall{}, err
 	}
 	return tc, nil
+}
+
+// ListToolCalls returns a task's tool calls in the order they were made.
+//
+// The task view carries them alongside the messages, so anything rebuilding a
+// task outside GetTask — which preloads both — has to load them itself, or it
+// publishes a task that looks like it never called a tool.
+func (r *repository) ListToolCalls(ctx context.Context, taskID int64) ([]model.ToolCall, error) {
+	var tcs []model.ToolCall
+	err := r.conn(ctx).Where("task_id = ?", taskID).Order("created_at asc").Find(&tcs).Error
+	return tcs, err
 }
 
 func (r *repository) UpdateToolCallStatus(ctx context.Context, id int64, status string) (model.ToolCall, error) {

--- a/backend/internal/repository/base/repository_test.go
+++ b/backend/internal/repository/base/repository_test.go
@@ -666,3 +666,48 @@ func TestRepository_ListTasksByTriggerID(t *testing.T) {
 		}
 	}
 }
+
+// A task's tool calls are what the trajectory's tool lane is drawn from, and
+// anything rebuilding a task without GetTask's preloads has to load them
+// through here. Scoped to the task and ordered oldest-first, the way the
+// trajectory reads them.
+func TestRepository_ListToolCalls(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+	_ = db.AutoMigrate(&model.ToolCall{})
+	repo := New(&mockDB{db: db})
+
+	ctx := context.Background()
+	taskID := int64(42)
+	base := time.Date(2026, 9, 3, 10, 0, 0, 0, time.UTC)
+
+	db.Create(&model.ToolCall{ID: 2, TaskID: taskID, WorkspaceID: 10, ToolName: "Edit", CreatedAt: base.Add(time.Minute)})
+	db.Create(&model.ToolCall{ID: 1, TaskID: taskID, WorkspaceID: 10, ToolName: "Read", CreatedAt: base})
+	db.Create(&model.ToolCall{ID: 3, TaskID: 99, WorkspaceID: 10, ToolName: "Bash", CreatedAt: base})
+
+	calls, err := repo.ListToolCalls(ctx, taskID)
+	if err != nil {
+		t.Fatalf("ListToolCalls: %v", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 tool calls for task %d, got %d", taskID, len(calls))
+	}
+	if calls[0].ToolName != "Read" || calls[1].ToolName != "Edit" {
+		t.Errorf("expected oldest-first order, got %s then %s", calls[0].ToolName, calls[1].ToolName)
+	}
+	for _, tc := range calls {
+		if tc.TaskID != taskID {
+			t.Errorf("tool call from another task leaked in: taskID %d", tc.TaskID)
+		}
+	}
+
+	empty, err := repo.ListToolCalls(ctx, 1234)
+	if err != nil {
+		t.Fatalf("ListToolCalls on a task with none: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("expected no tool calls, got %d", len(empty))
+	}
+}

--- a/frontend/src/composables/useTaskEvents.js
+++ b/frontend/src/composables/useTaskEvents.js
@@ -1,0 +1,49 @@
+/**
+ * Folding a task pushed over SSE into the task already on screen.
+ *
+ * An event payload is meant to be the whole task, and the view used to take it
+ * at its word and replace what it had. But the payloads are built in several
+ * places in the backend, and one built without a relation is indistinguishable
+ * from one whose relation is genuinely empty — so a single publisher that
+ * forgot to load the tool calls emptied the trajectory's tool lane the moment
+ * any new message arrived.
+ *
+ * Merging instead of replacing makes that unrepresentable: a relation the
+ * payload does not carry keeps the value the client already had. Nothing in
+ * the product removes a message or a tool call from a task, so the only way an
+ * arriving list can be shorter than the one on screen is that it was not
+ * loaded.
+ */
+
+/** The task's collection-valued relations, in the shape the API sends them. */
+const TASK_RELATIONS = ['messages', 'toolCalls'];
+
+function hasEntries(value) {
+  return Array.isArray(value) && value.length > 0;
+}
+
+/**
+ * The task to render, given the one on screen and the one an event carried.
+ *
+ * Scalar fields always come from the event — status, title and the rest are
+ * exactly what it is reporting. Relations come from the event too, unless it
+ * carries none and the current task does.
+ *
+ * @param {object|null} current  the task the view is holding, if any
+ * @param {object|null} incoming the task payload the event carried
+ * @returns {object|null}
+ */
+export function mergeTaskUpdate(current, incoming) {
+  if (!incoming) return current ?? null;
+  // A payload for a different task replaces nothing: it describes something
+  // else, and merging the two would splice one task's history onto another.
+  if (!current || current.id !== incoming.id) return incoming;
+
+  const merged = { ...incoming };
+  for (const relation of TASK_RELATIONS) {
+    if (!hasEntries(merged[relation]) && hasEntries(current[relation])) {
+      merged[relation] = current[relation];
+    }
+  }
+  return merged;
+}

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -775,6 +775,7 @@ import {
   telemetryText,
   thoughtPreview,
 } from '../composables/useAgentTelemetry';
+import { mergeTaskUpdate } from '../composables/useTaskEvents';
 import TrajectoryPanel from '../components/TrajectoryPanel.vue';
 
 const { notifyError, notifySuccess } = useToasts();
@@ -1341,7 +1342,9 @@ watch(events, (evts) => {
   
   if (['task.updated', 'task.created', 'reply.received', 'respond.ack', 'status.updated'].includes(last.type)) {
     if (last.payload && last.payload.id === taskId.value) {
-      task.value = last.payload;
+      // Merged, not assigned: a payload built without the task's tool calls
+      // would otherwise wipe the trajectory — see useTaskEvents.
+      task.value = mergeTaskUpdate(task.value, last.payload);
     }
   }
 }, { deep: true });

--- a/frontend/test/taskEvents.test.js
+++ b/frontend/test/taskEvents.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+
+import { mergeTaskUpdate } from '../src/composables/useTaskEvents'
+
+const task = (overrides = {}) => ({
+  id: 'task-1',
+  status: 'ongoing',
+  messages: [{ id: 'm1', text: 'hello' }],
+  toolCalls: [{ id: 't1', toolName: 'Read' }],
+  ...overrides,
+})
+
+describe('mergeTaskUpdate', () => {
+  it('takes the scalar fields from the event', () => {
+    const merged = mergeTaskUpdate(task(), task({ status: 'completed', title: 'Renamed' }))
+    expect(merged.status).toBe('completed')
+    expect(merged.title).toBe('Renamed')
+  })
+
+  // The bug this exists for: the SSE forwarder published a task loaded without
+  // its tool calls, and the trajectory's tool lane emptied on every new
+  // message.
+  it('keeps a relation the event did not carry', () => {
+    const current = task()
+    const incoming = task({ toolCalls: [], messages: [{ id: 'm1' }, { id: 'm2' }] })
+
+    const merged = mergeTaskUpdate(current, incoming)
+
+    expect(merged.toolCalls).toEqual(current.toolCalls)
+    expect(merged.messages).toHaveLength(2)
+  })
+
+  it('keeps a relation the event omitted entirely', () => {
+    const { toolCalls, ...withoutToolCalls } = task({ status: 'completed' })
+    expect(toolCalls).toHaveLength(1)
+
+    const merged = mergeTaskUpdate(task(), withoutToolCalls)
+
+    expect(merged.toolCalls).toHaveLength(1)
+    expect(merged.status).toBe('completed')
+  })
+
+  it('takes the relation from the event whenever it carries one', () => {
+    const incoming = task({ toolCalls: [{ id: 't1' }, { id: 't2' }] })
+
+    expect(mergeTaskUpdate(task(), incoming).toolCalls).toHaveLength(2)
+  })
+
+  it('leaves an empty relation empty when there is nothing to keep', () => {
+    const merged = mergeTaskUpdate(task({ toolCalls: [] }), task({ toolCalls: [] }))
+
+    expect(merged.toolCalls).toEqual([])
+  })
+
+  it('does not mutate the task on screen', () => {
+    const current = task()
+
+    mergeTaskUpdate(current, task({ toolCalls: [] }))
+
+    expect(current.toolCalls).toHaveLength(1)
+  })
+
+  it('takes the event whole when there is no task yet', () => {
+    const incoming = task()
+
+    expect(mergeTaskUpdate(null, incoming)).toBe(incoming)
+  })
+
+  // Merging across tasks would splice one task's history onto another.
+  it('takes the event whole when it describes a different task', () => {
+    const incoming = task({ id: 'task-2', toolCalls: [] })
+
+    expect(mergeTaskUpdate(task(), incoming)).toBe(incoming)
+  })
+
+  it('holds on to the current task when the event carried no payload', () => {
+    const current = task()
+
+    expect(mergeTaskUpdate(current, null)).toBe(current)
+    expect(mergeTaskUpdate(undefined, undefined)).toBeNull()
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -39,6 +39,7 @@ export default defineConfig({
         'src/composables/useChatScroll.js',
         'src/composables/useTaskGroups.js',
         'src/composables/useAgentTelemetry.js',
+        'src/composables/useTaskEvents.js',
         'src/composables/usePendingSend.js',
         'src/composables/useDirectoryPicker.js',
         'src/composables/useProfileDisplay.js',


### PR DESCRIPTION
## What changed

Opening a task's Trajectory tab now keeps showing the tools the agent used, even while the conversation carries on. Until now, the moment a new message arrived the tool half of the trajectory emptied itself and only the messages were left.

## Why

Every live update replaces the task the browser is holding with the one the server sends. One of the places that builds those updates loaded the task without its tool calls, so each new message told the browser the agent had never used a tool — and the trajectory dutifully cleared. The update now carries everything the task has, and the browser merges an update into what it already has instead of overwriting it wholesale, so a future gap on one side can no longer erase what is on screen.

## Test coverage report

- **New lines: 100%.** Backend: the payload builder and the new tool-call lookup are both at 100% (4 new Go tests). Frontend: the new merge composable is at 100% statements / branches / functions / lines (9 new tests) and is added to the frontend's enforced-100% coverage list.
- **Total coverage impact:** `internal/app` 11.1% → 13.1%, `internal/repository/base` 32.1% → 32.5%; the frontend's covered set stays at 100% across the board with one more file inside it. Frontend suite 158 → 167 tests; `go test ./internal/...` passes.

## Other notes

- The relations are loaded in a named function rather than inline in the forwarder goroutine, which is what makes that path testable at all — it had no coverage before.
- A relation that fails to load is left empty rather than failing the publish: an update that reports a status change incompletely is worth more than no update at all. A task that cannot be read at all still publishes nothing, since the browser would replace what it has with it.
- Merging is safe because nothing in the product removes a message or a tool call from a task, so an arriving list shorter than the one on screen can only mean it was not loaded. An update describing a different task still replaces outright.

TaskID: 0i8D66MARcH

---
Generated with [AgentRQ](https://agentrq.com)