### PR TITLE
feat(cache): the local task store, its schema and its clearing

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "@tailwindcss/vite": "^4.0.0",
         "@vitejs/plugin-vue": "^6.0.1",
         "@vitest/coverage-v8": "^3.2.7",
+        "fake-indexeddb": "^6.2.5",
         "jsdom": "^25.0.1",
         "tailwindcss": "^4.0.0",
         "vite": "^8.0.10",
@@ -5460,6 +5461,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vitest/coverage-v8": "^3.2.7",
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^25.0.1",
     "tailwindcss": "^4.0.0",
     "vite": "^8.0.10",

--- a/frontend/src/composables/useLocalCache.js
+++ b/frontend/src/composables/useLocalCache.js
@@ -1,0 +1,382 @@
+/**
+ * The local task cache: schema, writes, and clearing.
+ *
+ * This is a **cache, never a source of truth.** Everything in it was written
+ * from a server response or an SSE event, and an open task always renders what
+ * the backend last said. Nothing here is ever replayed back to the server, so
+ * there is no write queue and no conflict resolution to get wrong.
+ *
+ * ## Why the data is split across three stores
+ *
+ * The point of the cache is to answer "which tasks mention billing" without a
+ * request, which means walking every task's title and body. That is fast only
+ * while each record stays small — so the searchable record holds text and
+ * nothing else:
+ *
+ * - `tasks` is the scannable part: title, body, status, dates, and the term
+ *   index. A workspace with thousands of these is still only a few megabytes.
+ * - `threads` holds the message and tool-call history, read by exact key when a
+ *   task is opened and never touched by a search.
+ * - `attachments` holds *metadata only*. The bytes belong in Cache Storage,
+ *   which stores a binary response body rather than a JavaScript string.
+ *
+ * That last split is the one with teeth. `Attachment.data` arrives as base64
+ * **inside the task JSON**, including from the list endpoint, so a task written
+ * as it arrives would bury file bytes in the row we most need to keep small —
+ * and base64 costs a third again on top of the bytes, paid back on every read
+ * of the record holding it. `toTaskRecord` and `toThreadRecord` drop it.
+ */
+
+/** Bumping this runs `createSchema` again — see `openCache`. */
+export const DB_VERSION = 1;
+
+export const STORE_TASKS = 'tasks';
+export const STORE_THREADS = 'threads';
+export const STORE_ATTACHMENTS = 'attachments';
+export const STORE_META = 'meta';
+
+/**
+ * The fields worth caching from a task, in the order the schema lists them.
+ *
+ * An explicit list rather than a spread, for two reasons: it drops
+ * `attachments`, `messages` and `toolCalls` by construction rather than by
+ * remembering to delete them, and it produces a plain object from whatever it
+ * is handed — which is what makes a Vue reactive proxy safe to pass in.
+ */
+const TASK_FIELDS = [
+  'title',
+  'body',
+  'status',
+  'assignee',
+  'createdBy',
+  'createdAt',
+  'updatedAt',
+  'sortOrder',
+  'cronSchedule',
+  'eventId',
+  'workflowId',
+];
+
+/**
+ * A deep copy containing only structured-cloneable values.
+ *
+ * IndexedDB clones what it stores, and a Vue reactive object is a Proxy —
+ * handing one to `put()` raises `DataCloneError` and loses the write. Rebuilding
+ * the value as plain arrays and objects sidesteps that for every shape the API
+ * sends, and drops functions and `undefined` on the way through, which the clone
+ * algorithm would reject anyway.
+ */
+export function plain(value) {
+  if (Array.isArray(value)) return value.map(plain);
+  if (value === null || typeof value !== 'object') {
+    return typeof value === 'function' ? undefined : value;
+  }
+
+  const out = {};
+  for (const [key, raw] of Object.entries(value)) {
+    const copied = plain(raw);
+    if (copied !== undefined) out[key] = copied;
+  }
+  return out;
+}
+
+/** An attachment without its bytes: everything the UI draws it from. */
+function attachmentMeta(attachment) {
+  return {
+    id: attachment?.id,
+    filename: attachment?.filename ?? '',
+    mimeType: attachment?.mimeType ?? '',
+    // The API sends no size, so it is derived from the base64 it did send —
+    // 4 encoded characters carry 3 bytes. Useful for the storage budget even
+    // though the bytes themselves are not kept here.
+    size: Math.floor(((attachment?.data ?? '').length * 3) / 4),
+  };
+}
+
+function attachmentsOf(task) {
+  return Array.isArray(task?.attachments) ? task.attachments : [];
+}
+
+/**
+ * The searchable record for a task.
+ *
+ * `terms` is supplied by the caller rather than computed here: tokenising is a
+ * separate concern with its own tests, and the writer already knows whether the
+ * text changed.
+ *
+ * @param {object} task    a task as the API sends it
+ * @param {string[]} [terms]
+ */
+export function toTaskRecord(task, terms = []) {
+  const record = {
+    id: task.id,
+    workspaceId: task.workspaceId,
+    attachmentCount: attachmentsOf(task).length,
+    terms: plain(terms),
+  };
+  for (const field of TASK_FIELDS) {
+    if (task[field] !== undefined && task[field] !== null) record[field] = plain(task[field]);
+  }
+  return record;
+}
+
+/**
+ * The conversation record: messages and tool calls, with every attachment
+ * anywhere inside them reduced to metadata.
+ */
+export function toThreadRecord(task) {
+  const strip = (items) =>
+    (Array.isArray(items) ? items : []).map((item) => {
+      const copied = plain(item);
+      if (Array.isArray(item?.attachments)) copied.attachments = item.attachments.map(attachmentMeta);
+      return copied;
+    });
+
+  return {
+    workspaceId: task.workspaceId,
+    taskId: task.id,
+    messages: strip(task.messages),
+    toolCalls: strip(task.toolCalls),
+    attachments: attachmentsOf(task).map(attachmentMeta),
+  };
+}
+
+/**
+ * One metadata row per attachment on the task itself.
+ *
+ * `lastUsedAt` exists for the eviction pass that arrives with the bytes: the
+ * budget is spent on what people actually open.
+ */
+export function toAttachmentRecords(task, now = Date.now()) {
+  return attachmentsOf(task).map((attachment) => ({
+    ...attachmentMeta(attachment),
+    workspaceId: task.workspaceId,
+    taskId: task.id,
+    attachmentId: attachment?.id,
+    lastUsedAt: now,
+  }));
+}
+
+/**
+ * The database for one signed-in user.
+ *
+ * The user is in the name because a browser origin outlives a session: sign out
+ * of the web app, sign in as someone else, and a shared name would hand the
+ * second person the first person's task titles. The desktop app needs no such
+ * care between *profiles* — each runs on its own Electron session partition,
+ * which gives it its own storage — but a single profile whose account changes
+ * has exactly the web build's problem.
+ */
+export function databaseName(userId) {
+  return `agentrq-cache:${userId}`;
+}
+
+/** Create the stores and indexes. Runs inside `onupgradeneeded`. */
+export function createSchema(db) {
+  const tasks = db.createObjectStore(STORE_TASKS, { keyPath: ['workspaceId', 'id'] });
+  tasks.createIndex('by_workspace', 'workspaceId');
+  tasks.createIndex('by_recent', ['workspaceId', 'updatedAt']);
+  tasks.createIndex('by_status', ['workspaceId', 'status']);
+  // The search index. `multiEntry` gives one entry per term, which turns
+  // "find every task mentioning X" into a seek instead of a scan.
+  tasks.createIndex('by_term', 'terms', { multiEntry: true });
+
+  db.createObjectStore(STORE_THREADS, { keyPath: ['workspaceId', 'taskId'] });
+  db.createObjectStore(STORE_ATTACHMENTS, { keyPath: ['workspaceId', 'taskId', 'attachmentId'] });
+  db.createObjectStore(STORE_META, { keyPath: 'key' });
+}
+
+/**
+ * Every key beginning with `workspaceId`, for a store whose key is an array
+ * starting with it.
+ *
+ * The upper bound is `[workspaceId, []]` because IndexedDB sorts an array after
+ * every number, string and date — so an empty array is the smallest key that
+ * sorts above every real key in the workspace, whatever its remaining parts.
+ */
+export function workspaceRange(workspaceId, KeyRange) {
+  return KeyRange.bound([workspaceId], [workspaceId, []]);
+}
+
+/** Meta rows are keyed `<workspaceId>:<name>` so they clear by prefix too. */
+export function metaKey(workspaceId, name) {
+  return `${workspaceId}:${name}`;
+}
+
+/**
+ * An IndexedDB request as a promise.
+ *
+ * Exported so the failure path has a test: a request that errors is an ordinary
+ * event on a disk-backed store, not a hypothetical.
+ */
+export function requestResult(req) {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/** A transaction as a promise. Abort and error are the same answer: it did not happen. */
+export function transactionDone(tx) {
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve(true);
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+  });
+}
+
+/**
+ * Run a cache operation, and treat any failure as "there was no cache".
+ *
+ * The contract for this whole module is that a cache is an optimisation, so its
+ * failures must never reach a user who only wanted to read their tasks. A
+ * transaction can abort for reasons that have nothing to do with the caller —
+ * the quota filled, the store was evicted mid-flight, the connection closed
+ * underneath it — and in every one of those cases the right behaviour is the
+ * same as never having had a cache: return the empty answer and let the caller
+ * go to the network.
+ */
+async function attempt(run, fallback) {
+  try {
+    return await run();
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Open the cache, or report that there isn't one.
+ *
+ * **Every failure resolves to `null`, never to an exception.** A cache is an
+ * optimisation, and there are ordinary reasons it cannot be had: a private
+ * window may refuse to open a database at all, WebKit discards one that has not
+ * been used for a week, and an older tab still holding a connection blocks an
+ * upgrade indefinitely. None of those are worth an error in front of a user who
+ * only wanted to read their tasks — the caller checks for `null` and goes to the
+ * network, which is what it would have done anyway.
+ *
+ * The `versionchange` handler is what stops *this* tab becoming that older tab:
+ * it closes on request so a newer one can upgrade instead of hanging.
+ *
+ * @param {object} options
+ * @param {string} options.userId
+ * @param {IDBFactory} [options.factory]
+ * @param {number} [options.version]
+ * @returns {Promise<IDBDatabase|null>}
+ */
+export async function openCache({ userId, factory = globalThis.indexedDB, version = DB_VERSION } = {}) {
+  if (!factory || !userId) return null;
+
+  let req;
+  try {
+    req = factory.open(databaseName(userId), version);
+  } catch {
+    // Some browsers throw synchronously rather than firing onerror.
+    return null;
+  }
+
+  return new Promise((resolve) => {
+    req.onupgradeneeded = () => createSchema(req.result);
+    req.onerror = () => resolve(null);
+    // Another tab is holding the old version open. Waiting would hang the app.
+    req.onblocked = () => resolve(null);
+    req.onsuccess = () => {
+      const db = req.result;
+      db.onversionchange = () => db.close();
+      resolve(db);
+    };
+  });
+}
+
+/**
+ * Cache one task: its searchable record, its thread, and its attachment
+ * metadata, in a single transaction so a search can never find a task whose
+ * thread was not written.
+ */
+export async function putTask(db, task, terms = []) {
+  if (!db || !task?.id || !task?.workspaceId) return false;
+
+  return attempt(() => {
+    const tx = db.transaction([STORE_TASKS, STORE_THREADS, STORE_ATTACHMENTS], 'readwrite');
+    tx.objectStore(STORE_TASKS).put(toTaskRecord(task, terms));
+    tx.objectStore(STORE_THREADS).put(toThreadRecord(task));
+    const attachments = tx.objectStore(STORE_ATTACHMENTS);
+    for (const record of toAttachmentRecords(task)) attachments.put(record);
+    return transactionDone(tx);
+  }, false);
+}
+
+/** The cached task and its thread, or null when either is missing. */
+export async function getCachedTask(db, workspaceId, taskId) {
+  if (!db) return null;
+
+  return attempt(async () => {
+    const tx = db.transaction([STORE_TASKS, STORE_THREADS], 'readonly');
+    const [task, thread] = await Promise.all([
+      requestResult(tx.objectStore(STORE_TASKS).get([workspaceId, taskId])),
+      requestResult(tx.objectStore(STORE_THREADS).get([workspaceId, taskId])),
+    ]);
+
+    if (!task) return null;
+    return { ...task, messages: thread?.messages ?? [], toolCalls: thread?.toolCalls ?? [] };
+  }, null);
+}
+
+/** Every cached task in a workspace, newest first. */
+export async function listCachedTasks(db, workspaceId, KeyRange = globalThis.IDBKeyRange) {
+  if (!db) return [];
+
+  return attempt(async () => {
+    const tx = db.transaction(STORE_TASKS, 'readonly');
+    const rows = await requestResult(
+      tx.objectStore(STORE_TASKS).index('by_workspace').getAll(KeyRange.only(workspaceId))
+    );
+    return rows.sort((a, b) => String(b.updatedAt ?? '').localeCompare(String(a.updatedAt ?? '')));
+  }, []);
+}
+
+/**
+ * Forget everything cached for one workspace, leaving the others untouched.
+ *
+ * This is what the settings screen's Clear button runs, and what opting out of
+ * the cache runs so the setting never leaves orphaned data behind.
+ */
+export async function clearWorkspace(db, workspaceId, KeyRange = globalThis.IDBKeyRange) {
+  if (!db) return false;
+
+  return attempt(() => {
+    const tx = db.transaction(
+      [STORE_TASKS, STORE_THREADS, STORE_ATTACHMENTS, STORE_META],
+      'readwrite'
+    );
+    const range = workspaceRange(workspaceId, KeyRange);
+    tx.objectStore(STORE_TASKS).delete(range);
+    tx.objectStore(STORE_THREADS).delete(range);
+    tx.objectStore(STORE_ATTACHMENTS).delete(range);
+    tx.objectStore(STORE_META).delete(KeyRange.bound(`${workspaceId}:`, `${workspaceId}:￿`));
+    return transactionDone(tx);
+  }, false);
+}
+
+/**
+ * Delete the whole database.
+ *
+ * Signing out runs this. A browser that several people use must not leave one
+ * person's task titles readable by the next, and there is no partial version of
+ * that guarantee worth having.
+ */
+export async function destroyCache({ userId, factory = globalThis.indexedDB } = {}) {
+  if (!factory || !userId) return false;
+
+  return new Promise((resolve) => {
+    let req;
+    try {
+      req = factory.deleteDatabase(databaseName(userId));
+    } catch {
+      return resolve(false);
+    }
+    req.onsuccess = () => resolve(true);
+    req.onerror = () => resolve(false);
+    req.onblocked = () => resolve(false);
+  });
+}

--- a/frontend/test/localCache.test.js
+++ b/frontend/test/localCache.test.js
@@ -1,0 +1,543 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { IDBFactory, IDBKeyRange } from 'fake-indexeddb'
+
+import {
+  DB_VERSION,
+  STORE_ATTACHMENTS,
+  STORE_META,
+  STORE_TASKS,
+  STORE_THREADS,
+  clearWorkspace,
+  databaseName,
+  destroyCache,
+  getCachedTask,
+  listCachedTasks,
+  metaKey,
+  openCache,
+  plain,
+  putTask,
+  requestResult,
+  transactionDone,
+  toAttachmentRecords,
+  toTaskRecord,
+  toThreadRecord,
+  workspaceRange,
+} from '../src/composables/useLocalCache'
+
+/** A fresh in-memory IndexedDB, so no test can see another's data. */
+let factory
+beforeEach(() => {
+  factory = new IDBFactory()
+})
+
+const open = (userId = 'user1') => openCache({ userId, factory })
+
+/** A task in the shape the API sends, attachments and all. */
+const makeTask = (over = {}) => ({
+  id: '0iCYTqxKOqv',
+  workspaceId: 'ws1',
+  title: 'Ship the billing reconciliation fix',
+  body: 'The nightly job double-counts refunds.',
+  status: 'notstarted',
+  assignee: 'agent',
+  createdBy: 'human',
+  createdAt: '2026-09-01T10:00:00Z',
+  updatedAt: '2026-09-02T10:00:00Z',
+  sortOrder: 1,
+  messages: [],
+  toolCalls: [],
+  attachments: [],
+  ...over,
+})
+
+/** Four base64 characters carry three bytes, so this is 6 bytes of "file". */
+const attachment = (id) => ({ id, filename: `${id}.png`, mimeType: 'image/png', data: 'AAAAAAAA' })
+
+describe('plain', () => {
+  it('rebuilds a value as plain arrays and objects', () => {
+    expect(plain({ a: [1, { b: 'c' }], d: null })).toEqual({ a: [1, { b: 'c' }], d: null })
+  })
+
+  it('survives what IndexedDB would refuse to clone', () => {
+    // A Vue reactive object is a Proxy, and handing one to put() raises
+    // DataCloneError. Rebuilding the value is what makes the write safe.
+    const proxy = new Proxy({ title: 'Held in a ref' }, {})
+
+    expect(plain(proxy)).toEqual({ title: 'Held in a ref' })
+  })
+
+  it('drops functions and undefined, which cannot be stored', () => {
+    expect(plain({ keep: 1, fn: () => {}, gone: undefined })).toEqual({ keep: 1 })
+    expect(plain(() => {})).toBeUndefined()
+  })
+})
+
+describe('toTaskRecord', () => {
+  it('keeps the text a search needs', () => {
+    const record = toTaskRecord(makeTask(), ['billing', 'refunds'])
+
+    expect(record.title).toBe('Ship the billing reconciliation fix')
+    expect(record.body).toBe('The nightly job double-counts refunds.')
+    expect(record.terms).toEqual(['billing', 'refunds'])
+    expect(record.status).toBe('notstarted')
+  })
+
+  it('carries no conversation and no attachment bytes', () => {
+    // The whole reason the schema is split. `data` arrives as base64 inside the
+    // task JSON, so a record built by spreading the task would bury file bytes
+    // in the row a search has to walk.
+    const record = toTaskRecord(
+      makeTask({ messages: [{ id: 'm1' }], toolCalls: [{ id: 't1' }], attachments: [attachment('a1')] })
+    )
+
+    expect(record.messages).toBeUndefined()
+    expect(record.toolCalls).toBeUndefined()
+    expect(record.attachments).toBeUndefined()
+    expect(JSON.stringify(record)).not.toContain('AAAAAAAA')
+    expect(record.attachmentCount).toBe(1)
+  })
+
+  it('omits fields the task does not carry rather than storing null', () => {
+    const record = toTaskRecord(makeTask({ cronSchedule: undefined, eventId: null }))
+
+    expect('cronSchedule' in record).toBe(false)
+    expect('eventId' in record).toBe(false)
+  })
+
+  it('defaults the terms so a caller may skip them', () => {
+    expect(toTaskRecord(makeTask()).terms).toEqual([])
+  })
+})
+
+describe('toThreadRecord', () => {
+  it('keeps the conversation', () => {
+    const thread = toThreadRecord(
+      makeTask({ messages: [{ id: 'm1', text: 'hi' }], toolCalls: [{ id: 't1', toolName: 'Bash' }] })
+    )
+
+    expect(thread.messages).toEqual([{ id: 'm1', text: 'hi' }])
+    expect(thread.toolCalls).toEqual([{ id: 't1', toolName: 'Bash' }])
+    expect(thread.taskId).toBe('0iCYTqxKOqv')
+  })
+
+  it('reduces an attachment on a message to metadata', () => {
+    // Messages carry attachments too, and theirs are base64 in the same way.
+    const thread = toThreadRecord(
+      makeTask({ messages: [{ id: 'm1', attachments: [attachment('a1')] }] })
+    )
+
+    expect(thread.messages[0].attachments).toEqual([
+      { id: 'a1', filename: 'a1.png', mimeType: 'image/png', size: 6 },
+    ])
+    expect(JSON.stringify(thread)).not.toContain('AAAAAAAA')
+  })
+
+  it('copes with a task carrying no relations at all', () => {
+    const thread = toThreadRecord({ id: 't', workspaceId: 'ws1' })
+
+    expect(thread).toEqual({ workspaceId: 'ws1', taskId: 't', messages: [], toolCalls: [], attachments: [] })
+  })
+})
+
+describe('toAttachmentRecords', () => {
+  it('records one row per attachment, sized from the base64 it dropped', () => {
+    const rows = toAttachmentRecords(makeTask({ attachments: [attachment('a1')] }), 1234)
+
+    expect(rows).toEqual([
+      {
+        id: 'a1',
+        filename: 'a1.png',
+        mimeType: 'image/png',
+        size: 6,
+        workspaceId: 'ws1',
+        taskId: '0iCYTqxKOqv',
+        attachmentId: 'a1',
+        lastUsedAt: 1234,
+      },
+    ])
+  })
+
+  it('fills in what a malformed attachment omits', () => {
+    const [row] = toAttachmentRecords(makeTask({ attachments: [{ id: 'a1' }] }))
+
+    expect(row.filename).toBe('')
+    expect(row.mimeType).toBe('')
+    expect(row.size).toBe(0)
+    expect(typeof row.lastUsedAt).toBe('number')
+  })
+
+  it('has nothing to record for a task with no attachments', () => {
+    expect(toAttachmentRecords(makeTask())).toEqual([])
+    expect(toAttachmentRecords({ id: 't', workspaceId: 'ws1' })).toEqual([])
+  })
+})
+
+describe('databaseName and metaKey', () => {
+  it('names the database for the signed-in user', () => {
+    // A browser origin outlives a session: sign out, sign in as someone else,
+    // and a shared name hands over the previous person's task titles.
+    expect(databaseName('u1')).toBe('agentrq-cache:u1')
+    expect(databaseName('u2')).not.toBe(databaseName('u1'))
+  })
+
+  it('prefixes meta keys with the workspace so they clear with it', () => {
+    expect(metaKey('ws1', 'lastSyncedAt')).toBe('ws1:lastSyncedAt')
+  })
+})
+
+describe('workspaceRange', () => {
+  it('covers every key in the workspace and nothing beyond it', () => {
+    // An empty array sorts above every number, string and date in IndexedDB,
+    // so it is the smallest key above every real key in the workspace.
+    const range = workspaceRange('ws1', IDBKeyRange)
+
+    expect(range.includes(['ws1', 'aaa'])).toBe(true)
+    expect(range.includes(['ws1', 'zzz', 'deep'])).toBe(true)
+    expect(range.includes(['ws2', 'aaa'])).toBe(false)
+  })
+})
+
+describe('openCache', () => {
+  it('creates the four stores and the search index', async () => {
+    const db = await open()
+
+    expect([...db.objectStoreNames].sort()).toEqual(
+      [STORE_ATTACHMENTS, STORE_META, STORE_TASKS, STORE_THREADS].sort()
+    )
+    expect(db.version).toBe(DB_VERSION)
+
+    const tasks = db.transaction(STORE_TASKS).objectStore(STORE_TASKS)
+    expect([...tasks.indexNames].sort()).toEqual(['by_recent', 'by_status', 'by_term', 'by_workspace'])
+    expect(tasks.index('by_term').multiEntry).toBe(true)
+    db.close()
+  })
+
+  it('reports no cache rather than throwing when there is none to open', async () => {
+    // A private window can refuse outright. The caller checks for null and goes
+    // to the network, which is what it would have done anyway.
+    expect(await openCache({ userId: 'u1', factory: null })).toBeNull()
+    expect(await openCache({ factory })).toBeNull()
+    expect(await openCache()).toBeNull()
+  })
+
+  it('reports no cache when opening throws synchronously', async () => {
+    const throwing = {
+      open() {
+        throw new Error('denied in a private window')
+      },
+    }
+
+    expect(await openCache({ userId: 'u1', factory: throwing })).toBeNull()
+  })
+
+  it('reports no cache when the open errors', async () => {
+    const req = {}
+    const erroring = { open: () => req }
+    const opening = openCache({ userId: 'u1', factory: erroring })
+
+    req.onerror()
+
+    expect(await opening).toBeNull()
+  })
+
+  it('reports no cache rather than hanging when an older tab blocks the upgrade', async () => {
+    // onupgradeneeded stalls while another connection holds the old version.
+    // Waiting for it would freeze the view that asked.
+    const req = {}
+    const blocking = { open: () => req }
+    const opening = openCache({ userId: 'u1', factory: blocking })
+
+    req.onblocked()
+
+    expect(await opening).toBeNull()
+  })
+
+  it('closes on request so it never becomes the tab blocking someone else', async () => {
+    const db = await open()
+    let closed = false
+    const realClose = db.close.bind(db)
+    db.close = () => {
+      closed = true
+      realClose()
+    }
+
+    db.onversionchange()
+
+    expect(closed).toBe(true)
+  })
+
+  it('gives different users different databases', async () => {
+    const a = await openCache({ userId: 'u1', factory })
+    await putTask(a, makeTask())
+    a.close()
+
+    const b = await openCache({ userId: 'u2', factory })
+    expect(await listCachedTasks(b, 'ws1', IDBKeyRange)).toEqual([])
+    b.close()
+  })
+})
+
+describe('createSchema', () => {
+  it('keys every store by the workspace first, which is what makes clearing possible', async () => {
+    // Clearing a workspace is a key-range delete, and that only works while the
+    // workspace is the leading part of every key. A future store added without
+    // that would silently survive a clear.
+    const db = await open()
+    const tx = db.transaction([STORE_TASKS, STORE_THREADS, STORE_ATTACHMENTS], 'readonly')
+
+    expect(tx.objectStore(STORE_TASKS).keyPath).toEqual(['workspaceId', 'id'])
+    expect(tx.objectStore(STORE_THREADS).keyPath).toEqual(['workspaceId', 'taskId'])
+    expect(tx.objectStore(STORE_ATTACHMENTS).keyPath).toEqual([
+      'workspaceId',
+      'taskId',
+      'attachmentId',
+    ])
+    db.close()
+  })
+})
+
+describe('putTask and getCachedTask', () => {
+  it('round-trips a task with its conversation reassembled', async () => {
+    const db = await open()
+    const task = makeTask({ messages: [{ id: 'm1', text: 'hi' }], toolCalls: [{ id: 't1' }] })
+
+    expect(await putTask(db, task, ['billing'])).toBe(true)
+    const back = await getCachedTask(db, 'ws1', '0iCYTqxKOqv')
+
+    expect(back.title).toBe('Ship the billing reconciliation fix')
+    expect(back.messages).toEqual([{ id: 'm1', text: 'hi' }])
+    expect(back.toolCalls).toEqual([{ id: 't1' }])
+    db.close()
+  })
+
+  it('writes attachment metadata but never the bytes', async () => {
+    const db = await open()
+    await putTask(db, makeTask({ attachments: [attachment('a1'), attachment('a2')] }))
+
+    const rows = await new Promise((resolve) => {
+      const req = db.transaction(STORE_ATTACHMENTS).objectStore(STORE_ATTACHMENTS).getAll()
+      req.onsuccess = () => resolve(req.result)
+    })
+
+    expect(rows).toHaveLength(2)
+    expect(rows.every((r) => !('data' in r))).toBe(true)
+    db.close()
+  })
+
+  it('accepts a reactive-shaped object without a clone error', async () => {
+    const db = await open()
+    const proxied = new Proxy(makeTask(), {})
+
+    expect(await putTask(db, proxied)).toBe(true)
+    db.close()
+  })
+
+  it('declines to write something that is not a task', async () => {
+    const db = await open()
+
+    expect(await putTask(db, null)).toBe(false)
+    expect(await putTask(db, { id: 'x' })).toBe(false)
+    expect(await putTask(db, { workspaceId: 'ws1' })).toBe(false)
+    db.close()
+  })
+
+  it('does nothing at all without a database', async () => {
+    expect(await putTask(null, makeTask())).toBe(false)
+    expect(await getCachedTask(null, 'ws1', 't1')).toBeNull()
+    expect(await listCachedTasks(null, 'ws1', IDBKeyRange)).toEqual([])
+    expect(await clearWorkspace(null, 'ws1', IDBKeyRange)).toBe(false)
+  })
+
+  it('reports a miss for a task it has never seen', async () => {
+    const db = await open()
+    expect(await getCachedTask(db, 'ws1', 'nope')).toBeNull()
+    db.close()
+  })
+
+  it('returns empty relations for a task whose thread went missing', async () => {
+    const db = await open()
+    await putTask(db, makeTask())
+    await new Promise((resolve) => {
+      const tx = db.transaction(STORE_THREADS, 'readwrite')
+      tx.objectStore(STORE_THREADS).delete(['ws1', '0iCYTqxKOqv'])
+      tx.oncomplete = resolve
+    })
+
+    const back = await getCachedTask(db, 'ws1', '0iCYTqxKOqv')
+
+    expect(back.messages).toEqual([])
+    expect(back.toolCalls).toEqual([])
+    db.close()
+  })
+})
+
+describe('listCachedTasks', () => {
+  it('returns a workspace newest first', async () => {
+    const db = await open()
+    await putTask(db, makeTask({ id: 'old', updatedAt: '2026-01-01T00:00:00Z' }))
+    await putTask(db, makeTask({ id: 'new', updatedAt: '2026-09-01T00:00:00Z' }))
+    await putTask(db, makeTask({ id: 'other', workspaceId: 'ws2' }))
+
+    const rows = await listCachedTasks(db, 'ws1', IDBKeyRange)
+
+    expect(rows.map((r) => r.id)).toEqual(['new', 'old'])
+    db.close()
+  })
+
+  it('orders a task with no timestamp last rather than throwing', async () => {
+    const db = await open()
+    await putTask(db, makeTask({ id: 'dated', updatedAt: '2026-09-01T00:00:00Z' }))
+    await putTask(db, makeTask({ id: 'undated', updatedAt: undefined }))
+    await putTask(db, makeTask({ id: 'undated2', updatedAt: undefined }))
+
+    const ids = (await listCachedTasks(db, 'ws1', IDBKeyRange)).map((r) => r.id)
+
+    expect(ids[0]).toBe('dated')
+    expect(ids.slice(1).sort()).toEqual(['undated', 'undated2'])
+    db.close()
+  })
+})
+
+describe('requestResult and transactionDone', () => {
+  it('resolve with what the operation produced', async () => {
+    const req = {}
+    const reading = requestResult(req)
+    req.result = 'the row'
+    req.onsuccess()
+    expect(await reading).toBe('the row')
+
+    const tx = {}
+    const writing = transactionDone(tx)
+    tx.oncomplete()
+    expect(await writing).toBe(true)
+  })
+
+  it('reject when the operation fails, aborts, or errors', async () => {
+    const req = { error: new Error('read failed') }
+    const reading = requestResult(req)
+    req.onerror()
+    await expect(reading).rejects.toThrow('read failed')
+
+    const errored = { error: new Error('write failed') }
+    const writing = transactionDone(errored)
+    errored.onerror()
+    await expect(writing).rejects.toThrow('write failed')
+
+    const aborted = { error: new Error('quota exceeded') }
+    const aborting = transactionDone(aborted)
+    aborted.onabort()
+    await expect(aborting).rejects.toThrow('quota exceeded')
+  })
+})
+
+describe('a cache that fails mid-operation', () => {
+  // The contract for the whole module: a cache is an optimisation, so its
+  // failures never reach a user who only wanted to read their tasks. Every one
+  // of these returns the same answer as having had no cache at all.
+  const broken = {
+    transaction() {
+      throw new Error('the connection went away')
+    },
+  }
+
+  it('reports a write as not written', async () => {
+    expect(await putTask(broken, makeTask())).toBe(false)
+  })
+
+  it('reports a read as a miss', async () => {
+    expect(await getCachedTask(broken, 'ws1', 't1')).toBeNull()
+  })
+
+  it('reports a list as empty', async () => {
+    expect(await listCachedTasks(broken, 'ws1', IDBKeyRange)).toEqual([])
+  })
+
+  it('reports a clear as not cleared', async () => {
+    expect(await clearWorkspace(broken, 'ws1', IDBKeyRange)).toBe(false)
+  })
+
+  it('does the same when the connection closes underneath it', async () => {
+    // A real path: the tab was told to close for an upgrade while a read was
+    // in flight.
+    const db = await open()
+    await putTask(db, makeTask())
+    db.close()
+
+    expect(await getCachedTask(db, 'ws1', '0iCYTqxKOqv')).toBeNull()
+    expect(await putTask(db, makeTask())).toBe(false)
+  })
+})
+
+describe('clearWorkspace', () => {
+  it('forgets one workspace and leaves the others alone', async () => {
+    const db = await open()
+    await putTask(db, makeTask({ attachments: [attachment('a1')] }))
+    await putTask(db, makeTask({ id: 'keep', workspaceId: 'ws2', attachments: [attachment('a2')] }))
+    await new Promise((resolve) => {
+      const tx = db.transaction(STORE_META, 'readwrite')
+      tx.objectStore(STORE_META).put({ key: metaKey('ws1', 'lastSyncedAt'), value: 1 })
+      tx.objectStore(STORE_META).put({ key: metaKey('ws2', 'lastSyncedAt'), value: 2 })
+      tx.oncomplete = resolve
+    })
+
+    expect(await clearWorkspace(db, 'ws1', IDBKeyRange)).toBe(true)
+
+    expect(await listCachedTasks(db, 'ws1', IDBKeyRange)).toEqual([])
+    expect(await getCachedTask(db, 'ws1', '0iCYTqxKOqv')).toBeNull()
+    expect((await listCachedTasks(db, 'ws2', IDBKeyRange)).map((r) => r.id)).toEqual(['keep'])
+
+    const meta = await new Promise((resolve) => {
+      const req = db.transaction(STORE_META).objectStore(STORE_META).getAll()
+      req.onsuccess = () => resolve(req.result)
+    })
+    expect(meta.map((m) => m.key)).toEqual(['ws2:lastSyncedAt'])
+
+    const atts = await new Promise((resolve) => {
+      const req = db.transaction(STORE_ATTACHMENTS).objectStore(STORE_ATTACHMENTS).getAll()
+      req.onsuccess = () => resolve(req.result)
+    })
+    expect(atts.map((a) => a.workspaceId)).toEqual(['ws2'])
+    db.close()
+  })
+})
+
+describe('destroyCache', () => {
+  it('removes the whole database, which is what signing out needs', async () => {
+    const db = await open()
+    await putTask(db, makeTask())
+    db.close()
+
+    expect(await destroyCache({ userId: 'user1', factory })).toBe(true)
+
+    const fresh = await open()
+    expect(await listCachedTasks(fresh, 'ws1', IDBKeyRange)).toEqual([])
+    fresh.close()
+  })
+
+  it('has nothing to delete without a user or a factory', async () => {
+    expect(await destroyCache({ userId: 'u1', factory: null })).toBe(false)
+    expect(await destroyCache({ factory })).toBe(false)
+    expect(await destroyCache()).toBe(false)
+  })
+
+  it('reports failure rather than throwing when the delete cannot run', async () => {
+    const throwing = {
+      deleteDatabase() {
+        throw new Error('denied')
+      },
+    }
+    expect(await destroyCache({ userId: 'u1', factory: throwing })).toBe(false)
+
+    const req = {}
+    const erroring = { deleteDatabase: () => req }
+    const erroringRun = destroyCache({ userId: 'u1', factory: erroring })
+    req.onerror()
+    expect(await erroringRun).toBe(false)
+
+    const blockedReq = {}
+    const blocking = { deleteDatabase: () => blockedReq }
+    const blockedRun = destroyCache({ userId: 'u1', factory: blocking })
+    blockedReq.onblocked()
+    expect(await blockedRun).toBe(false)
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -48,6 +48,7 @@ export default defineConfig({
         'src/composables/useAuthedFetch.js',
         'src/composables/useKeyboardShortcuts.js',
         'src/composables/useTaskFinder.js',
+        'src/composables/useLocalCache.js',
       ],
       reporter: ['text', 'lcov'],
       thresholds: {


### PR DESCRIPTION
## What changed

The app can now keep a copy of a workspace's tasks in the browser's own database, with the plumbing to write, read and clear it. Nothing uses it yet — this is the storage layer on its own, so it can be proven before anything depends on it.

First of seven steps toward searching tasks by title and description without touching the backend. [Full plan](https://claude.ai/code/artifact/721b0aaf-e687-488c-a9b1-9077b60e4d2a).

## Why changed

Searching means walking every task's title and body, and that is only fast while each record stays small. So the schema is split three ways rather than storing tasks as they arrive:

- **Searchable records** hold text, dates, status and the term index — nothing else.
- **Threads** hold the message and tool-call history, read by exact key when a task is opened and never touched by a search.
- **Attachments** are stored as metadata only.

That last one is the split with teeth. Attachment bytes arrive as base64 *inside the task JSON*, from the list endpoint included, so a task written as it arrives would bury file bytes in exactly the row a search has to scan — and base64 costs a third again on top of the bytes, paid back on every read of the record holding it. The bytes belong in Cache Storage, which holds a binary response body rather than a JavaScript string, and which the UI already reaches through the attachment URL it uses today. That arrives in a later step.

Three traps are handled here rather than left to be found later:

- A Vue reactive object is a Proxy, and handing one to `put()` raises `DataCloneError` and silently loses the write. Every value is rebuilt as plain arrays and objects first — which the field projection needed to do anyway, to drop the attachment bytes.
- A schema upgrade blocks while an older tab still holds a connection. This one closes on `versionchange` so it never becomes that tab, and treats `blocked` as "run without a cache this session" rather than hanging the view that asked.
- A private window can refuse to open a database at all, and WebKit discards one that has gone unused for a week.

That last point generalised into the module's contract while the tests were being written: **every failure returns the same answer as having had no cache.** Opening resolves to null, a read misses, a list comes back empty, a write reports that it did not happen. A cache is an optimisation, and its failures have no business reaching someone who only wanted to read their tasks. Callers check for the empty answer and go to the network, which is what they would have done anyway.

Clearing a workspace is a key-range delete, which works only while the workspace is the leading part of every key — so every store is keyed workspace-first, and there is a test that fails if a later store is not.

The database is named per signed-in user. Desktop profiles already partition their own storage through their Electron session, so they need nothing here, but a browser origin outlives a session and a single profile can change account.

## Test coverage report

**New lines introduced: 100%.** The new module is added to the enforced `coverage.include` list and covers on all four metrics:

```
File               | % Stmts | % Branch | % Funcs | % Lines
useLocalCache.js   |     100 |      100 |     100 |     100
All files          |     100 |      100 |     100 |     100
```

**Total coverage impact: none — the suite stays at the 100% the config enforces.** 321 tests passing, up from 277; 44 are new.

`fake-indexeddb` is added as a dev dependency because jsdom provides no IndexedDB. Each test gets its own in-memory factory, so no test can see another's data.

Worth noting about how the coverage gate was met: two error paths were unreachable through the public API on the first pass. Rather than reaching into internals to touch them, the fix was to make failures part of the contract — the operations now degrade to the empty answer instead of rejecting, which is both better behaviour and reachable from a test.

## Other reports

- `npm run build` clean.
- `npm ci --dry-run` exits 0; the lockfile change is 11 lines for the one new dev dependency, with no other dependency movement and no change to the app version fields.
- No backend change, and no change to any existing view.

TaskID: 0iCioozARaT

🤖 Generated with [Claude Code](https://claude.com/claude-code)