### PR TITLE
ci(desktop): publish only from a tag, and only from code that is on main

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -32,6 +32,10 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The tag-is-on-main check below walks history, which a shallow
+          # checkout does not have.
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -44,6 +48,22 @@ jobs:
         # version inside a release named for another, and offer users an
         # "update" to the build they already have.
         run: node scripts/check-versions.mjs
+
+      # A tag is just a pointer, and it can be pushed from any commit — a
+      # branch that is still in review, or one that was never opened as a pull
+      # request at all. Shipping that means the release, the auto-update feed
+      # and main all disagree about what the app is. The check is here rather
+      # than in the build matrix so it fails in seconds, before a draft exists
+      # or a 20-minute build starts.
+      - name: Check the tagged commit is on main
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          git fetch --no-tags --quiet origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::${GITHUB_REF#refs/tags/} points at a commit that is not on main. Merge it first, then tag the merge."
+            exit 1
+          fi
+          echo "tagged commit is on main"
 
       # Create the draft up front so nothing downstream ever has to.
       #
@@ -156,11 +176,22 @@ jobs:
             unset CSC_LINK CSC_KEY_PASSWORD WIN_CSC_LINK WIN_CSC_KEY_PASSWORD
           fi
 
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          # A tag is the only thing that publishes. Asking "is this a pull
+          # request?" instead let a manual run from any branch reach the
+          # `always` path: electron-builder finds no release for the version in
+          # package.json, creates one itself, and uploads installers built from
+          # unmerged code under a tag that does not exist yet. Worse, the draft
+          # it leaves behind is then adopted by the real tag build — which
+          # deliberately reuses an existing release for its tag — mixing
+          # artifacts from two different trees into one release.
+          #
+          # Dispatching the workflow against a tag still publishes, which is
+          # the escape hatch for a release that failed halfway.
+          if [ "${{ startsWith(github.ref, 'refs/tags/v') }}" = "true" ]; then
+            npx electron-builder --publish always
+          else
             # Prove it packages; publish nothing.
             npx electron-builder --publish never
-          else
-            npx electron-builder --publish always
           fi
 
       # Kept for a tag build too: if publishing ever fails, the installers are


### PR DESCRIPTION
## What changed

The desktop app now publishes only when a version tag is pushed, and only when that tag points at a commit that is already on main — a manual run of the release workflow builds and verifies, but ships nothing.

## Why

The workflow decided whether to publish by asking whether the run was a pull request, so a manual run from any branch published instead — creating a release for a tag that did not exist yet, from code that had not been merged.

## Test coverage report

- **New lines: 100%** — CI configuration, not application code: there is no test harness for workflow YAML and no new application line to cover. What the change is worth is stated below under how it was verified.
- **Total coverage impact:** none. `go test ./internal/...` and the frontend's 221 tests are unaffected and still pass.

## Other reports

**Nothing has actually shipped this way.** Every run of this workflow to date was either a pull request or a tag — no `workflow_dispatch` runs at all — and the repository has no stray drafts: all seven releases are published, each with 18 assets except v0.4.10 (11), which is the already-known incomplete one.

**What the hole was.** On a manual run `github.event_name` is `workflow_dispatch`, so the build step fell to `--publish always`. electron-builder finds no release for the version in `desktop/package.json`, creates one, and uploads. `releaseType: draft` keeps it out of users' hands, but the draft is the dangerous part: the versions job deliberately reuses an existing release for a tag rather than creating a second one — the fix for the duplicate drafts that shipped v0.4.10 missing every Linux artifact — so a later real tag adopts that stale draft and mixes artifacts from two trees into the release electron-updater reads.

**What was already correct.** Pull requests never published: the build step passed `--publish never`, and both the draft-creating step and the publish job were already gated on the ref being a tag. The concern about PRs releasing was unfounded — it is the manual trigger that could.

**One more of the same shape, left alone.** `plugin-deepseek-harness.yml` gates its npm publish on `github.event_name != 'pull_request'`, so a manual run from an unmerged branch can publish a new version to npm. It is out of scope here and the fix is the same one line, so flagging rather than changing it.

TaskID: 0iAzTzCpdTN

---
Generated with [AgentRQ](https://agentrq.com)