### PR TITLE
chore: bump patch version to v0.4.17

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.4.16"
+	_appVersion   = "v0.4.17"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.4.16" {
-			t.Errorf("Expected version v0.4.16, got %s", s.Version())
+		if s.Version() != "v0.4.17" {
+			t.Errorf("Expected version v0.4.17, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.4.16",
+      "version": "0.4.17",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.4.16",
+      "version": "0.4.17",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.4.16",
+  "version": "0.4.17",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
## What changed

The application's version number moves from 0.4.16 to 0.4.17 everywhere it is declared — the desktop shell, the frontend, their lockfiles, and the backend — so the release build sees one consistent version.

## Why changed

Routine patch bump to cut the next release. The version-sync check runs before packaging and rejects a tree whose versions disagree, and electron-updater compares this number against the published release, so all six declarations have to move together.

## What is shipping in v0.4.17

**Features**
- A supervisor can now build systems out of events and triggers (#402)
- The agent's reasoning and its tool calls are read in the trajectory view rather than in the chat (#401)

**Fixes**
- Workflow steps say which workspace they will run in when the name is cut off (#403)
- A new message no longer empties the task's tool lane in the trajectory (#400)

**Chores, CI and docs**
- The npm plugin publishes only from main (#407)
- The desktop app publishes only from a tag, and only from code that is on main (#406)
- Setup docs gained an ACP tab that is not Gemini's, plus one for Antigravity (#405)
- The sidebar's experimental section is now called Advanced (#404)

## Test coverage report

No new executable lines are introduced — the change is version constants and package metadata only, so new-line coverage is 100% (the changed backend constant is exercised by the existing version assertion, which was updated alongside it).

Total coverage impact: none. `backend/internal/service/config` holds at 92.2% of statements, unchanged from before the bump.

## Other reports

Version sync verified in both forms the release uses:

- `node desktop/scripts/check-versions.mjs` → desktop, frontend and backend are all at 0.4.17
- `GITHUB_REF=refs/tags/v0.4.17 node desktop/scripts/check-versions.mjs` → sources agree, and tag v0.4.17 matches version 0.4.17

`go test ./internal/service/config/` passes. Both lockfiles were edited by hand rather than regenerated, and `npm ci` validates cleanly for desktop and frontend with no dependency drift.

TaskID: 0iB7kJ4bntp

🤖 Generated with [Claude Code](https://claude.com/claude-code)