### PR TITLE
feat(cache): search titles and descriptions with no request at all

### DIFF
--- a/frontend/src/components/CommandPalette.vue
+++ b/frontend/src/components/CommandPalette.vue
@@ -11,6 +11,8 @@ import { useRouter } from 'vue-router';
 
 import { fetchGlobalTasks, getTask } from '../api';
 import { looksLikeTaskId, matchTasks, resolveTaskById, taskRoute } from '../composables/useTaskFinder';
+import { searchCachedTasks } from '../composables/useCachedReads';
+import { sharedCache } from '../composables/useCachedTasks';
 import { useWorkspaceStore } from '../stores/workspaceStore';
 
 const props = defineProps({
@@ -31,10 +33,32 @@ const resolving = ref(false);
 const notFound = ref(false);
 const inputRef = ref(null);
 
-const results = computed(() => matchTasks(tasks.value, query.value));
+/**
+ * The rows on screen, and which search produced them.
+ *
+ * Not a computed, because the better of the two searches is asynchronous. The
+ * local index answers across every task this device has saved; the fallback
+ * filters whatever the recent-task fetch happened to return. `searchedLocally`
+ * exists so the panel can say which one answered — the two do not reach the
+ * same distance, and a box that hides the difference misleads whoever searches
+ * a title, finds nothing, and concludes the task is gone.
+ */
+const results = ref([]);
+const searchedLocally = ref(false);
+
+async function runSearch() {
+  const asked = query.value;
+  const local = await searchCachedTasks(sharedCache(), asked, { limit: 8 });
+
+  // A slower search for an older query must not overwrite a newer one's answer.
+  if (asked !== query.value) return;
+
+  searchedLocally.value = local !== null;
+  results.value = local ?? matchTasks(tasks.value, asked);
+}
 
 /**
- * Offer the ID lookup only when the filter has come up empty — until then the
+ * Offer the ID lookup only when the search has come up empty — until then the
  * query is answered by rows the user can already see, and firing one request
  * per workspace behind that would be noise.
  */
@@ -42,20 +66,29 @@ const canResolveId = computed(
   () => results.value.length === 0 && looksLikeTaskId(query.value) && !resolving.value
 );
 
-/**
- * How far each kind of search actually reaches.
- *
- * The two halves of this box do not have the same range, and the difference is
- * invisible unless it is said out loud: a title is matched here in the browser
- * against the tasks that happen to be loaded, while an ID is asked of the
- * server and finds anything the user owns. Someone who searches a title, sees
- * nothing, and concludes the task is gone has been misled by a box that looked
- * like it searched everything.
- *
- * Deliberately the real number rather than the 50 the API caps at — claiming a
- * reach the panel does not have is the same mistake in the other direction.
- */
+/** How many recent tasks the fallback has to work with. */
 const loadedCount = computed(() => tasks.value.length);
+
+/**
+ * Whether this device can answer a text search on its own.
+ *
+ * Drives the resting copy, which has to promise the right thing before anyone
+ * has typed: the local index reaches every task saved here, and the fallback
+ * reaches only what the last fetch returned.
+ */
+const canSearchLocally = computed(() => Boolean(sharedCache()));
+
+/**
+ * How far a title search actually reaches, in the fewest honest words.
+ *
+ * "Saved here" rather than "everything": the cache holds what has been opened,
+ * not a whole history, and claiming otherwise would be the same mistake this
+ * line exists to prevent.
+ */
+const titlesReach = computed(() => {
+  if (loading.value) return '…';
+  return canSearchLocally.value ? 'saved here' : `${loadedCount.value} recent`;
+});
 
 watch(
   () => props.show,
@@ -64,6 +97,8 @@ watch(
     query.value = '';
     highlighted.value = 0;
     notFound.value = false;
+    results.value = [];
+    searchedLocally.value = false;
     await nextTick();
     inputRef.value?.focus();
     loadRecent();
@@ -73,7 +108,12 @@ watch(
 watch(query, () => {
   highlighted.value = 0;
   notFound.value = false;
+  runSearch();
 });
+
+// The recent-task fetch only matters to the fallback, but it lands after the
+// panel opens, so the resting list has to be refreshed when it does.
+watch(tasks, () => runSearch());
 
 async function loadRecent() {
   loading.value = true;
@@ -140,7 +180,7 @@ async function submit() {
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35M17 11a6 6 0 11-12 0 6 6 0 0112 0z" />
             </svg>
             <input ref="inputRef" v-model="query" type="text" autocomplete="off" spellcheck="false"
-                   placeholder="Task ID, or part of a recent title"
+                   :placeholder="canSearchLocally ? 'Task ID, or any word in a title or description' : 'Task ID, or part of a recent title'"
                    class="grow bg-transparent text-[14px] text-gray-900 dark:text-zinc-100 placeholder:text-gray-400 dark:placeholder:text-zinc-600 focus:outline-none"
                    @keydown.down.prevent="move(1)"
                    @keydown.up.prevent="move(-1)"
@@ -175,15 +215,18 @@ async function submit() {
               Not in the recent tasks. Press <span class="font-semibold text-gray-900 dark:text-zinc-100">Enter</span> to look this ID up across your workspaces.
             </p>
             <p v-else-if="query" class="text-[12px] text-gray-500 dark:text-zinc-400">
-              No match in your {{ loadedCount }} most recent tasks.
+              <span v-if="searchedLocally">No match in the tasks saved on this device.</span>
+              <span v-else>No match in your {{ loadedCount }} most recent tasks.</span>
               <span class="block mt-1 text-gray-400 dark:text-zinc-500">
-                Title search only covers those — paste a full task ID to search every workspace.
+                <template v-if="searchedLocally">A task you have never opened here was never saved — paste its ID to search every workspace.</template>
+                <template v-else>Title search only covers those — paste a full task ID to search every workspace.</template>
               </span>
             </p>
             <p v-else class="text-[12px] text-gray-500 dark:text-zinc-400">
-              Search the titles of your {{ loadedCount }} most recent tasks.
+              <span v-if="canSearchLocally">Search the titles and descriptions of every task saved on this device, offline.</span>
+              <span v-else>Search the titles of your {{ loadedCount }} most recent tasks.</span>
               <span class="block mt-1 text-gray-400 dark:text-zinc-500">
-                To reach older ones, paste a task ID<span v-if="shortcutLabel"> — {{ shortcutLabel }} reopens this</span>.
+                To reach a task that is not here, paste its ID<span v-if="shortcutLabel"> — {{ shortcutLabel }} reopens this</span>.
               </span>
             </p>
           </div>
@@ -197,7 +240,7 @@ async function submit() {
               <span class="text-[9px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-500">↵ Open</span>
             </span>
             <span class="text-[9px] text-right text-gray-400 dark:text-zinc-500 truncate">
-              Titles: <span class="text-gray-500 dark:text-zinc-400">{{ loading ? '…' : loadedCount }} recent</span>
+              Titles: <span class="text-gray-500 dark:text-zinc-400">{{ titlesReach }}</span>
               · IDs: <span class="text-gray-500 dark:text-zinc-400">every workspace</span>
             </span>
           </div>

--- a/frontend/src/composables/useCachedReads.js
+++ b/frontend/src/composables/useCachedReads.js
@@ -1,7 +1,14 @@
 import { onMounted, onUnmounted, ref } from 'vue';
 
 import { isCacheEnabled } from './useCachedTasks';
-import { getCachedTask, listAllCachedTasks, listCachedTasks } from './useLocalCache';
+import {
+  getCachedTask,
+  listAllCachedTasks,
+  listCachedTasks,
+  taskKeysForTerm,
+  tasksByKeys,
+} from './useLocalCache';
+import { intersect, rank, termRanges } from './useTaskIndex';
 
 /**
  * Reading the local copy, and the rules about when it is allowed to be shown.
@@ -79,6 +86,39 @@ export async function readAllCachedTasks(db, options = {}) {
   });
 
   return limit > 0 ? rows.slice(0, limit) : rows;
+}
+
+/**
+ * Search cached task titles and descriptions, with no request at all.
+ *
+ * This is the point of the whole cache. Each word becomes a seek into the term
+ * index rather than a scan of every task, the seeks are intersected so a second
+ * word narrows rather than widens, and only the survivors are read as records.
+ *
+ * Returns null — not an empty array — when the local index cannot answer, which
+ * the caller needs to tell apart from "searched and found nothing". Null means
+ * fall back to filtering whatever is already loaded; empty means the local index
+ * genuinely holds no match.
+ *
+ * @returns {Promise<Array<object>|null>}
+ */
+export async function searchCachedTasks(db, query, options = {}) {
+  const { storage, KeyRange = globalThis.IDBKeyRange, limit = 8 } = options;
+  if (!db) return null;
+
+  const ranges = termRanges(query, KeyRange);
+  // A query of nothing, or of nothing but stopwords, constrains nothing — and
+  // an unconstrained "search" is just the recent list, which the caller already
+  // has. Saying so is more useful than returning everything.
+  if (ranges.length === 0) return null;
+
+  const keyLists = await Promise.all(ranges.map((range) => taskKeysForTerm(db, range)));
+  const keys = intersect(keyLists);
+  if (keys.length === 0) return [];
+
+  const rows = await tasksByKeys(db, keys);
+  const visible = rows.filter((row) => isCacheEnabled(row.workspaceId, storage));
+  return rank(visible, query, limit);
 }
 
 /**

--- a/frontend/src/composables/useLocalCache.js
+++ b/frontend/src/composables/useLocalCache.js
@@ -336,6 +336,35 @@ export async function listCachedTasks(db, workspaceId, KeyRange = globalThis.IDB
 }
 
 /**
+ * The primary keys of every task carrying a term in `range`.
+ *
+ * Keys rather than records, because a query with two words asks this twice and
+ * only the intersection is worth reading. Fetching whole records for each word
+ * and discarding most of them is the version of this that does not scale.
+ */
+export async function taskKeysForTerm(db, range) {
+  if (!db) return [];
+
+  return attempt(async () => {
+    const tx = db.transaction(STORE_TASKS, 'readonly');
+    return requestResult(tx.objectStore(STORE_TASKS).index('by_term').getAllKeys(range));
+  }, []);
+}
+
+/** The task records for a set of primary keys, in the order given. */
+export async function tasksByKeys(db, keys) {
+  const list = Array.isArray(keys) ? keys : [];
+  if (!db || list.length === 0) return [];
+
+  return attempt(async () => {
+    const tx = db.transaction(STORE_TASKS, 'readonly');
+    const store = tx.objectStore(STORE_TASKS);
+    const rows = await Promise.all(list.map((key) => requestResult(store.get(key))));
+    return rows.filter(Boolean);
+  }, []);
+}
+
+/**
  * Every cached task, across every workspace, newest first.
  *
  * One scan rather than a read per workspace, because the caller that needs this

--- a/frontend/test/cachedSearch.test.js
+++ b/frontend/test/cachedSearch.test.js
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { IDBFactory, IDBKeyRange } from 'fake-indexeddb'
+
+import { searchCachedTasks } from '../src/composables/useCachedReads'
+import { cacheSettingKey, cacheTask, resetSharedCache } from '../src/composables/useCachedTasks'
+import { openCache, taskKeysForTerm, tasksByKeys } from '../src/composables/useLocalCache'
+
+let factory
+beforeEach(() => {
+  factory = new IDBFactory()
+})
+afterEach(() => {
+  resetSharedCache()
+})
+
+const allOn = { getItem: () => null }
+const offFor = (id) => ({ getItem: (key) => (key === cacheSettingKey(id) ? 'off' : null) })
+const opts = { storage: allOn, KeyRange: IDBKeyRange }
+
+const makeTask = (over = {}) => ({
+  id: 'aaaaaaaaaaa',
+  workspaceId: 'ws1',
+  title: 'Ship the billing reconciliation fix',
+  body: 'The nightly job double-counts refunds.',
+  updatedAt: '2026-09-02T10:00:00Z',
+  ...over,
+})
+
+/** A cache holding three tasks that overlap in useful ways. */
+async function seeded() {
+  const db = await openCache({ userId: 'u1', factory })
+  await cacheTask(db, makeTask(), { storage: allOn })
+  await cacheTask(
+    db,
+    makeTask({ id: 'bbbbbbbbbbb', title: 'Billing dashboard copy', body: 'Wording only.' }),
+    { storage: allOn }
+  )
+  await cacheTask(
+    db,
+    makeTask({
+      id: 'ccccccccccc',
+      workspaceId: 'ws2',
+      title: 'Unrelated groundwork',
+      body: 'Nothing to do with money.',
+    }),
+    { storage: allOn }
+  )
+  return db
+}
+
+describe('taskKeysForTerm and tasksByKeys', () => {
+  it('finds keys by term and reads only those records', async () => {
+    // Keys first, records second: a two-word query asks the index twice and
+    // only the intersection is worth reading.
+    const db = await seeded()
+
+    const keys = await taskKeysForTerm(db, IDBKeyRange.bound('billing', 'billing￿'))
+    expect(keys).toHaveLength(2)
+
+    const rows = await tasksByKeys(db, keys)
+    expect(rows.map((r) => r.id).sort()).toEqual(['aaaaaaaaaaa', 'bbbbbbbbbbb'])
+    db.close()
+  })
+
+  it('returns nothing rather than throwing when there is no cache', async () => {
+    expect(await taskKeysForTerm(null, IDBKeyRange.only('x'))).toEqual([])
+    expect(await tasksByKeys(null, [['ws1', 'a']])).toEqual([])
+  })
+
+  it('returns nothing for an empty or missing key set', async () => {
+    const db = await seeded()
+
+    expect(await tasksByKeys(db, [])).toEqual([])
+    expect(await tasksByKeys(db, undefined)).toEqual([])
+    expect(await tasksByKeys(db, [['ws1', 'never-existed']])).toEqual([])
+    db.close()
+  })
+
+  it('falls through rather than breaking when the read fails', async () => {
+    const broken = {
+      transaction() {
+        throw new Error('gone')
+      },
+    }
+
+    expect(await taskKeysForTerm(broken, IDBKeyRange.only('x'))).toEqual([])
+    expect(await tasksByKeys(broken, [['ws1', 'a']])).toEqual([])
+  })
+})
+
+describe('searchCachedTasks', () => {
+  it('searches titles across every workspace with no request at all', async () => {
+    const db = await seeded()
+
+    const rows = await searchCachedTasks(db, 'billing', opts)
+
+    expect(rows.map((r) => r.id).sort()).toEqual(['aaaaaaaaaaa', 'bbbbbbbbbbb'])
+    db.close()
+  })
+
+  it('searches descriptions, which the old finder could not reach', async () => {
+    // "refunds" appears only in a body. This is the requirement the whole
+    // feature exists for.
+    const db = await seeded()
+
+    const rows = await searchCachedTasks(db, 'refunds', opts)
+
+    expect(rows.map((r) => r.id)).toEqual(['aaaaaaaaaaa'])
+    db.close()
+  })
+
+  it('narrows on a second word rather than widening', async () => {
+    const db = await seeded()
+
+    expect(await searchCachedTasks(db, 'billing', opts)).toHaveLength(2)
+    expect((await searchCachedTasks(db, 'billing dashboard', opts)).map((r) => r.id)).toEqual([
+      'bbbbbbbbbbb',
+    ])
+    db.close()
+  })
+
+  it('matches a word the user has only partly typed', async () => {
+    const db = await seeded()
+
+    expect((await searchCachedTasks(db, 'reconcil', opts)).map((r) => r.id)).toEqual([
+      'aaaaaaaaaaa',
+    ])
+    db.close()
+  })
+
+  it('ranks a title match above a body match', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+    await cacheTask(db, makeTask({ id: 'inbody', title: 'Something else', body: 'about billing' }), {
+      storage: allOn,
+    })
+    await cacheTask(db, makeTask({ id: 'intitle', title: 'Billing work', body: 'nothing' }), {
+      storage: allOn,
+    })
+
+    expect((await searchCachedTasks(db, 'billing', opts)).map((r) => r.id)).toEqual([
+      'intitle',
+      'inbody',
+    ])
+    db.close()
+  })
+
+  it('leaves out a workspace whose owner turned the cache off', async () => {
+    const db = await seeded()
+    await cacheTask(db, makeTask({ id: 'ddddddddddd', workspaceId: 'ws2', title: 'Billing in ws2' }), {
+      storage: allOn,
+    })
+
+    const rows = await searchCachedTasks(db, 'billing', { ...opts, storage: offFor('ws2') })
+
+    expect(rows.map((r) => r.id).sort()).toEqual(['aaaaaaaaaaa', 'bbbbbbbbbbb'])
+    db.close()
+  })
+
+  it('reports an honest empty when it searched and found nothing', async () => {
+    // Empty, not null: the caller must be able to tell "no match here" from
+    // "I could not look", because only one of them justifies falling back.
+    const db = await seeded()
+
+    expect(await searchCachedTasks(db, 'quarterly', opts)).toEqual([])
+    db.close()
+  })
+
+  it('declines to answer when it cannot, so the caller falls back', async () => {
+    const db = await seeded()
+
+    expect(await searchCachedTasks(null, 'billing', opts)).toBeNull()
+    // Nothing but stopwords constrains nothing, and an unconstrained search is
+    // just the recent list the caller already has.
+    expect(await searchCachedTasks(db, 'the and of', opts)).toBeNull()
+    expect(await searchCachedTasks(db, '', opts)).toBeNull()
+    expect(await searchCachedTasks(db, '   ', opts)).toBeNull()
+    db.close()
+  })
+
+  it('caps the list so the panel stays a panel', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+    for (let i = 0; i < 20; i += 1) {
+      await cacheTask(db, makeTask({ id: `id${i}`.padEnd(11, 'x'), title: 'billing' }), {
+        storage: allOn,
+      })
+    }
+
+    expect(await searchCachedTasks(db, 'billing', opts)).toHaveLength(8)
+    expect(await searchCachedTasks(db, 'billing', { ...opts, limit: 3 })).toHaveLength(3)
+    db.close()
+  })
+})


### PR DESCRIPTION
> **Stacked on #417 → #416 → #415 → #414 → #413.** Merge those first; GitHub retargets this automatically as each lands with "Squash and merge" + "Delete branch". The diff shown here is this change alone.

## What changed

The task finder now searches every task saved on the device — titles *and* descriptions, across every workspace, offline, without a single request. Looking a task up by its ID still asks the server, which is the one thing a local copy cannot answer for a task it has never seen.

Sixth of seven steps, and the one the whole cache was built for. [Full plan](https://claude.ai/code/artifact/721b0aaf-e687-488c-a9b1-9077b60e4d2a).

## Why changed

Until now the finder matched titles against the fifty most recent tasks the API will return, and the panel said so. That was honest but small: descriptions were unsearchable, and anything older than fifty rows was invisible.

Each word in the query is now a seek into the term index rather than a scan. The seeks are intersected, so a second word narrows the result instead of widening it, and only the survivors are read as full records — the cost tracks the number of *matching* terms rather than the number of tasks.

**The search reports "could not look" and "looked and found nothing" as different answers.** Only the first justifies falling back to filtering whatever the recent-task fetch happened to return; conflating them would silently replace a correct empty result with a worse one.

## The copy from #412 is now wrong, and is rewritten

That PR shipped an honesty message about the finder's limited reach — "Titles: 50 recent", and "No match in your 50 most recent tasks. Title search only covers those." Both stop being true the moment the index is live, and a stale honesty message is worse than none.

The panel now says **"Titles: saved here"**, and a fruitless search says what is actually true: a task never opened on this device was never saved, so its ID is the way to reach it. Deliberately *saved here* rather than *everything* — there is no backfill, and overclaiming reach is the same mistake the original line existed to prevent.

## Test coverage report

**New lines introduced: 100%.** Both touched modules stay on the enforced `coverage.include` list:

```
File               | % Stmts | % Branch | % Funcs | % Lines
useCachedReads.js  |     100 |      100 |     100 |     100
useLocalCache.js   |     100 |      100 |     100 |     100
All files          |     100 |      100 |     100 |     100
```

**Total coverage impact: none — the suite stays at the 100% the config enforces.** 441 tests passing; 13 are new. They cover searching a description rather than a title, a second word narrowing the result, prefix matching on a partly-typed word, a title match ranking above a body match, an opted-out workspace staying invisible, the empty-versus-null distinction, and the result cap.

## Other reports

Verified in a real browser against an isolated backend, with the network cut mid-session:

- Searching a word from a title returned the right task and made **zero** requests, counted by instrumenting `fetch`
- Searching a word that appears only in task descriptions matched every task carrying it — something the finder could not do at all before
- A fruitless search showed the new copy: *"No match in the tasks saved on this device. A task you have never opened here was never saved — paste its ID to search every workspace."*
- The footer reads *"Titles: saved here · IDs: every workspace"*

`npm run build` is clean. No backend change and no new dependency.

TaskID: 0iCiwyfqGeX

🤖 Generated with [Claude Code](https://claude.com/claude-code)