### PR TITLE
feat(cache): let people see the local copy, stop it, and delete it

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -395,6 +395,7 @@ import { useFormat } from './composables/useFormat'
 import { usePushNotifications } from './composables/usePushNotifications'
 import Toast from './components/Toast.vue'
 import { cacheTaskEvent, connectCache, sharedCache } from './composables/useCachedTasks'
+import { forgetEverything } from './composables/useCacheStorage'
 import CommandPalette from './components/CommandPalette.vue'
 import ShortcutsHelp from './components/ShortcutsHelp.vue'
 import {
@@ -593,6 +594,10 @@ const hideTooltip = () => {
 
 async function logout() {
   await unsubscribePush()
+  // Unconditional, and before the request: a browser several people use must
+  // not leave one person's task titles readable by the next, and that has to
+  // hold even if the sign-out call itself fails.
+  await forgetEverything({ userId: user.value?.id })
   await fetch(`${API_BASE_URL}/auth/logout`, { method: 'POST' })
   router.push('/login')
 }

--- a/frontend/src/composables/useCacheStorage.js
+++ b/frontend/src/composables/useCacheStorage.js
@@ -1,0 +1,138 @@
+import { cacheSettingKey, resetSharedCache, SETTING_OFF } from './useCachedTasks';
+import { clearWorkspace, destroyCache } from './useLocalCache';
+
+/**
+ * Owning the local copy: turning it off, seeing what it costs, and getting rid
+ * of it.
+ *
+ * The cache holds a readable copy of someone's task titles and conversations on
+ * their disk, so the three things they must be able to do are see how much of
+ * it there is, stop it, and delete it. Everything here exists for one of those.
+ */
+
+/**
+ * Turn the local copy on or off for one workspace, on this device.
+ *
+ * Off is stored; on is the absence of the setting. That keeps the default in
+ * one place — the reader — rather than in every device that has ever opened the
+ * workspace, and it means a workspace nobody has an opinion about takes up no
+ * storage keys at all.
+ *
+ * @returns {boolean} whether the preference was recorded
+ */
+export function setCacheEnabled(workspaceId, enabled, storage = globalThis.localStorage) {
+  if (!workspaceId || !storage) return false;
+  try {
+    if (enabled) storage.removeItem(cacheSettingKey(workspaceId));
+    else storage.setItem(cacheSettingKey(workspaceId), SETTING_OFF);
+    return true;
+  } catch {
+    // A storage that cannot be written is one the reader will refuse to trust
+    // either, so this resolves to the same place: no local copy.
+    return false;
+  }
+}
+
+/** Sizes as people read them, at the precision the number deserves. */
+const UNITS = ['B', 'KB', 'MB', 'GB'];
+
+/**
+ * A byte count as a short human string.
+ *
+ * One decimal place below 10 and none above it, so "9.4 MB" and "312 MB" both
+ * read at a glance without implying precision the estimate does not have —
+ * browsers deliberately round what they report.
+ */
+export function formatBytes(bytes) {
+  const n = Number(bytes);
+  if (!Number.isFinite(n) || n <= 0) return '0 B';
+
+  let value = n;
+  let unit = 0;
+  while (value >= 1024 && unit < UNITS.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  const rounded = value < 10 && unit > 0 ? value.toFixed(1) : Math.round(value);
+  return `${rounded} ${UNITS[unit]}`;
+}
+
+/**
+ * How much storage this origin is using, as the browser reports it.
+ *
+ * Whole-origin rather than per-workspace: the browser does not break its
+ * estimate down, and inventing a per-workspace figure by adding up record sizes
+ * would be a guess presented as a measurement. Better to say what is actually
+ * known.
+ *
+ * Resolves to null when the browser will not say — older engines, and private
+ * windows that decline. The caller hides the figure rather than showing zero,
+ * because zero is a claim and null is an absence.
+ */
+export async function estimateUsage(manager = globalThis.navigator?.storage) {
+  if (!manager?.estimate) return null;
+  try {
+    const { usage, quota } = (await manager.estimate()) ?? {};
+    if (!Number.isFinite(usage)) return null;
+    return { usage, quota: Number.isFinite(quota) ? quota : 0 };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ask the browser not to evict this data under storage pressure.
+ *
+ * Worth asking once, and worth not caring about the answer: every engine has
+ * its own rules for granting it, and a cache that gets evicted behaves exactly
+ * like a cache that was never written. Never throws.
+ */
+export async function requestPersistence(manager = globalThis.navigator?.storage) {
+  if (!manager?.persist) return false;
+  try {
+    return (await manager.persist()) === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Forget one workspace's local copy, and report what that freed.
+ *
+ * The figure is measured rather than calculated — the difference between two
+ * estimates either side of the delete. That makes it honest about being an
+ * estimate, and it stays right when the stored shape changes later.
+ *
+ * A browser that will not estimate still clears; it just cannot say how much,
+ * and `reclaimed` is null rather than a made-up zero.
+ *
+ * @returns {Promise<{cleared: boolean, reclaimed: number|null}>}
+ */
+export async function clearWorkspaceData(db, workspaceId, options = {}) {
+  const { KeyRange = globalThis.IDBKeyRange, manager } = options;
+  if (!db || !workspaceId) return { cleared: false, reclaimed: null };
+
+  const before = await estimateUsage(manager);
+  const cleared = await clearWorkspace(db, workspaceId, KeyRange);
+  if (!cleared) return { cleared: false, reclaimed: null };
+
+  const after = await estimateUsage(manager);
+  const reclaimed =
+    before && after ? Math.max(0, before.usage - after.usage) : null;
+  return { cleared: true, reclaimed };
+}
+
+/**
+ * Everything this device holds for a user, gone.
+ *
+ * Signing out runs this, and it is deliberately unconditional. A browser that
+ * several people use must not leave one person's task titles readable by the
+ * next, and there is no partial version of that guarantee worth having — so it
+ * does not consult the per-workspace setting, and does not care whether the
+ * delete was blocked by another tab. The connection is dropped either way.
+ */
+export async function forgetEverything({ userId, factory = globalThis.indexedDB } = {}) {
+  resetSharedCache();
+  if (!userId) return false;
+  return destroyCache({ userId, factory });
+}

--- a/frontend/src/views/WorkspaceSettingsView.vue
+++ b/frontend/src/views/WorkspaceSettingsView.vue
@@ -101,6 +101,43 @@
                     </div>
                     <p class="text-[9px] text-gray-500 dark:text-zinc-500 font-bold uppercase tracking-wider ml-1 mt-1">Hold sent messages for a countdown before delivery, with a chance to cancel.</p>
                   </div>
+
+                  <!-- Local data.
+                       Set apart from everything above it on purpose: those
+                       settings follow the account, and this one does not. A
+                       toggle that looks like its neighbours would be flipped
+                       here and expected to take effect on another machine. -->
+                  <div class="border border-dashed border-gray-300 dark:border-zinc-700 rounded-sm p-6 space-y-4 bg-gray-50/40 dark:bg-zinc-800/20">
+                    <div class="flex items-start justify-between gap-6">
+                      <div class="min-w-0">
+                        <div class="flex items-center gap-2 flex-wrap">
+                          <h4 class="text-sm font-bold text-gray-900 dark:text-zinc-100">Keep a copy on this device</h4>
+                          <span class="text-[9px] font-black uppercase tracking-widest text-gray-500 dark:text-zinc-400 border border-gray-300 dark:border-zinc-600 rounded-sm px-1.5 py-0.5">This device only</span>
+                        </div>
+                        <p class="text-[11px] text-gray-600 dark:text-zinc-400 mt-1.5 font-medium leading-relaxed">
+                          Tasks you open are kept locally so lists appear instantly and you can search their titles and descriptions without a connection.
+                          <span class="block mt-1 text-gray-500 dark:text-zinc-500">This choice is not shared with your other devices, and the server is always what an open task shows.</span>
+                        </p>
+                      </div>
+                      <button type="button" role="switch" :aria-checked="localCacheOn" @click="toggleLocalCache"
+                              class="shrink-0 mt-1 w-11 h-6 rounded-full border transition-colors relative"
+                              :class="localCacheOn ? 'bg-gray-900 dark:bg-white border-gray-900 dark:border-white' : 'bg-gray-200 dark:bg-zinc-700 border-gray-300 dark:border-zinc-600'">
+                        <span class="absolute top-0.5 w-4 h-4 rounded-full transition-all"
+                              :class="localCacheOn ? 'left-[22px] bg-white dark:bg-zinc-900' : 'left-0.5 bg-white dark:bg-zinc-400'"></span>
+                      </button>
+                    </div>
+
+                    <div class="flex items-center justify-between gap-4 pt-3 border-t border-gray-200 dark:border-zinc-700/60">
+                      <p class="text-[11px] text-gray-500 dark:text-zinc-400 font-medium">
+                        <span v-if="localUsageLabel">This browser is storing <span class="font-bold text-gray-900 dark:text-zinc-100">{{ localUsageLabel }}</span> across all workspaces.</span>
+                        <span v-else>Your browser does not report how much it is storing.</span>
+                      </p>
+                      <button type="button" @click="clearLocalData()" :disabled="isClearingLocal"
+                              class="shrink-0 px-5 py-2 bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-700 text-[10px] font-bold text-gray-900 dark:text-zinc-100 hover:border-black dark:hover:border-white transition-all shadow-sm rounded-sm uppercase tracking-widest disabled:opacity-50 whitespace-nowrap">
+                        {{ isClearingLocal ? 'Clearing' : 'Clear this workspace' }}
+                      </button>
+                    </div>
+                  </div>
                 </div>
 
                 <!-- Setup -->
@@ -684,13 +721,21 @@ import ArchiveModal from '../components/ArchiveModal.vue';
 import DeleteModal from '../components/DeleteModal.vue';
 import { useWorkspaceStore } from '../stores/workspaceStore';
 import { useFormat } from '../composables/useFormat';
+import { isCacheEnabled, sharedCache } from '../composables/useCachedTasks';
+import {
+  clearWorkspaceData,
+  estimateUsage,
+  formatBytes,
+  requestPersistence,
+  setCacheEnabled,
+} from '../composables/useCacheStorage';
 import { WHISPER_LANGUAGES } from '../utils/whisperLanguages';
 
 const { toKebabCase, liveKebabCase } = useFormat();
 
 const route = useRoute();
 const router = useRouter();
-const { notifySuccess, notifyError } = useToasts();
+const { notifySuccess, notifyError, notifyInfo } = useToasts();
 const workspaceId = computed(() => route.params.id);
 
 const workspace = ref(null);
@@ -1216,6 +1261,8 @@ async function doDelete() {
   showDeleteConfirm.value = false;
   try {
     await deleteWorkspace(workspaceId.value);
+    // Otherwise the finder keeps offering tasks that no longer exist anywhere.
+    await clearWorkspaceData(sharedCache(), workspaceId.value);
     notifySuccess("Workspace purged");
     router.push('/');
   } catch (err) {
@@ -1231,8 +1278,59 @@ function getShellPattern(tool) {
   return pattern === '*' ? 'all commands' : pattern;
 }
 
+// --- Local data -------------------------------------------------------------
+// Unlike everything else on this screen, this preference never leaves the
+// device. It is read straight from local storage rather than from `form`, which
+// is the shape that gets sent to the server on save.
+
+const localCacheOn = ref(true);
+const localUsage = ref(null);
+const isClearingLocal = ref(false);
+
+const localUsageLabel = computed(() =>
+  localUsage.value ? formatBytes(localUsage.value.usage) : ''
+);
+
+async function refreshLocalUsage() {
+  localUsage.value = await estimateUsage();
+}
+
+async function toggleLocalCache() {
+  const next = !localCacheOn.value;
+  setCacheEnabled(workspaceId.value, next);
+  localCacheOn.value = isCacheEnabled(workspaceId.value);
+
+  // Turning it off clears immediately rather than leaving data behind that
+  // nothing will ever update again.
+  if (!localCacheOn.value) await clearLocalData({ quiet: true });
+  else notifySuccess('This workspace will be kept on this device');
+}
+
+async function clearLocalData({ quiet = false } = {}) {
+  if (isClearingLocal.value) return;
+  isClearingLocal.value = true;
+  try {
+    const { cleared, reclaimed } = await clearWorkspaceData(sharedCache(), workspaceId.value);
+    await refreshLocalUsage();
+    if (quiet) return;
+    if (!cleared) notifyInfo('There was nothing stored on this device');
+    else notifySuccess(
+      reclaimed === null
+        ? 'Local copy cleared'
+        : `Local copy cleared, freeing ${formatBytes(reclaimed)}`
+    );
+  } finally {
+    isClearingLocal.value = false;
+  }
+}
+
 onMounted(() => {
   load();
+  localCacheOn.value = isCacheEnabled(workspaceId.value);
+  refreshLocalUsage();
+  // Asked once, and the answer does not change what the app does — a cache that
+  // gets evicted behaves exactly like one that was never written.
+  requestPersistence();
   if (route.query.tab) {
     activeTab.value = route.query.tab;
   }

--- a/frontend/test/cacheStorage.test.js
+++ b/frontend/test/cacheStorage.test.js
@@ -1,0 +1,287 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { IDBFactory, IDBKeyRange } from 'fake-indexeddb'
+
+import {
+  clearWorkspaceData,
+  estimateUsage,
+  forgetEverything,
+  formatBytes,
+  requestPersistence,
+  setCacheEnabled,
+} from '../src/composables/useCacheStorage'
+import {
+  cacheSettingKey,
+  cacheTask,
+  connectCache,
+  isCacheEnabled,
+  resetSharedCache,
+  sharedCache,
+} from '../src/composables/useCachedTasks'
+import { listCachedTasks, openCache } from '../src/composables/useLocalCache'
+
+let factory
+beforeEach(() => {
+  factory = new IDBFactory()
+})
+afterEach(() => {
+  resetSharedCache()
+})
+
+/** A localStorage that records what it was told. */
+const makeStorage = () => {
+  const entries = new Map()
+  return {
+    entries,
+    getItem: (key) => (entries.has(key) ? entries.get(key) : null),
+    setItem: (key, value) => entries.set(key, value),
+    removeItem: (key) => entries.delete(key),
+  }
+}
+
+const makeTask = (over = {}) => ({
+  id: '0iCYTqxKOqv',
+  workspaceId: 'ws1',
+  title: 'Ship the billing reconciliation fix',
+  body: 'The nightly job double-counts refunds.',
+  updatedAt: '2026-09-02T10:00:00Z',
+  ...over,
+})
+
+const allOn = { getItem: () => null }
+
+describe('setCacheEnabled', () => {
+  it('records off, and records on as the absence of the setting', () => {
+    // The default lives in the reader, not in every device that has ever opened
+    // the workspace — so "on" leaves no key behind.
+    const storage = makeStorage()
+
+    setCacheEnabled('ws1', false, storage)
+    expect(storage.getItem(cacheSettingKey('ws1'))).toBe('off')
+
+    setCacheEnabled('ws1', true, storage)
+    expect(storage.entries.has(cacheSettingKey('ws1'))).toBe(false)
+  })
+
+  it('round-trips with the reader', () => {
+    const storage = makeStorage()
+
+    setCacheEnabled('ws1', false, storage)
+    expect(isCacheEnabled('ws1', storage)).toBe(false)
+
+    setCacheEnabled('ws1', true, storage)
+    expect(isCacheEnabled('ws1', storage)).toBe(true)
+  })
+
+  it('answers for one workspace without touching another', () => {
+    const storage = makeStorage()
+
+    setCacheEnabled('ws1', false, storage)
+
+    expect(isCacheEnabled('ws1', storage)).toBe(false)
+    expect(isCacheEnabled('ws2', storage)).toBe(true)
+  })
+
+  it('reports it could not record the choice', () => {
+    const throwing = {
+      setItem() {
+        throw new Error('storage full')
+      },
+      removeItem() {
+        throw new Error('storage full')
+      },
+    }
+
+    expect(setCacheEnabled('ws1', false, throwing)).toBe(false)
+    expect(setCacheEnabled('ws1', true, throwing)).toBe(false)
+    expect(setCacheEnabled('ws1', false, null)).toBe(false)
+    expect(setCacheEnabled('', false, makeStorage())).toBe(false)
+  })
+})
+
+describe('formatBytes', () => {
+  it('reads at a glance at every scale', () => {
+    expect(formatBytes(0)).toBe('0 B')
+    expect(formatBytes(512)).toBe('512 B')
+    expect(formatBytes(1024)).toBe('1.0 KB')
+    expect(formatBytes(1024 * 1024 * 9.4)).toBe('9.4 MB')
+    expect(formatBytes(1024 * 1024 * 312)).toBe('312 MB')
+    expect(formatBytes(1024 * 1024 * 1024 * 2.5)).toBe('2.5 GB')
+  })
+
+  it('stops at gigabytes rather than inventing a unit', () => {
+    expect(formatBytes(1024 ** 4)).toBe('1024 GB')
+  })
+
+  it('says nothing rather than something wrong for a non-number', () => {
+    expect(formatBytes(undefined)).toBe('0 B')
+    expect(formatBytes(null)).toBe('0 B')
+    expect(formatBytes(-5)).toBe('0 B')
+    expect(formatBytes(NaN)).toBe('0 B')
+    expect(formatBytes(Infinity)).toBe('0 B')
+  })
+})
+
+describe('estimateUsage', () => {
+  it('reports what the browser says', async () => {
+    const manager = { estimate: async () => ({ usage: 1234, quota: 99999 }) }
+
+    expect(await estimateUsage(manager)).toEqual({ usage: 1234, quota: 99999 })
+  })
+
+  it('reports a usage without a quota rather than nothing', async () => {
+    const manager = { estimate: async () => ({ usage: 1234 }) }
+
+    expect(await estimateUsage(manager)).toEqual({ usage: 1234, quota: 0 })
+  })
+
+  it('says nothing when the browser will not', async () => {
+    // Null is an absence and zero is a claim. The caller hides the figure
+    // rather than reporting a number it does not have.
+    expect(await estimateUsage(undefined)).toBeNull()
+    expect(await estimateUsage({})).toBeNull()
+    expect(await estimateUsage({ estimate: async () => ({}) })).toBeNull()
+    expect(await estimateUsage({ estimate: async () => null })).toBeNull()
+    expect(
+      await estimateUsage({
+        estimate() {
+          throw new Error('denied in a private window')
+        },
+      })
+    ).toBeNull()
+  })
+})
+
+describe('requestPersistence', () => {
+  it('reports whether the browser agreed', async () => {
+    expect(await requestPersistence({ persist: async () => true })).toBe(true)
+    expect(await requestPersistence({ persist: async () => false })).toBe(false)
+  })
+
+  it('never throws, whatever the engine does', async () => {
+    // A cache that gets evicted behaves exactly like one that was never
+    // written, so a refusal is not worth an error.
+    expect(await requestPersistence(undefined)).toBe(false)
+    expect(await requestPersistence({})).toBe(false)
+    expect(
+      await requestPersistence({
+        persist() {
+          throw new Error('not supported')
+        },
+      })
+    ).toBe(false)
+  })
+})
+
+describe('clearWorkspaceData', () => {
+  it('forgets one workspace and leaves the others', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+    await cacheTask(db, makeTask(), { storage: allOn })
+    await cacheTask(db, makeTask({ id: 'keep', workspaceId: 'ws2' }), { storage: allOn })
+
+    const result = await clearWorkspaceData(db, 'ws1', { KeyRange: IDBKeyRange })
+
+    expect(result.cleared).toBe(true)
+    expect(await listCachedTasks(db, 'ws1', IDBKeyRange)).toEqual([])
+    expect(await listCachedTasks(db, 'ws2', IDBKeyRange)).toHaveLength(1)
+    db.close()
+  })
+
+  it('measures what it freed rather than calculating it', async () => {
+    // The difference between two estimates either side of the delete, so it
+    // stays right when the stored shape changes later.
+    const db = await openCache({ userId: 'u1', factory })
+    await cacheTask(db, makeTask(), { storage: allOn })
+    const readings = [{ usage: 5000 }, { usage: 1200 }]
+    const manager = { estimate: async () => readings.shift() }
+
+    const result = await clearWorkspaceData(db, 'ws1', { KeyRange: IDBKeyRange, manager })
+
+    expect(result).toEqual({ cleared: true, reclaimed: 3800 })
+    db.close()
+  })
+
+  it('never reports a negative saving when the estimate wobbles', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+    const readings = [{ usage: 1000 }, { usage: 1400 }]
+    const manager = { estimate: async () => readings.shift() }
+
+    const result = await clearWorkspaceData(db, 'ws1', { KeyRange: IDBKeyRange, manager })
+
+    expect(result.reclaimed).toBe(0)
+    db.close()
+  })
+
+  it('still clears when the browser will not estimate', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+    await cacheTask(db, makeTask(), { storage: allOn })
+
+    const result = await clearWorkspaceData(db, 'ws1', { KeyRange: IDBKeyRange, manager: {} })
+
+    expect(result).toEqual({ cleared: true, reclaimed: null })
+    expect(await listCachedTasks(db, 'ws1', IDBKeyRange)).toEqual([])
+    db.close()
+  })
+
+  it('reports nothing cleared when there is nothing to clear from', async () => {
+    expect(await clearWorkspaceData(null, 'ws1', { KeyRange: IDBKeyRange })).toEqual({
+      cleared: false,
+      reclaimed: null,
+    })
+    const db = await openCache({ userId: 'u1', factory })
+    expect(await clearWorkspaceData(db, '', { KeyRange: IDBKeyRange })).toEqual({
+      cleared: false,
+      reclaimed: null,
+    })
+    db.close()
+  })
+
+  it('reports failure rather than throwing when the clear cannot run', async () => {
+    const broken = {
+      transaction() {
+        throw new Error('the connection went away')
+      },
+    }
+
+    expect(await clearWorkspaceData(broken, 'ws1', { KeyRange: IDBKeyRange })).toEqual({
+      cleared: false,
+      reclaimed: null,
+    })
+  })
+})
+
+describe('forgetEverything', () => {
+  it('deletes the database and drops the connection', async () => {
+    // Signing out. A browser several people use must not leave one person's
+    // task titles readable by the next.
+    const db = await connectCache('u1', { factory })
+    await cacheTask(db, makeTask(), { storage: allOn })
+
+    expect(await forgetEverything({ userId: 'u1', factory })).toBe(true)
+    expect(sharedCache()).toBeNull()
+
+    const fresh = await openCache({ userId: 'u1', factory })
+    expect(await listCachedTasks(fresh, 'ws1', IDBKeyRange)).toEqual([])
+    fresh.close()
+  })
+
+  it('does not consult the per-workspace setting', async () => {
+    // Deliberately unconditional: there is no partial version of this
+    // guarantee worth having.
+    const db = await connectCache('u1', { factory })
+    await cacheTask(db, makeTask(), { storage: allOn })
+
+    expect(await forgetEverything({ userId: 'u1', factory })).toBe(true)
+  })
+
+  it('still drops the connection when there is no user to name a database', async () => {
+    await connectCache('u1', { factory })
+
+    expect(await forgetEverything({})).toBe(false)
+    expect(sharedCache()).toBeNull()
+  })
+
+  it('runs safely when nothing was ever opened', async () => {
+    expect(await forgetEverything()).toBe(false)
+    expect(sharedCache()).toBeNull()
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -51,6 +51,7 @@ export default defineConfig({
         'src/composables/useLocalCache.js',
         'src/composables/useTaskIndex.js',
         'src/composables/useCachedTasks.js',
+        'src/composables/useCacheStorage.js',
       ],
       reporter: ['text', 'lcov'],
       thresholds: {


### PR DESCRIPTION
> **Stacked on #415 → #414 → #413.** Merge those first; GitHub retargets this automatically as each lands with "Squash and merge" + "Delete branch". The diff shown here is this change alone.

## What changed

Workspace settings gain a Local data block: a switch for whether this workspace is kept on this device, how much the browser is currently storing, and a button to delete it. Signing out, opting out, and purging a workspace all clear the local copy too.

Fourth of seven steps toward searching tasks by title and description without touching the backend. [Full plan](https://claude.ai/code/artifact/721b0aaf-e687-488c-a9b1-9077b60e4d2a).

## Why changed

The cache keeps a readable copy of someone's task titles and conversations on their own disk. The three things they must therefore be able to do are see how much of it there is, turn it off, and get rid of it — and all three now exist.

**The setting is local only, deliberately unlike every other setting on that screen.** It never reaches the backend and never syncs, so the same person in the same workspace can have it on at their desk and off on a laptop, with neither machine learning about the other. Two consequences are built in rather than left to be discovered: the copy says *on this device*, and the block is set apart from its neighbours with a dashed border and a badge — a control that looks like the synced ones will be flipped here and expected to take effect elsewhere.

Off is stored; on is the absence of the setting. That keeps the default in one place — the reader — rather than in every device that has ever opened the workspace.

**Four things clear the copy, for four different reasons:**

- The button, for one workspace.
- Turning the setting off, immediately, rather than orphaning data nothing will ever update again.
- Purging a workspace — otherwise the finder keeps offering tasks that no longer exist anywhere.
- Signing out. Unconditional, and *before* the sign-out request, so a browser several people use cannot leave one person's task titles readable by the next even if that request fails.

**The space freed is measured, not calculated** — the difference between two estimates taken either side of the delete. That stays right when the stored shape changes later, and it is reported as unknown rather than as zero when the browser will not estimate. Zero is a claim; nothing is an absence.

Desktop needed no work here: each profile already runs on its own Electron session partition, which partitions local storage and the database alike, so two profiles get two independent copies of both the data and the choice for free.

## Test coverage report

**New lines introduced: 100%.** The new module is on the enforced `coverage.include` list:

```
File               | % Stmts | % Branch | % Funcs | % Lines
useCacheStorage.js |     100 |      100 |     100 |     100
All files          |     100 |      100 |     100 |     100
```

**Total coverage impact: none — the suite stays at the 100% the config enforces.** 406 tests passing; 22 are new. They cover the default being on, the preference round-tripping with the reader, one workspace's choice not touching another's, byte formatting at every scale and for values that are not numbers, an unavailable estimate degrading to hiding the figure rather than erroring, the measured reclaim including the case where the estimate wobbles upward, and sign-out deleting everything regardless of any per-workspace choice.

## Other reports

Verified in a real browser against an isolated backend and database:

- The block renders with a live figure — *"This browser is storing 87 KB across all workspaces"*
- The switch reads on by default
- Turning it off writes the preference and empties that workspace's records on the spot, confirmed by reading the database directly afterwards

`npm run build` is clean. No backend change and no new dependency.

TaskID: 0iCitmbnrRR

🤖 Generated with [Claude Code](https://claude.com/claude-code)