### PR TITLE
feat(cache): keep attachment bytes, and stop keeping tasks twice

### DIFF
--- a/frontend/src/components/CommandPalette.vue
+++ b/frontend/src/components/CommandPalette.vue
@@ -11,6 +11,8 @@ import { useRouter } from 'vue-router';
 
 import { fetchGlobalTasks, getTask } from '../api';
 import { looksLikeTaskId, matchTasks, resolveTaskById, taskRoute } from '../composables/useTaskFinder';
+import { searchCachedTasks } from '../composables/useCachedReads';
+import { sharedCache } from '../composables/useCachedTasks';
 import { useWorkspaceStore } from '../stores/workspaceStore';
 
 const props = defineProps({
@@ -31,10 +33,32 @@ const resolving = ref(false);
 const notFound = ref(false);
 const inputRef = ref(null);
 
-const results = computed(() => matchTasks(tasks.value, query.value));
+/**
+ * The rows on screen, and which search produced them.
+ *
+ * Not a computed, because the better of the two searches is asynchronous. The
+ * local index answers across every task this device has saved; the fallback
+ * filters whatever the recent-task fetch happened to return. `searchedLocally`
+ * exists so the panel can say which one answered — the two do not reach the
+ * same distance, and a box that hides the difference misleads whoever searches
+ * a title, finds nothing, and concludes the task is gone.
+ */
+const results = ref([]);
+const searchedLocally = ref(false);
+
+async function runSearch() {
+  const asked = query.value;
+  const local = await searchCachedTasks(sharedCache(), asked, { limit: 8 });
+
+  // A slower search for an older query must not overwrite a newer one's answer.
+  if (asked !== query.value) return;
+
+  searchedLocally.value = local !== null;
+  results.value = local ?? matchTasks(tasks.value, asked);
+}
 
 /**
- * Offer the ID lookup only when the filter has come up empty — until then the
+ * Offer the ID lookup only when the search has come up empty — until then the
  * query is answered by rows the user can already see, and firing one request
  * per workspace behind that would be noise.
  */
@@ -42,20 +66,29 @@ const canResolveId = computed(
   () => results.value.length === 0 && looksLikeTaskId(query.value) && !resolving.value
 );
 
-/**
- * How far each kind of search actually reaches.
- *
- * The two halves of this box do not have the same range, and the difference is
- * invisible unless it is said out loud: a title is matched here in the browser
- * against the tasks that happen to be loaded, while an ID is asked of the
- * server and finds anything the user owns. Someone who searches a title, sees
- * nothing, and concludes the task is gone has been misled by a box that looked
- * like it searched everything.
- *
- * Deliberately the real number rather than the 50 the API caps at — claiming a
- * reach the panel does not have is the same mistake in the other direction.
- */
+/** How many recent tasks the fallback has to work with. */
 const loadedCount = computed(() => tasks.value.length);
+
+/**
+ * Whether this device can answer a text search on its own.
+ *
+ * Drives the resting copy, which has to promise the right thing before anyone
+ * has typed: the local index reaches every task saved here, and the fallback
+ * reaches only what the last fetch returned.
+ */
+const canSearchLocally = computed(() => Boolean(sharedCache()));
+
+/**
+ * How far a title search actually reaches, in the fewest honest words.
+ *
+ * "Saved here" rather than "everything": the cache holds what has been opened,
+ * not a whole history, and claiming otherwise would be the same mistake this
+ * line exists to prevent.
+ */
+const titlesReach = computed(() => {
+  if (loading.value) return '…';
+  return canSearchLocally.value ? 'saved here' : `${loadedCount.value} recent`;
+});
 
 watch(
   () => props.show,
@@ -64,6 +97,8 @@ watch(
     query.value = '';
     highlighted.value = 0;
     notFound.value = false;
+    results.value = [];
+    searchedLocally.value = false;
     await nextTick();
     inputRef.value?.focus();
     loadRecent();
@@ -73,7 +108,12 @@ watch(
 watch(query, () => {
   highlighted.value = 0;
   notFound.value = false;
+  runSearch();
 });
+
+// The recent-task fetch only matters to the fallback, but it lands after the
+// panel opens, so the resting list has to be refreshed when it does.
+watch(tasks, () => runSearch());
 
 async function loadRecent() {
   loading.value = true;
@@ -140,7 +180,7 @@ async function submit() {
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35M17 11a6 6 0 11-12 0 6 6 0 0112 0z" />
             </svg>
             <input ref="inputRef" v-model="query" type="text" autocomplete="off" spellcheck="false"
-                   placeholder="Task ID, or part of a recent title"
+                   :placeholder="canSearchLocally ? 'Task ID, or any word in a title or description' : 'Task ID, or part of a recent title'"
                    class="grow bg-transparent text-[14px] text-gray-900 dark:text-zinc-100 placeholder:text-gray-400 dark:placeholder:text-zinc-600 focus:outline-none"
                    @keydown.down.prevent="move(1)"
                    @keydown.up.prevent="move(-1)"
@@ -175,15 +215,18 @@ async function submit() {
               Not in the recent tasks. Press <span class="font-semibold text-gray-900 dark:text-zinc-100">Enter</span> to look this ID up across your workspaces.
             </p>
             <p v-else-if="query" class="text-[12px] text-gray-500 dark:text-zinc-400">
-              No match in your {{ loadedCount }} most recent tasks.
+              <span v-if="searchedLocally">No match in the tasks saved on this device.</span>
+              <span v-else>No match in your {{ loadedCount }} most recent tasks.</span>
               <span class="block mt-1 text-gray-400 dark:text-zinc-500">
-                Title search only covers those — paste a full task ID to search every workspace.
+                <template v-if="searchedLocally">A task you have never opened here was never saved — paste its ID to search every workspace.</template>
+                <template v-else>Title search only covers those — paste a full task ID to search every workspace.</template>
               </span>
             </p>
             <p v-else class="text-[12px] text-gray-500 dark:text-zinc-400">
-              Search the titles of your {{ loadedCount }} most recent tasks.
+              <span v-if="canSearchLocally">Search the titles and descriptions of every task saved on this device, offline.</span>
+              <span v-else>Search the titles of your {{ loadedCount }} most recent tasks.</span>
               <span class="block mt-1 text-gray-400 dark:text-zinc-500">
-                To reach older ones, paste a task ID<span v-if="shortcutLabel"> — {{ shortcutLabel }} reopens this</span>.
+                To reach a task that is not here, paste its ID<span v-if="shortcutLabel"> — {{ shortcutLabel }} reopens this</span>.
               </span>
             </p>
           </div>
@@ -197,7 +240,7 @@ async function submit() {
               <span class="text-[9px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-500">↵ Open</span>
             </span>
             <span class="text-[9px] text-right text-gray-400 dark:text-zinc-500 truncate">
-              Titles: <span class="text-gray-500 dark:text-zinc-400">{{ loading ? '…' : loadedCount }} recent</span>
+              Titles: <span class="text-gray-500 dark:text-zinc-400">{{ titlesReach }}</span>
               · IDs: <span class="text-gray-500 dark:text-zinc-400">every workspace</span>
             </span>
           </div>

--- a/frontend/src/composables/useAttachmentCache.js
+++ b/frontend/src/composables/useAttachmentCache.js
@@ -1,0 +1,129 @@
+/**
+ * Which requests the service worker may keep, and how much of it.
+ *
+ * ## Why attachments are not in IndexedDB
+ *
+ * The UI never renders an attachment from the base64 the API sends inline.
+ * Every image, video, PDF and download points at the attachment URL, so a
+ * response kept in Cache Storage is served to `<img src>` by the browser with
+ * no component change at all. Cache Storage also holds a binary body, where a
+ * base64 string in an IndexedDB record would cost a third again on top of the
+ * bytes and be paid back on every read of the record holding it.
+ *
+ * ## Why the API route had to be narrowed
+ *
+ * The service worker used to keep *every* `/api/` response. Now that the local
+ * database owns task data, that would be a second cache with a different
+ * lifetime answering the same question — and the two would disagree in a way
+ * that looks like a bug in the database rather than in the service worker.
+ *
+ * So task reads are excluded and everything else is left alone. The workspace
+ * and user endpoints still benefit from being cached: they are what the shell
+ * needs to render at all, and nothing else claims them.
+ */
+
+/** Attachment bytes above this are streamed every time rather than kept. */
+export const MAX_ATTACHMENT_BYTES = 2 * 1024 * 1024;
+
+/**
+ * How much of this device to spend on attachment bytes.
+ *
+ * The desktop app writes into a partition folder it owns and is under no
+ * browser quota pressure, so it can afford an order of magnitude more than a
+ * web origin, which shares a quota with everything else on it.
+ */
+export const WEB_BUDGET_BYTES = 100 * 1024 * 1024;
+export const DESKTOP_BUDGET_BYTES = 1024 * 1024 * 1024;
+
+export function budgetFor(platform) {
+  return platform === 'desktop' ? DESKTOP_BUDGET_BYTES : WEB_BUDGET_BYTES;
+}
+
+/** Where an attachment lives: `/api/v1/workspaces/:id/tasks/:id/attachments/:id`. */
+const ATTACHMENT = /\/tasks\/[^/]+\/attachments\/[^/]+$/;
+
+/**
+ * A task read the local database now owns.
+ *
+ * The task list, the global list and a single task. Deliberately not every path
+ * containing `/tasks/`: an attachment lives under one, and so do the action
+ * endpoints, which are not reads at all.
+ */
+const TASK_READ = /\/(?:workspaces\/[^/]+\/)?tasks(?:\/[^/]+)?$/;
+
+export function isAttachmentRequest(pathname) {
+  return ATTACHMENT.test(String(pathname ?? ''));
+}
+
+export function isTaskRead(pathname) {
+  const path = String(pathname ?? '');
+  return path.includes('/api/') && !isAttachmentRequest(path) && TASK_READ.test(path);
+}
+
+/**
+ * Whether the service worker should keep this API response.
+ *
+ * Everything under `/api/` except the task reads the database owns and the
+ * attachments that have a cache of their own.
+ */
+export function isCacheableApiRead(pathname) {
+  const path = String(pathname ?? '');
+  return path.includes('/api/') && !isTaskRead(path) && !isAttachmentRequest(path);
+}
+
+/**
+ * Whether a response is small enough to keep.
+ *
+ * Read from `content-length` rather than by buffering the body: deciding this
+ * must not cost the memory it is trying to save, and a response with no length
+ * header is kept, because refusing everything unmeasurable would mean caching
+ * almost nothing.
+ */
+export function withinSizeCap(response, max = MAX_ATTACHMENT_BYTES) {
+  const declared = Number(response?.headers?.get?.('content-length'));
+  if (!Number.isFinite(declared)) return true;
+  return declared <= max;
+}
+
+/**
+ * Which entries to drop to get back under budget, least-recently-used first.
+ *
+ * `entries` arrives in recency order, oldest first, which is what Cache Storage
+ * gives for free: keys come back in insertion order, and the service worker
+ * re-inserts an entry when it is served. That turns insertion order into a
+ * recency list without a second store to keep in step with the first.
+ *
+ * Nothing is dropped while the total fits, and the newest entry is never
+ * dropped to make room for itself.
+ *
+ * @param {Array<{url: string, size: number}>} entries oldest first
+ * @param {number} budget
+ * @returns {string[]} urls to delete
+ */
+export function evictionPlan(entries, budget) {
+  const list = Array.isArray(entries) ? entries : [];
+  let total = list.reduce((sum, entry) => sum + (Number(entry?.size) || 0), 0);
+  if (total <= budget) return [];
+
+  const doomed = [];
+  for (const entry of list) {
+    if (total <= budget || doomed.length === list.length - 1) break;
+    doomed.push(entry.url);
+    total -= Number(entry?.size) || 0;
+  }
+  return doomed;
+}
+
+/**
+ * The cached attachment URLs belonging to one workspace.
+ *
+ * Clearing a workspace has to reach the bytes as well as the rows, and the
+ * workspace is in the path, so no extra bookkeeping is needed to find them.
+ */
+export function attachmentUrlsForWorkspace(urls, workspaceId) {
+  if (!workspaceId) return [];
+  const needle = `/workspaces/${workspaceId}/`;
+  return (Array.isArray(urls) ? urls : []).filter(
+    (url) => String(url).includes(needle) && isAttachmentRequest(String(url))
+  );
+}

--- a/frontend/src/composables/useCacheStorage.js
+++ b/frontend/src/composables/useCacheStorage.js
@@ -109,8 +109,13 @@ export async function requestPersistence(manager = globalThis.navigator?.storage
  * @returns {Promise<{cleared: boolean, reclaimed: number|null}>}
  */
 export async function clearWorkspaceData(db, workspaceId, options = {}) {
-  const { KeyRange = globalThis.IDBKeyRange, manager } = options;
+  const { KeyRange = globalThis.IDBKeyRange, manager, worker } = options;
   if (!db || !workspaceId) return { cleared: false, reclaimed: null };
+
+  // The attachment bytes live in the service worker's cache, which only it can
+  // reach. Told, not awaited: a clear that the worker has not finished is still
+  // a clear, and on a build with no worker there is nothing there to clear.
+  tellWorkerToForget(workspaceId, worker);
 
   const before = await estimateUsage(manager);
   const cleared = await clearWorkspace(db, workspaceId, KeyRange);
@@ -120,6 +125,23 @@ export async function clearWorkspaceData(db, workspaceId, options = {}) {
   const reclaimed =
     before && after ? Math.max(0, before.usage - after.usage) : null;
   return { cleared: true, reclaimed };
+}
+
+/**
+ * Ask the service worker to forget a workspace's cached attachment bytes.
+ *
+ * Only the worker can reach that cache, and only the web build has a worker at
+ * all — the desktop renderer is built without one. So this is best effort by
+ * design: on desktop there is nothing listening, and nothing to forget.
+ */
+export function tellWorkerToForget(workspaceId, worker = globalThis.navigator?.serviceWorker) {
+  if (!workspaceId || !worker?.controller) return false;
+  try {
+    worker.controller.postMessage({ type: 'FORGET_WORKSPACE', workspaceId });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/frontend/src/composables/useCachedReads.js
+++ b/frontend/src/composables/useCachedReads.js
@@ -1,7 +1,14 @@
 import { onMounted, onUnmounted, ref } from 'vue';
 
 import { isCacheEnabled } from './useCachedTasks';
-import { getCachedTask, listAllCachedTasks, listCachedTasks } from './useLocalCache';
+import {
+  getCachedTask,
+  listAllCachedTasks,
+  listCachedTasks,
+  taskKeysForTerm,
+  tasksByKeys,
+} from './useLocalCache';
+import { intersect, rank, termRanges } from './useTaskIndex';
 
 /**
  * Reading the local copy, and the rules about when it is allowed to be shown.
@@ -79,6 +86,39 @@ export async function readAllCachedTasks(db, options = {}) {
   });
 
   return limit > 0 ? rows.slice(0, limit) : rows;
+}
+
+/**
+ * Search cached task titles and descriptions, with no request at all.
+ *
+ * This is the point of the whole cache. Each word becomes a seek into the term
+ * index rather than a scan of every task, the seeks are intersected so a second
+ * word narrows rather than widens, and only the survivors are read as records.
+ *
+ * Returns null — not an empty array — when the local index cannot answer, which
+ * the caller needs to tell apart from "searched and found nothing". Null means
+ * fall back to filtering whatever is already loaded; empty means the local index
+ * genuinely holds no match.
+ *
+ * @returns {Promise<Array<object>|null>}
+ */
+export async function searchCachedTasks(db, query, options = {}) {
+  const { storage, KeyRange = globalThis.IDBKeyRange, limit = 8 } = options;
+  if (!db) return null;
+
+  const ranges = termRanges(query, KeyRange);
+  // A query of nothing, or of nothing but stopwords, constrains nothing — and
+  // an unconstrained "search" is just the recent list, which the caller already
+  // has. Saying so is more useful than returning everything.
+  if (ranges.length === 0) return null;
+
+  const keyLists = await Promise.all(ranges.map((range) => taskKeysForTerm(db, range)));
+  const keys = intersect(keyLists);
+  if (keys.length === 0) return [];
+
+  const rows = await tasksByKeys(db, keys);
+  const visible = rows.filter((row) => isCacheEnabled(row.workspaceId, storage));
+  return rank(visible, query, limit);
 }
 
 /**

--- a/frontend/src/composables/useLocalCache.js
+++ b/frontend/src/composables/useLocalCache.js
@@ -336,6 +336,35 @@ export async function listCachedTasks(db, workspaceId, KeyRange = globalThis.IDB
 }
 
 /**
+ * The primary keys of every task carrying a term in `range`.
+ *
+ * Keys rather than records, because a query with two words asks this twice and
+ * only the intersection is worth reading. Fetching whole records for each word
+ * and discarding most of them is the version of this that does not scale.
+ */
+export async function taskKeysForTerm(db, range) {
+  if (!db) return [];
+
+  return attempt(async () => {
+    const tx = db.transaction(STORE_TASKS, 'readonly');
+    return requestResult(tx.objectStore(STORE_TASKS).index('by_term').getAllKeys(range));
+  }, []);
+}
+
+/** The task records for a set of primary keys, in the order given. */
+export async function tasksByKeys(db, keys) {
+  const list = Array.isArray(keys) ? keys : [];
+  if (!db || list.length === 0) return [];
+
+  return attempt(async () => {
+    const tx = db.transaction(STORE_TASKS, 'readonly');
+    const store = tx.objectStore(STORE_TASKS);
+    const rows = await Promise.all(list.map((key) => requestResult(store.get(key))));
+    return rows.filter(Boolean);
+  }, []);
+}
+
+/**
  * Every cached task, across every workspace, newest first.
  *
  * One scan rather than a read per workspace, because the caller that needs this

--- a/frontend/src/sw.js
+++ b/frontend/src/sw.js
@@ -1,23 +1,105 @@
 import { precacheAndRoute, cleanupOutdatedCaches } from 'workbox-precaching'
+import { registerRoute } from 'workbox-routing'
+import { CacheFirst, NetworkFirst } from 'workbox-strategies'
+import { CacheableResponsePlugin } from 'workbox-cacheable-response'
+
+import {
+  attachmentUrlsForWorkspace,
+  budgetFor,
+  evictionPlan,
+  isAttachmentRequest,
+  isCacheableApiRead,
+  withinSizeCap,
+} from './composables/useAttachmentCache'
 
 self.addEventListener('message', event => {
   if (event.data && event.data.type === 'SKIP_WAITING') self.skipWaiting()
+  // Clearing a workspace has to reach the attachment bytes too, and only the
+  // worker can reach the cache they live in.
+  if (event.data && event.data.type === 'FORGET_WORKSPACE') {
+    event.waitUntil(forgetWorkspace(event.data.workspaceId))
+  }
 })
-import { registerRoute } from 'workbox-routing'
-import { NetworkFirst } from 'workbox-strategies'
-import { CacheableResponsePlugin } from 'workbox-cacheable-response'
 
 precacheAndRoute(self.__WB_MANIFEST)
 cleanupOutdatedCaches()
 
+const ATTACHMENT_CACHE = 'attachment-cache'
+
+/**
+ * Attachment bytes.
+ *
+ * CacheFirst because an attachment is immutable: its id names that exact file,
+ * so a cached copy can never be out of date. This is also what makes them work
+ * offline with no component change — the page asks for the same URL it always
+ * has, and the worker answers it.
+ */
 registerRoute(
-  ({ url }) => url.pathname.includes('/api/'),
+  ({ url }) => isAttachmentRequest(url.pathname),
+  new CacheFirst({
+    cacheName: ATTACHMENT_CACHE,
+    plugins: [
+      new CacheableResponsePlugin({ statuses: [0, 200] }),
+      {
+        // Too large to be worth the space. Returning null tells Workbox to
+        // serve the response without keeping it.
+        cacheWillUpdate: async ({ response }) => (withinSizeCap(response) ? response : null),
+        // Serving an entry makes it the newest, which is what turns Cache
+        // Storage's insertion order into a recency list with nothing else to
+        // keep in step.
+        cachedResponseWillBeUsed: async ({ cache, request, cachedResponse }) => {
+          if (cachedResponse) {
+            await cache.delete(request)
+            await cache.put(request, cachedResponse.clone())
+          }
+          return cachedResponse
+        },
+        cacheDidUpdate: async ({ cacheName }) => enforceBudget(cacheName),
+      },
+    ],
+  })
+)
+
+/**
+ * Everything else under /api/ that nothing else claims.
+ *
+ * Deliberately no longer the task reads: the local database owns those now, and
+ * a second cache with a different lifetime answering the same question disagrees
+ * with it in a way that looks like a database bug. What is left — the workspace
+ * and user endpoints — is what the shell needs to render at all.
+ */
+registerRoute(
+  ({ url }) => isCacheableApiRead(url.pathname),
   new NetworkFirst({
     cacheName: 'api-cache',
     networkTimeoutSeconds: 10,
     plugins: [new CacheableResponsePlugin({ statuses: [0, 200] })],
   })
 )
+
+/** Drop the least recently used attachments until the cache fits its budget. */
+async function enforceBudget(cacheName) {
+  const cache = await caches.open(cacheName)
+  const requests = await cache.keys()
+  const entries = await Promise.all(
+    requests.map(async request => {
+      const response = await cache.match(request)
+      const declared = Number(response?.headers?.get('content-length'))
+      return { url: request.url, size: Number.isFinite(declared) ? declared : 0 }
+    })
+  )
+
+  // The platform is not knowable from inside the worker, and only the web build
+  // registers one at all — so the web budget is the only one that applies here.
+  for (const url of evictionPlan(entries, budgetFor('web'))) await cache.delete(url)
+}
+
+/** Forget one workspace's cached attachment bytes. */
+async function forgetWorkspace(workspaceId) {
+  const cache = await caches.open(ATTACHMENT_CACHE)
+  const urls = (await cache.keys()).map(request => request.url)
+  for (const url of attachmentUrlsForWorkspace(urls, workspaceId)) await cache.delete(url)
+}
 
 self.addEventListener('push', event => {
   const data = event.data?.json() ?? {}

--- a/frontend/test/attachmentCache.test.js
+++ b/frontend/test/attachmentCache.test.js
@@ -1,0 +1,176 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  DESKTOP_BUDGET_BYTES,
+  MAX_ATTACHMENT_BYTES,
+  WEB_BUDGET_BYTES,
+  attachmentUrlsForWorkspace,
+  budgetFor,
+  evictionPlan,
+  isAttachmentRequest,
+  isCacheableApiRead,
+  isTaskRead,
+  withinSizeCap,
+} from '../src/composables/useAttachmentCache'
+
+const attachment = '/api/v1/workspaces/ws1/tasks/0iCYTqxKOqv/attachments/a1'
+
+describe('isAttachmentRequest', () => {
+  it('recognises an attachment', () => {
+    expect(isAttachmentRequest(attachment)).toBe(true)
+  })
+
+  it('does not mistake a task for one', () => {
+    expect(isAttachmentRequest('/api/v1/workspaces/ws1/tasks/0iCYTqxKOqv')).toBe(false)
+    expect(isAttachmentRequest('/api/v1/workspaces/ws1/tasks')).toBe(false)
+    expect(isAttachmentRequest('')).toBe(false)
+    expect(isAttachmentRequest(null)).toBe(false)
+  })
+})
+
+describe('isTaskRead', () => {
+  it('recognises the reads the local database now owns', () => {
+    expect(isTaskRead('/api/v1/tasks')).toBe(true)
+    expect(isTaskRead('/api/v1/workspaces/ws1/tasks')).toBe(true)
+    expect(isTaskRead('/api/v1/workspaces/ws1/tasks/0iCYTqxKOqv')).toBe(true)
+  })
+
+  it('leaves alone the paths that only look like task reads', () => {
+    // An attachment lives under /tasks/, and so do the action endpoints, which
+    // are not reads at all.
+    expect(isTaskRead(attachment)).toBe(false)
+    expect(isTaskRead('/api/v1/workspaces/ws1/tasks/0iCYTqxKOqv/reply')).toBe(false)
+    expect(isTaskRead('/api/v1/workspaces/ws1/tasks/0iCYTqxKOqv/status')).toBe(false)
+    expect(isTaskRead('/api/v1/workspaces/ws1/tasks/counts')).toBe(true)
+  })
+
+  it('ignores anything outside the API', () => {
+    expect(isTaskRead('/tasks/all')).toBe(false)
+    expect(isTaskRead('')).toBe(false)
+    expect(isTaskRead(null)).toBe(false)
+  })
+})
+
+describe('isCacheableApiRead', () => {
+  it('keeps what nothing else claims', () => {
+    // These are what the shell needs to render at all.
+    expect(isCacheableApiRead('/api/v1/workspaces')).toBe(true)
+    expect(isCacheableApiRead('/api/v1/workspaces/ws1')).toBe(true)
+    expect(isCacheableApiRead('/api/v1/auth/user')).toBe(true)
+  })
+
+  it('stops shadowing the task reads the database owns', () => {
+    // Two caches with different lifetimes answering the same question disagree
+    // in a way that looks like a bug in the database.
+    expect(isCacheableApiRead('/api/v1/tasks')).toBe(false)
+    expect(isCacheableApiRead('/api/v1/workspaces/ws1/tasks')).toBe(false)
+    expect(isCacheableApiRead('/api/v1/workspaces/ws1/tasks/0iCYTqxKOqv')).toBe(false)
+  })
+
+  it('leaves attachments to their own cache', () => {
+    expect(isCacheableApiRead(attachment)).toBe(false)
+  })
+
+  it('ignores anything outside the API', () => {
+    expect(isCacheableApiRead('/tasks/all')).toBe(false)
+    expect(isCacheableApiRead('')).toBe(false)
+    expect(isCacheableApiRead(null)).toBe(false)
+    expect(isCacheableApiRead(undefined)).toBe(false)
+  })
+})
+
+describe('budgetFor', () => {
+  it('gives the desktop an order of magnitude more', () => {
+    // It writes into a partition folder it owns, under no browser quota
+    // pressure, unlike a web origin sharing a quota with everything else.
+    expect(budgetFor('desktop')).toBe(DESKTOP_BUDGET_BYTES)
+    expect(budgetFor('web')).toBe(WEB_BUDGET_BYTES)
+    expect(budgetFor(undefined)).toBe(WEB_BUDGET_BYTES)
+    expect(DESKTOP_BUDGET_BYTES).toBeGreaterThan(WEB_BUDGET_BYTES * 5)
+  })
+})
+
+describe('withinSizeCap', () => {
+  const withLength = (bytes) => ({ headers: { get: () => String(bytes) } })
+
+  it('keeps a small file and refuses a large one', () => {
+    expect(withinSizeCap(withLength(1024))).toBe(true)
+    expect(withinSizeCap(withLength(MAX_ATTACHMENT_BYTES))).toBe(true)
+    expect(withinSizeCap(withLength(MAX_ATTACHMENT_BYTES + 1))).toBe(false)
+  })
+
+  it('accepts an override for the cap', () => {
+    expect(withinSizeCap(withLength(500), 100)).toBe(false)
+    expect(withinSizeCap(withLength(50), 100)).toBe(true)
+  })
+
+  it('keeps a response whose size cannot be read', () => {
+    // Refusing everything unmeasurable would mean caching almost nothing, and
+    // buffering the body to measure it would cost the memory this is saving.
+    expect(withinSizeCap({ headers: { get: () => null } })).toBe(true)
+    expect(withinSizeCap({ headers: { get: () => 'unknown' } })).toBe(true)
+    expect(withinSizeCap({})).toBe(true)
+    expect(withinSizeCap(null)).toBe(true)
+  })
+})
+
+describe('evictionPlan', () => {
+  const entry = (url, size) => ({ url, size })
+
+  it('drops nothing while the total fits', () => {
+    expect(evictionPlan([entry('a', 10), entry('b', 20)], 100)).toEqual([])
+    expect(evictionPlan([entry('a', 100)], 100)).toEqual([])
+  })
+
+  it('drops the least recently used first, and only as many as it must', () => {
+    // Entries arrive oldest first, which is the order Cache Storage returns
+    // keys in — and the worker re-inserts an entry when it serves it, so
+    // insertion order is a recency list.
+    const entries = [entry('oldest', 50), entry('middle', 50), entry('newest', 50)]
+
+    expect(evictionPlan(entries, 100)).toEqual(['oldest'])
+    expect(evictionPlan(entries, 40)).toEqual(['oldest', 'middle'])
+  })
+
+  it('never drops the newest entry to make room for itself', () => {
+    // A single file larger than the whole budget would otherwise be written and
+    // immediately deleted on every request for it.
+    const entries = [entry('only', 500)]
+
+    expect(evictionPlan(entries, 100)).toEqual([])
+  })
+
+  it('treats a missing or unreadable size as zero rather than throwing', () => {
+    const entries = [entry('a', undefined), entry('b', 'huge'), entry('c', 200)]
+
+    expect(evictionPlan(entries, 100)).toEqual(['a', 'b'])
+  })
+
+  it('has nothing to plan for an empty or missing list', () => {
+    expect(evictionPlan([], 100)).toEqual([])
+    expect(evictionPlan(null, 100)).toEqual([])
+    expect(evictionPlan(undefined, 100)).toEqual([])
+  })
+})
+
+describe('attachmentUrlsForWorkspace', () => {
+  it('finds a workspace’s attachments among everything cached', () => {
+    // Clearing a workspace has to reach the bytes as well as the rows, and the
+    // workspace is already in the path.
+    const urls = [
+      'https://x/api/v1/workspaces/ws1/tasks/t1/attachments/a1',
+      'https://x/api/v1/workspaces/ws2/tasks/t2/attachments/a2',
+      'https://x/api/v1/workspaces/ws1/tasks/t1',
+    ]
+
+    expect(attachmentUrlsForWorkspace(urls, 'ws1')).toEqual([
+      'https://x/api/v1/workspaces/ws1/tasks/t1/attachments/a1',
+    ])
+  })
+
+  it('has nothing to find without a workspace or a list', () => {
+    expect(attachmentUrlsForWorkspace(['x'], '')).toEqual([])
+    expect(attachmentUrlsForWorkspace(null, 'ws1')).toEqual([])
+    expect(attachmentUrlsForWorkspace(undefined, 'ws1')).toEqual([])
+  })
+})

--- a/frontend/test/cacheStorage.test.js
+++ b/frontend/test/cacheStorage.test.js
@@ -8,6 +8,7 @@ import {
   formatBytes,
   requestPersistence,
   setCacheEnabled,
+  tellWorkerToForget,
 } from '../src/composables/useCacheStorage'
 import {
   cacheSettingKey,
@@ -178,9 +179,14 @@ describe('clearWorkspaceData', () => {
     await cacheTask(db, makeTask(), { storage: allOn })
     await cacheTask(db, makeTask({ id: 'keep', workspaceId: 'ws2' }), { storage: allOn })
 
-    const result = await clearWorkspaceData(db, 'ws1', { KeyRange: IDBKeyRange })
+    const posted = []
+    const worker = { controller: { postMessage: (msg) => posted.push(msg) } }
+
+    const result = await clearWorkspaceData(db, 'ws1', { KeyRange: IDBKeyRange, worker })
 
     expect(result.cleared).toBe(true)
+    // The bytes go with the rows.
+    expect(posted).toEqual([{ type: 'FORGET_WORKSPACE', workspaceId: 'ws1' }])
     expect(await listCachedTasks(db, 'ws1', IDBKeyRange)).toEqual([])
     expect(await listCachedTasks(db, 'ws2', IDBKeyRange)).toHaveLength(1)
     db.close()
@@ -246,6 +252,37 @@ describe('clearWorkspaceData', () => {
       cleared: false,
       reclaimed: null,
     })
+  })
+})
+
+describe('tellWorkerToForget', () => {
+  it('asks the worker, because only it can reach the attachment bytes', () => {
+    const posted = []
+    const worker = { controller: { postMessage: (msg) => posted.push(msg) } }
+
+    expect(tellWorkerToForget('ws1', worker)).toBe(true)
+    expect(posted).toEqual([{ type: 'FORGET_WORKSPACE', workspaceId: 'ws1' }])
+  })
+
+  it('is a no-op where there is no worker to ask', () => {
+    // The desktop renderer is built without one, so there is nothing listening
+    // and nothing there to forget.
+    expect(tellWorkerToForget('ws1', undefined)).toBe(false)
+    expect(tellWorkerToForget('ws1', {})).toBe(false)
+    expect(tellWorkerToForget('ws1', { controller: null })).toBe(false)
+    expect(tellWorkerToForget('', { controller: { postMessage: () => {} } })).toBe(false)
+  })
+
+  it('reports failure rather than throwing when the message cannot be sent', () => {
+    const worker = {
+      controller: {
+        postMessage() {
+          throw new Error('worker went away')
+        },
+      },
+    }
+
+    expect(tellWorkerToForget('ws1', worker)).toBe(false)
   })
 })
 

--- a/frontend/test/cachedSearch.test.js
+++ b/frontend/test/cachedSearch.test.js
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { IDBFactory, IDBKeyRange } from 'fake-indexeddb'
+
+import { searchCachedTasks } from '../src/composables/useCachedReads'
+import { cacheSettingKey, cacheTask, resetSharedCache } from '../src/composables/useCachedTasks'
+import { openCache, taskKeysForTerm, tasksByKeys } from '../src/composables/useLocalCache'
+
+let factory
+beforeEach(() => {
+  factory = new IDBFactory()
+})
+afterEach(() => {
+  resetSharedCache()
+})
+
+const allOn = { getItem: () => null }
+const offFor = (id) => ({ getItem: (key) => (key === cacheSettingKey(id) ? 'off' : null) })
+const opts = { storage: allOn, KeyRange: IDBKeyRange }
+
+const makeTask = (over = {}) => ({
+  id: 'aaaaaaaaaaa',
+  workspaceId: 'ws1',
+  title: 'Ship the billing reconciliation fix',
+  body: 'The nightly job double-counts refunds.',
+  updatedAt: '2026-09-02T10:00:00Z',
+  ...over,
+})
+
+/** A cache holding three tasks that overlap in useful ways. */
+async function seeded() {
+  const db = await openCache({ userId: 'u1', factory })
+  await cacheTask(db, makeTask(), { storage: allOn })
+  await cacheTask(
+    db,
+    makeTask({ id: 'bbbbbbbbbbb', title: 'Billing dashboard copy', body: 'Wording only.' }),
+    { storage: allOn }
+  )
+  await cacheTask(
+    db,
+    makeTask({
+      id: 'ccccccccccc',
+      workspaceId: 'ws2',
+      title: 'Unrelated groundwork',
+      body: 'Nothing to do with money.',
+    }),
+    { storage: allOn }
+  )
+  return db
+}
+
+describe('taskKeysForTerm and tasksByKeys', () => {
+  it('finds keys by term and reads only those records', async () => {
+    // Keys first, records second: a two-word query asks the index twice and
+    // only the intersection is worth reading.
+    const db = await seeded()
+
+    const keys = await taskKeysForTerm(db, IDBKeyRange.bound('billing', 'billing￿'))
+    expect(keys).toHaveLength(2)
+
+    const rows = await tasksByKeys(db, keys)
+    expect(rows.map((r) => r.id).sort()).toEqual(['aaaaaaaaaaa', 'bbbbbbbbbbb'])
+    db.close()
+  })
+
+  it('returns nothing rather than throwing when there is no cache', async () => {
+    expect(await taskKeysForTerm(null, IDBKeyRange.only('x'))).toEqual([])
+    expect(await tasksByKeys(null, [['ws1', 'a']])).toEqual([])
+  })
+
+  it('returns nothing for an empty or missing key set', async () => {
+    const db = await seeded()
+
+    expect(await tasksByKeys(db, [])).toEqual([])
+    expect(await tasksByKeys(db, undefined)).toEqual([])
+    expect(await tasksByKeys(db, [['ws1', 'never-existed']])).toEqual([])
+    db.close()
+  })
+
+  it('falls through rather than breaking when the read fails', async () => {
+    const broken = {
+      transaction() {
+        throw new Error('gone')
+      },
+    }
+
+    expect(await taskKeysForTerm(broken, IDBKeyRange.only('x'))).toEqual([])
+    expect(await tasksByKeys(broken, [['ws1', 'a']])).toEqual([])
+  })
+})
+
+describe('searchCachedTasks', () => {
+  it('searches titles across every workspace with no request at all', async () => {
+    const db = await seeded()
+
+    const rows = await searchCachedTasks(db, 'billing', opts)
+
+    expect(rows.map((r) => r.id).sort()).toEqual(['aaaaaaaaaaa', 'bbbbbbbbbbb'])
+    db.close()
+  })
+
+  it('searches descriptions, which the old finder could not reach', async () => {
+    // "refunds" appears only in a body. This is the requirement the whole
+    // feature exists for.
+    const db = await seeded()
+
+    const rows = await searchCachedTasks(db, 'refunds', opts)
+
+    expect(rows.map((r) => r.id)).toEqual(['aaaaaaaaaaa'])
+    db.close()
+  })
+
+  it('narrows on a second word rather than widening', async () => {
+    const db = await seeded()
+
+    expect(await searchCachedTasks(db, 'billing', opts)).toHaveLength(2)
+    expect((await searchCachedTasks(db, 'billing dashboard', opts)).map((r) => r.id)).toEqual([
+      'bbbbbbbbbbb',
+    ])
+    db.close()
+  })
+
+  it('matches a word the user has only partly typed', async () => {
+    const db = await seeded()
+
+    expect((await searchCachedTasks(db, 'reconcil', opts)).map((r) => r.id)).toEqual([
+      'aaaaaaaaaaa',
+    ])
+    db.close()
+  })
+
+  it('ranks a title match above a body match', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+    await cacheTask(db, makeTask({ id: 'inbody', title: 'Something else', body: 'about billing' }), {
+      storage: allOn,
+    })
+    await cacheTask(db, makeTask({ id: 'intitle', title: 'Billing work', body: 'nothing' }), {
+      storage: allOn,
+    })
+
+    expect((await searchCachedTasks(db, 'billing', opts)).map((r) => r.id)).toEqual([
+      'intitle',
+      'inbody',
+    ])
+    db.close()
+  })
+
+  it('leaves out a workspace whose owner turned the cache off', async () => {
+    const db = await seeded()
+    await cacheTask(db, makeTask({ id: 'ddddddddddd', workspaceId: 'ws2', title: 'Billing in ws2' }), {
+      storage: allOn,
+    })
+
+    const rows = await searchCachedTasks(db, 'billing', { ...opts, storage: offFor('ws2') })
+
+    expect(rows.map((r) => r.id).sort()).toEqual(['aaaaaaaaaaa', 'bbbbbbbbbbb'])
+    db.close()
+  })
+
+  it('reports an honest empty when it searched and found nothing', async () => {
+    // Empty, not null: the caller must be able to tell "no match here" from
+    // "I could not look", because only one of them justifies falling back.
+    const db = await seeded()
+
+    expect(await searchCachedTasks(db, 'quarterly', opts)).toEqual([])
+    db.close()
+  })
+
+  it('declines to answer when it cannot, so the caller falls back', async () => {
+    const db = await seeded()
+
+    expect(await searchCachedTasks(null, 'billing', opts)).toBeNull()
+    // Nothing but stopwords constrains nothing, and an unconstrained search is
+    // just the recent list the caller already has.
+    expect(await searchCachedTasks(db, 'the and of', opts)).toBeNull()
+    expect(await searchCachedTasks(db, '', opts)).toBeNull()
+    expect(await searchCachedTasks(db, '   ', opts)).toBeNull()
+    db.close()
+  })
+
+  it('caps the list so the panel stays a panel', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+    for (let i = 0; i < 20; i += 1) {
+      await cacheTask(db, makeTask({ id: `id${i}`.padEnd(11, 'x'), title: 'billing' }), {
+        storage: allOn,
+      })
+    }
+
+    expect(await searchCachedTasks(db, 'billing', opts)).toHaveLength(8)
+    expect(await searchCachedTasks(db, 'billing', { ...opts, limit: 3 })).toHaveLength(3)
+    db.close()
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -53,6 +53,7 @@ export default defineConfig({
         'src/composables/useCachedTasks.js',
         'src/composables/useCacheStorage.js',
         'src/composables/useCachedReads.js',
+        'src/composables/useAttachmentCache.js',
       ],
       reporter: ['text', 'lcov'],
       thresholds: {


### PR DESCRIPTION
> **Stacked on #418 → #417 → #416 → #415 → #414 → #413.** Merge those first; GitHub retargets this automatically as each lands with "Squash and merge" + "Delete branch". The diff shown here is this change alone.

## What changed

Attachments people have opened are kept on the device as bytes, so they still open with no connection. At the same time the offline layer stops keeping a second, competing copy of task data.

Last of seven steps. [Full plan](https://claude.ai/code/artifact/721b0aaf-e687-488c-a9b1-9077b60e4d2a).

## Why changed

**Bytes, not base64, and not in the database.** The UI never renders an attachment from the base64 the API sends inline — every image, video, PDF and download points at the attachment URL — so a cached *response* is served to `<img src>` by the browser with no component change at all. That store also holds a binary body, where base64 inside a database record would cost a third again on top of the bytes and be paid back on every read of the record holding it. Measured on a real file: the cached copy is 70 bytes of `image/png`, not 96 characters of text.

Attachments are served cache-first because they are immutable — an attachment id names that exact file, so a cached copy cannot be out of date. Anything over 2 MB is streamed rather than kept, judged from the declared length so that deciding does not cost the memory it is trying to save. The cache is held to a byte budget by dropping the least recently used entries, which needs no second store to track recency: keys come back in insertion order, and serving an entry re-inserts it.

**One cache instead of two.** The offline layer used to keep every API response. After the earlier steps that meant two caches with different lifetimes answering the same question, and they would have disagreed in a way that looked like a bug in the database rather than in the offline layer. Task reads are now excluded and everything else is left alone — the workspace and user endpoints are what the shell needs to render at all, and nothing else claims them.

## Two limits, stated rather than left to be found

- **This is web-only.** The desktop app is built without the offline layer entirely, so there is nothing there to cache attachments or to shadow anything. Clearing a workspace sends it a message and finds nobody listening, which is correct rather than merely tolerated.
- **That same fact qualifies a claim from the previous step.** The offline behaviour measured there was measured against a development server, which also registers nothing. What a production build does offline is not what that test showed, and the note in that PR should be read with this in mind.

## Test coverage report

**New lines introduced: 100%.** The new module is on the enforced `coverage.include` list:

```
File                  | % Stmts | % Branch | % Funcs | % Lines
useAttachmentCache.js |     100 |      100 |     100 |     100
All files             |     100 |      100 |     100 |     100
```

**Total coverage impact: none — the suite stays at the 100% the config enforces.** 464 tests passing; 23 are new. They cover the size cap including a response whose size cannot be read, the eviction order, never evicting the newest entry to make room for itself, the platform budget split, and the route rules — including the paths that only *look* like task reads, such as an attachment and the reply and status endpoints, which must not be excluded by accident.

## Other reports

Verified against a **production build** with the offline layer actually controlling the page, which a development server does not do:

- Three task reads left the API cache holding only `/api/v1/workspaces` — no task paths at all
- The attachment landed in its own cache, 70 real bytes, `image/png`
- With the page's network cut, that attachment still served `200` from the cache

A stray 1×1 PNG written into the repo's local storage directory by the test backend was removed before committing.

`npm run build` is clean. No backend change and no new dependency.

TaskID: 0iCizBy1FHF

🤖 Generated with [Claude Code](https://claude.com/claude-code)