### PR TITLE
fix(workflows): say which workspace a step will run in when the name is cut

### DIFF
--- a/frontend/src/composables/useWorkflowLabels.js
+++ b/frontend/src/composables/useWorkflowLabels.js
@@ -1,0 +1,111 @@
+/**
+ * What a workflow's boxes say when you hover them.
+ *
+ * The canvas draws fixed-width nodes and the palette is a narrow column, so
+ * both truncate: a workspace called "agentrq-release-engineering" reads as
+ * "agentrq-release-engi…" and there was no way to see the rest. Worse, the
+ * truncated thing is the one fact a reader most needs — which workspace a
+ * running event is about to create work in.
+ *
+ * So every label that can be cut carries a tooltip, and the tooltip leads with
+ * the full name, then says what the box actually is. The shared tooltip
+ * preserves newlines, so these are written as short lines rather than one long
+ * sentence.
+ *
+ * Kept out of the view so it can be tested: the project has no component-test
+ * harness.
+ */
+
+/** The name a workspace goes by, or a marker when it is no longer there. */
+export function workspaceLabel(workspacesById, workspaceId) {
+  return workspacesById?.[workspaceId]?.name ?? '(deleted workspace)';
+}
+
+/** The name an event goes by, or a marker when it is no longer there. */
+export function eventLabel(eventsById, eventId) {
+  return eventsById?.[eventId]?.name ?? '(deleted event)';
+}
+
+function lines(...parts) {
+  return parts.filter((part) => part).join('\n');
+}
+
+/**
+ * The tooltip for a node on the workflow canvas.
+ *
+ * @param {object} node a graph node: {kind, label, isStart?, step?, trigger?}
+ * @returns {string}
+ */
+export function nodeTooltip(node) {
+  if (!node) return '';
+  const name = node.label ?? '';
+  switch (node.kind) {
+    case 'event':
+      return lines(name, node.isStart ? 'Event · starts this workflow' : 'Event');
+    case 'global-event':
+      return lines(name, 'Event · published outside this workflow');
+    case 'step':
+      return lines(name, taskLine(node.step), scheduleLine(node.step));
+    case 'global':
+      return lines(
+        name,
+        taskLine(node.trigger),
+        scheduleLine(node.trigger),
+        'Global subscriber · always runs on this event',
+      );
+    default:
+      return name;
+  }
+}
+
+/**
+ * What a box in a workspace column will do when the event above it fires.
+ * This is the answer to "which workspace gets the work, and what work" — the
+ * node itself only has room for the first half.
+ */
+function taskLine(target) {
+  const title = target?.title?.trim();
+  return title ? `Workspace · creates "${title}"` : 'Workspace';
+}
+
+function scheduleLine(target) {
+  const cron = target?.cronSchedule?.trim();
+  return cron ? `Runs on schedule ${cron}` : '';
+}
+
+/**
+ * The tooltip for a draggable chip in the palette. The chips are the narrowest
+ * thing on the page, so this is often the only place the full name is legible.
+ *
+ * @param {'workspace'|'event'} kind
+ * @param {string} name
+ * @returns {string}
+ */
+export function paletteTooltip(kind, name) {
+  const label = name ?? '';
+  return kind === 'event'
+    ? lines(label, 'Event · drag onto a workspace to emit it on completion')
+    : lines(label, 'Workspace · drag onto an event to create tasks here');
+}
+
+/**
+ * The tooltip for the event a step publishes when its task completes. The line
+ * is rendered at nine pixels and truncates almost immediately, so the name it
+ * names is usually only half there.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+export function emittedEventTooltip(name) {
+  return lines(name ?? '', 'Event · published when this task completes');
+}
+
+/**
+ * The tooltip for the workspace a trigger fires into, on an event's page.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+export function triggerWorkspaceTooltip(name) {
+  return lines(name ?? '', 'Workspace · a task is created here when this event fires');
+}

--- a/frontend/src/views/EventDetailView.vue
+++ b/frontend/src/views/EventDetailView.vue
@@ -5,6 +5,8 @@ import { getEvent, updateEvent, deleteEvent, fetchEvents, fetchEventTriggers, cr
 import { useToasts } from '../composables/useToasts'
 import { useCron } from '../composables/useCron'
 import { useWorkspaceStore } from '../stores/workspaceStore'
+import { useTooltipStore } from '../stores/tooltipStore'
+import { triggerWorkspaceTooltip, workspaceLabel } from '../composables/useWorkflowLabels'
 import DeleteModal from '../components/DeleteModal.vue'
 import LoadingState from '../components/LoadingState.vue'
 
@@ -13,6 +15,7 @@ const router = useRouter()
 const { notifyError, notifySuccess } = useToasts()
 const { getNextRunLabel, daysOptions } = useCron()
 const workspaceStore = useWorkspaceStore()
+const tooltipStore = useTooltipStore()
 
 const eventId = route.params.id
 
@@ -270,8 +273,16 @@ async function handleDeleteTrigger() {
   }
 }
 
+// Keyed once rather than scanned per row: a busy event lists a trigger for
+// every workspace that reacts to it.
+const workspacesById = computed(() => {
+  const map = {}
+  for (const ws of workspaceStore.workspaces) map[ws.id] = ws
+  return map
+})
+
 function workspaceName(wsId) {
-  return workspaceStore.workspaces.find(w => w.id === wsId)?.name ?? wsId
+  return workspaceLabel(workspacesById.value, wsId)
 }
 
 // ── tasks ─────────────────────────────────────────────────────────────────────
@@ -526,7 +537,10 @@ onMounted(async () => {
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 flex-wrap">
-                <span class="text-[10px] font-bold text-gray-400 dark:text-zinc-500 uppercase tracking-wider">{{ workspaceName(t.workspaceId) }}</span>
+                <span
+                  @mouseenter="tooltipStore.show($event, triggerWorkspaceTooltip(workspaceName(t.workspaceId)), 'top')"
+                  @mouseleave="tooltipStore.hide()"
+                  class="max-w-[12rem] truncate text-[10px] font-bold text-gray-400 dark:text-zinc-500 uppercase tracking-wider">{{ workspaceName(t.workspaceId) }}</span>
                 <svg class="w-3 h-3 text-gray-300 dark:text-zinc-600 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
                 <span class="text-xs font-bold text-gray-800 dark:text-zinc-200 truncate">{{ t.title }}</span>
               </div>

--- a/frontend/src/views/WorkflowDetailView.vue
+++ b/frontend/src/views/WorkflowDetailView.vue
@@ -9,6 +9,13 @@ import {
 import { useWorkspaceStore } from '../stores/workspaceStore';
 import { useTooltipStore } from '../stores/tooltipStore';
 import { useToasts } from '../composables/useToasts';
+import {
+  emittedEventTooltip,
+  eventLabel,
+  nodeTooltip,
+  paletteTooltip,
+  workspaceLabel,
+} from '../composables/useWorkflowLabels';
 import DeleteModal from '../components/DeleteModal.vue';
 import LoadingState from '../components/LoadingState.vue';
 
@@ -71,11 +78,11 @@ const workspacesById = computed(() => {
 });
 
 function eventName(id) {
-  return eventsById.value[id]?.name ?? '(deleted event)';
+  return eventLabel(eventsById.value, id);
 }
 
 function workspaceName(id) {
-  return workspacesById.value[id]?.name ?? '(deleted workspace)';
+  return workspaceLabel(workspacesById.value, id);
 }
 
 // stepsByEvent groups the fan-out for each event.
@@ -894,6 +901,8 @@ onMounted(async () => {
                   draggable="true"
                   @dragstart="startPaletteDrag('workspace', ws.id, $event)"
                   @dragend="dragItem = null; dropTarget = null"
+                  @mouseenter="tooltipStore.show($event, paletteTooltip('workspace', ws.name), 'right')"
+                  @mouseleave="tooltipStore.hide()"
                   class="px-2.5 py-1.5 text-[11px] font-semibold text-gray-700 dark:text-zinc-300 bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-lg cursor-grab active:cursor-grabbing hover:border-gray-300 dark:hover:border-zinc-600 transition-all truncate">
                   {{ ws.name }}
                 </div>
@@ -910,6 +919,8 @@ onMounted(async () => {
                   draggable="true"
                   @dragstart="startPaletteDrag('event', ev.id, $event)"
                   @dragend="dragItem = null; dropTarget = null"
+                  @mouseenter="tooltipStore.show($event, paletteTooltip('event', ev.name), 'right')"
+                  @mouseleave="tooltipStore.hide()"
                   class="px-2.5 py-1.5 text-[11px] font-mono font-semibold text-violet-700 dark:text-violet-400 bg-violet-50 dark:bg-violet-900/20 border border-violet-100 dark:border-violet-900/40 rounded-lg cursor-grab active:cursor-grabbing hover:border-violet-300 dark:hover:border-violet-700 transition-all truncate">
                   {{ ev.name }}
                 </div>
@@ -981,6 +992,8 @@ onMounted(async () => {
                     {{ node.kind === 'event' || node.kind === 'global-event' ? 'event' : 'agent' }}
                   </span>
                   <span
+                    @mouseenter="tooltipStore.show($event, nodeTooltip(node), 'top')"
+                    @mouseleave="tooltipStore.hide()"
                     class="min-w-0 grow truncate text-[11px] font-mono font-semibold"
                     :class="node.kind === 'global' || node.kind === 'global-event' ? 'text-gray-500 dark:text-zinc-400' : 'text-gray-900 dark:text-zinc-100'">
                     {{ node.label }}
@@ -1020,7 +1033,10 @@ onMounted(async () => {
                   </button>
                 </div>
                 <div v-if="node.kind === 'step' && node.step.emitEventId" class="flex items-center gap-1.5 px-3 pb-1.5 -mt-1">
-                  <span class="min-w-0 grow truncate text-[9px] text-gray-400 dark:text-zinc-500">
+                  <span
+                    @mouseenter="tooltipStore.show($event, emittedEventTooltip(eventName(node.step.emitEventId)), 'top')"
+                    @mouseleave="tooltipStore.hide()"
+                    class="min-w-0 grow truncate text-[9px] text-gray-400 dark:text-zinc-500">
                     emits <span class="font-mono">{{ eventName(node.step.emitEventId) }}</span>
                   </span>
                   <!-- Removing the emitted event breaks the chain here, so the

--- a/frontend/test/workflowLabels.test.js
+++ b/frontend/test/workflowLabels.test.js
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  emittedEventTooltip,
+  eventLabel,
+  nodeTooltip,
+  paletteTooltip,
+  triggerWorkspaceTooltip,
+  workspaceLabel,
+} from '../src/composables/useWorkflowLabels'
+
+const workspaces = { w1: { id: 'w1', name: 'agentrq-release-engineering' } }
+const events = { e1: { id: 'e1', name: 'deploy_done' } }
+
+describe('workspaceLabel', () => {
+  it('names the workspace', () => {
+    expect(workspaceLabel(workspaces, 'w1')).toBe('agentrq-release-engineering')
+  })
+
+  // A raw base62 ID says nothing about which workspace runs, which is the
+  // question the label exists to answer.
+  it('says so when the workspace is gone, rather than showing an ID', () => {
+    expect(workspaceLabel(workspaces, 'w404')).toBe('(deleted workspace)')
+    expect(workspaceLabel(undefined, 'w1')).toBe('(deleted workspace)')
+  })
+})
+
+describe('eventLabel', () => {
+  it('names the event', () => {
+    expect(eventLabel(events, 'e1')).toBe('deploy_done')
+  })
+
+  it('says so when the event is gone', () => {
+    expect(eventLabel(events, 'e404')).toBe('(deleted event)')
+    expect(eventLabel(undefined, 'e1')).toBe('(deleted event)')
+  })
+})
+
+describe('nodeTooltip', () => {
+  // The name leads every tooltip: the node truncates it, and reading the rest
+  // is why anyone hovers.
+  it('leads with the full name of an event', () => {
+    const tooltip = nodeTooltip({ kind: 'event', label: 'deploy_done' })
+
+    expect(tooltip.split('\n')[0]).toBe('deploy_done')
+    expect(tooltip).toBe('deploy_done\nEvent')
+  })
+
+  it('marks the event a run begins at', () => {
+    expect(nodeTooltip({ kind: 'event', label: 'deploy_done', isStart: true }))
+      .toBe('deploy_done\nEvent · starts this workflow')
+  })
+
+  it('marks an event that is published outside the workflow', () => {
+    expect(nodeTooltip({ kind: 'global-event', label: 'docs_updated' }))
+      .toBe('docs_updated\nEvent · published outside this workflow')
+  })
+
+  // The node has room for the workspace and nothing else, so the work it will
+  // create is only ever visible here.
+  it('says which workspace runs and what it is asked to do', () => {
+    expect(nodeTooltip({
+      kind: 'step',
+      label: 'agentrq-release-engineering',
+      step: { title: 'Cut the release notes' },
+    })).toBe('agentrq-release-engineering\nWorkspace · creates "Cut the release notes"')
+  })
+
+  it('adds the schedule when the task is a scheduled one', () => {
+    expect(nodeTooltip({
+      kind: 'step',
+      label: 'agentrq-code',
+      step: { title: 'Sweep the queue', cronSchedule: '30 * * * *' },
+    })).toBe('agentrq-code\nWorkspace · creates "Sweep the queue"\nRuns on schedule 30 * * * *')
+  })
+
+  it('still names the workspace when the step carries no title', () => {
+    expect(nodeTooltip({ kind: 'step', label: 'agentrq-code', step: { title: '   ' } }))
+      .toBe('agentrq-code\nWorkspace')
+    expect(nodeTooltip({ kind: 'step', label: 'agentrq-code' }))
+      .toBe('agentrq-code\nWorkspace')
+  })
+
+  // A global subscriber is not part of this workflow but does run on its
+  // events, so the tooltip has to say both.
+  it('marks a global subscriber as one', () => {
+    expect(nodeTooltip({
+      kind: 'global',
+      label: 'agentrq-docs',
+      trigger: { title: 'Update the changelog', cronSchedule: '0 9 * * *' },
+    })).toBe([
+      'agentrq-docs',
+      'Workspace · creates "Update the changelog"',
+      'Runs on schedule 0 9 * * *',
+      'Global subscriber · always runs on this event',
+    ].join('\n'))
+  })
+
+  it('has nothing to say about a node that is not there', () => {
+    expect(nodeTooltip(null)).toBe('')
+    expect(nodeTooltip({ kind: 'something-else', label: 'mystery' })).toBe('mystery')
+    // No blank first line when there is no name to lead with.
+    expect(nodeTooltip({ kind: 'event' })).toBe('Event')
+  })
+})
+
+describe('paletteTooltip', () => {
+  it('names the chip and what dragging it does', () => {
+    expect(paletteTooltip('workspace', 'agentrq-release-engineering'))
+      .toBe('agentrq-release-engineering\nWorkspace · drag onto an event to create tasks here')
+    expect(paletteTooltip('event', 'deploy_done'))
+      .toBe('deploy_done\nEvent · drag onto a workspace to emit it on completion')
+  })
+
+  it('survives a chip with no name yet', () => {
+    expect(paletteTooltip('workspace', undefined))
+      .toBe('Workspace · drag onto an event to create tasks here')
+  })
+})
+
+describe('emittedEventTooltip', () => {
+  it('names the event and when it fires', () => {
+    expect(emittedEventTooltip('docs_updated'))
+      .toBe('docs_updated\nEvent · published when this task completes')
+  })
+
+  it('survives a missing name', () => {
+    expect(emittedEventTooltip(null)).toBe('Event · published when this task completes')
+  })
+})
+
+describe('triggerWorkspaceTooltip', () => {
+  it('spells out where the work lands', () => {
+    expect(triggerWorkspaceTooltip('agentrq-code'))
+      .toBe('agentrq-code\nWorkspace · a task is created here when this event fires')
+  })
+
+  it('survives a missing name', () => {
+    expect(triggerWorkspaceTooltip(undefined))
+      .toBe('Workspace · a task is created here when this event fires')
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -41,6 +41,7 @@ export default defineConfig({
         'src/composables/useAgentTelemetry.js',
         'src/composables/useTaskEvents.js',
         'src/composables/useTrajectory.js',
+        'src/composables/useWorkflowLabels.js',
         'src/composables/usePendingSend.js',
         'src/composables/useDirectoryPicker.js',
         'src/composables/useProfileDisplay.js',


### PR DESCRIPTION
## What changed

Hovering any box, chip or tag in a workflow now shows the full name it was too narrow to display, along with what it actually is — which workspace the work lands in, the task that gets created, and its schedule. An event's trigger list no longer falls back to showing a raw ID when a workspace name isn't available.

## Why

The canvas draws fixed-width boxes and the palette is a narrow column, so both cut their labels — and the cut label is the one fact a reader most needs: which workspace an event is about to create work in. Nothing on hover gave the rest of it back.

## Test coverage report

- **New lines: 100%.** The tooltip text is built in a new composable at 100% statements / branches / functions / lines (18 new tests), added to the frontend's enforced-100% coverage list.
- **Total coverage impact:** the frontend's covered set stays at 100% across the board with one more file inside it. Suite 203 → 221 tests, all passing; `npm run build` clean. No backend change.

## Other notes

- Each tooltip leads with the full name and then says what the box is: an event, and whether a run starts there; a workspace, the task it creates and its schedule; a global subscriber, marked as running on the event whether or not this workflow owns it.
- The emitted-event line under a node is rendered at nine pixels and truncates almost immediately, so it got a tooltip too.
- On an event's page the workspace was looked up with a fallback to the raw base62 ID, so a workspace list that hadn't loaded — or one since deleted — left a trigger describing itself with a string identifying nothing. It now reads "(deleted workspace)", the same as the canvas, and the tag says on hover that this is where the task lands. That lookup also became a keyed map rather than a scan per row.
- Verified in a headless browser at the real widths: the node label does truncate at 200px (the reported bug reproduced), and the tooltip returns the full name plus the task and schedule on separate lines.

TaskID: 0iAsS14u6tt

---
Generated with [AgentRQ](https://agentrq.com)