### PR TITLE
feat(shortcuts): drive the app from the keyboard

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -371,6 +371,11 @@
 
     <!-- Global Toasts -->
     <Toast />
+
+    <!-- Keyboard-driven overlays. Both are shell-level: the finder crosses
+         workspaces, and the help sheet describes shortcuts a view may own. -->
+    <CommandPalette :show="isPaletteOpen" :shortcut-label="findTaskLabel" @close="isPaletteOpen = false" />
+    <ShortcutsHelp :show="isHelpOpen" :mac="isMacKeyboard" @close="isHelpOpen = false" />
   </div>
 </template>
 
@@ -389,6 +394,15 @@ import { useWorkspaceStore } from './stores/workspaceStore'
 import { useFormat } from './composables/useFormat'
 import { usePushNotifications } from './composables/usePushNotifications'
 import Toast from './components/Toast.vue'
+import CommandPalette from './components/CommandPalette.vue'
+import ShortcutsHelp from './components/ShortcutsHelp.vue'
+import {
+  SHORTCUTS,
+  formatShortcut,
+  newTaskRoute,
+  useShortcuts,
+  usesCommandKey,
+} from './composables/useKeyboardShortcuts'
 
 const appVersion = __APP_VERSION__
 const { needRefresh, updateServiceWorker } = useRegisterSW()
@@ -476,6 +490,42 @@ const workspaces = computed(() => workspaceStore.workspaces)
 
 const currentWorkspaceId = computed(() => route.params.id || route.params.workspaceId)
 
+// --- Keyboard shortcuts -----------------------------------------------------
+// The shell owns the ones that work anywhere. A view registers its own on top
+// of these; see TaskDetailView for the chat/trajectory pair.
+
+const isPaletteOpen = ref(false)
+const isHelpOpen = ref(false)
+
+/** Command on a Mac keyboard, Control everywhere else. */
+const isMacKeyboard = computed(() => usesCommandKey(platformStore.$state))
+const findTaskLabel = computed(() =>
+  formatShortcut(SHORTCUTS.find((s) => s.id === 'find-task'), { mac: isMacKeyboard.value })
+)
+
+useShortcuts(
+  {
+    'find-task': () => {
+      isHelpOpen.value = false
+      isPaletteOpen.value = true
+    },
+    'new-task': () => router.push(newTaskRoute(currentWorkspaceId.value, workspaces.value)),
+    'show-help': () => {
+      isPaletteOpen.value = false
+      isHelpOpen.value = true
+    },
+  },
+  { mac: () => isMacKeyboard.value }
+)
+
+// Escape closes an overlay wherever focus happens to be. The palette handles it
+// on its own input too — this is for the help sheet, which has nothing focused.
+const closeOverlaysOnEscape = (e) => {
+  if (e.key !== 'Escape') return
+  isPaletteOpen.value = false
+  isHelpOpen.value = false
+}
+
 // Setup Global Event Bus (Global stream receives events for all workspaces)
 const { connect, disconnect, events } = useEventBus()
 
@@ -520,6 +570,7 @@ onMounted(() => {
   workspaceStore.fetchWorkspaces()
   connect() // Connect to global event stream
   document.addEventListener('click', handleClickOutside)
+  window.addEventListener('keydown', closeOverlaysOnEscape)
 })
 
 const showTooltip = (event, text) => {
@@ -562,6 +613,7 @@ const handleClickOutside = (e) => {
 
 onUnmounted(() => {
   document.removeEventListener('click', handleClickOutside)
+  window.removeEventListener('keydown', closeOverlaysOnEscape)
 })
 
 watch(() => route.fullPath, (fullPath) => {

--- a/frontend/src/components/CommandPalette.vue
+++ b/frontend/src/components/CommandPalette.vue
@@ -1,0 +1,182 @@
+<script setup>
+/**
+ * The task finder, opened with Cmd/Ctrl+K.
+ *
+ * The matching and the ID resolution live in `useTaskFinder` — this component
+ * is the box around them: it owns the open/closed state, the highlighted row
+ * and the navigation, and nothing else.
+ */
+import { computed, nextTick, ref, watch } from 'vue';
+import { useRouter } from 'vue-router';
+
+import { fetchGlobalTasks, getTask } from '../api';
+import { looksLikeTaskId, matchTasks, resolveTaskById, taskRoute } from '../composables/useTaskFinder';
+import { useWorkspaceStore } from '../stores/workspaceStore';
+
+const props = defineProps({
+  show: Boolean,
+  /** Rendered in the empty state so the shortcut stays discoverable. */
+  shortcutLabel: { type: String, default: '' },
+});
+const emit = defineEmits(['close']);
+
+const router = useRouter();
+const workspaceStore = useWorkspaceStore();
+
+const query = ref('');
+const tasks = ref([]);
+const highlighted = ref(0);
+const loading = ref(false);
+const resolving = ref(false);
+const notFound = ref(false);
+const inputRef = ref(null);
+
+const results = computed(() => matchTasks(tasks.value, query.value));
+
+/**
+ * Offer the ID lookup only when the filter has come up empty — until then the
+ * query is answered by rows the user can already see, and firing one request
+ * per workspace behind that would be noise.
+ */
+const canResolveId = computed(
+  () => results.value.length === 0 && looksLikeTaskId(query.value) && !resolving.value
+);
+
+watch(
+  () => props.show,
+  async (open) => {
+    if (!open) return;
+    query.value = '';
+    highlighted.value = 0;
+    notFound.value = false;
+    await nextTick();
+    inputRef.value?.focus();
+    loadRecent();
+  }
+);
+
+watch(query, () => {
+  highlighted.value = 0;
+  notFound.value = false;
+});
+
+async function loadRecent() {
+  loading.value = true;
+  try {
+    // The API caps this at 50, which is also the most this list is worth
+    // holding: past that, the ID lookup is the honest answer.
+    const res = await fetchGlobalTasks({ limit: 50 });
+    tasks.value = res.tasks || [];
+  } catch {
+    // A finder that cannot list still resolves an ID, so an empty list is a
+    // degraded box rather than a broken one.
+    tasks.value = [];
+  } finally {
+    loading.value = false;
+  }
+}
+
+function move(delta) {
+  const count = results.value.length;
+  if (count === 0) return;
+  highlighted.value = (highlighted.value + delta + count) % count;
+}
+
+function open(task) {
+  emit('close');
+  router.push(taskRoute(task));
+}
+
+async function submit() {
+  const hit = results.value[highlighted.value];
+  if (hit) return open(hit);
+  if (!canResolveId.value) return;
+
+  resolving.value = true;
+  notFound.value = false;
+  try {
+    const found = await resolveTaskById(
+      query.value.trim(),
+      workspaceStore.workspaces.map((w) => w.id),
+      getTask
+    );
+    if (found) {
+      emit('close');
+      router.push(taskRoute(found.task, found.workspaceId));
+      return;
+    }
+    notFound.value = true;
+  } finally {
+    resolving.value = false;
+  }
+}
+</script>
+
+<template>
+  <Transition name="fade">
+    <div v-if="show" class="fixed inset-0 z-[150]" role="dialog" aria-modal="true" aria-label="Find task">
+      <div class="fixed inset-0 bg-gray-900/60 backdrop-blur-sm" @click="emit('close')"></div>
+
+      <div class="relative mx-auto mt-[12vh] w-[92%] max-w-xl">
+        <div class="bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-xl shadow-2xl overflow-hidden">
+          <!-- Query -->
+          <div class="flex items-center gap-3 px-4 py-3 border-b border-gray-100 dark:border-zinc-800">
+            <svg class="w-4 h-4 shrink-0 text-gray-400 dark:text-zinc-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35M17 11a6 6 0 11-12 0 6 6 0 0112 0z" />
+            </svg>
+            <input ref="inputRef" v-model="query" type="text" autocomplete="off" spellcheck="false"
+                   placeholder="Task ID, or part of a title"
+                   class="grow bg-transparent text-[14px] text-gray-900 dark:text-zinc-100 placeholder:text-gray-400 dark:placeholder:text-zinc-600 focus:outline-none"
+                   @keydown.down.prevent="move(1)"
+                   @keydown.up.prevent="move(-1)"
+                   @keydown.enter.prevent="submit"
+                   @keydown.esc.prevent="emit('close')" />
+            <kbd class="shrink-0 text-[9px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-500 border border-gray-200 dark:border-zinc-700 rounded px-1.5 py-0.5">Esc</kbd>
+          </div>
+
+          <!-- Results -->
+          <ul v-if="results.length" class="max-h-80 overflow-y-auto py-1">
+            <li v-for="(task, i) in results" :key="task.id">
+              <button type="button" @click="open(task)" @mouseenter="highlighted = i"
+                      class="w-full text-left px-4 py-2.5 flex items-center gap-3 transition-colors"
+                      :class="i === highlighted ? 'bg-gray-50 dark:bg-zinc-800' : 'hover:bg-gray-50/60 dark:hover:bg-zinc-800/60'">
+                <span class="grow min-w-0">
+                  <span class="block truncate text-[13px] font-medium text-gray-900 dark:text-zinc-100">{{ task.title }}</span>
+                  <span class="block truncate text-[10px] font-mono text-gray-400 dark:text-zinc-500">{{ task.id }}</span>
+                </span>
+                <span class="shrink-0 text-[9px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-500">{{ task.status }}</span>
+              </button>
+            </li>
+          </ul>
+
+          <!-- Empty states -->
+          <div v-else class="px-4 py-6 text-center">
+            <p v-if="loading" class="text-[12px] text-gray-400 dark:text-zinc-500">Loading recent tasks…</p>
+            <p v-else-if="resolving" class="text-[12px] text-gray-400 dark:text-zinc-500">Looking that ID up across your workspaces…</p>
+            <p v-else-if="notFound" class="text-[12px] text-gray-500 dark:text-zinc-400">
+              No task with that ID in any of your workspaces.
+            </p>
+            <p v-else-if="canResolveId" class="text-[12px] text-gray-500 dark:text-zinc-400">
+              Not in the recent tasks. Press <span class="font-semibold text-gray-900 dark:text-zinc-100">Enter</span> to look this ID up across your workspaces.
+            </p>
+            <p v-else-if="query" class="text-[12px] text-gray-400 dark:text-zinc-500">No recent task matches that.</p>
+            <p v-else class="text-[12px] text-gray-400 dark:text-zinc-500">
+              Search your recent tasks<span v-if="shortcutLabel">, or reopen this with {{ shortcutLabel }}</span>.
+            </p>
+          </div>
+
+          <!-- Footer hints -->
+          <div class="flex items-center gap-4 px-4 py-2 border-t border-gray-100 dark:border-zinc-800 bg-gray-50/50 dark:bg-zinc-800/30">
+            <span class="text-[9px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-500">↑↓ Navigate</span>
+            <span class="text-[9px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-500">↵ Open</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.fade-enter-active, .fade-leave-active { transition: opacity 0.18s ease; }
+.fade-enter-from, .fade-leave-to { opacity: 0; }
+</style>

--- a/frontend/src/components/ShortcutsHelp.vue
+++ b/frontend/src/components/ShortcutsHelp.vue
@@ -1,0 +1,93 @@
+<script setup>
+/**
+ * The `?` sheet.
+ *
+ * Rendered straight from `SHORTCUTS`, so a binding added there shows up here
+ * without anyone remembering to document it — a shortcut nobody can discover is
+ * a shortcut nobody uses.
+ */
+import { computed } from 'vue';
+
+import { SHORTCUTS, formatAccelerator, formatShortcut } from '../composables/useKeyboardShortcuts';
+import { usePlatformStore } from '../stores/platformStore';
+
+const props = defineProps({
+  show: Boolean,
+  /** Whether this keyboard's modifier is Command rather than Control. */
+  mac: Boolean,
+});
+const emit = defineEmits(['close']);
+
+const platformStore = usePlatformStore();
+
+const GROUPS = [
+  { scope: 'global', title: 'Anywhere' },
+  { scope: 'task', title: 'In a task' },
+];
+
+const groups = computed(() =>
+  GROUPS.map((group) => ({
+    ...group,
+    items: SHORTCUTS.filter((s) => s.scope === group.scope).map((s) => ({
+      ...s,
+      combo: formatShortcut(s, { mac: props.mac }),
+      // The desktop menu owns this one; the renderer never sees the key, so it
+      // is described rather than claimed.
+      alsoCombo:
+        platformStore.isDesktop && s.desktopAlso
+          ? formatAccelerator(s.desktopAlso, { mac: props.mac })
+          : '',
+    })),
+  }))
+);
+</script>
+
+<template>
+  <Transition name="fade">
+    <div v-if="show" class="fixed inset-0 z-[150]" role="dialog" aria-modal="true" aria-label="Keyboard shortcuts">
+      <div class="fixed inset-0 bg-gray-900/60 backdrop-blur-sm" @click="emit('close')"></div>
+
+      <div class="relative mx-auto mt-[14vh] w-[92%] max-w-md">
+        <div class="bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-xl shadow-2xl overflow-hidden"
+             tabindex="-1" @keydown.esc.prevent="emit('close')">
+          <div class="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-zinc-800">
+            <h2 class="text-[11px] font-black uppercase tracking-widest text-gray-900 dark:text-zinc-100">Keyboard Shortcuts</h2>
+            <button type="button" @click="emit('close')" class="text-gray-400 hover:text-gray-600 dark:hover:text-zinc-300 transition-colors" aria-label="Close">
+              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          <div v-for="group in groups" :key="group.scope" class="px-5 py-4 border-b border-gray-100 dark:border-zinc-800 last:border-b-0">
+            <p class="text-[9px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-500 mb-3">{{ group.title }}</p>
+            <ul class="flex flex-col gap-2.5">
+              <li v-for="item in group.items" :key="item.id" class="flex items-baseline justify-between gap-4">
+                <span class="min-w-0">
+                  <span class="block text-[13px] font-medium text-gray-900 dark:text-zinc-100">{{ item.label }}</span>
+                  <span v-if="item.hint" class="block text-[11px] text-gray-400 dark:text-zinc-500">{{ item.hint }}</span>
+                </span>
+                <span class="shrink-0 flex items-center gap-1.5">
+                  <kbd class="text-[10px] font-mono text-gray-700 dark:text-zinc-200 border border-gray-200 dark:border-zinc-700 rounded px-1.5 py-0.5">{{ item.combo }}</kbd>
+                  <template v-if="item.alsoCombo">
+                    <span class="text-[10px] text-gray-400 dark:text-zinc-600">or</span>
+                    <kbd class="text-[10px] font-mono text-gray-700 dark:text-zinc-200 border border-gray-200 dark:border-zinc-700 rounded px-1.5 py-0.5">{{ item.alsoCombo }}</kbd>
+                  </template>
+                </span>
+              </li>
+            </ul>
+          </div>
+
+          <p class="px-5 py-3 text-[11px] text-gray-400 dark:text-zinc-500 bg-gray-50/50 dark:bg-zinc-800/30 border-t border-gray-100 dark:border-zinc-800">
+            Single-key shortcuts pause while you are typing in a field.
+          </p>
+        </div>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.fade-enter-active, .fade-leave-active { transition: opacity 0.18s ease; }
+.fade-enter-from, .fade-leave-to { opacity: 0; }
+</style>

--- a/frontend/src/composables/useKeyboardShortcuts.js
+++ b/frontend/src/composables/useKeyboardShortcuts.js
@@ -1,0 +1,280 @@
+import { onMounted, onUnmounted } from 'vue';
+
+/**
+ * The application's keyboard shortcuts.
+ *
+ * ## Why so few of these use a modifier
+ *
+ * The obvious bindings — Cmd+N for a new task, Cmd+H for history, Cmd+M for
+ * messages — cannot be implemented. They never reach the page:
+ *
+ * - **Cmd/Ctrl+N** is *New Window* in every browser, claimed by the browser's
+ *   own menu. (Cmd+Shift+N is *New Incognito Window*, so shifting it does not
+ *   help either — see `desktop/src/main/menu.js`, which reaches the same
+ *   conclusion for the desktop menu.)
+ * - **Cmd+H** is *Hide Application* on macOS, handled by the window server
+ *   before any application — browser or Electron — is offered the event.
+ * - **Cmd+M** is *Minimize Window* on macOS, in the standard Window menu.
+ *
+ * A handler bound to those would simply never fire, which is worse than having
+ * no shortcut: the app would document a key that does nothing.
+ *
+ * So the scheme is the one every web task tracker converges on for exactly this
+ * reason — Linear, GitHub, Jira, Gmail: **Cmd/Ctrl+K for the finder, and bare
+ * letters for the rest.** Cmd+K is the one modifier combination browsers leave
+ * to the page, and a bare letter collides with nothing at all as long as it is
+ * suppressed while the user is typing (see `isTypingTarget`).
+ *
+ * The desktop build additionally reaches New Task through its application menu
+ * on Cmd/Ctrl+Shift+N. That accelerator is consumed by the menu and never
+ * arrives here, so it is described rather than bound — see `SHORTCUTS`.
+ */
+export const SHORTCUTS = [
+  {
+    id: 'find-task',
+    key: 'k',
+    mod: true,
+    label: 'Find task by ID',
+    // The finder is how you leave a screen you are typing on, so unlike the
+    // bare letters it stays live while a text box has focus.
+    hint: 'Search the recent tasks, or paste a task ID from anywhere',
+    scope: 'global',
+  },
+  {
+    id: 'new-task',
+    key: 'n',
+    label: 'New task',
+    hint: 'Opens the task form for the workspace you are in',
+    scope: 'global',
+    /** Shown in the help sheet on the desktop build only. */
+    desktopAlso: 'CommandOrControl+Shift+N',
+  },
+  {
+    id: 'show-help',
+    key: '?',
+    label: 'Show keyboard shortcuts',
+    scope: 'global',
+  },
+  {
+    // `M` for messages, not `C` for chat: `C` sits close enough to copying to
+    // read as a conflict even though it is not one — a bare letter never fires
+    // with a modifier held, so Cmd+C is untouched either way.
+    id: 'chat-view',
+    key: 'm',
+    label: 'Chat view',
+    hint: 'The message thread',
+    scope: 'task',
+  },
+  {
+    id: 'trajectory-view',
+    key: 't',
+    label: 'Trajectory view',
+    hint: "The agent's reasoning and tool calls",
+    scope: 'task',
+  },
+];
+
+/**
+ * Which physical key stands for "the command modifier" here.
+ *
+ * Two sources, because the two builds know different things. The desktop shell
+ * passes `process.platform` down to the platform store, which is authoritative.
+ * The browser build has no such value — the store deliberately leaves `os`
+ * empty there — so it falls back to what the navigator reports.
+ *
+ * This is *not* the user-agent sniffing the frontend guide warns against. That
+ * rule is about deciding which build is running, a question the platform store
+ * answers. "Does this keyboard have a Command key" is a different question, and
+ * in the browser the navigator is the only thing that can answer it.
+ *
+ * @param {{ os?: string }} [platform] the platform store's state
+ * @param {{ userAgentData?: { platform?: string }, platform?: string }} [nav]
+ * @returns {boolean} true when Command, false when Control
+ */
+export function usesCommandKey(platform = {}, nav = globalThis.navigator) {
+  if (platform.os === 'darwin') return true;
+
+  const reported = nav?.userAgentData?.platform || nav?.platform || '';
+  return /mac/i.test(reported);
+}
+
+/**
+ * Whether a key event is the user writing text rather than driving the app.
+ *
+ * This is the whole reason a bare letter is safe: `n` opens the task form from
+ * the board, but typing "not started" into the reply box must stay text. A
+ * `contenteditable` counts, and so does anything the page has explicitly opted
+ * out with `data-shortcuts="off"`.
+ *
+ * @param {EventTarget | null} target
+ */
+export function isTypingTarget(target) {
+  const el = /** @type {HTMLElement | null} */ (target);
+  if (!el || typeof el !== 'object') return false;
+  if (el.isContentEditable) return true;
+  if (el.closest?.('[data-shortcuts="off"]')) return true;
+
+  const tag = typeof el.tagName === 'string' ? el.tagName.toUpperCase() : '';
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+}
+
+/**
+ * The shortcut a key event stands for, or null.
+ *
+ * A modifier-less shortcut must be pressed with *no* modifier at all: that keeps
+ * the app clear of every browser and OS binding built on Cmd, Ctrl or Alt, which
+ * is what makes bare letters usable in the first place. It is also why a bare
+ * letter is ignored while typing, whereas Cmd+K is not — the finder is how you
+ * get out of a screen you are writing on.
+ *
+ * @param {KeyboardEvent} event
+ * @param {{ mac?: boolean, shortcuts?: typeof SHORTCUTS }} [options]
+ */
+export function matchShortcut(event, { mac = false, shortcuts = SHORTCUTS } = {}) {
+  if (!event?.key) return null;
+
+  const modPressed = mac ? Boolean(event.metaKey) : Boolean(event.ctrlKey);
+  const otherMod = mac ? Boolean(event.ctrlKey) : Boolean(event.metaKey);
+  const typing = isTypingTarget(event.target);
+
+  return (
+    shortcuts.find((s) => {
+      if (event.key.toLowerCase() !== s.key) return false;
+
+      if (s.mod) return modPressed && !otherMod && !event.altKey;
+
+      // `?` is Shift+/ on most layouts, so Shift is judged by the resulting
+      // character rather than by the flag.
+      return !typing && !modPressed && !otherMod && !event.altKey;
+    }) ?? null
+  );
+}
+
+/**
+ * How a shortcut is written on screen.
+ *
+ * macOS spells modifiers as glyphs with no separator, which is what users there
+ * expect to see next to a menu item; everywhere else they are words joined by
+ * `+`.
+ *
+ * @param {{ key: string, mod?: boolean }} shortcut
+ * @param {{ mac?: boolean }} [options]
+ */
+export function formatShortcut(shortcut, { mac = false } = {}) {
+  const key = shortcut.key.toUpperCase();
+  if (!shortcut.mod) return key;
+  return mac ? `⌘${key}` : `Ctrl+${key}`;
+}
+
+/**
+ * The same, for an Electron accelerator string like `CommandOrControl+Shift+N`.
+ * Only used to describe the desktop menu's binding in the help sheet.
+ *
+ * @param {string} accelerator
+ * @param {{ mac?: boolean }} [options]
+ */
+export function formatAccelerator(accelerator, { mac = false } = {}) {
+  const parts = accelerator.split('+');
+  const glyphs = { CommandOrControl: '⌘', Command: '⌘', Control: '⌃', Shift: '⇧', Alt: '⌥' };
+  const words = { CommandOrControl: 'Ctrl', Command: 'Ctrl', Control: 'Ctrl', Shift: 'Shift', Alt: 'Alt' };
+
+  if (mac) return parts.map((p) => glyphs[p] ?? p.toUpperCase()).join('');
+  return parts.map((p) => words[p] ?? p.toUpperCase()).join('+');
+}
+
+/**
+ * The registrations a key press is dispatched to, newest first.
+ *
+ * A stack rather than a map so a view can take over a shortcut the shell also
+ * defines: the task detail mounts after the shell, so its handler sits on top
+ * and wins. Module scope is deliberate — there is one keyboard, and therefore
+ * one listener, however many components are listening through it.
+ *
+ * @type {Array<Record<string, (event: KeyboardEvent) => void>>}
+ */
+const registrations = [];
+
+/** Test seam: forget every registration. */
+export function resetShortcuts() {
+  registrations.length = 0;
+}
+
+/**
+ * Run the handler for whatever `event` means, if anyone is listening for it.
+ *
+ * A matched shortcut has its default suppressed — without that, Cmd+K would
+ * also drop the browser into its address bar — but only when it was actually
+ * handled. An unclaimed shortcut is left alone so the browser keeps its
+ * behaviour on screens that do not implement it.
+ *
+ * @param {KeyboardEvent} event
+ * @param {{ mac?: boolean, shortcuts?: typeof SHORTCUTS }} [options]
+ * @returns {string | null} the id that ran, for tests and callers
+ */
+export function dispatchShortcut(event, options = {}) {
+  const shortcut = matchShortcut(event, options);
+  if (!shortcut) return null;
+
+  for (let i = registrations.length - 1; i >= 0; i -= 1) {
+    const handler = registrations[i][shortcut.id];
+    if (!handler) continue;
+    event.preventDefault?.();
+    handler(event);
+    return shortcut.id;
+  }
+  return null;
+}
+
+/**
+ * Listen for shortcuts for as long as the calling component is mounted.
+ *
+ * @param {Record<string, (event: KeyboardEvent) => void>} handlers
+ *        keyed by shortcut id; ids nobody handles simply do nothing
+ * @param {{ mac?: () => boolean, target?: EventTarget,
+ *           onMounted?: Function, onUnmounted?: Function }} [options]
+ */
+export function useShortcuts(handlers, options = {}) {
+  const {
+    mac = () => false,
+    target = globalThis.window,
+    onMounted: mount = onMounted,
+    onUnmounted: unmount = onUnmounted,
+  } = options;
+
+  const onKeydown = (event) => dispatchShortcut(event, { mac: mac() });
+
+  mount(() => {
+    registrations.push(handlers);
+    target?.addEventListener('keydown', onKeydown);
+  });
+
+  unmount(() => {
+    const at = registrations.indexOf(handlers);
+    if (at !== -1) registrations.splice(at, 1);
+    target?.removeEventListener('keydown', onKeydown);
+  });
+
+  return { onKeydown };
+}
+
+/**
+ * Where the new-task shortcut goes.
+ *
+ * The task form belongs to a workspace, so the shortcut has to pick one. The
+ * workspace on screen is the obvious answer; failing that, a user with a single
+ * workspace can only have meant that one. With no way to tell, the workspace
+ * list is the honest destination — better than guessing and dropping a task in
+ * the wrong place.
+ *
+ * The desktop menu answers the same question from its recent-workspace list
+ * (`newTaskRoute` in `desktop/src/main/index.js`); this is the browser's
+ * equivalent, using what the router already knows.
+ *
+ * @param {string | undefined} currentWorkspaceId
+ * @param {Array<{ id: string }>} [workspaces]
+ */
+export function newTaskRoute(currentWorkspaceId, workspaces = []) {
+  if (currentWorkspaceId) return `/workspaces/${currentWorkspaceId}/tasks/new`;
+  if (workspaces.length === 1) return `/workspaces/${workspaces[0].id}/tasks/new`;
+  return '/';
+}

--- a/frontend/src/composables/useTaskFinder.js
+++ b/frontend/src/composables/useTaskFinder.js
@@ -1,0 +1,113 @@
+/**
+ * Finding a task from the keyboard.
+ *
+ * Two different lookups sit behind one text box, because the backend offers no
+ * single endpoint that answers "where is task X":
+ *
+ * 1. **Filtering what is already loaded.** The global task list is capped at 50
+ *    rows by the API, so this is fast and covers the recent work — which is
+ *    what almost every search is for. It matches titles as well as IDs, so the
+ *    box is useful even when you cannot remember an ID.
+ * 2. **Resolving an exact ID.** A task older than those 50 rows is invisible to
+ *    the filter, and an ID pasted from a commit message or a chat is exactly the
+ *    case where the task is old. So a query that looks like an ID and matches
+ *    nothing is asked for by ID, against each of the user's workspaces.
+ *
+ * The second lookup is deliberately *not* run while typing: it is one request
+ * per workspace, so it waits for the user to commit to the query.
+ */
+
+/** Task IDs are base62 monoflakes — 11 characters today, with room to grow. */
+const TASK_ID = /^[0-9A-Za-z]{8,16}$/;
+
+/**
+ * Whether `query` could be a task ID.
+ *
+ * Only a shape test. A real title can pass it ("deadline" is eight letters),
+ * which is harmless: this only ever decides whether to *also* try an ID lookup
+ * after the filter has already come up empty.
+ *
+ * @param {string} query
+ */
+export function looksLikeTaskId(query) {
+  return TASK_ID.test((query ?? '').trim());
+}
+
+/**
+ * Tasks matching `query`, best match first.
+ *
+ * The ordering is what makes the box feel right: an exact ID is what you get
+ * when you paste one, an ID prefix comes next, and title matches fill the rest.
+ * Within a group the incoming order is kept, which is the API's — newest first.
+ *
+ * An empty query is not "match everything filtered": it is the resting state of
+ * the box, and showing the most recent tasks there is more useful than a blank
+ * panel.
+ *
+ * @param {Array<{ id: string, title?: string }>} tasks
+ * @param {string} query
+ * @param {number} [limit]
+ */
+export function matchTasks(tasks, query, limit = 8) {
+  const list = Array.isArray(tasks) ? tasks : [];
+  const q = (query ?? '').trim().toLowerCase();
+  if (!q) return list.slice(0, limit);
+
+  const rank = (task) => {
+    const id = String(task?.id ?? '').toLowerCase();
+    if (id === q) return 0;
+    if (id.startsWith(q)) return 1;
+    if (String(task?.title ?? '').toLowerCase().includes(q)) return 2;
+    return -1;
+  };
+
+  return list
+    .map((task, order) => ({ task, order, rank: rank(task) }))
+    .filter((row) => row.rank !== -1)
+    .sort((a, b) => a.rank - b.rank || a.order - b.order)
+    .slice(0, limit)
+    .map((row) => row.task);
+}
+
+/**
+ * Look an ID up in every workspace and return the first one that has it.
+ *
+ * The requests go out together rather than in sequence: a user with a dozen
+ * workspaces should not wait a dozen round trips, and all but one of them are
+ * expected to 404. A rejection is therefore an answer, not a failure — only the
+ * case where *every* workspace says no is reported, as null.
+ *
+ * @param {string} taskId
+ * @param {string[]} workspaceIds
+ * @param {(workspaceId: string, taskId: string) => Promise<any>} getTask
+ * @returns {Promise<{ workspaceId: string, task: any } | null>}
+ */
+export async function resolveTaskById(taskId, workspaceIds, getTask) {
+  const ids = Array.isArray(workspaceIds) ? workspaceIds : [];
+  if (!taskId || ids.length === 0) return null;
+
+  const settled = await Promise.allSettled(ids.map((workspaceId) => getTask(workspaceId, taskId)));
+
+  for (let i = 0; i < settled.length; i += 1) {
+    const outcome = settled[i];
+    if (outcome.status !== 'fulfilled') continue;
+    const task = outcome.value?.task ?? outcome.value;
+    if (task?.id) return { workspaceId: ids[i], task };
+  }
+  return null;
+}
+
+/**
+ * Where a task lives.
+ *
+ * The task list route and the workspace route both render the task detail, but
+ * only the workspace one can be built from a task alone — the other needs a
+ * filter the finder has no opinion about.
+ *
+ * @param {{ id: string, workspaceId?: string }} task
+ * @param {string} [workspaceId] when the caller knows it and the task does not
+ */
+export function taskRoute(task, workspaceId) {
+  const ws = task?.workspaceId ?? workspaceId;
+  return `/workspaces/${ws}/tasks/${task.id}`;
+}

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -67,7 +67,7 @@
             <!-- Chat / Trajectory view toggle -->
             <div class="flex p-0.5 bg-gray-100 dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700/50 rounded-lg h-7">
               <button @click.stop="activeView = 'chat'"
-                      @mouseenter="tooltipStore.show($event, 'Message thread', 'bottom')"
+                      @mouseenter="tooltipStore.show($event, `Message thread  ${viewShortcut('chat-view')}`, 'bottom')"
                       @mouseleave="tooltipStore.hide()"
                       :class="activeView === 'chat' ? 'bg-white dark:bg-zinc-700 text-black dark:text-white shadow-sm' : 'text-gray-400 dark:text-zinc-500 hover:text-gray-600 dark:hover:text-zinc-300'"
                       class="px-1.5 rounded-md text-[8px] font-black uppercase tracking-tighter transition-all flex items-center justify-center">
@@ -75,7 +75,7 @@
                 <svg class="sm:hidden w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8-1.06 0-2.077-.163-3.02-.463L3 21l1.51-4.532A7.965 7.965 0 013 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/></svg>
               </button>
               <button @click.stop="activeView = 'trajectory'"
-                      @mouseenter="tooltipStore.show($event, 'Tool call trajectory', 'bottom')"
+                      @mouseenter="tooltipStore.show($event, `Tool call trajectory  ${viewShortcut('trajectory-view')}`, 'bottom')"
                       @mouseleave="tooltipStore.hide()"
                       :class="activeView === 'trajectory' ? 'bg-white dark:bg-zinc-700 text-black dark:text-white shadow-sm' : 'text-gray-400 dark:text-zinc-500 hover:text-gray-600 dark:hover:text-zinc-300'"
                       class="px-1.5 rounded-md text-[8px] font-black uppercase tracking-tighter transition-all flex items-center gap-1 justify-center">
@@ -758,9 +758,17 @@ import {
 import { belongsInThread } from '../composables/useTrajectory';
 import { mergeTaskUpdate } from '../composables/useTaskEvents';
 import TrajectoryPanel from '../components/TrajectoryPanel.vue';
+import {
+  SHORTCUTS,
+  formatShortcut,
+  useShortcuts,
+  usesCommandKey,
+} from '../composables/useKeyboardShortcuts';
+import { usePlatformStore } from '../stores/platformStore';
 
 const { notifyError, notifySuccess } = useToasts();
 const tooltipStore = useTooltipStore();
+const platformStore = usePlatformStore();
 const route = useRoute();
 const router = useRouter();
 const workspaceId = computed(() => route.params.id || route.params.workspaceId);
@@ -962,6 +970,22 @@ const displayMessages = computed(() => {
 });
 
 const activeView = ref('chat');
+
+// The two view shortcuts are registered by the view that owns the state rather
+// than by the shell, which has no `activeView` to switch. Registering on mount
+// also means they only exist while a task is open — pressing C on the board
+// does nothing, which is correct.
+useShortcuts(
+  {
+    'chat-view': () => { activeView.value = 'chat'; },
+    'trajectory-view': () => { activeView.value = 'trajectory'; },
+  },
+  { mac: () => usesCommandKey(platformStore.$state) }
+);
+
+/** The key hint shown in each toggle's tooltip. */
+const viewShortcut = (id) =>
+  formatShortcut(SHORTCUTS.find((s) => s.id === id), { mac: usesCommandKey(platformStore.$state) });
 
 const sortedToolCalls = computed(() => {
   if (!task.value || !task.value.toolCalls) return [];

--- a/frontend/test/keyboardShortcuts.test.js
+++ b/frontend/test/keyboardShortcuts.test.js
@@ -1,0 +1,352 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { createApp, h } from 'vue'
+
+import {
+  SHORTCUTS,
+  dispatchShortcut,
+  formatAccelerator,
+  formatShortcut,
+  isTypingTarget,
+  matchShortcut,
+  newTaskRoute,
+  resetShortcuts,
+  useShortcuts,
+  usesCommandKey,
+} from '../src/composables/useKeyboardShortcuts'
+
+/** A key event as the dispatcher sees it, with only what it reads. */
+const press = (key, extra = {}) => ({
+  key,
+  metaKey: false,
+  ctrlKey: false,
+  altKey: false,
+  target: null,
+  preventDefault: vi.fn(),
+  ...extra,
+})
+
+/**
+ * Run `setup` inside a real component instance, so `onMounted` and
+ * `onUnmounted` are the genuine article rather than injected stand-ins. That is
+ * the only way to exercise the composable's defaults.
+ */
+function mountWith(setup) {
+  const app = createApp({ setup, render: () => h('div') })
+  app.mount(document.createElement('div'))
+  return () => app.unmount()
+}
+
+afterEach(() => {
+  resetShortcuts()
+})
+
+describe('SHORTCUTS', () => {
+  it('binds nothing to a key the operating system or browser has already taken', () => {
+    // The point of the whole scheme. Cmd+N is New Window, Cmd+H is Hide on
+    // macOS and Cmd+M is Minimize — a handler on any of them would never run,
+    // so the table must not claim them.
+    const claimed = SHORTCUTS.filter((s) => s.mod).map((s) => s.key)
+
+    expect(claimed).toEqual(['k'])
+  })
+
+  it('gives every shortcut an id, a key and a scope the help sheet groups by', () => {
+    for (const s of SHORTCUTS) {
+      expect(s.id).toBeTruthy()
+      expect(s.key).toBeTruthy()
+      expect(['global', 'task']).toContain(s.scope)
+    }
+  })
+})
+
+describe('usesCommandKey', () => {
+  it('trusts the desktop shell when it reports macOS', () => {
+    expect(usesCommandKey({ os: 'darwin' }, null)).toBe(true)
+  })
+
+  it('falls back to the navigator in the browser, where the store has no os', () => {
+    expect(usesCommandKey({ os: '' }, { userAgentData: { platform: 'macOS' } })).toBe(true)
+    expect(usesCommandKey({}, { platform: 'MacIntel' })).toBe(true)
+    expect(usesCommandKey({}, { platform: 'Win32' })).toBe(false)
+  })
+
+  it('assumes Control when nothing can say otherwise', () => {
+    expect(usesCommandKey({}, null)).toBe(false)
+    expect(usesCommandKey({}, {})).toBe(false)
+  })
+
+  it('reads the real navigator when none is passed', () => {
+    // jsdom reports a non-Mac platform, which is all this needs to assert:
+    // the default argument is wired to something real.
+    expect(usesCommandKey({})).toBe(false)
+  })
+})
+
+describe('isTypingTarget', () => {
+  it('recognises the fields a bare letter must not disturb', () => {
+    for (const tagName of ['INPUT', 'TEXTAREA', 'SELECT']) {
+      expect(isTypingTarget({ tagName })).toBe(true)
+    }
+  })
+
+  it('counts a rich-text region as typing', () => {
+    expect(isTypingTarget({ isContentEditable: true })).toBe(true)
+  })
+
+  it('honours an explicit opt-out on an ancestor', () => {
+    expect(isTypingTarget({ tagName: 'DIV', closest: () => ({}) })).toBe(true)
+    expect(isTypingTarget({ tagName: 'DIV', closest: () => null })).toBe(false)
+  })
+
+  it('says no for anything that is not an element', () => {
+    expect(isTypingTarget(null)).toBe(false)
+    expect(isTypingTarget('window')).toBe(false)
+    expect(isTypingTarget({})).toBe(false)
+  })
+})
+
+describe('matchShortcut', () => {
+  it('reads Cmd+K on a Mac keyboard and Ctrl+K elsewhere', () => {
+    expect(matchShortcut(press('k', { metaKey: true }), { mac: true }).id).toBe('find-task')
+    expect(matchShortcut(press('k', { ctrlKey: true })).id).toBe('find-task')
+  })
+
+  it('does not read the other platform’s modifier', () => {
+    // Ctrl+K on a Mac is a text-editing binding, and Cmd+K on Windows is not a
+    // thing users press. Matching either would fire the finder by accident.
+    expect(matchShortcut(press('k', { ctrlKey: true }), { mac: true })).toBeNull()
+    expect(matchShortcut(press('k', { metaKey: true }))).toBeNull()
+    expect(matchShortcut(press('k', { ctrlKey: true, altKey: true }))).toBeNull()
+    expect(matchShortcut(press('k'))).toBeNull()
+  })
+
+  it('reads the bare letters', () => {
+    expect(matchShortcut(press('n')).id).toBe('new-task')
+    expect(matchShortcut(press('N')).id).toBe('new-task')
+    expect(matchShortcut(press('m')).id).toBe('chat-view')
+    expect(matchShortcut(press('t')).id).toBe('trajectory-view')
+    expect(matchShortcut(press('?')).id).toBe('show-help')
+  })
+
+  it('stands down while the user is typing', () => {
+    // Writing "not started" in the reply box must not open the task form.
+    const inReply = { target: { tagName: 'TEXTAREA' } }
+
+    expect(matchShortcut(press('n', inReply))).toBeNull()
+    expect(matchShortcut(press('t', inReply))).toBeNull()
+  })
+
+  it('keeps the finder live while typing, because it is the way out', () => {
+    const inReply = { target: { tagName: 'TEXTAREA' }, ctrlKey: true }
+
+    expect(matchShortcut(press('k', inReply)).id).toBe('find-task')
+  })
+
+  it('leaves a bare letter alone when any modifier is held', () => {
+    expect(matchShortcut(press('n', { ctrlKey: true }))).toBeNull()
+    expect(matchShortcut(press('n', { metaKey: true }))).toBeNull()
+    expect(matchShortcut(press('n', { altKey: true }))).toBeNull()
+  })
+
+  it('ignores a key nothing is bound to, and a key event with no key', () => {
+    expect(matchShortcut(press('z'))).toBeNull()
+    expect(matchShortcut({ key: '' })).toBeNull()
+    expect(matchShortcut(null)).toBeNull()
+  })
+
+  it('can be pointed at a different table', () => {
+    const only = [{ id: 'x', key: 'x', scope: 'global' }]
+
+    expect(matchShortcut(press('x'), { shortcuts: only }).id).toBe('x')
+    expect(matchShortcut(press('n'), { shortcuts: only })).toBeNull()
+  })
+})
+
+describe('formatShortcut', () => {
+  it('writes macOS modifiers as glyphs and everything else as words', () => {
+    const findTask = SHORTCUTS.find((s) => s.id === 'find-task')
+
+    expect(formatShortcut(findTask, { mac: true })).toBe('⌘K')
+    expect(formatShortcut(findTask)).toBe('Ctrl+K')
+  })
+
+  it('writes a bare key as itself on every platform', () => {
+    expect(formatShortcut({ key: 'n' }, { mac: true })).toBe('N')
+    expect(formatShortcut({ key: '?' })).toBe('?')
+  })
+})
+
+describe('formatAccelerator', () => {
+  it('renders the desktop menu’s accelerator the way each platform writes it', () => {
+    expect(formatAccelerator('CommandOrControl+Shift+N', { mac: true })).toBe('⌘⇧N')
+    expect(formatAccelerator('CommandOrControl+Shift+N')).toBe('Ctrl+Shift+N')
+  })
+
+  it('passes through parts it has no name for', () => {
+    expect(formatAccelerator('Command+Control+Alt+F1', { mac: true })).toBe('⌘⌃⌥F1')
+    expect(formatAccelerator('Control+Alt+F1')).toBe('Ctrl+Alt+F1')
+  })
+})
+
+describe('dispatchShortcut', () => {
+  it('does nothing when nobody is listening', () => {
+    const event = press('n')
+
+    expect(dispatchShortcut(event)).toBeNull()
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('does nothing for a key that is not a shortcut', () => {
+    useShortcuts({ 'new-task': vi.fn() }, fakeLifecycle().options)
+
+    expect(dispatchShortcut(press('z'))).toBeNull()
+  })
+
+  it('suppresses the browser default only once a handler has claimed the key', () => {
+    // Cmd+K would otherwise drop into the address bar. On a screen with no
+    // handler the browser keeps its own behaviour.
+    const handler = vi.fn()
+    const { options, mount } = fakeLifecycle()
+    useShortcuts({ 'find-task': handler }, options)
+    mount()
+
+    const claimed = press('k', { ctrlKey: true })
+    expect(dispatchShortcut(claimed)).toBe('find-task')
+    expect(handler).toHaveBeenCalledOnce()
+    expect(claimed.preventDefault).toHaveBeenCalledOnce()
+
+    const unclaimed = press('n')
+    expect(dispatchShortcut(unclaimed)).toBeNull()
+    expect(unclaimed.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('survives an event object with no preventDefault', () => {
+    const handler = vi.fn()
+    const { options, mount } = fakeLifecycle()
+    useShortcuts({ 'new-task': handler }, options)
+    mount()
+
+    expect(dispatchShortcut({ key: 'n' })).toBe('new-task')
+    expect(handler).toHaveBeenCalledOnce()
+  })
+
+  it('lets the view on top win over the shell underneath', () => {
+    // The task detail mounts after the shell, so its handler is the one that
+    // runs — that is what lets a view take a shortcut over.
+    const shell = vi.fn()
+    const view = vi.fn()
+    const a = fakeLifecycle()
+    const b = fakeLifecycle()
+    useShortcuts({ 'chat-view': shell }, a.options)
+    a.mount()
+    useShortcuts({ 'chat-view': view }, b.options)
+    b.mount()
+
+    dispatchShortcut(press('m'))
+
+    expect(view).toHaveBeenCalledOnce()
+    expect(shell).not.toHaveBeenCalled()
+  })
+
+  it('falls through a registration that does not handle the key', () => {
+    const shell = vi.fn()
+    const a = fakeLifecycle()
+    const b = fakeLifecycle()
+    useShortcuts({ 'new-task': shell }, a.options)
+    a.mount()
+    useShortcuts({ 'chat-view': vi.fn() }, b.options)
+    b.mount()
+
+    dispatchShortcut(press('n'))
+
+    expect(shell).toHaveBeenCalledOnce()
+  })
+})
+
+describe('useShortcuts', () => {
+  it('listens only while its component is mounted', () => {
+    const handler = vi.fn()
+    const { options, mount, unmount, target } = fakeLifecycle()
+
+    useShortcuts({ 'new-task': handler }, options)
+    expect(target.addEventListener).not.toHaveBeenCalled()
+
+    mount()
+    expect(target.addEventListener).toHaveBeenCalledWith('keydown', expect.any(Function))
+    expect(dispatchShortcut(press('n'))).toBe('new-task')
+
+    unmount()
+    expect(target.removeEventListener).toHaveBeenCalledWith('keydown', expect.any(Function))
+    expect(dispatchShortcut(press('n'))).toBeNull()
+  })
+
+  it('unmounts cleanly even if it was never registered', () => {
+    const { options, unmount } = fakeLifecycle()
+    useShortcuts({ 'new-task': vi.fn() }, options)
+
+    expect(() => unmount()).not.toThrow()
+  })
+
+  it('tolerates having nowhere to listen', () => {
+    const { options, mount, unmount } = fakeLifecycle()
+    useShortcuts({ 'new-task': vi.fn() }, { ...options, target: null })
+
+    expect(() => {
+      mount()
+      unmount()
+    }).not.toThrow()
+  })
+
+  it('routes a real key press through the window by default', () => {
+    // No options at all: real lifecycle hooks, the real window, and the
+    // Control-key default.
+    const handler = vi.fn()
+    const unmount = mountWith(() => {
+      useShortcuts({ 'find-task': handler })
+      return {}
+    })
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true }))
+    expect(handler).toHaveBeenCalledOnce()
+
+    unmount()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true }))
+    expect(handler).toHaveBeenCalledOnce()
+  })
+})
+
+describe('newTaskRoute', () => {
+  it('creates the task where the user already is', () => {
+    expect(newTaskRoute('ws1', [{ id: 'ws1' }, { id: 'ws2' }])).toBe('/workspaces/ws1/tasks/new')
+  })
+
+  it('uses the only workspace there is when the route names none', () => {
+    expect(newTaskRoute(undefined, [{ id: 'solo' }])).toBe('/workspaces/solo/tasks/new')
+  })
+
+  it('asks rather than guesses when several workspaces are in play', () => {
+    // Dropping a task into an arbitrary workspace is worse than a short detour
+    // through the list.
+    expect(newTaskRoute(undefined, [{ id: 'a' }, { id: 'b' }])).toBe('/')
+    expect(newTaskRoute(undefined)).toBe('/')
+  })
+})
+
+/** Lifecycle hooks and an event target the test drives by hand. */
+function fakeLifecycle() {
+  const mounts = []
+  const unmounts = []
+  const target = { addEventListener: vi.fn(), removeEventListener: vi.fn() }
+
+  return {
+    target,
+    mount: () => mounts.forEach((fn) => fn()),
+    unmount: () => unmounts.forEach((fn) => fn()),
+    options: {
+      target,
+      mac: () => false,
+      onMounted: (fn) => mounts.push(fn),
+      onUnmounted: (fn) => unmounts.push(fn),
+    },
+  }
+}

--- a/frontend/test/taskFinder.test.js
+++ b/frontend/test/taskFinder.test.js
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import {
+  looksLikeTaskId,
+  matchTasks,
+  resolveTaskById,
+  taskRoute,
+} from '../src/composables/useTaskFinder'
+
+const task = (id, title, extra = {}) => ({ id, title, ...extra })
+
+describe('looksLikeTaskId', () => {
+  it('accepts a base62 monoflake', () => {
+    expect(looksLikeTaskId('0iCWbYTwIiH')).toBe(true)
+  })
+
+  it('rejects anything that cannot be one', () => {
+    expect(looksLikeTaskId('short')).toBe(false)
+    expect(looksLikeTaskId('a task about billing')).toBe(false)
+    expect(looksLikeTaskId('0iCWbYTwIiH-extra-long-string')).toBe(false)
+    expect(looksLikeTaskId('')).toBe(false)
+    expect(looksLikeTaskId(null)).toBe(false)
+    expect(looksLikeTaskId(undefined)).toBe(false)
+  })
+
+  it('ignores the whitespace around a pasted ID', () => {
+    expect(looksLikeTaskId('  0iCWbYTwIiH  ')).toBe(true)
+  })
+})
+
+describe('matchTasks', () => {
+  const tasks = [
+    task('0aaaaaaaaaa', 'Ship the billing fix'),
+    task('0bbbbbbbbbb', 'Billing dashboard copy'),
+    task('0bbbbbbbbbc', 'Unrelated'),
+  ]
+
+  it('shows the most recent tasks before anything is typed', () => {
+    // The resting state of the box. A blank panel would be a worse answer.
+    expect(matchTasks(tasks, '')).toEqual(tasks)
+    expect(matchTasks(tasks, '   ')).toEqual(tasks)
+    expect(matchTasks(tasks, null)).toEqual(tasks)
+  })
+
+  it('puts an exact ID first, then ID prefixes, then titles', () => {
+    const ranked = matchTasks(tasks, '0bbbbbbbbbc')
+
+    expect(ranked.map((t) => t.id)).toEqual(['0bbbbbbbbbc'])
+  })
+
+  it('matches an ID the user has only partly typed', () => {
+    expect(matchTasks(tasks, '0bbbb').map((t) => t.id)).toEqual(['0bbbbbbbbbb', '0bbbbbbbbbc'])
+  })
+
+  it('matches titles, case-insensitively, so the box works without an ID', () => {
+    expect(matchTasks(tasks, 'BILLING').map((t) => t.id)).toEqual(['0aaaaaaaaaa', '0bbbbbbbbbb'])
+  })
+
+  it('ranks an exact ID above a title that also matches', () => {
+    const both = [task('0zzzzzzzzzz', 'mentions 0aaaaaaaaaa'), task('0aaaaaaaaaa', 'The real one')]
+
+    expect(matchTasks(both, '0aaaaaaaaaa').map((t) => t.id)).toEqual([
+      '0aaaaaaaaaa',
+      '0zzzzzzzzzz',
+    ])
+  })
+
+  it('returns nothing when nothing matches', () => {
+    expect(matchTasks(tasks, 'nothing here')).toEqual([])
+  })
+
+  it('caps the list so the panel stays a panel', () => {
+    const many = Array.from({ length: 20 }, (_, i) => task(`id${i}`, 'billing'))
+
+    expect(matchTasks(many, 'billing')).toHaveLength(8)
+    expect(matchTasks(many, '')).toHaveLength(8)
+    expect(matchTasks(many, 'billing', 3)).toHaveLength(3)
+  })
+
+  it('copes with a list that never arrived', () => {
+    expect(matchTasks(undefined, 'billing')).toEqual([])
+    expect(matchTasks(null, '')).toEqual([])
+  })
+
+  it('copes with rows missing an id or a title', () => {
+    expect(matchTasks([{}], 'billing')).toEqual([])
+  })
+})
+
+describe('resolveTaskById', () => {
+  it('finds the workspace that holds the task', async () => {
+    const getTask = vi.fn(async (workspaceId) => {
+      if (workspaceId !== 'ws2') throw new Error('404')
+      return { task: task('0iCWbYTwIiH', 'Found') }
+    })
+
+    const found = await resolveTaskById('0iCWbYTwIiH', ['ws1', 'ws2', 'ws3'], getTask)
+
+    expect(found).toEqual({ workspaceId: 'ws2', task: task('0iCWbYTwIiH', 'Found') })
+  })
+
+  it('asks every workspace at once rather than one after another', async () => {
+    // A user with a dozen workspaces should not wait a dozen round trips for
+    // eleven expected 404s.
+    const getTask = vi.fn(async () => {
+      throw new Error('404')
+    })
+
+    await resolveTaskById('0iCWbYTwIiH', ['a', 'b', 'c'], getTask)
+
+    expect(getTask).toHaveBeenCalledTimes(3)
+  })
+
+  it('accepts a bare task as well as a wrapped one', async () => {
+    const getTask = async () => task('0iCWbYTwIiH', 'Bare')
+
+    const found = await resolveTaskById('0iCWbYTwIiH', ['ws1'], getTask)
+
+    expect(found.task.title).toBe('Bare')
+  })
+
+  it('treats an empty answer as a miss and keeps looking', async () => {
+    const getTask = vi.fn(async (workspaceId) => (workspaceId === 'ws1' ? null : task('t', 'Hit')))
+
+    const found = await resolveTaskById('t', ['ws1', 'ws2'], getTask)
+
+    expect(found.workspaceId).toBe('ws2')
+  })
+
+  it('reports a miss when no workspace has it', async () => {
+    const getTask = async () => {
+      throw new Error('404')
+    }
+
+    expect(await resolveTaskById('0iCWbYTwIiH', ['ws1'], getTask)).toBeNull()
+  })
+
+  it('does not go looking with nothing to look for', async () => {
+    const getTask = vi.fn()
+
+    expect(await resolveTaskById('', ['ws1'], getTask)).toBeNull()
+    expect(await resolveTaskById('0iCWbYTwIiH', [], getTask)).toBeNull()
+    expect(await resolveTaskById('0iCWbYTwIiH', undefined, getTask)).toBeNull()
+    expect(getTask).not.toHaveBeenCalled()
+  })
+})
+
+describe('taskRoute', () => {
+  it('uses the workspace the task carries', () => {
+    expect(taskRoute(task('t1', 'x', { workspaceId: 'ws9' }))).toBe('/workspaces/ws9/tasks/t1')
+  })
+
+  it('falls back to the workspace the caller resolved', () => {
+    // The per-workspace lookup knows where it found the task even when the
+    // payload does not repeat it.
+    expect(taskRoute(task('t1', 'x'), 'ws9')).toBe('/workspaces/ws9/tasks/t1')
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -46,6 +46,8 @@ export default defineConfig({
         'src/composables/useDirectoryPicker.js',
         'src/composables/useProfileDisplay.js',
         'src/composables/useAuthedFetch.js',
+        'src/composables/useKeyboardShortcuts.js',
+        'src/composables/useTaskFinder.js',
       ],
       reporter: ['text', 'lcov'],
       thresholds: {


### PR DESCRIPTION
## What changed

The app can now be driven from the keyboard: one key opens a task finder that searches by ID or title across every workspace, another starts a new task, and two more switch a task between its message thread and its trajectory. A help sheet lists them all.

| Action | Key | Scope |
|---|---|---|
| Find task by ID | `⌘K` / `Ctrl+K` | Anywhere |
| New task | `N` | Anywhere |
| Show keyboard shortcuts | `?` | Anywhere |
| Chat view | `M` | In a task |
| Trajectory view | `T` | In a task |

## Why changed

To move around the app without reaching for the mouse. Three of the four originally requested bindings had to change, because they cannot work: `Cmd/Ctrl+N` is *New Window* in every browser, and `Cmd+H` and `Cmd+M` are *Hide* and *Minimize* on macOS. All three are claimed before the page is offered the event, so a handler bound to them would never run — worse than no shortcut, because the app would document a key that does nothing. The repo already reached the same conclusion for the desktop menu, which picks `Cmd/Ctrl+Shift+N` for New Task with that reasoning in a comment.

So this uses the scheme web task trackers converge on for exactly that reason: `Cmd/Ctrl+K` — the one modifier combination browsers leave to the page — plus bare letters. Three rules keep bare letters safe:

- A bare letter never fires with any modifier held, so copy, minimise and new-window behave exactly as before.
- Bare letters stand down inside inputs, textareas and contenteditable regions, so typing is never intercepted.
- `Cmd/Ctrl+K` is the deliberate exception and stays live in a text field, because it is how you leave a screen you are writing on.

Finding a task by ID needed no backend or API change. The finder filters the recent tasks as you type, and a query that looks like an ID but matches nothing there is resolved against each workspace on Enter — one request per workspace, so it waits until the user commits to the query rather than firing on every keystroke.

## Test coverage report

**New lines introduced: 100%.** Both new composables are added to the enforced `coverage.include` list in `vitest.config.js` and hit 100% on statements, branches, functions and lines:

```
File               | % Stmts | % Branch | % Funcs | % Lines
useKeyboardShortcuts.js |  100 |  100 |  100 |  100
useTaskFinder.js        |  100 |  100 |  100 |  100
All files               |  100 |  100 |  100 |  100
```

**Total coverage impact: none — the suite stays at 100%**, which is the threshold the config enforces, so the gate would fail otherwise. 55 new tests; the suite goes from 221 to 276, all passing.

The two new components are intentionally thin and hold no logic that is not already covered by a composable, matching how the rest of the frontend is tested.

## Other reports

Verified end to end against a real headless Chrome, on an isolated backend, database and port so no running dev server was touched:

- `⌘K` opens the finder and lists the recent tasks; typing `billing` narrows to the matching task; Enter navigates to it and closes the panel
- An ID-shaped query that is not in the recent list offers to look it up, and reports honestly when no workspace has it
- `N` lands on the task form for the current workspace, and on the workspace list it also resolves correctly when only one workspace exists
- `?` opens the sheet; `Esc` closes either overlay
- `M` and `T` switch the task view, and `C` — the earlier binding, dropped during review — now does nothing
- Typing `t n m ?` into the reply box changes nothing, while `⌘K` still opens from inside it
- `⌘M`, `⌘N` and `⌘T` move nothing at all

The help sheet renders from the shortcut table itself, so a binding added later documents itself rather than drifting out of date.

TaskID: 0iCWbYTwIiH

🤖 Generated with [Claude Code](https://claude.com/claude-code)