### PR TITLE
feat(trajectory): read the agent's reasoning and its tools there, not in the chat

### DIFF
--- a/frontend/src/components/TrajectoryPanel.vue
+++ b/frontend/src/components/TrajectoryPanel.vue
@@ -24,6 +24,22 @@
         </div>
       </div>
 
+      <!-- Categories — the trace answers one question at a time: what was said,
+           what the agent thought, what it ran. -->
+      <div v-if="items.length > 0" class="px-4 py-2 border-b border-gray-100 dark:border-zinc-800 shrink-0 flex items-center gap-1.5 overflow-x-auto custom-scrollbar">
+        <button type="button" @click="laneFilter = null" :class="laneChipClass(null)"
+                class="shrink-0 text-[9px] font-black uppercase tracking-wider px-2 py-1 rounded-lg border transition-colors">
+          All <span class="font-bold opacity-60">{{ items.length }}</span>
+        </button>
+        <button v-for="lane in LANES" :key="lane.key" type="button"
+                @click="toggleLane(lane.key)"
+                :disabled="laneCounts[lane.key] === 0"
+                :class="laneChipClass(lane.key)"
+                class="shrink-0 text-[9px] font-black uppercase tracking-wider px-2 py-1 rounded-lg border transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+          {{ lane.label }} <span class="font-bold opacity-60">{{ laneCounts[lane.key] }}</span>
+        </button>
+      </div>
+
       <!-- Search -->
       <div class="px-4 py-2 border-b border-gray-100 dark:border-zinc-800 shrink-0">
         <div class="relative">
@@ -38,7 +54,7 @@
         <!-- List -->
         <div class="w-2/5 border-r border-gray-100 dark:border-zinc-800 overflow-y-auto custom-scrollbar">
           <div v-if="filteredItems.length === 0" class="py-10 text-center text-[11px] text-gray-400 dark:text-zinc-500 font-medium px-4">
-            {{ items.length === 0 ? 'No activity recorded yet.' : 'No matches for this search.' }}
+            {{ emptyListMessage }}
           </div>
           <button v-for="it in filteredItems" :key="it.id"
                   type="button"
@@ -83,7 +99,7 @@
                 <span class="text-gray-800 dark:text-zinc-200">{{ formatAbsolute(selectedItem.createdAt) }}</span>
               </div>
               <div v-else class="grid grid-cols-[80px_1fr] gap-y-1.5 text-[11px]">
-                <span class="text-gray-400 dark:text-zinc-500 font-semibold">Sender</span>
+                <span class="text-gray-400 dark:text-zinc-500 font-semibold">{{ selectedItem.lane === 'thought' ? 'Kind' : 'Sender' }}</span>
                 <span class="text-gray-800 dark:text-zinc-200">{{ selectedItem.label }}</span>
                 <span class="text-gray-400 dark:text-zinc-500 font-semibold">Created</span>
                 <span class="text-gray-800 dark:text-zinc-200">{{ formatAbsolute(selectedItem.createdAt) }}</span>
@@ -120,109 +136,48 @@
 <script setup>
 import { ref, computed, watch } from 'vue';
 import { renderMarkdown } from '../utils/markdown';
+import {
+  TRAJECTORY_LANES,
+  buildTrajectory,
+  defaultDetailTab,
+  filterTrajectory,
+  trajectoryLaneCounts,
+} from '../composables/useTrajectory';
 
 const props = defineProps({
   messages: { type: Array, default: () => [] },
   toolCalls: { type: Array, default: () => [] },
 });
 
-const LANES = [
-  { key: 'input', label: 'INPUT' },
-  { key: 'agent', label: 'AGENT' },
-  { key: 'tool', label: 'TOOLS' },
-];
+const LANES = TRAJECTORY_LANES;
 
-function truncate(text, len) {
-  if (!text) return '';
-  const t = String(text).trim().replace(/\s+/g, ' ');
-  return t.length > len ? t.slice(0, len) + '…' : t;
+const items = computed(() => buildTrajectory(props.messages, props.toolCalls));
+
+const laneCounts = computed(() => trajectoryLaneCounts(items.value));
+
+// Which category the reader has narrowed to, or null for all of them. Reading
+// a long run means asking one question at a time — what did it think, what did
+// it run — and the lanes are what separate those.
+const laneFilter = ref(null);
+function toggleLane(key) {
+  laneFilter.value = laneFilter.value === key ? null : key;
 }
 
-function permissionStatus(status) {
-  switch (status) {
-    case 'allow': return 'allowed';
-    case 'allow_always': return 'auto_allowed';
-    case 'deny': return 'denied';
-    default: return status || 'pending';
-  }
+function laneChipClass(key) {
+  return laneFilter.value === key
+    ? 'bg-gray-900 dark:bg-white text-white dark:text-black border-transparent'
+    : 'bg-white dark:bg-zinc-900 text-gray-500 dark:text-zinc-400 border-gray-200 dark:border-zinc-700 hover:border-gray-300 dark:hover:border-zinc-600';
 }
-
-const items = computed(() => {
-  const fromMessages = (props.messages || []).map(m => {
-    const isPermissionRequest = m.metadata?.type === 'permission_request';
-    if (isPermissionRequest) {
-      // The API sends camelCase keys; messages persisted before that change
-      // still have snake_case keys, so fall back to those.
-      const toolName = m.metadata?.toolName || m.metadata?.tool_name || 'Permission Request';
-      const inputPreview = m.metadata?.inputPreview || m.metadata?.input_preview;
-      return {
-        id: `m-${m.id}`,
-        lane: 'tool',
-        laneLabel: 'TOOL',
-        createdAt: m.createdAt,
-        label: toolName,
-        preview: truncate(`${toolName} ${inputPreview || m.metadata?.description || ''}`, 140),
-        raw: {
-          ...m,
-          toolName,
-          description: m.metadata?.description,
-          inputPreview,
-          status: permissionStatus(m.metadata?.status),
-        },
-      };
-    }
-    if (m.metadata?.type === 'elicitation_request') {
-      const label = m.metadata.message || (m.metadata.mode === 'url' ? 'Open link' : 'Answer question');
-      const payload = m.metadata.mode === 'form'
-        ? { mode: 'form', requestedSchema: m.metadata.requestedSchema }
-        : { mode: 'url', url: m.metadata.url };
-      if (m.metadata.content) payload.answer = m.metadata.content;
-      return {
-        id: `m-${m.id}`,
-        lane: 'tool',
-        laneLabel: 'ASK',
-        createdAt: m.createdAt,
-        label,
-        preview: truncate(label, 140),
-        raw: {
-          ...m,
-          toolName: label,
-          inputPreview: JSON.stringify(payload),
-          status: m.metadata.status || 'pending',
-        },
-      };
-    }
-    return {
-      id: `m-${m.id}`,
-      lane: m.sender === 'agent' ? 'agent' : 'input',
-      laneLabel: m.sender === 'agent' ? 'AGENT' : (m.sender === 'slack' ? 'SLACK' : 'INPUT'),
-      createdAt: m.createdAt,
-      label: m.sender === 'agent' ? 'Agent' : (m.sender === 'slack' ? 'Slack' : 'You'),
-      preview: truncate(m.text, 140) || '(no text)',
-      raw: m,
-    };
-  });
-  const fromToolCalls = (props.toolCalls || []).map(tc => ({
-    id: `t-${tc.id}`,
-    lane: 'tool',
-    laneLabel: 'TOOL',
-    createdAt: tc.createdAt,
-    label: tc.toolName,
-    preview: truncate(`${tc.toolName} ${tc.inputPreview || tc.description || ''}`, 140),
-    raw: tc,
-  }));
-  return [...fromMessages, ...fromToolCalls].sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
-});
 
 const query = ref('');
-const filteredItems = computed(() => {
-  const q = query.value.trim().toLowerCase();
-  if (!q) return items.value;
-  return items.value.filter(it =>
-    it.label?.toLowerCase().includes(q) ||
-    it.preview?.toLowerCase().includes(q) ||
-    it.raw?.description?.toLowerCase().includes(q)
-  );
+const filteredItems = computed(() =>
+  filterTrajectory(items.value, { lane: laneFilter.value, query: query.value })
+);
+
+const emptyListMessage = computed(() => {
+  if (items.value.length === 0) return 'No activity recorded yet.';
+  if (query.value.trim()) return 'No matches for this search.';
+  return 'Nothing in this category.';
 });
 
 const selectedId = ref(null);
@@ -246,8 +201,8 @@ const detailTabs = computed(() => {
     : [{ key: 'summary', label: 'Summary' }, { key: 'content', label: 'Content' }];
 });
 
-watch(selectedItem, () => {
-  activeTab.value = 'summary';
+watch(selectedItem, (item) => {
+  activeTab.value = defaultDetailTab(item);
 });
 
 const formattedPayload = computed(() => {
@@ -294,14 +249,15 @@ function laneDotClass(it) {
         return 'bg-emerald-500';
     }
   }
-  return it.lane === 'agent' ? 'bg-violet-500' : 'bg-sky-400';
+  if (it.lane === 'agent') return 'bg-violet-500';
+  return it.lane === 'thought' ? 'bg-teal-500' : 'bg-sky-400';
 }
 
 function laneBadgeClass(it) {
   if (it.lane === 'tool') return 'text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-500/10';
-  return it.lane === 'agent'
-    ? 'text-violet-700 dark:text-violet-400 bg-violet-50 dark:bg-violet-500/10'
-    : 'text-sky-700 dark:text-sky-400 bg-sky-50 dark:bg-sky-500/10';
+  if (it.lane === 'agent') return 'text-violet-700 dark:text-violet-400 bg-violet-50 dark:bg-violet-500/10';
+  if (it.lane === 'thought') return 'text-teal-700 dark:text-teal-400 bg-teal-50 dark:bg-teal-500/10';
+  return 'text-sky-700 dark:text-sky-400 bg-sky-50 dark:bg-sky-500/10';
 }
 
 function toolCallStatusStyle(status) {

--- a/frontend/src/composables/useAgentTelemetry.js
+++ b/frontend/src/composables/useAgentTelemetry.js
@@ -35,18 +35,22 @@ export function isAgentTelemetry(message) {
 }
 
 /**
- * Telemetry that belongs in the message thread, as opposed to the composer.
+ * Telemetry that belongs in the message thread.
  *
- * Reasoning and plans are moments in a conversation and are read in sequence.
- * The context counters are not: they describe the session as a whole, and only
- * the current value means anything — so they live on the composer as a gauge
- * rather than as a message that scrolls away.
+ * Only the plan does. It is addressed to the human — this is what I am about
+ * to do — and the same card is revised as the agent works, so it reads as part
+ * of the conversation.
+ *
+ * The other two are about the conversation rather than in it. Reasoning is the
+ * agent thinking aloud, and belongs with the tools it ran, in the trajectory
+ * (see belongsInThread in useTrajectory). The context counters describe the
+ * session as a whole, and only the current value means anything — so they live
+ * on the composer as a gauge rather than as a message that scrolls away.
  *
  * @param {object} message
  */
 export function isThreadTelemetry(message) {
-  const kind = agentTelemetryKind(message);
-  return kind === 'thought' || kind === 'plan';
+  return agentTelemetryKind(message) === 'plan';
 }
 
 /**

--- a/frontend/src/composables/useTrajectory.js
+++ b/frontend/src/composables/useTrajectory.js
@@ -1,0 +1,304 @@
+/**
+ * Where a task's activity belongs: the conversation, or the trajectory.
+ *
+ * The chat thread is what was *said* — what a person asked for, what the agent
+ * answered, and anything still waiting on a human. Everything else is how the
+ * agent got there: its reasoning, and every tool it ran. That record is worth
+ * keeping, but reading it inline means scrolling past a hundred resolved
+ * permission cards to find the sentence that mattered, so it lives in the
+ * trajectory instead — the one place where it can be filtered and searched.
+ *
+ * A card only leaves the thread once it has nothing left to ask of anyone: a
+ * permission request stays put until it has a verdict, because it is the thing
+ * the human is being asked to act on.
+ *
+ * The logic lives here rather than in TrajectoryPanel.vue so it can be tested:
+ * the project has no component-test harness.
+ */
+
+import {
+  agentTelemetryKind,
+  isAgentTelemetry,
+  planContent,
+  planProgress,
+  telemetryText,
+  thoughtPreview,
+} from './useAgentTelemetry';
+
+/**
+ * The trajectory's categories, in the order they are shown.
+ *
+ * A lane is the category an entry is filed under; an entry can still carry a
+ * more specific badge of its own — a plan sits in THINKING but says PLAN, an
+ * elicitation sits in TOOLS but says ASK.
+ */
+export const TRAJECTORY_LANES = [
+  { key: 'input', label: 'INPUT' },
+  { key: 'agent', label: 'AGENT' },
+  { key: 'thought', label: 'THINKING' },
+  { key: 'tool', label: 'TOOLS' },
+];
+
+/** A permission request that has been decided one way or the other. */
+function isResolvedPermissionRequest(message) {
+  if (message?.metadata?.type !== 'permission_request') return false;
+  return (message.metadata.status ?? 'pending') !== 'pending';
+}
+
+/**
+ * Whether a message belongs in the chat thread.
+ *
+ * Plans are the one piece of telemetry that stays: an agent publishes a plan
+ * to tell the human what it intends to do, and revises the same card as it
+ * works, so it reads as part of the conversation rather than a trace of it.
+ *
+ * @param {object} message
+ * @returns {boolean}
+ */
+export function belongsInThread(message) {
+  if (isAgentTelemetry(message)) return agentTelemetryKind(message) === 'plan';
+  return !isResolvedPermissionRequest(message);
+}
+
+/** Collapses whitespace and clips to a single readable line. */
+function truncate(text, len) {
+  if (!text) return '';
+  const t = String(text).trim().replace(/\s+/g, ' ');
+  return t.length > len ? `${t.slice(0, len)}…` : t;
+}
+
+/** The status a verdict on a permission request reads as in the tool lane. */
+function permissionStatus(status) {
+  switch (status) {
+    case 'allow': return 'allowed';
+    case 'allow_always': return 'auto_allowed';
+    case 'deny': return 'denied';
+    default: return status || 'pending';
+  }
+}
+
+/**
+ * How a tool call is recognised as the one a permission request is asking
+ * about.
+ *
+ * Both records are written from the same notification, so the tool and its
+ * input identify the pair — but only the tool call's input is truncated for
+ * storage, so the comparison is made on a prefix short enough that both sides
+ * always have it.
+ */
+const MATCH_PREFIX = 200;
+function toolIdentity(toolName, inputPreview) {
+  return `${toolName} ${(inputPreview ?? '').slice(0, MATCH_PREFIX)}`;
+}
+
+/**
+ * Counts each tool call by identity, so a permission request can find the row
+ * that already stands for it. A count rather than a set: an agent that runs
+ * the same command twice has two of everything, and each request should pair
+ * with one row rather than all of them collapsing into one.
+ */
+function toolCallIdentities(toolCalls) {
+  const counts = new Map();
+  for (const call of toolCalls) {
+    const key = toolIdentity(call?.toolName, call?.inputPreview);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function byCreatedAt(a, b) {
+  return new Date(a?.createdAt) - new Date(b?.createdAt);
+}
+
+/** The API sends camelCase; messages written before that have snake_case. */
+function permissionToolName(metadata) {
+  return metadata.toolName || metadata.tool_name || 'Permission Request';
+}
+
+function permissionInputPreview(metadata) {
+  return metadata.inputPreview || metadata.input_preview;
+}
+
+/** A one-line summary of a plan: how far along it is, and what it is on. */
+function planPreview(message) {
+  const plan = planContent(message);
+  const progress = planProgress(message);
+  if (!progress) return truncate(plan.type === 'markdown' ? plan.content : telemetryText(message), 140);
+  const current = plan.entries.find((entry) => entry.active)
+    ?? plan.entries.find((entry) => !entry.done)
+    ?? plan.entries[plan.entries.length - 1];
+  return truncate(`${progress.done}/${progress.total} · ${current.content}`, 140);
+}
+
+/**
+ * One message as a trajectory entry, or null if it does not belong there.
+ *
+ * The counters are the one thing kept out: they describe the session as a
+ * whole and are shown as a gauge on the composer, so a running total of them
+ * down the trajectory would say nothing the reader can use.
+ */
+function messageEntry(message, matchedToolCalls) {
+  const kind = agentTelemetryKind(message);
+  if (kind === 'usage') return null;
+
+  const base = { id: `m-${message.id}`, createdAt: message.createdAt, raw: message };
+
+  if (kind === 'thought') {
+    return {
+      ...base,
+      lane: 'thought',
+      laneLabel: 'THINKING',
+      label: 'Thinking',
+      preview: thoughtPreview(message, 140) || '(empty)',
+      raw: { ...message, text: telemetryText(message) },
+    };
+  }
+  if (kind === 'plan') {
+    return {
+      ...base,
+      lane: 'thought',
+      laneLabel: 'PLAN',
+      label: 'Plan',
+      preview: planPreview(message),
+      raw: { ...message, text: telemetryText(message) },
+    };
+  }
+
+  const metadata = message.metadata ?? {};
+  if (metadata.type === 'permission_request') {
+    const toolName = permissionToolName(metadata);
+    const inputPreview = permissionInputPreview(metadata);
+    // The tool call recorded alongside this request already stands for it, and
+    // carries the verdict as it changes — so the request is only shown when
+    // nothing was recorded, as on tasks that predate tool calls being kept.
+    const key = toolIdentity(toolName, inputPreview);
+    const unmatched = matchedToolCalls.get(key) ?? 0;
+    if (unmatched > 0) {
+      matchedToolCalls.set(key, unmatched - 1);
+      return null;
+    }
+    return {
+      ...base,
+      lane: 'tool',
+      laneLabel: 'TOOL',
+      label: toolName,
+      preview: truncate(`${toolName} ${inputPreview || metadata.description || ''}`, 140),
+      raw: {
+        ...message,
+        toolName,
+        description: metadata.description,
+        inputPreview,
+        status: permissionStatus(metadata.status),
+      },
+    };
+  }
+
+  if (metadata.type === 'elicitation_request') {
+    const label = metadata.message || (metadata.mode === 'url' ? 'Open link' : 'Answer question');
+    const payload = metadata.mode === 'form'
+      ? { mode: 'form', requestedSchema: metadata.requestedSchema }
+      : { mode: 'url', url: metadata.url };
+    if (metadata.content) payload.answer = metadata.content;
+    return {
+      ...base,
+      lane: 'tool',
+      laneLabel: 'ASK',
+      label,
+      preview: truncate(label, 140),
+      raw: {
+        ...message,
+        toolName: label,
+        inputPreview: JSON.stringify(payload),
+        status: metadata.status || 'pending',
+      },
+    };
+  }
+
+  const isAgent = message.sender === 'agent';
+  const isSlack = message.sender === 'slack';
+  return {
+    ...base,
+    lane: isAgent ? 'agent' : 'input',
+    laneLabel: isAgent ? 'AGENT' : (isSlack ? 'SLACK' : 'INPUT'),
+    label: isAgent ? 'Agent' : (isSlack ? 'Slack' : 'You'),
+    preview: truncate(message.text, 140) || '(no text)',
+  };
+}
+
+function toolCallEntry(call) {
+  return {
+    id: `t-${call.id}`,
+    lane: 'tool',
+    laneLabel: 'TOOL',
+    createdAt: call.createdAt,
+    label: call.toolName,
+    preview: truncate(`${call.toolName} ${call.inputPreview || call.description || ''}`, 140),
+    raw: call,
+  };
+}
+
+/**
+ * Everything that happened in a task, oldest first.
+ *
+ * @param {Array<object>} messages
+ * @param {Array<object>} toolCalls
+ * @returns {Array<object>} entries carrying {id, lane, laneLabel, label, preview, createdAt, raw}
+ */
+export function buildTrajectory(messages, toolCalls) {
+  const calls = Array.isArray(toolCalls) ? [...toolCalls].sort(byCreatedAt) : [];
+  const unmatched = toolCallIdentities(calls);
+  const entries = Array.isArray(messages) ? [...messages].sort(byCreatedAt) : [];
+
+  const fromMessages = [];
+  for (const message of entries) {
+    const entry = messageEntry(message, unmatched);
+    if (entry) fromMessages.push(entry);
+  }
+  return [...fromMessages, ...calls.map(toolCallEntry)].sort(byCreatedAt);
+}
+
+/**
+ * The tab an entry opens on.
+ *
+ * A tool's summary is the interesting part — what ran, and whether it was
+ * allowed. Reasoning and plans are the opposite: the summary knows only when
+ * they were written, and what the reader came for is the text itself.
+ *
+ * @param {object|null} item
+ * @returns {'summary'|'content'}
+ */
+export function defaultDetailTab(item) {
+  return item?.lane === 'thought' ? 'content' : 'summary';
+}
+
+/**
+ * How many entries each lane holds, so the filter can say what it would show
+ * before it is clicked.
+ *
+ * @param {Array<object>} items
+ * @returns {Record<string, number>}
+ */
+export function trajectoryLaneCounts(items) {
+  const counts = Object.fromEntries(TRAJECTORY_LANES.map((lane) => [lane.key, 0]));
+  for (const item of items ?? []) {
+    if (item?.lane in counts) counts[item.lane] += 1;
+  }
+  return counts;
+}
+
+/**
+ * The entries a lane filter and a search leave visible.
+ *
+ * @param {Array<object>} items
+ * @param {{lane?: string|null, query?: string}} [filter] a null lane is every lane
+ * @returns {Array<object>}
+ */
+export function filterTrajectory(items, { lane = null, query = '' } = {}) {
+  const needle = query.trim().toLowerCase();
+  return (items ?? []).filter((item) => {
+    if (lane && item.lane !== lane) return false;
+    if (!needle) return true;
+    return [item.label, item.preview, item.raw?.description]
+      .some((field) => field?.toLowerCase().includes(needle));
+  });
+}

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -161,33 +161,15 @@
       <!-- Messages -->
       <template v-for="m in displayMessages" :key="m.id">
 
-        <!-- Agent telemetry — the reasoning, plan and counters an ACP gateway
-             streams alongside the answer. Muted and indented under the agent's
-             avatar: this is how the answer came about, not the answer. -->
+        <!-- The agent's plan, indented under its avatar. The rest of the
+             telemetry is not in the conversation but about it, and is read in
+             the trajectory instead — see belongsInThread. -->
         <div v-if="isThreadTelemetry(m)" class="flex gap-3 animate-in fade-in slide-in-from-bottom-2 duration-300 max-w-full md:max-w-[90%] w-full">
           <div class="w-8 shrink-0"></div>
           <div class="flex flex-col items-start min-w-0 w-full">
 
-            <!-- Reasoning: collapsed to a single line until asked for -->
-            <div v-if="agentTelemetryKind(m) === 'thought'"
-                 @click="toggleTelemetry(m.id)"
-                 class="w-full border border-dashed border-gray-200 dark:border-zinc-700 rounded-sm bg-gray-50/70 dark:bg-zinc-900/40 px-3 py-2 cursor-pointer select-none hover:border-gray-300 dark:hover:border-zinc-600 transition-colors">
-              <div class="flex items-center gap-2 min-w-0">
-                <svg class="w-3 h-3 shrink-0 text-gray-400 dark:text-zinc-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" /></svg>
-                <span class="text-[9px] font-semibold uppercase tracking-wider text-gray-400 dark:text-zinc-500 shrink-0">Thinking</span>
-                <span v-if="!expandedTelemetry.has(m.id)" class="text-[11px] italic text-gray-500 dark:text-zinc-400 truncate min-w-0">{{ thoughtPreview(m) }}</span>
-                <span class="flex-1"></span>
-                <span class="text-[8px] font-semibold text-gray-400 dark:text-zinc-600 shrink-0 hidden sm:block">{{ formatDateTime(m.createdAt) }}</span>
-                <svg class="w-3 h-3 shrink-0 text-gray-400 dark:text-zinc-500 transition-transform duration-200" :class="expandedTelemetry.has(m.id) ? 'rotate-180' : ''" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
-              </div>
-              <div v-if="expandedTelemetry.has(m.id)"
-                   class="md-body mt-2 pt-2 border-t border-dashed border-gray-200 dark:border-zinc-700 text-[12px] italic text-gray-600 dark:text-zinc-400"
-                   v-html="renderMarkdown(telemetryText(m))"></div>
-            </div>
-
             <!-- Plan: one card per plan, rewritten in place as the agent works -->
-            <div v-else
-                 class="w-full border border-gray-200 dark:border-zinc-700 rounded-sm bg-white dark:bg-zinc-900 overflow-hidden shadow-sm"
+            <div class="w-full border border-gray-200 dark:border-zinc-700 rounded-sm bg-white dark:bg-zinc-900 overflow-hidden shadow-sm"
                  :class="planIsWithdrawn(m) ? 'opacity-60' : ''">
               <div class="bg-gray-50 dark:bg-zinc-800/80 border-b border-gray-200 dark:border-zinc-700 px-3 py-2 flex items-center gap-2">
                 <svg class="w-3.5 h-3.5 shrink-0 text-gray-500 dark:text-zinc-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" /></svg>
@@ -765,7 +747,6 @@ import { scrollToBottom as scrollContainerToBottom, shouldScrollOnViewChange } f
 import { useEventBus } from '../useEventBus';
 import { renderMarkdown } from '../utils/markdown';
 import {
-  agentTelemetryKind,
   contextGauge,
   isThreadTelemetry,
   latestUsageMessage,
@@ -773,8 +754,8 @@ import {
   planIsWithdrawn,
   planProgress,
   telemetryText,
-  thoughtPreview,
 } from '../composables/useAgentTelemetry';
+import { belongsInThread } from '../composables/useTrajectory';
 import { mergeTaskUpdate } from '../composables/useTaskEvents';
 import TrajectoryPanel from '../components/TrajectoryPanel.vue';
 
@@ -836,15 +817,6 @@ function toggleMessageRender(id) {
   s.has(id) ? s.delete(id) : s.add(id);
   rawMessages.value = s;
 }
-// Reasoning blocks are collapsed by default: they explain the answer, they are
-// not the answer, and a turn can produce a great many of them.
-const expandedTelemetry = ref(new Set());
-function toggleTelemetry(id) {
-  const s = new Set(expandedTelemetry.value);
-  s.has(id) ? s.delete(id) : s.add(id);
-  expandedTelemetry.value = s;
-}
-
 const copiedMessages = ref(new Set());
 async function copyMessageText(id, text) {
   await navigator.clipboard.writeText(text || '');
@@ -964,11 +936,11 @@ const sortedMessages = computed(() => {
   return [...task.value.messages].sort((a,b) => new Date(a.createdAt) - new Date(b.createdAt));
 });
 
-// The context counters are telemetry, but they belong on the composer's gauge
-// rather than in the thread — see isThreadTelemetry.
-const threadMessages = computed(() =>
-  sortedMessages.value.filter((m) => agentTelemetryKind(m) !== 'usage')
-);
+// What the conversation shows: what was said, and anything still waiting on a
+// human. The agent's reasoning and its resolved permission cards are how the
+// answer came about rather than part of it, and are read in the trajectory —
+// see belongsInThread.
+const threadMessages = computed(() => sortedMessages.value.filter(belongsInThread));
 
 // The session's context and cost as they stand, or null until an agent reports
 // them. Only a connected ACP gateway sends these.

--- a/frontend/test/agentTelemetry.test.js
+++ b/frontend/test/agentTelemetry.test.js
@@ -225,15 +225,17 @@ describe('thoughtPreview', () => {
 })
 
 describe('isThreadTelemetry', () => {
-  // Reasoning and plans are moments in a conversation. The context counters
-  // describe the session as a whole, so they live on the composer's gauge and
-  // must not also scroll past in the thread.
-  it('keeps reasoning and plans in the thread', () => {
-    expect(isThreadTelemetry(message({ type: 'agent_thought' }))).toBe(true)
+  // A plan is addressed to the human and revised as the agent works, so it
+  // reads as part of the conversation.
+  it('keeps the plan in the thread', () => {
     expect(isThreadTelemetry(message({ type: 'agent_plan' }))).toBe(true)
   })
 
-  it('keeps the context counters out of it', () => {
+  // Reasoning is the agent thinking aloud and belongs with the tools it ran;
+  // the counters describe the session as a whole and live on the composer's
+  // gauge. Neither should scroll past in the thread.
+  it('keeps reasoning and the context counters out of it', () => {
+    expect(isThreadTelemetry(message({ type: 'agent_thought' }))).toBe(false)
     expect(isThreadTelemetry(message({ type: 'agent_usage' }))).toBe(false)
   })
 

--- a/frontend/test/trajectory.test.js
+++ b/frontend/test/trajectory.test.js
@@ -1,0 +1,390 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  TRAJECTORY_LANES,
+  belongsInThread,
+  buildTrajectory,
+  defaultDetailTab,
+  filterTrajectory,
+  trajectoryLaneCounts,
+} from '../src/composables/useTrajectory'
+
+const at = (minutes) => new Date(Date.UTC(2026, 8, 4, 10, minutes)).toISOString()
+
+const message = (overrides = {}) => ({
+  id: 'm1',
+  sender: 'agent',
+  text: 'hello',
+  createdAt: at(0),
+  ...overrides,
+})
+
+const permission = (status, overrides = {}) => message({
+  id: `perm-${status}`,
+  text: 'Permission requested',
+  metadata: {
+    type: 'permission_request',
+    requestId: 'req-1',
+    toolName: 'Bash',
+    inputPreview: 'ls -la',
+    status,
+  },
+  ...overrides,
+})
+
+const thought = (text, overrides = {}) => message({
+  id: 'thought-1',
+  text: '',
+  metadata: { type: 'agent_thought', text },
+  ...overrides,
+})
+
+const plan = (entries, overrides = {}) => message({
+  id: 'plan-1',
+  text: '',
+  metadata: { type: 'agent_plan', entries },
+  ...overrides,
+})
+
+const toolCall = (overrides = {}) => ({
+  id: 'tc1',
+  toolName: 'Bash',
+  inputPreview: 'ls -la',
+  status: 'allowed',
+  createdAt: at(0),
+  ...overrides,
+})
+
+describe('belongsInThread', () => {
+  it('keeps what was said', () => {
+    expect(belongsInThread(message())).toBe(true)
+    expect(belongsInThread(message({ sender: 'human', text: 'do the thing' }))).toBe(true)
+  })
+
+  // A permission request is the one card addressed to the reader: it stays
+  // until they have answered it.
+  it('keeps a permission request until it has a verdict', () => {
+    expect(belongsInThread(permission('pending'))).toBe(true)
+    expect(belongsInThread(permission('allow'))).toBe(false)
+    expect(belongsInThread(permission('allow_always'))).toBe(false)
+    expect(belongsInThread(permission('deny'))).toBe(false)
+    expect(belongsInThread(permission('cancelled'))).toBe(false)
+  })
+
+  it('treats a permission request with no status as still pending', () => {
+    const noStatus = message({ metadata: { type: 'permission_request', toolName: 'Bash' } })
+
+    expect(belongsInThread(noStatus)).toBe(true)
+  })
+
+  it('sends reasoning and the counters to the trajectory, and keeps plans', () => {
+    expect(belongsInThread(thought('weighing the options'))).toBe(false)
+    expect(belongsInThread(message({ metadata: { type: 'agent_usage', used: 10 } }))).toBe(false)
+    expect(belongsInThread(plan([{ content: 'step', status: 'pending' }]))).toBe(true)
+  })
+})
+
+describe('buildTrajectory', () => {
+  it('files each kind of activity under its lane', () => {
+    const items = buildTrajectory([
+      message({ id: 'a', sender: 'human', text: 'do it', createdAt: at(0) }),
+      thought('checking the config', { id: 'b', createdAt: at(1) }),
+      message({ id: 'c', sender: 'agent', text: 'done', createdAt: at(2) }),
+      message({ id: 'd', sender: 'slack', text: 'from slack', createdAt: at(3) }),
+    ], [toolCall({ id: 'e', createdAt: at(4) })])
+
+    expect(items.map((it) => [it.lane, it.laneLabel])).toEqual([
+      ['input', 'INPUT'],
+      ['thought', 'THINKING'],
+      ['agent', 'AGENT'],
+      ['input', 'SLACK'],
+      ['tool', 'TOOL'],
+    ])
+  })
+
+  it('orders everything oldest first, whatever order it arrives in', () => {
+    const items = buildTrajectory(
+      [message({ id: 'late', createdAt: at(9) }), message({ id: 'early', createdAt: at(1) })],
+      [toolCall({ id: 'mid', createdAt: at(5) })],
+    )
+
+    expect(items.map((it) => it.id)).toEqual(['m-early', 't-mid', 'm-late'])
+  })
+
+  it('previews reasoning by its first line and a plan by its progress', () => {
+    const items = buildTrajectory([
+      thought('Looking at the failing test\nthen the fix', { id: 't', createdAt: at(0) }),
+      plan([
+        { content: 'read the code', status: 'completed' },
+        { content: 'write the fix', status: 'in_progress' },
+      ], { id: 'p', createdAt: at(1) }),
+    ], [])
+
+    expect(items[0].preview).toBe('Looking at the failing test')
+    expect(items[0].laneLabel).toBe('THINKING')
+    expect(items[1].preview).toBe('1/2 · write the fix')
+    expect(items[1].laneLabel).toBe('PLAN')
+    expect(items[1].lane).toBe('thought')
+  })
+
+  it('reads reasoning out of the metadata, which is where revisions land', () => {
+    const items = buildTrajectory([thought('the current wording', { text: 'the original body' })], [])
+
+    expect(items[0].raw.text).toBe('the current wording')
+  })
+
+  it('falls back to a plan\'s text when it has no entries to count', () => {
+    const markdown = message({
+      id: 'p',
+      metadata: { type: 'agent_plan', planType: 'markdown', content: '# Plan\n\nDo the thing' },
+    })
+    const empty = message({ id: 'q', text: 'no entries yet', metadata: { type: 'agent_plan', entries: [] } })
+
+    const items = buildTrajectory([markdown, empty], [])
+
+    expect(items[0].preview).toBe('# Plan Do the thing')
+    expect(items[1].preview).toBe('no entries yet')
+  })
+
+  it('names the step a plan is on, or its last one when it is finished', () => {
+    const next = plan([
+      { content: 'first', status: 'completed' },
+      { content: 'second', status: 'pending' },
+    ], { id: 'a', createdAt: at(0) })
+    const finished = plan([
+      { content: 'first', status: 'completed' },
+      { content: 'last', status: 'completed' },
+    ], { id: 'b', createdAt: at(1) })
+
+    const items = buildTrajectory([next, finished], [])
+
+    expect(items[0].preview).toBe('1/2 · second')
+    expect(items[1].preview).toBe('2/2 · last')
+  })
+
+  it('leaves the context counters out — the composer shows those', () => {
+    const items = buildTrajectory([
+      message({ id: 'u', metadata: { type: 'agent_usage', used: 100, size: 1000 } }),
+    ], [])
+
+    expect(items).toEqual([])
+  })
+
+  // Every permission request is recorded as a tool call too, so showing both
+  // listed each prompted tool twice.
+  it('shows the recorded tool call rather than the request that produced it', () => {
+    const items = buildTrajectory(
+      [permission('allow', { createdAt: at(0) })],
+      [toolCall({ id: 'tc1', status: 'allowed', createdAt: at(0) })],
+    )
+
+    expect(items).toHaveLength(1)
+    expect(items[0].id).toBe('t-tc1')
+    expect(items[0].raw.status).toBe('allowed')
+  })
+
+  it('pairs each request with one tool call, not all of them', () => {
+    const items = buildTrajectory(
+      [
+        permission('allow', { id: 'p1', createdAt: at(0) }),
+        permission('allow', { id: 'p2', createdAt: at(1) }),
+        permission('allow', { id: 'p3', createdAt: at(2) }),
+      ],
+      [toolCall({ id: 'tc1', createdAt: at(0) }), toolCall({ id: 'tc2', createdAt: at(1) })],
+    )
+
+    expect(items.filter((it) => it.id.startsWith('m-'))).toHaveLength(1)
+    expect(items.filter((it) => it.id.startsWith('t-'))).toHaveLength(2)
+  })
+
+  it('matches a request against a tool call whose input was truncated for storage', () => {
+    const long = 'x'.repeat(4000)
+    const items = buildTrajectory(
+      [permission('allow', { metadata: { type: 'permission_request', toolName: 'Bash', inputPreview: long, status: 'allow' } })],
+      [toolCall({ inputPreview: `${long.slice(0, 2000)}…` })],
+    )
+
+    expect(items).toHaveLength(1)
+    expect(items[0].id).toBe('t-tc1')
+  })
+
+  // Tasks that ran before tool calls were recorded have the message and
+  // nothing else; dropping it would erase their tool history.
+  it('keeps a permission request that no tool call stands for', () => {
+    const items = buildTrajectory([permission('deny')], [toolCall({ toolName: 'Edit' })])
+
+    expect(items).toHaveLength(2)
+    const request = items.find((it) => it.id.startsWith('m-'))
+    expect(request.lane).toBe('tool')
+    expect(request.raw.status).toBe('denied')
+    expect(request.label).toBe('Bash')
+  })
+
+  it('reads a permission request written before the API sent camelCase', () => {
+    const legacy = message({
+      id: 'old',
+      metadata: {
+        type: 'permission_request',
+        tool_name: 'Bash',
+        input_preview: 'rm -rf /tmp/x',
+        description: 'clean up',
+        status: 'allow_always',
+      },
+    })
+
+    const [item] = buildTrajectory([legacy], [])
+
+    expect(item.label).toBe('Bash')
+    expect(item.raw.inputPreview).toBe('rm -rf /tmp/x')
+    expect(item.raw.status).toBe('auto_allowed')
+  })
+
+  it('falls back to a name and a pending status when the request says neither', () => {
+    const bare = message({ id: 'bare', metadata: { type: 'permission_request' } })
+
+    const [item] = buildTrajectory([bare], [])
+
+    expect(item.label).toBe('Permission Request')
+    expect(item.raw.status).toBe('pending')
+    expect(item.preview).toBe('Permission Request')
+  })
+
+  it('describes an elicitation by what it asks for', () => {
+    const form = message({
+      id: 'f',
+      createdAt: at(0),
+      metadata: { type: 'elicitation_request', mode: 'form', message: 'Which branch?', requestedSchema: { properties: {} }, content: 'main' },
+    })
+    const url = message({
+      id: 'u',
+      createdAt: at(1),
+      metadata: { type: 'elicitation_request', mode: 'url', url: 'https://example.com', status: 'accept' },
+    })
+
+    const items = buildTrajectory([form, url], [])
+
+    expect(items[0].laneLabel).toBe('ASK')
+    expect(items[0].label).toBe('Which branch?')
+    expect(JSON.parse(items[0].raw.inputPreview)).toEqual({ mode: 'form', requestedSchema: { properties: {} }, answer: 'main' })
+    expect(items[1].label).toBe('Open link')
+    expect(items[1].raw.status).toBe('accept')
+    expect(JSON.parse(items[1].raw.inputPreview)).toEqual({ mode: 'url', url: 'https://example.com' })
+  })
+
+  it('names an elicitation that asks a question without a mode', () => {
+    const ask = message({ id: 'a', metadata: { type: 'elicitation_request' } })
+
+    expect(buildTrajectory([ask], [])[0].label).toBe('Answer question')
+  })
+
+  it('says so when a message or a tool call has nothing to preview', () => {
+    const items = buildTrajectory(
+      [message({ id: 'blank', text: '' })],
+      [toolCall({ inputPreview: '', description: '' })],
+    )
+
+    expect(items.find((it) => it.id === 'm-blank').preview).toBe('(no text)')
+    expect(items.find((it) => it.id === 't-tc1').preview).toBe('Bash')
+  })
+
+  it('says so when reasoning arrives empty', () => {
+    expect(buildTrajectory([thought('   ')], [])[0].preview).toBe('(empty)')
+  })
+
+  it('clips a long preview to one line', () => {
+    const items = buildTrajectory([message({ text: 'word '.repeat(100) })], [])
+
+    expect(items[0].preview).toHaveLength(141)
+    expect(items[0].preview.endsWith('…')).toBe(true)
+  })
+
+  it('describes a tool call by its description when it has no input', () => {
+    const items = buildTrajectory([], [toolCall({ inputPreview: '', description: 'list the files' })])
+
+    expect(items[0].preview).toBe('Bash list the files')
+  })
+
+  it('has nothing to show for a task with no activity', () => {
+    expect(buildTrajectory(undefined, undefined)).toEqual([])
+    expect(buildTrajectory([], [])).toEqual([])
+  })
+})
+
+describe('trajectoryLaneCounts', () => {
+  it('counts what each category holds', () => {
+    const items = buildTrajectory([
+      message({ id: 'a', sender: 'human', createdAt: at(0) }),
+      message({ id: 'b', sender: 'agent', createdAt: at(1) }),
+      thought('one', { id: 'c', createdAt: at(2) }),
+      plan([{ content: 'step', status: 'pending' }], { id: 'd', createdAt: at(3) }),
+    ], [toolCall({ id: 'e', createdAt: at(4) })])
+
+    expect(trajectoryLaneCounts(items)).toEqual({ input: 1, agent: 1, thought: 2, tool: 1 })
+  })
+
+  it('counts an empty trajectory as empty rather than absent', () => {
+    expect(trajectoryLaneCounts([])).toEqual({ input: 0, agent: 0, thought: 0, tool: 0 })
+    expect(trajectoryLaneCounts(undefined)).toEqual({ input: 0, agent: 0, thought: 0, tool: 0 })
+  })
+
+  it('ignores an entry filed under no lane at all', () => {
+    expect(trajectoryLaneCounts([{ lane: 'nowhere' }, null])).toEqual({
+      input: 0, agent: 0, thought: 0, tool: 0,
+    })
+  })
+
+  it('has a count for every lane the panel offers', () => {
+    const counts = trajectoryLaneCounts([])
+
+    expect(Object.keys(counts)).toEqual(TRAJECTORY_LANES.map((lane) => lane.key))
+  })
+})
+
+describe('filterTrajectory', () => {
+  const items = buildTrajectory([
+    message({ id: 'a', sender: 'human', text: 'deploy the backend', createdAt: at(0) }),
+    thought('the backend needs a migration first', { id: 'b', createdAt: at(1) }),
+  ], [toolCall({ id: 'c', toolName: 'Bash', inputPreview: 'make deploy', description: 'ship it', createdAt: at(2) })])
+
+  it('shows everything when nothing is asked of it', () => {
+    expect(filterTrajectory(items)).toHaveLength(3)
+    expect(filterTrajectory(items, {})).toHaveLength(3)
+  })
+
+  it('narrows to one category', () => {
+    expect(filterTrajectory(items, { lane: 'thought' }).map((it) => it.id)).toEqual(['m-b'])
+  })
+
+  it('searches the label, the preview and the description', () => {
+    expect(filterTrajectory(items, { query: 'migration' }).map((it) => it.id)).toEqual(['m-b'])
+    expect(filterTrajectory(items, { query: 'bash' }).map((it) => it.id)).toEqual(['t-c'])
+    expect(filterTrajectory(items, { query: 'ship it' }).map((it) => it.id)).toEqual(['t-c'])
+  })
+
+  it('ignores case and surrounding space in the search', () => {
+    expect(filterTrajectory(items, { query: '  DEPLOY  ' })).toHaveLength(2)
+  })
+
+  it('applies the category and the search together', () => {
+    expect(filterTrajectory(items, { lane: 'input', query: 'deploy' }).map((it) => it.id)).toEqual(['m-a'])
+    expect(filterTrajectory(items, { lane: 'input', query: 'migration' })).toEqual([])
+  })
+
+  it('has nothing to filter when there is nothing there', () => {
+    expect(filterTrajectory(undefined, { query: 'anything' })).toEqual([])
+  })
+})
+
+describe('defaultDetailTab', () => {
+  // What a reader came to a thought for is the text; the summary of one knows
+  // only when it was written.
+  it('opens reasoning and plans on their content', () => {
+    expect(defaultDetailTab({ lane: 'thought' })).toBe('content')
+  })
+
+  it('opens everything else on its summary', () => {
+    expect(defaultDetailTab({ lane: 'tool' })).toBe('summary')
+    expect(defaultDetailTab({ lane: 'agent' })).toBe('summary')
+    expect(defaultDetailTab(null)).toBe('summary')
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -40,6 +40,7 @@ export default defineConfig({
         'src/composables/useTaskGroups.js',
         'src/composables/useAgentTelemetry.js',
         'src/composables/useTaskEvents.js',
+        'src/composables/useTrajectory.js',
         'src/composables/usePendingSend.js',
         'src/composables/useDirectoryPicker.js',
         'src/composables/useProfileDisplay.js',


### PR DESCRIPTION
## What changed

The conversation now holds what was actually said, plus anything still waiting on you: a permission card stays until you answer it and then moves out. The agent's thinking and its finished tool calls are read in the Trajectory tab instead, which gained a category filter so you can look at just the thinking, just the tools, or just the messages.

## Why

A long run buried the answer. Every reasoning block and every already-answered permission card sat in the thread, so finding the sentence that mattered meant scrolling past the whole trace. The trace is worth keeping — it just belongs where it can be filtered and searched rather than in the middle of a conversation.

## Test coverage report

- **New lines: 100%.** The split rule and the trajectory's entry-building moved into a new composable at 100% statements / branches / functions / lines (37 new tests), added to the frontend's enforced-100% coverage list.
- **Total coverage impact:** the frontend's covered set stays at 100% across the board with one more file inside it. Suite 167 → 203 tests, all passing; `npm run build` clean. No backend change, so `go test ./internal/...` is untouched.

## Other notes

- The plan is the one piece of telemetry that stays in the thread: it is addressed to the reader, and the agent revises the same card as it works, so it reads as part of the conversation rather than a trace of it. Reasoning and plans both file under THINKING in the trajectory, each with its own badge.
- Every permission request is *also* recorded as a tool call, so the tool lane had been listing each prompted tool twice. The recorded row wins now — it is the one that carries the verdict as it changes — and the request is only shown when no row stands for it, so tasks from before tool calls were recorded keep their history.
- Selecting a piece of thinking opens its text rather than a summary that only knows when it was written.
- Verified against the real component in a headless browser on an isolated port, in both themes: the chips filter and count correctly, and the duplicate tool entry is gone.

TaskID: 0i8ZEimx3Hl

---
Generated with [AgentRQ](https://agentrq.com)