### PR TITLE
chore: bump patch version to v0.4.18

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.4.17"
+	_appVersion   = "v0.4.18"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.4.17" {
-			t.Errorf("Expected version v0.4.17, got %s", s.Version())
+		if s.Version() != "v0.4.18" {
+			t.Errorf("Expected version v0.4.18, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.4.17",
+      "version": "0.4.18",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.4.17",
+      "version": "0.4.18",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.4.17",
+  "version": "0.4.18",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
## What changed

The application's version number moves from 0.4.17 to 0.4.18 everywhere it is declared — the desktop shell, the frontend, their lockfiles, and the backend — so the release build sees one consistent version.

## Why changed

Routine patch bump to cut the next release, which ships the new keyboard shortcuts. The version-sync check runs before packaging and rejects a tree whose versions disagree, and electron-updater compares this number against the published release, so all six declarations have to move together.

## What is shipping in v0.4.18

Three PRs, all merged to `main` ahead of this bump:

**Features**
- **#409 — the app can be driven from the keyboard.** `Cmd/Ctrl+K` opens a task finder, `N` starts a task, `?` lists every binding, and `M` and `T` switch a task between its message thread and its trajectory. The keys deliberately avoid every combination the browser or macOS has already claimed, and bare letters stand down while the user is typing.
- **#412 — the task finder says how far it actually searches.** Titles are matched in the browser against the loaded tasks while an ID is asked of the server, so the panel states the reach of each rather than letting an empty result be read as "no such task".

**Fixes**
- **#411 — only ask the backend for something that can be a task ID.** The gate accepted 8 to 16 base62 characters; a monoflake ID is always exactly 11, so an ordinary word could fall through it and fan a request out to every workspace for a task that could not exist.

## Test coverage report

No new executable lines are introduced — the change is version constants and package metadata only, so new-line coverage is 100% (the changed backend constant is exercised by the existing version assertion, which was updated alongside it).

Total coverage impact: none. `backend/internal/service/config` holds at 92.2% of statements, unchanged from before the bump, and the frontend suite stays at its enforced 100% with 277 tests passing.

## Other reports

Rebased onto `44f6821` (post-#412 `main`) with no conflicts, and re-verified on the rebased tree:

- `node desktop/scripts/check-versions.mjs` → desktop, frontend and backend are all at 0.4.18
- `GITHUB_REF=refs/tags/v0.4.18 node desktop/scripts/check-versions.mjs` → sources agree, and tag v0.4.18 matches version 0.4.18
- `go test ./internal/service/config/` → ok, 92.2% of statements
- `npm test` (frontend) → 277 passed
- `npm ci --dry-run` (frontend and desktop) → exit 0, no dependency drift

Both lockfiles were edited by hand rather than regenerated. One thing worth noting for reviewers: `frontend/package-lock.json` contains a third `"version": "0.4.17"` at line 4527, which belongs to the `babel-plugin-polyfill-corejs2` dependency and coincidentally matched the old app version. It is deliberately untouched — only the two app-level fields in each lockfile were changed, so the diff is exactly 9 lines across 6 files.

TaskID: 0iCWbYTwIiH

🤖 Generated with [Claude Code](https://claude.com/claude-code)
