### PR TITLE
feat(cache): fill the local store from what the server said

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -394,6 +394,7 @@ import { useWorkspaceStore } from './stores/workspaceStore'
 import { useFormat } from './composables/useFormat'
 import { usePushNotifications } from './composables/usePushNotifications'
 import Toast from './components/Toast.vue'
+import { cacheTaskEvent, connectCache, sharedCache } from './composables/useCachedTasks'
 import CommandPalette from './components/CommandPalette.vue'
 import ShortcutsHelp from './components/ShortcutsHelp.vue'
 import {
@@ -545,6 +546,14 @@ watch(events, (newEvents) => {
     workspaceStore.updateWorkspaceMetadata(event.payload)
   }
   
+  // Keep the local copy current. Merged against what the cache already holds
+  // rather than written straight through: a payload built without its relations
+  // is indistinguishable from one whose relations are genuinely empty, and this
+  // stream carries tasks nobody has open to merge against. See useCachedTasks.
+  if (event.type === 'task.created' || event.type === 'task.updated') {
+    cacheTaskEvent(sharedCache(), event.payload)
+  }
+
   if (event.type === 'task.created' && event.payload.createdBy === 'agent') {
     notifySuccess(`Agent started a new task: ${event.payload.title}`)
   } else if (event.type === 'task.updated') {
@@ -596,6 +605,10 @@ const loadUser = async () => {
   if (isLoginPage.value) return;
   try {
     user.value = await fetchUser()
+    // The database is named for the signed-in user, so it cannot be opened
+    // before we know who that is. Failing to open one is not an error worth
+    // showing: the app reads from the network either way.
+    if (user.value?.id) connectCache(user.value.id)
   } catch (err) {
     console.error('Failed to fetch user:', err)
   }

--- a/frontend/src/composables/useCachedTasks.js
+++ b/frontend/src/composables/useCachedTasks.js
@@ -1,0 +1,193 @@
+import { mergeTaskUpdate } from './useTaskEvents';
+import { getCachedTask, openCache, putTask } from './useLocalCache';
+import { taskTerms } from './useTaskIndex';
+
+/**
+ * Filling the local cache from what the server said.
+ *
+ * ## The rule this module exists to enforce
+ *
+ * **The cache is written only from server responses and SSE events.** Never
+ * from a user action, and never replayed back. There is no write queue and no
+ * conflict resolution, because there is nothing to reconcile: every row here
+ * came from the backend, and while the user is online the backend is what any
+ * open task renders. The cache can be stale, but it can never be *divergent*.
+ *
+ * That is a deliberately small promise, and it is what makes the feature safe
+ * to ship. Anything that let a local edit outlive a failed request would need
+ * an answer for two people editing the same task, and this has none.
+ *
+ * ## What gets cached
+ *
+ * Exactly what the user loads, and nothing else. There is no backfill: a
+ * workspace nobody opens costs nothing, and the cache grows to fit how the
+ * person actually works rather than how large their history happens to be.
+ */
+
+/** Per-workspace, per-device. See `isCacheEnabled`. */
+export const CACHE_SETTING_PREFIX = 'local_cache_';
+
+/** The stored value that means off. Anything else, including nothing, is on. */
+export const SETTING_OFF = 'off';
+
+export function cacheSettingKey(workspaceId) {
+  return `${CACHE_SETTING_PREFIX}${workspaceId}`;
+}
+
+/**
+ * Whether this workspace is cached on this device.
+ *
+ * On by default: the setting exists to turn something off, so its absence is
+ * consent to the default rather than an unanswered question.
+ *
+ * It is deliberately **local and unsynced**, unlike every other workspace
+ * setting. What it controls is a per-device store against a per-device quota,
+ * so the same workspace can be cached on one machine and not another, and
+ * neither learns about the other. On the desktop each profile has its own
+ * Electron session partition, so profiles get their own answer for free.
+ *
+ * A storage that cannot be read resolves to **off**, not on. Failing to cache
+ * costs a little speed; caching for someone who turned it off breaks a promise
+ * that was made to them, and only one of those is worth risking.
+ */
+export function isCacheEnabled(workspaceId, storage = globalThis.localStorage) {
+  if (!workspaceId || !storage) return false;
+  try {
+    return storage.getItem(cacheSettingKey(workspaceId)) !== SETTING_OFF;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Cache one task, if its workspace is cached at all.
+ *
+ * Terms are computed here rather than by the caller: a write is the only moment
+ * the text is known to have changed, and computing them anywhere else invites a
+ * record whose index does not match its own title.
+ *
+ * @returns {Promise<boolean>} whether it was written
+ */
+export async function cacheTask(db, task, { storage } = {}) {
+  if (!db || !task?.workspaceId) return false;
+  if (!isCacheEnabled(task.workspaceId, storage)) return false;
+
+  return putTask(db, task, taskTerms(task));
+}
+
+/**
+ * Cache a page of tasks.
+ *
+ * Sequential rather than parallel: a list is up to fifty tasks, each opening a
+ * transaction across three stores, and firing them all at once buys nothing
+ * while making the database contend with itself behind whatever the user does
+ * next.
+ *
+ * @returns {Promise<number>} how many were written
+ */
+export async function cacheTasks(db, tasks, options = {}) {
+  const list = Array.isArray(tasks) ? tasks : [];
+  let written = 0;
+  for (const task of list) {
+    if (await cacheTask(db, task, options)) written += 1;
+  }
+  return written;
+}
+
+/**
+ * Fold an SSE payload into the task on screen, and cache the result.
+ *
+ * **The merged task is what gets cached, never the raw payload.** The backend
+ * builds those payloads in several places, and one built without its relations
+ * is indistinguishable from one whose relations are genuinely empty — which is
+ * the bug `mergeTaskUpdate` exists to make unrepresentable. Caching the raw
+ * payload would take that same emptied tool lane and write it to disk, where it
+ * would outlive the reload that currently fixes it.
+ *
+ * Returns the merged task so the caller renders and caches the same thing
+ * rather than computing the merge twice.
+ */
+export function cacheTaskUpdate(db, current, incoming, options = {}) {
+  const merged = mergeTaskUpdate(current, incoming);
+  // Not awaited: the view should paint the merge now, and a write that has not
+  // landed yet is indistinguishable from a cache that never held the task.
+  if (merged) cacheTask(db, merged, options);
+  return merged;
+}
+
+/**
+ * Cache a task an event announced, when there is no copy on screen to merge
+ * against.
+ *
+ * The shell watches a stream covering every workspace, so most events it sees
+ * are for tasks nobody has open. Writing those payloads straight through would
+ * hit the exact problem `cacheTaskUpdate` avoids — a payload built without its
+ * relations would overwrite the relations already stored.
+ *
+ * So the merge happens against the *cached* copy instead, which plays the part
+ * the on-screen task plays elsewhere. A task the cache has never seen has
+ * nothing to lose, and is written as it arrived.
+ */
+export async function cacheTaskEvent(db, incoming, options = {}) {
+  if (!db || !incoming?.id || !incoming?.workspaceId) return false;
+  if (!isCacheEnabled(incoming.workspaceId, options.storage)) return false;
+
+  const held = await getCachedTask(db, incoming.workspaceId, incoming.id);
+  return cacheTask(db, mergeTaskUpdate(held, incoming), options);
+}
+
+/**
+ * The one open connection, and who it belongs to.
+ *
+ * Module scope because there is one database per signed-in user and no reason
+ * for two views to hold separate handles to it. Keyed by user because signing
+ * in as someone else must not keep talking to the previous person's database —
+ * on the web that is a real sequence, and on the desktop a single profile can
+ * change account too.
+ */
+let current = { userId: null, db: null, pending: null };
+
+/** Test seam, and what signing out calls. */
+export function resetSharedCache() {
+  current.db?.close?.();
+  current = { userId: null, db: null, pending: null };
+}
+
+/** The open connection, or null when there is none. Never throws. */
+export function sharedCache() {
+  return current.db;
+}
+
+/**
+ * Open the cache for a user, once.
+ *
+ * Concurrent callers share one attempt rather than racing to open the same
+ * database, and a different user closes the old connection first.
+ *
+ * Resolves to `null` when there is no cache to be had — a private window, a
+ * blocked upgrade, storage turned off. Callers treat that the way they treat an
+ * empty cache, which is to say they go to the network.
+ */
+export async function connectCache(userId, options = {}) {
+  if (!userId) return null;
+  if (current.userId === userId) {
+    if (current.db) return current.db;
+    if (current.pending) return current.pending;
+  } else {
+    resetSharedCache();
+  }
+
+  current.userId = userId;
+  current.pending = openCache({ userId, ...options }).then((db) => {
+    // A reset while opening wins: whoever called it wanted this connection gone.
+    if (current.userId !== userId) {
+      db?.close?.();
+      return null;
+    }
+    current.db = db;
+    current.pending = null;
+    return db;
+  });
+
+  return current.pending;
+}

--- a/frontend/src/views/KanbanBoardView.vue
+++ b/frontend/src/views/KanbanBoardView.vue
@@ -95,6 +95,7 @@ import { useWorkspaceStore } from '../stores/workspaceStore';
 import LoadingState from '../components/LoadingState.vue';
 import MoveTaskModal from '../components/MoveTaskModal.vue';
 import ContextMenu from '../components/ContextMenu.vue';
+import { cacheTasks, sharedCache } from '../composables/useCachedTasks';
 
 const route = useRoute();
 const router = useRouter();
@@ -160,6 +161,9 @@ async function loadColumn(colId, isLoadMore = false) {
     const col = columnById[colId];
     const offset = isLoadMore ? offsets.value[colId] : 0;
     const res = await fetchTasks(workspaceId.value, { status: col.statuses.join(','), limit: PAGE_SIZE, offset });
+    // Write-through, same as the other lists: what the server just returned is
+    // what the local copy should hold.
+    cacheTasks(sharedCache(), res.tasks || []);
     const fetched = res.tasks || [];
     if (!isLoadMore) {
       // Drop any locally-known tasks for this column that no longer exist server-side.

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -765,6 +765,7 @@ import {
   usesCommandKey,
 } from '../composables/useKeyboardShortcuts';
 import { usePlatformStore } from '../stores/platformStore';
+import { cacheTask, cacheTaskUpdate, sharedCache } from '../composables/useCachedTasks';
 
 const { notifyError, notifySuccess } = useToasts();
 const tooltipStore = useTooltipStore();
@@ -1034,6 +1035,9 @@ async function load() {
     workspace.value = pRes.workspace;
     const tRes = await getTask(workspaceId.value, taskId.value);
     task.value = tRes.task;
+    // The server is the source of truth for an open task, so the cache is
+    // brought in line with what it just said rather than the other way round.
+    cacheTask(sharedCache(), tRes.task);
     connect();
     nextTick(() => {
       scrollToBottom();
@@ -1339,8 +1343,9 @@ watch(events, (evts) => {
   if (['task.updated', 'task.created', 'reply.received', 'respond.ack', 'status.updated'].includes(last.type)) {
     if (last.payload && last.payload.id === taskId.value) {
       // Merged, not assigned: a payload built without the task's tool calls
-      // would otherwise wipe the trajectory — see useTaskEvents.
-      task.value = mergeTaskUpdate(task.value, last.payload);
+      // would otherwise wipe the trajectory — see useTaskEvents. The cache gets
+      // the merge for the same reason, never the raw payload.
+      task.value = cacheTaskUpdate(sharedCache(), task.value, last.payload);
     }
   }
 }, { deep: true });

--- a/frontend/src/views/TaskListView.vue
+++ b/frontend/src/views/TaskListView.vue
@@ -163,6 +163,7 @@ import { buildTaskGroups, pendingOnHuman } from '../composables/useTaskGroups';
 import { useEventBus } from '../useEventBus';
 import { useViewport } from '../composables/useViewport';
 import LoadingState from '../components/LoadingState.vue';
+import { cacheTasks, sharedCache } from '../composables/useCachedTasks';
 
 const { getNextRunLabel, getNextRunDateTime, getNextRunDate } = useCron();
 const route = useRoute();
@@ -352,6 +353,9 @@ const fetchNext = async () => {
     
     tasks.value = [...tasks.value, ...newTasks];
     offset.value += newTasks.length;
+    // Write-through: the server just told us about these, so the local copy is
+    // brought up to date with the same answer the view is rendering.
+    cacheTasks(sharedCache(), newTasks);
   } catch (err) {
     console.error('Failed to load more tasks:', err);
   }

--- a/frontend/test/cachedTasks.test.js
+++ b/frontend/test/cachedTasks.test.js
@@ -1,0 +1,370 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { IDBFactory, IDBKeyRange } from 'fake-indexeddb'
+
+import {
+  CACHE_SETTING_PREFIX,
+  SETTING_OFF,
+  cacheSettingKey,
+  cacheTask,
+  cacheTaskEvent,
+  cacheTaskUpdate,
+  cacheTasks,
+  connectCache,
+  isCacheEnabled,
+  resetSharedCache,
+  sharedCache,
+} from '../src/composables/useCachedTasks'
+import { getCachedTask, listCachedTasks, openCache } from '../src/composables/useLocalCache'
+
+let factory
+beforeEach(() => {
+  factory = new IDBFactory()
+})
+afterEach(() => {
+  resetSharedCache()
+})
+
+/** A localStorage that answers however the test needs. */
+const storageWith = (entries = {}) => ({
+  getItem: (key) => (key in entries ? entries[key] : null),
+})
+
+/** Every workspace cached. The default, so most tests want this. */
+const allOn = storageWith({})
+
+const makeTask = (over = {}) => ({
+  id: '0iCYTqxKOqv',
+  workspaceId: 'ws1',
+  title: 'Ship the billing reconciliation fix',
+  body: 'The nightly job double-counts refunds.',
+  status: 'notstarted',
+  updatedAt: '2026-09-02T10:00:00Z',
+  messages: [],
+  toolCalls: [],
+  attachments: [],
+  ...over,
+})
+
+const attachment = (id) => ({ id, filename: `${id}.png`, mimeType: 'image/png', data: 'AAAAAAAA' })
+
+describe('isCacheEnabled', () => {
+  it('is on unless someone turned it off', () => {
+    // The setting exists to turn something off, so its absence is consent to
+    // the default rather than an unanswered question.
+    expect(isCacheEnabled('ws1', allOn)).toBe(true)
+    expect(isCacheEnabled('ws1', storageWith({ [cacheSettingKey('ws1')]: 'on' }))).toBe(true)
+  })
+
+  it('is off when this workspace was turned off on this device', () => {
+    expect(isCacheEnabled('ws1', storageWith({ [cacheSettingKey('ws1')]: SETTING_OFF }))).toBe(false)
+  })
+
+  it('answers per workspace, not for all of them at once', () => {
+    const storage = storageWith({ [cacheSettingKey('ws1')]: SETTING_OFF })
+
+    expect(isCacheEnabled('ws1', storage)).toBe(false)
+    expect(isCacheEnabled('ws2', storage)).toBe(true)
+  })
+
+  it('is off when the opt-out cannot be read', () => {
+    // Failing to cache costs a little speed. Caching for someone who turned it
+    // off breaks a promise made to them, and only one of those is worth risking.
+    const throwing = {
+      getItem() {
+        throw new Error('storage disabled')
+      },
+    }
+
+    expect(isCacheEnabled('ws1', throwing)).toBe(false)
+    expect(isCacheEnabled('ws1', null)).toBe(false)
+  })
+
+  it('falls back to this device’s own storage when none is supplied', () => {
+    // Deliberately not asserting which answer comes back. `globalThis.localStorage`
+    // is a real Storage under some Node and jsdom combinations and absent under
+    // others, so pinning the value here passes on one machine and fails on the
+    // next. What must hold is that the default resolves to a decision rather
+    // than throwing.
+    expect(typeof isCacheEnabled('ws1')).toBe('boolean')
+  })
+
+  it('is off without a workspace to answer about', () => {
+    expect(isCacheEnabled('', allOn)).toBe(false)
+    expect(isCacheEnabled(undefined, allOn)).toBe(false)
+  })
+
+  it('namespaces the key so two workspaces cannot collide', () => {
+    expect(cacheSettingKey('ws1')).toBe(`${CACHE_SETTING_PREFIX}ws1`)
+    expect(cacheSettingKey('ws1')).not.toBe(cacheSettingKey('ws2'))
+  })
+})
+
+describe('cacheTask', () => {
+  it('writes the task with its search terms', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+
+    expect(await cacheTask(db, makeTask(), { storage: allOn })).toBe(true)
+
+    const [row] = await listCachedTasks(db, 'ws1', IDBKeyRange)
+    expect(row.terms).toContain('billing')
+    expect(row.terms).toContain('refunds')
+    db.close()
+  })
+
+  it('writes no attachment bytes', async () => {
+    // The trap this whole design is shaped around: `data` is base64 inside the
+    // task JSON, and the list endpoint returns it.
+    const db = await openCache({ userId: 'u1', factory })
+
+    await cacheTask(db, makeTask({ attachments: [attachment('a1')] }), { storage: allOn })
+
+    const back = await getCachedTask(db, 'ws1', '0iCYTqxKOqv')
+    expect(JSON.stringify(back)).not.toContain('AAAAAAAA')
+    expect(back.attachmentCount).toBe(1)
+    db.close()
+  })
+
+  it('writes nothing for a workspace that opted out', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+    const off = storageWith({ [cacheSettingKey('ws1')]: SETTING_OFF })
+
+    expect(await cacheTask(db, makeTask(), { storage: off })).toBe(false)
+    expect(await listCachedTasks(db, 'ws1', IDBKeyRange)).toEqual([])
+    db.close()
+  })
+
+  it('writes nothing when there is no cache to write to', async () => {
+    expect(await cacheTask(null, makeTask(), { storage: allOn })).toBe(false)
+  })
+
+  it('writes nothing for something that is not a task', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+
+    expect(await cacheTask(db, null, { storage: allOn })).toBe(false)
+    expect(await cacheTask(db, { id: 'x' }, { storage: allOn })).toBe(false)
+    db.close()
+  })
+
+  it('never breaks the view that triggered it', async () => {
+    // A cache is an optimisation. A write that cannot happen is not an error in
+    // front of someone who only wanted to read their tasks.
+    const broken = {
+      transaction() {
+        throw new Error('the connection went away')
+      },
+    }
+
+    await expect(cacheTask(broken, makeTask(), { storage: allOn })).resolves.toBe(false)
+  })
+})
+
+describe('cacheTasks', () => {
+  it('writes a page and reports how many landed', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+    const page = [makeTask({ id: 'a' }), makeTask({ id: 'b' }), makeTask({ id: 'c' })]
+
+    expect(await cacheTasks(db, page, { storage: allOn })).toBe(3)
+    expect(await listCachedTasks(db, 'ws1', IDBKeyRange)).toHaveLength(3)
+    db.close()
+  })
+
+  it('skips the workspaces that opted out and keeps the rest', async () => {
+    // A global task list spans workspaces, so one page can contain both.
+    const db = await openCache({ userId: 'u1', factory })
+    const storage = storageWith({ [cacheSettingKey('ws2')]: SETTING_OFF })
+    const page = [makeTask({ id: 'a' }), makeTask({ id: 'b', workspaceId: 'ws2' })]
+
+    expect(await cacheTasks(db, page, { storage })).toBe(1)
+    expect(await listCachedTasks(db, 'ws1', IDBKeyRange)).toHaveLength(1)
+    expect(await listCachedTasks(db, 'ws2', IDBKeyRange)).toHaveLength(0)
+    db.close()
+  })
+
+  it('has nothing to write for a list that never arrived', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+
+    expect(await cacheTasks(db, undefined, { storage: allOn })).toBe(0)
+    expect(await cacheTasks(db, null, { storage: allOn })).toBe(0)
+    expect(await cacheTasks(db, [], { storage: allOn })).toBe(0)
+    db.close()
+  })
+})
+
+describe('cacheTaskUpdate', () => {
+  it('caches the merged task, not the payload the event carried', async () => {
+    // A payload built without its relations is indistinguishable from one whose
+    // relations are genuinely empty. Caching the raw one would write an emptied
+    // tool lane to disk, where it would outlive the reload that fixes it today.
+    const db = await openCache({ userId: 'u1', factory })
+    const onScreen = makeTask({ toolCalls: [{ id: 't1' }], messages: [{ id: 'm1' }] })
+    const fromEvent = makeTask({ status: 'ongoing', toolCalls: [], messages: [] })
+
+    const merged = cacheTaskUpdate(db, onScreen, fromEvent, { storage: allOn })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(merged.status).toBe('ongoing')
+    expect(merged.toolCalls).toEqual([{ id: 't1' }])
+
+    const back = await getCachedTask(db, 'ws1', '0iCYTqxKOqv')
+    expect(back.toolCalls).toEqual([{ id: 't1' }])
+    expect(back.status).toBe('ongoing')
+    db.close()
+  })
+
+  it('returns the merge so the view and the cache agree', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+
+    const merged = cacheTaskUpdate(db, null, makeTask({ title: 'Fresh' }), { storage: allOn })
+
+    expect(merged.title).toBe('Fresh')
+    db.close()
+  })
+
+  it('caches nothing when the event carried nothing', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+
+    expect(cacheTaskUpdate(db, null, null, { storage: allOn })).toBeNull()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(await listCachedTasks(db, 'ws1', IDBKeyRange)).toEqual([])
+    db.close()
+  })
+})
+
+describe('cacheTaskEvent', () => {
+  it('merges against what the cache holds, since nothing is on screen', async () => {
+    // The shell watches every workspace, so most events it sees are for tasks
+    // nobody has open. Writing the payload straight through would overwrite the
+    // relations already stored with the ones the payload happens to omit.
+    const db = await openCache({ userId: 'u1', factory })
+    await cacheTask(db, makeTask({ toolCalls: [{ id: 't1' }] }), { storage: allOn })
+
+    const written = await cacheTaskEvent(db, makeTask({ status: 'ongoing', toolCalls: [] }), {
+      storage: allOn,
+    })
+
+    expect(written).toBe(true)
+    const back = await getCachedTask(db, 'ws1', '0iCYTqxKOqv')
+    expect(back.status).toBe('ongoing')
+    expect(back.toolCalls).toEqual([{ id: 't1' }])
+    db.close()
+  })
+
+  it('writes a task the cache has never seen as it arrived', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+
+    expect(await cacheTaskEvent(db, makeTask({ toolCalls: [{ id: 't1' }] }), { storage: allOn })).toBe(
+      true
+    )
+
+    const back = await getCachedTask(db, 'ws1', '0iCYTqxKOqv')
+    expect(back.toolCalls).toEqual([{ id: 't1' }])
+    db.close()
+  })
+
+  it('writes nothing for an opted-out workspace, without even reading it', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+    const off = storageWith({ [cacheSettingKey('ws1')]: SETTING_OFF })
+
+    expect(await cacheTaskEvent(db, makeTask(), { storage: off })).toBe(false)
+    db.close()
+  })
+
+  it('writes nothing without a cache or a usable payload', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+
+    expect(await cacheTaskEvent(null, makeTask(), { storage: allOn })).toBe(false)
+    expect(await cacheTaskEvent(db, null, { storage: allOn })).toBe(false)
+    expect(await cacheTaskEvent(db, { id: 'x' }, { storage: allOn })).toBe(false)
+    expect(await cacheTaskEvent(db, { workspaceId: 'ws1' }, { storage: allOn })).toBe(false)
+    db.close()
+  })
+})
+
+describe('connectCache', () => {
+  it('opens once and hands the same connection to everyone', async () => {
+    const db = await connectCache('u1', { factory })
+
+    expect(db).not.toBeNull()
+    expect(await connectCache('u1', { factory })).toBe(db)
+    expect(sharedCache()).toBe(db)
+  })
+
+  it('shares one attempt between callers who ask at the same time', async () => {
+    const opened = await Promise.all([
+      connectCache('u1', { factory }),
+      connectCache('u1', { factory }),
+      connectCache('u1', { factory }),
+    ])
+
+    expect(opened[0]).toBe(opened[1])
+    expect(opened[1]).toBe(opened[2])
+  })
+
+  it('drops the previous connection when a different user signs in', async () => {
+    // A real sequence on the web, where one origin outlives a session.
+    const first = await connectCache('u1', { factory })
+    let closed = false
+    const realClose = first.close.bind(first)
+    first.close = () => {
+      closed = true
+      realClose()
+    }
+
+    const second = await connectCache('u2', { factory })
+
+    expect(closed).toBe(true)
+    expect(second).not.toBe(first)
+    expect(sharedCache()).toBe(second)
+  })
+
+  it('lets a reset during the open win', async () => {
+    const opening = connectCache('u1', { factory })
+    resetSharedCache()
+
+    expect(await opening).toBeNull()
+    expect(sharedCache()).toBeNull()
+  })
+
+  it('reports no cache without a user to name the database after', async () => {
+    expect(await connectCache('', { factory })).toBeNull()
+    expect(await connectCache(undefined, { factory })).toBeNull()
+    expect(sharedCache()).toBeNull()
+  })
+
+  it('reports no cache when there is none to be had', async () => {
+    // A private window, or storage turned off. Callers go to the network, which
+    // is what they would have done anyway.
+    expect(await connectCache('u1', { factory: null })).toBeNull()
+    expect(sharedCache()).toBeNull()
+  })
+
+  it('retries after a failed open rather than caching the failure', async () => {
+    expect(await connectCache('u1', { factory: null })).toBeNull()
+
+    expect(await connectCache('u1', { factory })).not.toBeNull()
+  })
+
+  it('closes cleanly when there was never a connection', () => {
+    expect(() => resetSharedCache()).not.toThrow()
+    expect(sharedCache()).toBeNull()
+  })
+})
+
+describe('the rule this module enforces', () => {
+  it('offers no way to write a task the server did not send', async () => {
+    // There is no queue, no replay and no local-edit path — every export either
+    // reads a setting or writes something that arrived from the backend. If a
+    // later change adds one, this list is where it shows up.
+    const surface = await import('../src/composables/useCachedTasks')
+    const writers = Object.keys(surface).filter((name) => /^(cache|connect)/.test(name))
+
+    expect(writers.sort()).toEqual([
+      'cacheSettingKey',
+      'cacheTask',
+      'cacheTaskEvent',
+      'cacheTaskUpdate',
+      'cacheTasks',
+      'connectCache',
+    ])
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -50,6 +50,7 @@ export default defineConfig({
         'src/composables/useTaskFinder.js',
         'src/composables/useLocalCache.js',
         'src/composables/useTaskIndex.js',
+        'src/composables/useCachedTasks.js',
       ],
       reporter: ['text', 'lcov'],
       thresholds: {


### PR DESCRIPTION
> **Stacked on #414, which is stacked on #413.** Merge those two first; GitHub retargets this to `main` automatically when they land with "Squash and merge" + "Delete branch". The diff shown here is this change alone.

## What changed

Every place a task arrives from the backend now also writes it to the local store: the global task list, the workspace board, the open task, and both live event streams. Reads still go to the network — a later step starts reading from the cache. This one only makes sure there is something correct to read.

Third of seven steps toward searching tasks by title and description without touching the backend. [Full plan](https://claude.ai/code/artifact/721b0aaf-e687-488c-a9b1-9077b60e4d2a).

## Why changed

The cache is written **only from server responses and events** — never from a user action, and never replayed back. There is no write queue and no conflict resolution, because there is nothing to reconcile: every row came from the backend, so the local copy can be stale but never *divergent*. That is a deliberately small promise, and it is what makes the feature safe to ship. Anything that let a local edit outlive a failed request would need an answer for two people editing the same task, and this has none.

Two decisions worth stating:

**The merged task is cached, never the raw event payload.** A payload built without its relations is indistinguishable from one whose relations are genuinely empty — the bug the existing merge helper exists to make unrepresentable. Caching the raw payload would write that same emptied tool lane to disk, where it would outlive the reload that currently fixes it.

That turned out to need two paths rather than one. The task detail merges against the task on screen, which is freshest. But the shell watches a stream covering *every* workspace, so most events it sees are for tasks nobody has open — there is nothing on screen to merge against, and merging against nothing would write exactly the payload we are trying not to trust. So there it merges against the **cached** copy, which plays the same part. A task the cache has never seen has nothing to lose and is written as it arrived.

**A storage that cannot be read means off, not on.** Failing to cache costs a little speed; caching for someone who turned it off breaks a promise made to them. Only one of those is worth risking, so an unreadable setting resolves to off.

The per-workspace setting is *read* here and written by the settings step. It is per workspace and per device, deliberately unlike every other workspace setting: what it controls is a per-device store against a per-device quota, so the same workspace can be cached on one machine and not another, and neither learns about the other.

## Test coverage report

**New lines introduced: 100%.** The new module is on the enforced `coverage.include` list:

```
File               | % Stmts | % Branch | % Funcs | % Lines
useCachedTasks.js  |     100 |      100 |     100 |     100
All files          |     100 |      100 |     100 |     100
```

**Total coverage impact: none — the suite stays at the 100% the config enforces.** 384 tests passing; 31 are new. They cover the opt-out being honoured per workspace within a single mixed page, the merge-not-payload rule on both event paths, terms being written, attachment bytes never being written, and a write failure never breaking the view that triggered it.

There is also a test asserting the module's exported surface, so a later change that adds a way to write a task the server did not send has to change that list deliberately.

## Other reports

Verified in a real browser against an isolated backend and database, on ports that left the running dev server alone:

- Browsing the task list creates `agentrq-cache:<userId>` and writes 4 tasks, terms populated (`["ship","billing","reconciliation","fix"]`), with no attachment bytes present
- Opting a workspace out and clearing the store leaves **0** tasks written on the next load
- Removing the opt-out brings all 4 back

`npm run build` is clean. No backend change and no new dependency.

TaskID: 0iCis5DVpAH

🤖 Generated with [Claude Code](https://claude.com/claude-code)