### PR TITLE
ci(plugin): publish to npm only from main

### DIFF
--- a/.github/workflows/plugin-deepseek-harness.yml
+++ b/.github/workflows/plugin-deepseek-harness.yml
@@ -11,7 +11,8 @@ on:
     paths:
       - 'plugins/deepseek-harness/**'
       - '.github/workflows/plugin-deepseek-harness.yml'
-  # Manual re-run, for a publish that failed after the merge landed.
+  # Manual re-run, for a publish that failed after the merge landed. Run it
+  # against main: the publish job checks the ref, not the event.
   workflow_dispatch:
 
 env:
@@ -55,7 +56,12 @@ jobs:
   publish:
     name: Publish to npm
     needs: check
-    if: github.event_name != 'pull_request'
+    # main, not "anything that is not a pull request". A manual run carries the
+    # ref it was launched from, so the looser test let a dispatch from an
+    # unmerged branch publish that branch's version to npm — and npm has no
+    # undo: the version is taken from that moment on. Dispatching against main
+    # still republishes, which is what the trigger exists for.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## What changed

The DeepSeek Harness plugin now publishes to npm only from main, so a manual run of the workflow from an unmerged branch builds and tests but ships nothing.

## Why

The publish step asked whether the run was a pull request, and a manual run is not one — so it could publish an unmerged branch's version to npm, which cannot be undone once taken.

## Test coverage report

- **New lines: 100%** — CI configuration, not application code: there is no test harness for workflow YAML and no new application line to cover.
- **Total coverage impact:** none. The plugin's own typecheck, test and build job is unchanged and still gates every run.

## Other reports

- **Nothing shipped this way.** Every run of this workflow has been a pull request or a push to main — no `workflow_dispatch` runs — and npm holds only versions main produced (0.2.1, 0.2.2, 0.2.4, 0.2.5).
- The escape hatch the trigger exists for survives: dispatching against main still republishes, which is what it was added for — a publish that failed after the merge landed. The trigger's comment now says so.
- Same shape as the desktop fix in #406, which this follows: publish from the ref a release actually comes from — a tag there, main here — rather than from "not a pull request".

TaskID: 0iAzTzCpdTN

---
Generated with [AgentRQ](https://agentrq.com)