### PR TITLE
fix(shortcuts): only ask the backend for something that can be a task ID

### DIFF
--- a/frontend/src/composables/useTaskFinder.js
+++ b/frontend/src/composables/useTaskFinder.js
@@ -15,17 +15,31 @@
  *
  * The second lookup is deliberately *not* run while typing: it is one request
  * per workspace, so it waits for the user to commit to the query.
+ *
+ * Each of those requests is `GET /workspaces/:id/tasks/:taskID`, which the
+ * backend answers with `WHERE id = ? AND workspace_id = ? AND user_id = ?`. All
+ * three columns are in the query, so a task is only ever returned to the user it
+ * belongs to — there is no lookup by task ID alone anywhere in this path.
  */
 
-/** Task IDs are base62 monoflakes — 11 characters today, with room to grow. */
-const TASK_ID = /^[0-9A-Za-z]{8,16}$/;
+/**
+ * Task IDs are monoflake base62: **always exactly 11 characters**, because
+ * `monoflake.ID.String()` zero-pads to a fixed width rather than trimming
+ * leading zeros. The length is a property of the encoding, not of how large the
+ * IDs happen to have grown, so it does not drift.
+ */
+const TASK_ID = /^[0-9A-Za-z]{11}$/;
 
 /**
  * Whether `query` could be a task ID.
  *
- * Only a shape test. A real title can pass it ("deadline" is eight letters),
- * which is harmless: this only ever decides whether to *also* try an ID lookup
- * after the filter has already come up empty.
+ * This is the gate on every backend lookup: a query that cannot be an ID never
+ * becomes a request. Without it, typing an ordinary word would fan a round trip
+ * out to every workspace for something that could not possibly be found.
+ *
+ * A shape test is all it can be — an eleven-letter word ("performance") still
+ * passes — but that only costs one lookup that comes back empty, and it is
+ * checked *after* the filter has already failed to match anything.
  *
  * @param {string} query
  */

--- a/frontend/test/taskFinder.test.js
+++ b/frontend/test/taskFinder.test.js
@@ -14,16 +14,30 @@ describe('looksLikeTaskId', () => {
     expect(looksLikeTaskId('0iCWbYTwIiH')).toBe(true)
   })
 
+  it('holds to exactly eleven characters', () => {
+    // monoflake zero-pads to a fixed width, so a real ID is never shorter or
+    // longer. Accepting a range would send lookups for strings that cannot be
+    // IDs — every ten- or twelve-character word the user typed.
+    expect('0iCWbYTwIiH').toHaveLength(11)
+    expect(looksLikeTaskId('0iCWbYTwIi')).toBe(false)
+    expect(looksLikeTaskId('0iCWbYTwIiHx')).toBe(false)
+    expect(looksLikeTaskId('00000000001')).toBe(true)
+  })
+
   it('rejects anything that cannot be one', () => {
     expect(looksLikeTaskId('short')).toBe(false)
     expect(looksLikeTaskId('a task about billing')).toBe(false)
     expect(looksLikeTaskId('0iCWbYTwIiH-extra-long-string')).toBe(false)
+    // Eleven characters, but not all base62.
+    expect(looksLikeTaskId('0iCWb-YTwIi')).toBe(false)
     expect(looksLikeTaskId('')).toBe(false)
     expect(looksLikeTaskId(null)).toBe(false)
     expect(looksLikeTaskId(undefined)).toBe(false)
   })
 
   it('ignores the whitespace around a pasted ID', () => {
+    // Copying an ID out of a commit message or a chat usually brings a space
+    // with it, and that is the main way this box gets an ID at all.
     expect(looksLikeTaskId('  0iCWbYTwIiH  ')).toBe(true)
   })
 })


### PR DESCRIPTION
## What changed

The task finder now only asks the server about a query that could actually be a task ID — exactly eleven base62 characters — instead of anything roughly ID-shaped. Anything else is answered from the tasks already loaded and never leaves the browser.

## Why changed

The gate accepted 8 to 16 characters, which was a guess. A monoflake ID is always exactly 11: its string form zero-pads to a fixed width rather than trimming leading zeros, so the length is a property of the encoding and will not drift as IDs grow.

The loose gate let ordinary words through it. Typing a word like `deadline`, finding no match in the recent tasks, and pressing Enter would fan a round trip out to every workspace looking for a task that could not possibly exist. Tightening it removes that entire class of pointless request.

The lookup itself already had the right shape and is unchanged. It is `GET /workspaces/:id/tasks/:taskID` per workspace, which the repository answers with:

```sql
WHERE id = ? AND workspace_id = ? AND user_id = ?
```

All three columns are in the query — the user comes from the authenticated session rather than the request — so a task is only ever returned to the user who owns it, and there is no lookup by task ID alone anywhere in this path. That guarantee is now written into the composable's documentation so it is not quietly weakened later.

## Test coverage report

**New lines introduced: 100%.** `useTaskFinder.js` stays on the enforced `coverage.include` list at 100% of statements, branches, functions and lines, with new cases pinning the boundary at exactly eleven characters (ten rejected, twelve rejected, eleven non-base62 rejected).

```
useTaskFinder.js   |  100 |  100 |  100 |  100
All files          |  100 |  100 |  100 |  100
```

**Total coverage impact: none — the suite stays at the 100% the config enforces.** 277 tests passing, up from 276.

## Other reports

Verified against a running backend on an isolated port and database, reading the server's own request log:

- A ten-character query that matches nothing in the loaded list produces **zero** requests — the panel just says no recent task matches.
- An eleven-character query that matches nothing produces **exactly one request per workspace**, each carrying the workspace and task IDs in the path, and reports honestly that no workspace has it.
- A ten-character query that *does* prefix-match a loaded task still resolves instantly from the list, with no request at all.

TaskID: 0iCWbYTwIiH

🤖 Generated with [Claude Code](https://claude.com/claude-code)