### PR TITLE
feat(desktop): keep attachment bytes on disk, per profile

### DIFF
--- a/desktop/src/main/attachment-store.js
+++ b/desktop/src/main/attachment-store.js
@@ -1,0 +1,233 @@
+import { budgetFor, evictionPlan, withinSizeCap } from '../../../frontend/src/composables/useAttachmentCache.js'
+
+/**
+ * Attachment bytes on disk, for the desktop build.
+ *
+ * ## Why this exists at all
+ *
+ * On the web an attachment is kept by the service worker, and the page opens it
+ * offline without any component knowing. The desktop renderer is built without
+ * a service worker, so that route does not exist there — every image and PDF
+ * was re-downloaded on every view.
+ *
+ * Electron's own HTTP cache could not stand in: the attachment endpoint sends
+ * no `Cache-Control` and no `ETag`, so the network stack has nothing to cache
+ * on. And even with headers it would be the wrong answer, because Chromium's
+ * cache is not addressable per workspace — "Clear this workspace" would have to
+ * clear everything. That button makes a promise, so the bytes live in a store
+ * we own.
+ *
+ * ## Layout
+ *
+ *     <dir>/<workspaceId>/<taskId>/<attachmentId>
+ *     <dir>/<workspaceId>/<taskId>/<attachmentId>.meta
+ *
+ * The same shape as the URL the bytes came from, which is what makes the store
+ * legible: the path on disk and the path in the request read the same way. The
+ * attachment id *is* the filename, because it already names that exact file for
+ * all time — the server mints one per attachment and never reuses it.
+ *
+ * Nesting by task also means removing anything is a directory removal rather
+ * than a scan, at whichever level is being removed — a workspace today, a
+ * single task if that is ever wanted.
+ *
+ * ## Why only base62 ever reaches the filesystem
+ *
+ * Both ids come out of a URL, and a path built from unvalidated input is how a
+ * cache becomes a way to write anywhere on disk. They are monoflake ids —
+ * digits and letters, nothing else — so anything that is not plain alphanumeric
+ * is refused rather than escaped. A refused path is simply not cached, which
+ * the caller already handles.
+ */
+
+/** Ids are base62 monoflakes. Nothing else may become a path segment. */
+const SAFE_ID = /^[0-9A-Za-z]+$/
+
+/** `/api/v1/workspaces/:workspaceId/tasks/:taskId/attachments/:attachmentId` */
+const ATTACHMENT_PATH = /\/workspaces\/([^/]+)\/tasks\/([^/]+)\/attachments\/([^/]+)$/
+
+/** Suffix of the file holding a cached response's content type. */
+const META = '.meta'
+
+/**
+ * The workspace, task and attachment an attachment request names, or null.
+ *
+ * Null covers both "not an attachment path" and "an attachment path carrying
+ * something that must not become a filename", because the caller does the same
+ * thing for each: forward without caching.
+ */
+export function parseAttachmentPath(pathname) {
+  const match = ATTACHMENT_PATH.exec(String(pathname ?? ''))
+  if (!match) return null
+
+  const [, workspaceId, taskId, attachmentId] = match
+  // Every one of these becomes a path segment, so every one is checked.
+  if (![workspaceId, taskId, attachmentId].every((part) => SAFE_ID.test(part))) return null
+  return { workspaceId, taskId, attachmentId }
+}
+
+/**
+ * A cache of attachment bytes in one directory, for one profile.
+ *
+ * Every filesystem call is injected so the rules can be tested in plain Node
+ * with no Electron binary and no temporary directories, matching how the rest
+ * of this folder is tested.
+ *
+ * @param {object} options
+ * @param {string} options.dir       where the files live, per profile
+ * @param {object} options.fs        node:fs/promises, or a stand-in
+ * @param {number} [options.budget]  bytes; defaults to the desktop budget
+ */
+export function createAttachmentStore({ dir, fs, budget = budgetFor('desktop') } = {}) {
+  const workspaceDir = (workspaceId) => `${dir}/${workspaceId}`
+  const taskDir = (id) => `${workspaceDir(id.workspaceId)}/${id.taskId}`
+  const filePath = (id) => `${taskDir(id)}/${id.attachmentId}`
+
+  /** What a directory holds, or nothing when it cannot be read. */
+  async function namesIn(path) {
+    try {
+      return await fs.readdir(path)
+    } catch {
+      return []
+    }
+  }
+
+  /** Every stored attachment across every workspace, least recently used first. */
+  async function entries() {
+    let workspaces
+    try {
+      workspaces = await fs.readdir(dir)
+    } catch {
+      // No directory yet is the ordinary state on a first run, not a failure.
+      return []
+    }
+
+    const found = []
+    for (const workspaceId of workspaces) {
+      if (!SAFE_ID.test(workspaceId)) continue
+      for (const taskId of await namesIn(workspaceDir(workspaceId))) {
+        if (!SAFE_ID.test(taskId)) continue
+        const dirOfTask = `${workspaceDir(workspaceId)}/${taskId}`
+        for (const name of await namesIn(dirOfTask)) {
+          if (name.endsWith(META) || !SAFE_ID.test(name)) continue
+          const path = `${dirOfTask}/${name}`
+          try {
+            const stat = await fs.stat(path)
+            found.push({ path, size: stat.size, usedAt: stat.mtimeMs })
+          } catch {
+            // Vanished between listing and stat, which is not worth an error.
+          }
+        }
+      }
+    }
+    return found.sort((a, b) => a.usedAt - b.usedAt)
+  }
+
+  /** Remove an entry and the file describing it, ignoring either being gone. */
+  async function remove(path) {
+    await Promise.all([
+      fs.rm(path, { force: true }).catch(() => {}),
+      fs.rm(`${path}${META}`, { force: true }).catch(() => {}),
+    ])
+  }
+
+  return {
+    /**
+     * The stored response for a path, or null.
+     *
+     * Null covers every reason a hit cannot be served — never stored, half
+     * written, meta unreadable, disk error, an id that must not become a
+     * filename — because the caller does the same thing in all of them: forward
+     * to the server, which is what it would have done anyway.
+     */
+    async read(pathname) {
+      const id = parseAttachmentPath(pathname)
+      if (!id) return null
+
+      const path = filePath(id)
+      let body
+      let meta
+      try {
+        body = await fs.readFile(path)
+        meta = JSON.parse(await fs.readFile(`${path}${META}`, 'utf8'))
+      } catch {
+        return null
+      }
+      if (!meta?.contentType) return null
+
+      // Serving makes this the most recently used entry. Best effort: failing
+      // to record a hit costs a slightly worse eviction choice later, which is
+      // not worth failing the read over.
+      await fs.utimes?.(path, new Date(), new Date()).catch(() => {})
+
+      return { body, contentType: meta.contentType, contentDisposition: meta.contentDisposition ?? '' }
+    },
+
+    /**
+     * Keep a response, unless it is too large to be worth the space.
+     *
+     * @returns {Promise<boolean>} whether it was kept
+     */
+    async write(pathname, body, { contentType = '', contentDisposition = '', size } = {}) {
+      const id = parseAttachmentPath(pathname)
+      if (!id || !contentType) return false
+      // Judged from the length the caller measured, so the decision costs
+      // nothing beyond what has already been read.
+      if (!withinSizeCap({ headers: { get: () => (size === undefined ? null : String(size)) } })) {
+        return false
+      }
+
+      const path = filePath(id)
+      try {
+        await fs.mkdir(taskDir(id), { recursive: true })
+        await fs.writeFile(path, body)
+        await fs.writeFile(`${path}${META}`, JSON.stringify({ contentType, contentDisposition }))
+      } catch {
+        // A cache that cannot be written behaves like one that was never
+        // written, which the caller already handles.
+        return false
+      }
+
+      await this.evict()
+      return true
+    },
+
+    /** Drop the least recently used entries until the store fits its budget. */
+    async evict() {
+      const found = await entries()
+      const doomed = evictionPlan(
+        found.map((entry) => ({ url: entry.path, size: entry.size })),
+        budget
+      )
+      for (const path of doomed) await remove(path)
+      return doomed.length
+    },
+
+    /**
+     * Forget one workspace's attachments, leaving every other workspace's alone.
+     *
+     * One directory removal, because the workspace *is* a directory. This is
+     * what a store we own buys over cache headers, which cannot be addressed
+     * per workspace at all.
+     */
+    async forgetWorkspace(workspaceId) {
+      if (!workspaceId || !SAFE_ID.test(workspaceId)) return false
+      try {
+        await fs.rm(workspaceDir(workspaceId), { recursive: true, force: true })
+        return true
+      } catch {
+        return false
+      }
+    },
+
+    /** Everything, for signing out. */
+    async forgetAll() {
+      try {
+        await fs.rm(dir, { recursive: true, force: true })
+        return true
+      } catch {
+        return false
+      }
+    },
+  }
+}

--- a/desktop/src/main/index.js
+++ b/desktop/src/main/index.js
@@ -15,11 +15,13 @@ import {
   shell,
 } from 'electron'
 import { readFile, writeFile, access } from 'node:fs/promises'
+import * as fsPromises from 'node:fs/promises'
 import { constants } from 'node:fs'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { createAppProtocolHandler } from './protocol.js'
+import { createAttachmentStore } from './attachment-store.js'
 import { activeProfile, canDiscardActiveProfile, partitionFor } from './profiles.js'
 import { fetchProfileIdentity } from './identity.js'
 import {
@@ -138,6 +140,29 @@ const handledSessions = new WeakSet()
  * gets its own protocol registry, so a window opened on one without this would
  * fail to load the app at all.
  */
+/**
+ * The attachment store for a partition, created once and reused.
+ *
+ * Kept under `sessionData`, which is where Electron already writes this
+ * partition's IndexedDB, Cache Storage and disk cache — so everything the
+ * session owns stays in one place. The partition is in the path as well, so two
+ * profiles cannot collide even though they already have separate sessions.
+ */
+const attachmentStores = new Map()
+
+function attachmentStoreFor(partition) {
+  if (!attachmentStores.has(partition)) {
+    attachmentStores.set(
+      partition,
+      createAttachmentStore({
+        dir: join(app.getPath('sessionData'), 'attachments', encodeURIComponent(partition)),
+        fs: fsPromises,
+      })
+    )
+  }
+  return attachmentStores.get(partition)
+}
+
 function sessionFor(partition) {
   const ses = session.fromPartition(partition)
   if (!handledSessions.has(ses)) {
@@ -151,6 +176,9 @@ function sessionFor(partition) {
         fileExists,
         readFile: (pathname) => readFile(join(RENDERER_ROOT, pathname)),
         devServerUrl: process.env.AGENTRQ_RENDERER_DEV_URL ?? '',
+        // The web build caches attachments in a service worker. This build has
+        // none, so the bytes are kept on disk and served from here instead.
+        attachments: attachmentStoreFor(partition),
       })
     )
     handledSessions.add(ses)
@@ -692,6 +720,13 @@ function registerIpc(getWindow) {
 
   // Profiles. Only names and servers cross the bridge — never a session, a
   // partition or a cookie.
+  ipcMain.handle('agentrq:attachments:forgetWorkspace', (_event, workspaceId) =>
+    attachmentStoreFor(currentPartition()).forgetWorkspace(workspaceId)
+  )
+  ipcMain.handle('agentrq:attachments:forgetAll', () =>
+    attachmentStoreFor(currentPartition()).forgetAll()
+  )
+
   ipcMain.handle('agentrq:profiles:get', async () => {
     await refreshProfileIdentities()
     return profilesPayload()

--- a/desktop/src/main/protocol.js
+++ b/desktop/src/main/protocol.js
@@ -18,6 +18,8 @@
  * the routing rules can be tested in plain Node with no Electron binary.
  */
 
+import { isAttachmentRequest } from '../../../frontend/src/composables/useAttachmentCache.js'
+
 /**
  * Path prefixes forwarded to the AgentRQ server. These mirror the backend's own
  * routing in backend/internal/app/app.go — note `/mcp` has no trailing slash
@@ -231,7 +233,14 @@ export function mimeTypeFor(pathname) {
  *                                             so HMR works without breaking the
  *                                             same-origin illusion.
  */
-export function createAppProtocolHandler({ serverUrl, netFetch, fileExists, readFile, devServerUrl = '' }) {
+export function createAppProtocolHandler({
+  serverUrl,
+  netFetch,
+  fileExists,
+  readFile,
+  devServerUrl = '',
+  attachments = null,
+}) {
   const dev = Boolean(devServerUrl)
   const csp = buildCSP({ dev, devServerUrl })
 
@@ -310,10 +319,57 @@ export function createAppProtocolHandler({ serverUrl, netFetch, fileExists, read
     return new Response(body, { status: 200, headers })
   }
 
+  /**
+   * An attachment, served from disk when it has been seen before.
+   *
+   * Only this path buffers a response body. Everything else is streamed
+   * straight through, which is what keeps the SSE event stream live — buffering
+   * that would hold the whole stream in memory and deliver none of it.
+   *
+   * An attachment is safe to buffer because it is capped at a couple of
+   * megabytes and is not a stream in any meaningful sense, and it has to be
+   * buffered to be written at all.
+   */
+  async function proxyAttachment(request, url) {
+    const hit = await attachments.read(url.pathname).catch(() => null)
+    if (hit) {
+      const headers = new Headers({ 'content-type': hit.contentType })
+      if (hit.contentDisposition) headers.set('content-disposition', hit.contentDisposition)
+      return new Response(hit.body, { status: 200, headers })
+    }
+
+    const upstream = await proxyToServer(request, url)
+    // Only a successful body is worth keeping; an error page cached under an
+    // attachment's name would outlive whatever caused it.
+    if (upstream.status !== 200) return upstream
+
+    let buffered
+    try {
+      buffered = await upstream.arrayBuffer()
+    } catch {
+      // The body could not be read, so there is nothing to serve or to store.
+      return new Response('Bad Gateway', { status: 502 })
+    }
+
+    const contentType = upstream.headers.get('content-type') ?? ''
+    await attachments
+      .write(url.pathname, Buffer.from(buffered), {
+        contentType,
+        contentDisposition: upstream.headers.get('content-disposition') ?? '',
+        size: buffered.byteLength,
+      })
+      .catch(() => {})
+
+    return new Response(buffered, { status: 200, headers: upstream.headers })
+  }
+
   return async function handleAppProtocol(request) {
     const url = new URL(request.url)
 
     if (isProxyPath(url.pathname)) {
+      if (attachments && request.method === 'GET' && isAttachmentRequest(url.pathname)) {
+        return proxyAttachment(request, url)
+      }
       return proxyToServer(request, url)
     }
     if (dev) {

--- a/desktop/src/preload/index.js
+++ b/desktop/src/preload/index.js
@@ -9,6 +9,14 @@ const { contextBridge, ipcRenderer } = require('electron')
  * object.
  */
 contextBridge.exposeInMainWorld('agentrq', {
+  // The web build clears attachment bytes by messaging its service worker.
+  // There is none here, so the renderer asks the main process instead.
+  attachments: {
+    forgetWorkspace: (workspaceId) =>
+      ipcRenderer.invoke('agentrq:attachments:forgetWorkspace', workspaceId),
+    forgetAll: () => ipcRenderer.invoke('agentrq:attachments:forgetAll'),
+  },
+
   isDesktop: true,
   platform: process.platform,
   versions: {

--- a/desktop/test/attachment-store.test.js
+++ b/desktop/test/attachment-store.test.js
@@ -1,0 +1,374 @@
+import { describe, it, expect } from 'vitest'
+
+import { createAttachmentStore, parseAttachmentPath } from '../src/main/attachment-store.js'
+
+const path = (ws, att) => `/api/v1/workspaces/${ws}/tasks/0iCYTqxKOqv/attachments/${att}`
+const A = path('0iCYS9XKlnN', '0iCt6L19zvN')
+const B = path('0iCYS9XKlnN', '0iCt6L19zvP')
+const OTHER_WS = path('0aBcDeFgHiJ', '0iCt6L19zvQ')
+
+/**
+ * An in-memory filesystem with the surface the store uses.
+ *
+ * Real enough to catch a wrong path or a missing pair, and injectable so the
+ * rules are tested in plain Node with no temporary directories — matching how
+ * the rest of this folder is tested.
+ */
+function makeFs(initial = {}) {
+  const files = new Map(Object.entries(initial))
+  const times = new Map()
+  let clock = 1000
+
+  const childrenOf = (dir) => {
+    const prefix = `${dir}/`
+    const names = new Set()
+    for (const key of files.keys()) {
+      if (!key.startsWith(prefix)) continue
+      names.add(key.slice(prefix.length).split('/')[0])
+    }
+    return [...names]
+  }
+
+  return {
+    files,
+    times,
+    async readdir(dir) {
+      const names = childrenOf(dir)
+      if (names.length === 0) throw new Error('ENOENT')
+      return names
+    },
+    async stat(p) {
+      if (!files.has(p)) throw new Error('ENOENT')
+      return { size: String(files.get(p)).length, mtimeMs: times.get(p) ?? 0 }
+    },
+    async readFile(p) {
+      if (!files.has(p)) throw new Error('ENOENT')
+      return files.get(p)
+    },
+    async writeFile(p, body) {
+      files.set(p, body)
+      times.set(p, (clock += 1))
+    },
+    async mkdir() {},
+    async rm(p, { recursive } = {}) {
+      if (recursive) {
+        for (const key of [...files.keys()]) if (key === p || key.startsWith(`${p}/`)) files.delete(key)
+        return
+      }
+      files.delete(p)
+    },
+    async utimes(p) {
+      times.set(p, (clock += 1))
+    },
+  }
+}
+
+const store = (fs, budget) => createAttachmentStore({ dir: '/cache', fs, budget })
+const png = { contentType: 'image/png' }
+
+describe('parseAttachmentPath', () => {
+  it('names the workspace and the attachment', () => {
+    expect(parseAttachmentPath(A)).toEqual({
+      workspaceId: '0iCYS9XKlnN',
+      taskId: '0iCYTqxKOqv',
+      attachmentId: '0iCt6L19zvN',
+    })
+  })
+
+  it('is not fooled by a path that merely resembles one', () => {
+    expect(parseAttachmentPath('/api/v1/workspaces/ws1/tasks/t1')).toBeNull()
+    expect(parseAttachmentPath('/api/v1/workspaces/ws1/tasks/t1/attachments')).toBeNull()
+    expect(parseAttachmentPath('')).toBeNull()
+    expect(parseAttachmentPath(null)).toBeNull()
+  })
+
+  it('refuses an id that must not become a filename', () => {
+    // A path built from unvalidated input is how a cache becomes a way to write
+    // anywhere on disk. Ids are base62, so anything else is refused outright
+    // rather than escaped.
+    // Every one of the three becomes a path segment, so every one is checked.
+    expect(parseAttachmentPath('/api/v1/workspaces/../../etc/tasks/t1/attachments/a1')).toBeNull()
+    expect(parseAttachmentPath('/api/v1/workspaces/ws1/tasks/../../x/attachments/a1')).toBeNull()
+    expect(parseAttachmentPath('/api/v1/workspaces/ws1/tasks/t1/attachments/..')).toBeNull()
+    expect(parseAttachmentPath('/api/v1/workspaces/ws1/tasks/t1/attachments/a%2E%2E')).toBeNull()
+    expect(parseAttachmentPath('/api/v1/workspaces/ws-1/tasks/t1/attachments/a1')).toBeNull()
+  })
+})
+
+describe('read', () => {
+  it('serves a stored attachment with its content type', async () => {
+    const fs = makeFs()
+    const s = store(fs)
+    await s.write(A, 'PNGBYTES', png)
+
+    expect(await s.read(A)).toMatchObject({ body: 'PNGBYTES', contentType: 'image/png' })
+  })
+
+  it('mirrors the request path on disk', async () => {
+    // The path on disk and the path in the request read the same way, and the
+    // attachment id already names that exact file for all time.
+    const fs = makeFs()
+    await store(fs).write(A, 'BYTES', png)
+
+    expect([...fs.files.keys()]).toEqual([
+      '/cache/0iCYS9XKlnN/0iCYTqxKOqv/0iCt6L19zvN',
+      '/cache/0iCYS9XKlnN/0iCYTqxKOqv/0iCt6L19zvN.meta',
+    ])
+  })
+
+  it('defaults the disposition when the stored description predates it', async () => {
+    // A meta file written by an older build carries no disposition at all,
+    // which must read back as empty rather than undefined.
+    const fs = makeFs({
+      '/cache/0iCYS9XKlnN/0iCYTqxKOqv/0iCt6L19zvN': 'BYTES',
+      '/cache/0iCYS9XKlnN/0iCYTqxKOqv/0iCt6L19zvN.meta': JSON.stringify({ contentType: 'image/png' }),
+    })
+
+    expect((await store(fs).read(A)).contentDisposition).toBe('')
+  })
+
+  it('carries a content disposition back, and defaults it when absent', async () => {
+    const fs = makeFs()
+    const s = store(fs)
+    await s.write(A, 'BYTES', { contentType: 'application/pdf', contentDisposition: 'inline' })
+    await s.write(B, 'BYTES', png)
+
+    expect((await s.read(A)).contentDisposition).toBe('inline')
+    expect((await s.read(B)).contentDisposition).toBe('')
+  })
+
+  it('misses for something never stored, or a path it will not touch', async () => {
+    const s = store(makeFs())
+
+    expect(await s.read(A)).toBeNull()
+    expect(await s.read('/api/v1/workspaces/ws1/tasks/t1')).toBeNull()
+  })
+
+  it('misses when the pair is half written or unreadable', async () => {
+    // Every one of these means the same thing to the caller: forward to the
+    // server, which is what it would have done anyway.
+    const noMeta = makeFs({ '/cache/0iCYS9XKlnN/0iCYTqxKOqv/0iCt6L19zvN': 'BYTES' })
+    expect(await store(noMeta).read(A)).toBeNull()
+
+    const corrupt = makeFs({
+      '/cache/0iCYS9XKlnN/0iCYTqxKOqv/0iCt6L19zvN': 'BYTES',
+      '/cache/0iCYS9XKlnN/0iCYTqxKOqv/0iCt6L19zvN.meta': 'not json',
+    })
+    expect(await store(corrupt).read(A)).toBeNull()
+
+    const empty = makeFs({
+      '/cache/0iCYS9XKlnN/0iCYTqxKOqv/0iCt6L19zvN': 'BYTES',
+      '/cache/0iCYS9XKlnN/0iCYTqxKOqv/0iCt6L19zvN.meta': '{}',
+    })
+    expect(await store(empty).read(A)).toBeNull()
+  })
+
+  it('records the hit so eviction knows what is in use', async () => {
+    const fs = makeFs()
+    const s = store(fs)
+    await s.write(A, 'BYTES', png)
+    const before = fs.times.get('/cache/0iCYS9XKlnN/0iCYTqxKOqv/0iCt6L19zvN')
+
+    await s.read(A)
+
+    expect(fs.times.get('/cache/0iCYS9XKlnN/0iCYTqxKOqv/0iCt6L19zvN')).toBeGreaterThan(before)
+  })
+
+  it('still serves when the hit cannot be recorded, or cannot be at all', async () => {
+    const failing = makeFs()
+    await store(failing).write(A, 'BYTES', png)
+    failing.utimes = async () => {
+      throw new Error('read-only volume')
+    }
+    expect((await store(failing).read(A)).body).toBe('BYTES')
+
+    const none = makeFs()
+    await store(none).write(A, 'BYTES', png)
+    delete none.utimes
+    expect((await store(none).read(A)).body).toBe('BYTES')
+  })
+})
+
+describe('write', () => {
+  it('refuses a file too large to be worth the space', async () => {
+    const fs = makeFs()
+
+    expect(await store(fs).write(A, 'BIG', { ...png, size: 3 * 1024 * 1024 })).toBe(false)
+    expect(await store(fs).read(A)).toBeNull()
+  })
+
+  it('keeps a response whose size was not measured', async () => {
+    // Refusing everything unmeasurable would mean caching almost nothing.
+    expect(await store(makeFs()).write(A, 'BYTES', png)).toBe(true)
+  })
+
+  it('refuses what it could not serve back, or must not name a file', async () => {
+    const fs = makeFs()
+
+    expect(await store(fs).write(A, 'BYTES', {})).toBe(false)
+    expect(await store(fs).write('/api/v1/workspaces/ws-1/tasks/t/attachments/a', 'B', png)).toBe(
+      false
+    )
+  })
+
+  it('reports failure rather than throwing when the disk refuses', async () => {
+    const fs = makeFs()
+    fs.writeFile = async () => {
+      throw new Error('disk full')
+    }
+
+    expect(await store(fs).write(A, 'BYTES', png)).toBe(false)
+  })
+})
+
+describe('evict', () => {
+  it('drops the least recently used until the budget fits', async () => {
+    const fs = makeFs()
+    const small = store(fs, 20)
+    await small.write(A, '1234567890', png)
+    await small.write(B, '1234567890', png)
+    await small.write(OTHER_WS, '1234567890', png)
+
+    expect(await small.read(A)).toBeNull()
+    expect(await small.read(B)).not.toBeNull()
+  })
+
+  it('spares an entry that was read recently', async () => {
+    const fs = makeFs()
+    const small = store(fs, 20)
+    await small.write(A, '1234567890', png)
+    await small.write(B, '1234567890', png)
+    await small.read(A)
+
+    await small.write(OTHER_WS, '1234567890', png)
+
+    expect(await small.read(A)).not.toBeNull()
+    expect(await small.read(B)).toBeNull()
+  })
+
+  it('counts across workspaces, since the budget is for the device', async () => {
+    const fs = makeFs()
+    const small = store(fs, 15)
+    await small.write(A, '1234567890', png)
+
+    await small.write(OTHER_WS, '1234567890', png)
+
+    expect(await small.read(A)).toBeNull()
+  })
+
+  it('has nothing to drop while the budget fits, or before anything is stored', async () => {
+    const fs = makeFs()
+    await store(fs).write(A, 'BYTES', png)
+
+    expect(await store(fs).evict()).toBe(0)
+    expect(await store(makeFs()).evict()).toBe(0)
+  })
+
+  it('ignores names that are not ours, and files that vanish mid-scan', async () => {
+    // `.DS_Store` and the like are not base62, so they are never treated as a
+    // workspace directory — the scan skips them before touching the disk.
+    const fs = makeFs({
+      '/cache/.DS_Store': 'x',
+      '/cache/tmp-scratch/x': 'y',
+      '/cache/0iCYS9XKlnN/0iCYTqxKOqv/not-an-id': 'y',
+      '/cache/0iCYS9XKlnN/not-a-task-id/x': 'z',
+    })
+    await store(fs).write(A, 'BYTES', png)
+    const original = fs.stat.bind(fs)
+    fs.stat = async (p) => {
+      if (p.endsWith('0iCt6L19zvN')) throw new Error('vanished')
+      return original(p)
+    }
+
+    expect(await store(fs).evict()).toBe(0)
+  })
+
+  it('ignores a directory it cannot read at either level', async () => {
+    const fs = makeFs()
+    await store(fs).write(A, 'BYTES', png)
+    const original = fs.readdir.bind(fs)
+    fs.readdir = async (dir) => {
+      if (dir !== '/cache') throw new Error('EACCES')
+      return original(dir)
+    }
+    expect(await store(fs).evict()).toBe(0)
+
+    const deeper = makeFs()
+    await store(deeper).write(A, 'BYTES', png)
+    const originalDeeper = deeper.readdir.bind(deeper)
+    deeper.readdir = async (dir) => {
+      if (dir.split('/').length > 3) throw new Error('EACCES')
+      return originalDeeper(dir)
+    }
+    expect(await store(deeper).evict()).toBe(0)
+  })
+})
+
+describe('forgetWorkspace', () => {
+  it('removes one workspace and leaves the others', async () => {
+    // One directory removal, because the workspace is a directory. This is what
+    // a store we own buys over cache headers.
+    const fs = makeFs()
+    const s = store(fs)
+    await s.write(A, 'A', png)
+    await s.write(OTHER_WS, 'B', png)
+
+    expect(await s.forgetWorkspace('0iCYS9XKlnN')).toBe(true)
+
+    expect(await s.read(A)).toBeNull()
+    expect(await s.read(OTHER_WS)).not.toBeNull()
+  })
+
+  it('refuses a workspace id that must not become a path', async () => {
+    const fs = makeFs()
+    await store(fs).write(A, 'A', png)
+
+    expect(await store(fs).forgetWorkspace('../..')).toBe(false)
+    expect(await store(fs).forgetWorkspace('')).toBe(false)
+    expect(await store(fs).read(A)).not.toBeNull()
+  })
+
+  it('reports failure rather than throwing', async () => {
+    const fs = makeFs()
+    fs.rm = async () => {
+      throw new Error('busy')
+    }
+
+    expect(await store(fs).forgetWorkspace('0iCYS9XKlnN')).toBe(false)
+  })
+})
+
+describe('forgetAll', () => {
+  it('drops everything, which is what signing out needs', async () => {
+    const fs = makeFs()
+    const s = store(fs)
+    await s.write(A, 'A', png)
+    await s.write(OTHER_WS, 'B', png)
+
+    expect(await s.forgetAll()).toBe(true)
+    expect([...fs.files.keys()]).toEqual([])
+  })
+
+  it('reports failure rather than throwing', async () => {
+    const fs = makeFs()
+    fs.rm = async () => {
+      throw new Error('busy')
+    }
+
+    expect(await store(fs).forgetAll()).toBe(false)
+  })
+})
+
+describe('createAttachmentStore', () => {
+  it('defaults to the desktop budget, a gigabyte', async () => {
+    const fs = makeFs()
+    const s = createAttachmentStore({ dir: '/cache', fs })
+    await s.write(A, 'BYTES', png)
+
+    expect(await s.evict()).toBe(0)
+  })
+
+  it('can be constructed with nothing and simply does nothing', async () => {
+    expect(await createAttachmentStore().read(A)).toBeNull()
+  })
+})

--- a/desktop/test/protocol.test.js
+++ b/desktop/test/protocol.test.js
@@ -30,6 +30,21 @@ function makeHandler(overrides = {}) {
       fileExists: overrides.fileExists ?? (async () => false),
       readFile: overrides.readFile ?? (async () => new TextEncoder().encode('<html></html>')),
       ...(overrides.devServerUrl !== undefined ? { devServerUrl: overrides.devServerUrl } : {}),
+      ...(overrides.attachments !== undefined ? { attachments: overrides.attachments } : {}),
+    }),
+  }
+}
+
+const ATTACHMENT = 'app://x/api/v1/workspaces/ws1/tasks/t1/attachments/a1'
+
+/** An attachment store that remembers what it was asked to keep. */
+function makeStore(initial = null) {
+  return {
+    written: [],
+    read: vi.fn(async () => initial),
+    write: vi.fn(async function (pathname, body, meta) {
+      this.written.push({ pathname, body, meta })
+      return true
     }),
   }
 }
@@ -460,5 +475,146 @@ describe('createAppProtocolHandler — dev server mode', () => {
 
     await handler(makeRequest('app://agentrq/src/App.vue?vue&type=style'))
     expect(netFetch.mock.calls[0][0]).toBe('http://localhost:5174/src/App.vue?vue&type=style')
+  })
+})
+
+describe('attachments', () => {
+  it('serves a stored attachment without asking the server', async () => {
+    const attachments = makeStore({
+      body: new Uint8Array([1, 2, 3]),
+      contentType: 'image/png',
+      contentDisposition: 'inline; filename="a.png"',
+    })
+    const { handler, netFetch } = makeHandler({ attachments })
+
+    const res = await handler(makeRequest(ATTACHMENT))
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('image/png')
+    expect(res.headers.get('content-disposition')).toBe('inline; filename="a.png"')
+    expect(netFetch).not.toHaveBeenCalled()
+  })
+
+  it('omits a disposition the store did not have', async () => {
+    const attachments = makeStore({ body: new Uint8Array([1]), contentType: 'image/png' })
+    const { handler } = makeHandler({ attachments })
+
+    const res = await handler(makeRequest(ATTACHMENT))
+
+    expect(res.headers.get('content-disposition')).toBeNull()
+  })
+
+  it('forwards a miss and keeps what comes back', async () => {
+    const attachments = makeStore(null)
+    const netFetch = vi.fn(
+      async () =>
+        new Response(new Uint8Array([9, 9]), {
+          status: 200,
+          headers: { 'content-type': 'image/png', 'content-disposition': 'inline' },
+        })
+    )
+    const { handler } = makeHandler({ attachments, netFetch })
+
+    const res = await handler(makeRequest(ATTACHMENT))
+
+    expect(res.status).toBe(200)
+    expect(netFetch).toHaveBeenCalledOnce()
+    expect(attachments.written).toHaveLength(1)
+    expect(attachments.written[0].meta).toMatchObject({ contentType: 'image/png', size: 2 })
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(new Uint8Array([9, 9]))
+  })
+
+  it('keeps nothing when the server did not answer with the file', async () => {
+    // An error page stored under an attachment's name would outlive whatever
+    // caused it.
+    const attachments = makeStore(null)
+    const netFetch = vi.fn(async () => new Response('nope', { status: 404 }))
+    const { handler } = makeHandler({ attachments, netFetch })
+
+    const res = await handler(makeRequest(ATTACHMENT))
+
+    expect(res.status).toBe(404)
+    expect(attachments.write).not.toHaveBeenCalled()
+  })
+
+  it('reports a bad gateway when the body fails mid-read', async () => {
+    // A stream that errors after the response headers have already been sent,
+    // which is the only way a 200 can still fail to produce bytes.
+    const attachments = makeStore(null)
+    const netFetch = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream({
+            pull(controller) {
+              controller.error(new Error('stream broke'))
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'image/png' } }
+        )
+    )
+    const { handler } = makeHandler({ attachments, netFetch })
+
+    const res = await handler(makeRequest(ATTACHMENT))
+
+    expect(res.status).toBe(502)
+    expect(attachments.write).not.toHaveBeenCalled()
+  })
+
+  it('keeps a response that arrived without headers describing it', async () => {
+    const attachments = makeStore(null)
+    const netFetch = vi.fn(async () => new Response(new Uint8Array([7]), { status: 200 }))
+    const { handler } = makeHandler({ attachments, netFetch })
+
+    await handler(makeRequest(ATTACHMENT))
+
+    expect(attachments.written[0].meta).toMatchObject({ contentDisposition: '' })
+  })
+
+  it('still serves when the store itself fails', async () => {
+    // A cache that cannot be read behaves like one that was never written.
+    const attachments = {
+      read: vi.fn(async () => {
+        throw new Error('disk gone')
+      }),
+      write: vi.fn(async () => {
+        throw new Error('disk gone')
+      }),
+    }
+    const { handler, netFetch } = makeHandler({ attachments })
+
+    const res = await handler(makeRequest(ATTACHMENT))
+
+    expect(res.status).toBe(200)
+    expect(netFetch).toHaveBeenCalledOnce()
+  })
+
+  it('leaves every other request streaming, which is what keeps SSE live', async () => {
+    const attachments = makeStore(null)
+    const { handler } = makeHandler({ attachments })
+
+    await handler(makeRequest('app://x/api/v1/workspaces/ws1/events'))
+    await handler(makeRequest('app://x/api/v1/workspaces/ws1/tasks'))
+
+    expect(attachments.read).not.toHaveBeenCalled()
+  })
+
+  it('does not intercept a write to an attachment path', async () => {
+    const attachments = makeStore(null)
+    const { handler } = makeHandler({ attachments })
+
+    await handler(makeRequest(ATTACHMENT, { method: 'POST' }))
+
+    expect(attachments.read).not.toHaveBeenCalled()
+  })
+
+  it('behaves exactly as before on a build with no store', async () => {
+    // The web build has a service worker instead, and this argument is how the
+    // desktop build opts in.
+    const { handler, netFetch } = makeHandler()
+
+    const res = await handler(makeRequest(ATTACHMENT))
+
+    expect(res.status).toBe(200)
+    expect(netFetch).toHaveBeenCalledOnce()
   })
 })

--- a/frontend/src/composables/useCacheStorage.js
+++ b/frontend/src/composables/useCacheStorage.js
@@ -116,6 +116,7 @@ export async function clearWorkspaceData(db, workspaceId, options = {}) {
   // reach. Told, not awaited: a clear that the worker has not finished is still
   // a clear, and on a build with no worker there is nothing there to clear.
   tellWorkerToForget(workspaceId, worker);
+  tellShellToForget(workspaceId, options.bridge);
 
   const before = await estimateUsage(manager);
   const cleared = await clearWorkspace(db, workspaceId, KeyRange);
@@ -145,6 +146,35 @@ export function tellWorkerToForget(workspaceId, worker = globalThis.navigator?.s
 }
 
 /**
+ * The same job on the desktop build, which has no worker to ask.
+ *
+ * There the bytes are files the main process owns, so the renderer goes through
+ * the bridge instead. Both paths are attempted rather than branched on the
+ * platform: exactly one of them exists in any given build, and asking the one
+ * that is absent is already a no-op.
+ */
+export async function tellShellToForget(workspaceId, bridge = globalThis.window?.agentrq) {
+  if (!workspaceId || !bridge?.attachments?.forgetWorkspace) return false;
+  try {
+    await bridge.attachments.forgetWorkspace(workspaceId);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Everything the shell holds for this profile, for signing out. */
+export async function tellShellToForgetAll(bridge = globalThis.window?.agentrq) {
+  if (!bridge?.attachments?.forgetAll) return false;
+  try {
+    await bridge.attachments.forgetAll();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Everything this device holds for a user, gone.
  *
  * Signing out runs this, and it is deliberately unconditional. A browser that
@@ -153,8 +183,11 @@ export function tellWorkerToForget(workspaceId, worker = globalThis.navigator?.s
  * does not consult the per-workspace setting, and does not care whether the
  * delete was blocked by another tab. The connection is dropped either way.
  */
-export async function forgetEverything({ userId, factory = globalThis.indexedDB } = {}) {
+export async function forgetEverything({ userId, factory = globalThis.indexedDB, bridge } = {}) {
   resetSharedCache();
+  // The desktop build keeps attachment bytes outside the database, so signing
+  // out has to reach those too. A build without the bridge simply has none.
+  await tellShellToForgetAll(bridge);
   if (!userId) return false;
   return destroyCache({ userId, factory });
 }

--- a/frontend/test/cacheStorage.test.js
+++ b/frontend/test/cacheStorage.test.js
@@ -8,6 +8,8 @@ import {
   formatBytes,
   requestPersistence,
   setCacheEnabled,
+  tellShellToForget,
+  tellShellToForgetAll,
   tellWorkerToForget,
 } from '../src/composables/useCacheStorage'
 import {
@@ -286,6 +288,65 @@ describe('tellWorkerToForget', () => {
   })
 })
 
+describe('tellShellToForget', () => {
+  it('asks the desktop shell, which owns the files there', async () => {
+    // The desktop build has no service worker, so the bytes are files the main
+    // process owns and the renderer goes through the bridge.
+    const calls = []
+    const bridge = { attachments: { forgetWorkspace: async (id) => calls.push(id) } }
+
+    expect(await tellShellToForget('ws1', bridge)).toBe(true)
+    expect(calls).toEqual(['ws1'])
+  })
+
+  it('is a no-op in the browser, where there is no shell', async () => {
+    // Both paths are attempted rather than branched on the platform: exactly
+    // one exists in any build, and asking the absent one already does nothing.
+    expect(await tellShellToForget('ws1', undefined)).toBe(false)
+    expect(await tellShellToForget('ws1', {})).toBe(false)
+    expect(await tellShellToForget('ws1', { attachments: {} })).toBe(false)
+    expect(await tellShellToForget('', { attachments: { forgetWorkspace: async () => {} } })).toBe(
+      false
+    )
+  })
+
+  it('reports failure rather than throwing when the bridge rejects', async () => {
+    const bridge = {
+      attachments: {
+        forgetWorkspace: async () => {
+          throw new Error('main process went away')
+        },
+      },
+    }
+
+    expect(await tellShellToForget('ws1', bridge)).toBe(false)
+  })
+})
+
+describe('tellShellToForgetAll', () => {
+  it('drops everything the shell holds for this profile', async () => {
+    let called = false
+    const bridge = { attachments: { forgetAll: async () => { called = true } } }
+
+    expect(await tellShellToForgetAll(bridge)).toBe(true)
+    expect(called).toBe(true)
+  })
+
+  it('is a no-op without a shell, and never throws', async () => {
+    expect(await tellShellToForgetAll(undefined)).toBe(false)
+    expect(await tellShellToForgetAll({})).toBe(false)
+    expect(
+      await tellShellToForgetAll({
+        attachments: {
+          forgetAll: async () => {
+            throw new Error('gone')
+          },
+        },
+      })
+    ).toBe(false)
+  })
+})
+
 describe('forgetEverything', () => {
   it('deletes the database and drops the connection', async () => {
     // Signing out. A browser several people use must not leave one person's
@@ -299,6 +360,15 @@ describe('forgetEverything', () => {
     const fresh = await openCache({ userId: 'u1', factory })
     expect(await listCachedTasks(fresh, 'ws1', IDBKeyRange)).toEqual([])
     fresh.close()
+  })
+
+  it('also clears what the desktop shell holds outside the database', async () => {
+    let clearedShell = false
+    const bridge = { attachments: { forgetAll: async () => { clearedShell = true } } }
+
+    await forgetEverything({ userId: 'u1', factory, bridge })
+
+    expect(clearedShell).toBe(true)
   })
 
   it('does not consult the per-workspace setting', async () => {


### PR DESCRIPTION
> **Stacked on #419 → #418 → #421.** Merge those first; GitHub retargets this automatically as each lands with "Squash and merge" + "Delete branch". The diff shown here is this change alone.

## What changed

The desktop app now keeps the attachments you have opened, so images and PDFs load instantly and still open with no connection — the same behaviour the browser has had since the previous change, which the desktop build could not share.

## Why changed

On the web an attachment is kept by the offline layer and opens without any component knowing. The desktop app is built without that layer, so every image and PDF was fetched again on every single view.

Letting the network stack handle it was not an option: the attachment endpoint sends no `Cache-Control` and no `ETag`, so there is nothing to cache on. And even with those headers it would have been the wrong answer, because a browser's own cache is not addressable per workspace — **"Clear this workspace" would have had to clear everything.** That button makes a promise, so the bytes go in a store the app owns.

The files are laid out as `<workspaceId>/<taskId>/<attachmentId>`, the same shape as the URL they came from, so the path on disk and the path in the request read the same way. The attachment id is the filename because it already names that exact file for all time — the server mints one per attachment and never reuses it. Nesting by task also makes removing anything a directory removal rather than a scan, at whichever level is being removed.

**All three ids come out of a URL and all three become path segments**, and a path built from unvalidated input is how a cache becomes a way to write anywhere on disk. They are monoflake ids, so anything that is not plain base62 is refused rather than escaped, and a refused path is simply not cached — which the caller already handles.

**Two more decisions worth stating:**

- **The policy is imported, not rewritten.** The size cap, the eviction plan and the budget are the very same code the browser runs — it has no imports, so the shell can use it directly. A second copy would drift, and the drift would show up as the two builds disagreeing about what they had kept.
- **Only attachment downloads are buffered.** Every other response still streams straight through, which is what keeps the live event stream working; buffering that would hold the whole stream in memory and deliver none of it. An attachment is safe to buffer because it is capped at a couple of megabytes and has to be buffered to be stored at all.

A half-written pair, an unreadable descriptor or a disk error all count as a miss, because the caller does the same thing in every one of them: ask the server, which is what it would have done anyway.

Clearing reaches the store from both sides — the browser messages its offline layer, the desktop app asks the shell. Both are attempted rather than branched on which build is running: exactly one exists in any build, and asking the absent one is already a no-op.

## Test coverage report

**New lines introduced: 100%**, across both packages, each of which enforces it independently:

```
desktop      All files    100 | 100 | 100 | 100      418 tests
frontend     All files    100 | 100 | 100 | 100      471 tests
```

The tests cover a hit served without asking the server, a miss stored on the way back, a file too large to keep, eviction order and an entry spared by a recent read, the budget counting across workspaces because it is a budget for the device, clear-by-workspace leaving other workspaces alone, and every way a stored file can be unusable — missing, half written, unparseable, or on a disk that has stopped answering.

Path safety has its own cases: `..` in the workspace segment, `..` in the task segment, `..` and `%2E%2E` as an attachment id, and a hyphenated id. All refused, nothing written, request forwarded.

Also covered: a response body that fails *after* its headers arrived, which is the only way a success can still produce no bytes.

## Other reports

Both packages build cleanly. No backend change, no new dependency, and no change to any view.

TaskID: 0iEJnJWxrJB

🤖 Generated with [Claude Code](https://claude.com/claude-code)
