### PR TITLE
feat(cache): let a workspace expire its local copy, and sweep it daily

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -396,6 +396,7 @@ import { usePushNotifications } from './composables/usePushNotifications'
 import Toast from './components/Toast.vue'
 import { cacheTaskEvent, connectCache, sharedCache } from './composables/useCachedTasks'
 import { forgetEverything } from './composables/useCacheStorage'
+import { SWEEP_INTERVAL_MS, sweepIfDue, whenIdle } from './composables/useCacheRetention'
 import CommandPalette from './components/CommandPalette.vue'
 import ShortcutsHelp from './components/ShortcutsHelp.vue'
 import {
@@ -491,6 +492,26 @@ const workspaceStore = useWorkspaceStore()
 const workspaces = computed(() => workspaceStore.workspaces)
 
 const currentWorkspaceId = computed(() => route.params.id || route.params.workspaceId)
+
+/**
+ * Enforce each workspace's retention limit, at most once a day.
+ *
+ * Started once the cache is open and repeated on a timer, because a desktop app
+ * or a pinned tab can stay open for weeks and would otherwise sweep only at
+ * launch. The daily guard lives in the database, so the interval firing more
+ * often than that costs one cheap check.
+ *
+ * Deliberately not a background job: browsers do not reliably offer one, and
+ * the only cost of sweeping while the app is open is holding data slightly
+ * longer than asked.
+ */
+let sweepTimer = null
+function startRetentionSweep(db) {
+  if (!db || sweepTimer) return
+  const run = () => whenIdle(() => sweepIfDue(db))
+  run()
+  sweepTimer = setInterval(run, SWEEP_INTERVAL_MS)
+}
 
 // --- Keyboard shortcuts -----------------------------------------------------
 // The shell owns the ones that work anywhere. A view registers its own on top
@@ -613,7 +634,10 @@ const loadUser = async () => {
     // The database is named for the signed-in user, so it cannot be opened
     // before we know who that is. Failing to open one is not an error worth
     // showing: the app reads from the network either way.
-    if (user.value?.id) connectCache(user.value.id)
+    if (user.value?.id) {
+      const db = await connectCache(user.value.id)
+      startRetentionSweep(db)
+    }
   } catch (err) {
     console.error('Failed to fetch user:', err)
   }
@@ -632,6 +656,7 @@ const handleClickOutside = (e) => {
 onUnmounted(() => {
   document.removeEventListener('click', handleClickOutside)
   window.removeEventListener('keydown', closeOverlaysOnEscape)
+  if (sweepTimer) clearInterval(sweepTimer)
 })
 
 watch(() => route.fullPath, (fullPath) => {

--- a/frontend/src/composables/useCacheRetention.js
+++ b/frontend/src/composables/useCacheRetention.js
@@ -1,0 +1,206 @@
+import { cacheSettingKey } from './useCachedTasks';
+import { deleteTasks, listAllCachedTasks, metaKey, STORE_META } from './useLocalCache';
+
+/**
+ * How long the local copy is kept, and the sweep that enforces it.
+ *
+ * ## What the clock measures
+ *
+ * A record's `cachedAt` — when this device last had a reason to keep it, which
+ * is stamped on every write. Deliberately **not** the server's `updatedAt`: a
+ * limit measured against that would delete a task the moment after someone
+ * opened an old one, which is the opposite of what a cache is for. Anything you
+ * keep touching stays; anything you stop touching ages out.
+ *
+ * ## What this is not
+ *
+ * Not an operating-system background job. Browsers do not reliably offer one —
+ * Periodic Background Sync is Chromium-only and gated on engagement heuristics
+ * nobody can predict — so the sweep runs while the app is open. That is enough
+ * for something whose only failure mode is holding data slightly longer than
+ * asked, and it is worth saying plainly rather than implying otherwise.
+ */
+
+/** Stored beside the on/off setting, and per device for the same reason. */
+export const RETENTION_PREFIX = 'local_cache_days_';
+
+/** How often a sweep is worth running. Expiry is measured in days. */
+export const SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** `0` means keep indefinitely, which is the default. */
+export const RETENTION_OPTIONS = [
+  { days: 0, label: 'Until I clear it' },
+  { days: 7, label: '7 days' },
+  { days: 30, label: '30 days' },
+  { days: 90, label: '90 days' },
+];
+
+export function retentionKey(workspaceId) {
+  return `${RETENTION_PREFIX}${workspaceId}`;
+}
+
+/**
+ * How many days this workspace keeps its local copy, on this device.
+ *
+ * Zero means indefinitely, and is what an unset, unreadable or nonsensical
+ * value resolves to. Keeping data slightly too long is a storage cost the
+ * budget already bounds; deleting someone's offline copy because a setting
+ * could not be parsed is a surprise they cannot undo.
+ */
+export function getRetentionDays(workspaceId, storage = globalThis.localStorage) {
+  if (!workspaceId || !storage) return 0;
+  try {
+    const days = Number(storage.getItem(retentionKey(workspaceId)));
+    return Number.isFinite(days) && days > 0 ? Math.floor(days) : 0;
+  } catch {
+    return 0;
+  }
+}
+
+/** Record the choice. Zero clears it rather than storing a zero. */
+export function setRetentionDays(workspaceId, days, storage = globalThis.localStorage) {
+  if (!workspaceId || !storage) return false;
+  try {
+    if (Number(days) > 0) storage.setItem(retentionKey(workspaceId), String(Math.floor(days)));
+    else storage.removeItem(retentionKey(workspaceId));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether a record has outlived its workspace's limit.
+ *
+ * A record with no `cachedAt` was written before this existed, and is treated
+ * as current rather than as infinitely old — an upgrade should not delete
+ * someone's cache on first run.
+ */
+export function isExpired(record, days, now = Date.now()) {
+  if (!(days > 0)) return false;
+  const cachedAt = Number(record?.cachedAt);
+  if (!Number.isFinite(cachedAt)) return false;
+  return now - cachedAt > days * DAY_MS;
+}
+
+/**
+ * The records to remove, given every record and the per-workspace limits.
+ *
+ * The limit is looked up once per workspace rather than once per record: a
+ * sweep reads thousands of rows and would otherwise hit local storage for each
+ * of them.
+ *
+ * @param {Array<object>} records
+ * @param {(workspaceId: string) => number} limitFor
+ * @param {number} [now]
+ */
+export function expiredRecords(records, limitFor, now = Date.now()) {
+  const list = Array.isArray(records) ? records : [];
+  const limits = new Map();
+
+  return list.filter((record) => {
+    const workspaceId = record?.workspaceId;
+    if (!workspaceId) return false;
+    if (!limits.has(workspaceId)) limits.set(workspaceId, limitFor(workspaceId));
+    return isExpired(record, limits.get(workspaceId), now);
+  });
+}
+
+/** Whether enough time has passed since the last sweep to run another. */
+export function dueForSweep(lastSweptAt, now = Date.now(), interval = SWEEP_INTERVAL_MS) {
+  const last = Number(lastSweptAt);
+  if (!Number.isFinite(last)) return true;
+  // A clock that has moved backwards — a timezone change, a corrected system
+  // clock — would otherwise park the sweep until the future caught up.
+  if (last > now) return true;
+  return now - last >= interval;
+}
+
+const SWEPT_AT = 'lastSweptAt';
+
+/** When the last sweep finished, or null if none has. */
+export async function readLastSweptAt(db) {
+  if (!db) return null;
+  return new Promise((resolve) => {
+    try {
+      const req = db.transaction(STORE_META, 'readonly').objectStore(STORE_META).get(SWEPT_AT);
+      req.onsuccess = () => resolve(Number(req.result?.value) || null);
+      req.onerror = () => resolve(null);
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+/**
+ * Record that a sweep finished.
+ *
+ * Kept in the database rather than in local storage so it survives alongside
+ * the data it describes: clearing the cache and keeping the timestamp would
+ * mean the next sweep is skipped for a day over nothing.
+ */
+export async function writeLastSweptAt(db, now = Date.now()) {
+  if (!db) return false;
+  return new Promise((resolve) => {
+    try {
+      const tx = db.transaction(STORE_META, 'readwrite');
+      tx.objectStore(STORE_META).put({ key: SWEPT_AT, value: now });
+      tx.oncomplete = () => resolve(true);
+      tx.onerror = () => resolve(false);
+      tx.onabort = () => resolve(false);
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+/**
+ * Remove everything that has outlived its workspace's limit.
+ *
+ * Returns the number removed, which is what the caller reports and what the
+ * tests assert on. Doing nothing is the common case and costs one scan.
+ */
+export async function sweepExpired(db, options = {}) {
+  const { storage, now = Date.now(), KeyRange } = options;
+  if (!db) return 0;
+
+  const records = await listAllCachedTasks(db);
+  const doomed = expiredRecords(records, (id) => getRetentionDays(id, storage), now);
+  if (doomed.length === 0) return 0;
+
+  return deleteTasks(db, doomed, KeyRange);
+}
+
+/**
+ * Sweep, but at most once a day.
+ *
+ * The guard is what makes this safe to call on every startup and on a timer:
+ * the work happens when it is due and is skipped the rest of the time, without
+ * the caller having to know which.
+ */
+export async function sweepIfDue(db, options = {}) {
+  const { now = Date.now(), interval = SWEEP_INTERVAL_MS } = options;
+  if (!db) return { swept: false, removed: 0 };
+
+  if (!dueForSweep(await readLastSweptAt(db), now, interval)) {
+    return { swept: false, removed: 0 };
+  }
+
+  const removed = await sweepExpired(db, options);
+  await writeLastSweptAt(db, now);
+  return { swept: true, removed };
+}
+
+/**
+ * Run `task` when the browser is not busy, or soon if it never says so.
+ *
+ * A sweep competes with rendering for the main thread, and there is never a
+ * reason for it to win — it is a day's worth of tidying, not something anyone
+ * is waiting on.
+ */
+export function whenIdle(task, scheduler = globalThis.requestIdleCallback) {
+  if (typeof scheduler === 'function') return scheduler(() => task());
+  return setTimeout(task, 0);
+}

--- a/frontend/src/composables/useLocalCache.js
+++ b/frontend/src/composables/useLocalCache.js
@@ -106,13 +106,19 @@ function attachmentsOf(task) {
  *
  * @param {object} task    a task as the API sends it
  * @param {string[]} [terms]
+ * @param {number} [now]   stamped as `cachedAt`; injectable for tests
  */
-export function toTaskRecord(task, terms = []) {
+export function toTaskRecord(task, terms = [], now = Date.now()) {
   const record = {
     id: task.id,
     workspaceId: task.workspaceId,
     attachmentCount: attachmentsOf(task).length,
     terms: plain(terms),
+    // When this device last had a reason to keep the record, which is what a
+    // retention limit is measured against. Deliberately not the server's
+    // `updatedAt`: that would expire a task the moment after someone opened an
+    // old one, which is the opposite of what a cache should do.
+    cachedAt: now,
   };
   for (const field of TASK_FIELDS) {
     if (task[field] !== undefined && task[field] !== null) record[field] = plain(task[field]);
@@ -380,6 +386,43 @@ export async function listAllCachedTasks(db) {
     const rows = await requestResult(tx.objectStore(STORE_TASKS).getAll());
     return rows.sort((a, b) => String(b.updatedAt ?? '').localeCompare(String(a.updatedAt ?? '')));
   }, []);
+}
+
+/**
+ * Forget specific tasks, wherever they live.
+ *
+ * Takes whole records rather than keys because the caller has just read them to
+ * decide, and re-deriving the key from a record is one more place to get the
+ * key shape wrong.
+ *
+ * @param {Array<{workspaceId: string, id: string}>} records
+ * @param {typeof IDBKeyRange} [KeyRange]
+ * @returns {Promise<number>} how many were removed
+ */
+export async function deleteTasks(db, records, KeyRange = globalThis.IDBKeyRange) {
+  const list = Array.isArray(records) ? records : [];
+  if (!db || list.length === 0) return 0;
+
+  return attempt(async () => {
+    const tx = db.transaction([STORE_TASKS, STORE_THREADS, STORE_ATTACHMENTS], 'readwrite');
+    const tasks = tx.objectStore(STORE_TASKS);
+    const threads = tx.objectStore(STORE_THREADS);
+    const attachments = tx.objectStore(STORE_ATTACHMENTS);
+
+    for (const record of list) {
+      const key = [record.workspaceId, record.id];
+      tasks.delete(key);
+      threads.delete(key);
+      // The attachment key carries the attachment id as a third part, so this
+      // is a range over everything belonging to the task rather than one key.
+      attachments.delete(
+        KeyRange.bound([record.workspaceId, record.id], [record.workspaceId, record.id, []])
+      );
+    }
+
+    await transactionDone(tx);
+    return list.length;
+  }, 0);
 }
 
 /**

--- a/frontend/src/views/WorkspaceSettingsView.vue
+++ b/frontend/src/views/WorkspaceSettingsView.vue
@@ -127,6 +127,26 @@
                       </button>
                     </div>
 
+                    <!-- Retention. Only meaningful while something is being
+                         kept, so it follows the switch rather than sitting
+                         beside it. -->
+                    <div v-if="localCacheOn" class="pt-3 border-t border-gray-200 dark:border-zinc-700/60">
+                      <p class="text-[10px] font-bold text-gray-400 dark:text-zinc-500 uppercase tracking-widest mb-2">Keep tasks for</p>
+                      <div class="flex flex-wrap gap-2">
+                        <button v-for="opt in retentionOptions" :key="opt.days" type="button"
+                                @click="changeRetention(opt.days)"
+                                class="px-3 py-1.5 rounded-sm border text-[10px] font-bold uppercase tracking-widest transition-all"
+                                :class="retentionDays === opt.days
+                                  ? 'bg-gray-900 dark:bg-white text-white dark:text-zinc-900 border-gray-900 dark:border-white'
+                                  : 'bg-white dark:bg-zinc-900 text-gray-600 dark:text-zinc-300 border-gray-200 dark:border-zinc-700 hover:border-gray-900 dark:hover:border-white'">
+                          {{ opt.label }}
+                        </button>
+                      </div>
+                      <p class="text-[11px] text-gray-500 dark:text-zinc-400 mt-2 font-medium">
+                        Counted from the last time you opened a task, not from when it was written — so anything you keep coming back to stays.
+                      </p>
+                    </div>
+
                     <div class="flex items-center justify-between gap-4 pt-3 border-t border-gray-200 dark:border-zinc-700/60">
                       <p class="text-[11px] text-gray-500 dark:text-zinc-400 font-medium">
                         <span v-if="localUsageLabel">This browser is storing <span class="font-bold text-gray-900 dark:text-zinc-100">{{ localUsageLabel }}</span> across all workspaces.</span>
@@ -729,6 +749,11 @@ import {
   requestPersistence,
   setCacheEnabled,
 } from '../composables/useCacheStorage';
+import {
+  RETENTION_OPTIONS,
+  getRetentionDays,
+  setRetentionDays,
+} from '../composables/useCacheRetention';
 import { WHISPER_LANGUAGES } from '../utils/whisperLanguages';
 
 const { toKebabCase, liveKebabCase } = useFormat();
@@ -1284,6 +1309,8 @@ function getShellPattern(tool) {
 // is the shape that gets sent to the server on save.
 
 const localCacheOn = ref(true);
+const retentionDays = ref(0);
+const retentionOptions = RETENTION_OPTIONS;
 const localUsage = ref(null);
 const isClearingLocal = ref(false);
 
@@ -1304,6 +1331,18 @@ async function toggleLocalCache() {
   // nothing will ever update again.
   if (!localCacheOn.value) await clearLocalData({ quiet: true });
   else notifySuccess('This workspace will be kept on this device');
+}
+
+function changeRetention(days) {
+  setRetentionDays(workspaceId.value, days);
+  retentionDays.value = getRetentionDays(workspaceId.value);
+  // The sweep runs at most once a day, so a shortened limit does not bite
+  // immediately. Saying so beats letting someone conclude it did nothing.
+  notifySuccess(
+    retentionDays.value === 0
+      ? 'This workspace will be kept until you clear it'
+      : `Tasks you stop opening will be dropped after ${retentionDays.value} days`
+  );
 }
 
 async function clearLocalData({ quiet = false } = {}) {
@@ -1327,6 +1366,7 @@ async function clearLocalData({ quiet = false } = {}) {
 onMounted(() => {
   load();
   localCacheOn.value = isCacheEnabled(workspaceId.value);
+  retentionDays.value = getRetentionDays(workspaceId.value);
   refreshLocalUsage();
   // Asked once, and the answer does not change what the app does — a cache that
   // gets evicted behaves exactly like one that was never written.

--- a/frontend/test/cacheRetention.test.js
+++ b/frontend/test/cacheRetention.test.js
@@ -1,0 +1,403 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { IDBFactory, IDBKeyRange } from 'fake-indexeddb'
+
+import {
+  RETENTION_OPTIONS,
+  RETENTION_PREFIX,
+  SWEEP_INTERVAL_MS,
+  dueForSweep,
+  expiredRecords,
+  getRetentionDays,
+  isExpired,
+  readLastSweptAt,
+  retentionKey,
+  setRetentionDays,
+  sweepExpired,
+  sweepIfDue,
+  whenIdle,
+  writeLastSweptAt,
+} from '../src/composables/useCacheRetention'
+import { cacheTask, resetSharedCache } from '../src/composables/useCachedTasks'
+import { getCachedTask, listAllCachedTasks, openCache } from '../src/composables/useLocalCache'
+
+const DAY = 24 * 60 * 60 * 1000
+const NOW = 1_800_000_000_000
+
+let factory
+beforeEach(() => {
+  factory = new IDBFactory()
+})
+afterEach(() => {
+  resetSharedCache()
+})
+
+const makeStorage = (entries = {}) => {
+  const store = new Map(Object.entries(entries))
+  return {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+    has: (k) => store.has(k),
+  }
+}
+
+const allOn = { getItem: () => null }
+
+/** Move a cached record's clock, so a test can be about the limit alone. */
+function setCachedAt(db, id, cachedAt) {
+  return new Promise((resolve) => {
+    const tx = db.transaction('tasks', 'readwrite')
+    const store = tx.objectStore('tasks')
+    const req = store.get(['ws1', id])
+    req.onsuccess = () => store.put({ ...req.result, cachedAt })
+    tx.oncomplete = resolve
+  })
+}
+
+const makeTask = (over = {}) => ({
+  id: '0iCYTqxKOqv',
+  workspaceId: 'ws1',
+  title: 'Ship the billing reconciliation fix',
+  body: 'Refunds double-count.',
+  updatedAt: '2026-09-02T10:00:00Z',
+  ...over,
+})
+
+describe('getRetentionDays and setRetentionDays', () => {
+  it('keeps indefinitely until someone says otherwise', () => {
+    expect(getRetentionDays('ws1', makeStorage())).toBe(0)
+  })
+
+  it('round-trips a choice', () => {
+    const storage = makeStorage()
+
+    expect(setRetentionDays('ws1', 30, storage)).toBe(true)
+    expect(getRetentionDays('ws1', storage)).toBe(30)
+  })
+
+  it('stores "keep indefinitely" as the absence of a value', () => {
+    // The default lives in the reader, not in every device that ever opened the
+    // workspace — the same rule the on/off setting follows.
+    const storage = makeStorage()
+    setRetentionDays('ws1', 30, storage)
+
+    setRetentionDays('ws1', 0, storage)
+
+    expect(storage.has(retentionKey('ws1'))).toBe(false)
+    expect(getRetentionDays('ws1', storage)).toBe(0)
+  })
+
+  it('answers per workspace', () => {
+    const storage = makeStorage()
+    setRetentionDays('ws1', 7, storage)
+
+    expect(getRetentionDays('ws1', storage)).toBe(7)
+    expect(getRetentionDays('ws2', storage)).toBe(0)
+  })
+
+  it('keeps indefinitely rather than trusting a value it cannot read', () => {
+    // Holding data slightly too long is a storage cost the budget already
+    // bounds. Deleting someone's offline copy because a setting would not parse
+    // is a surprise they cannot undo.
+    expect(getRetentionDays('ws1', makeStorage({ [retentionKey('ws1')]: 'soon' }))).toBe(0)
+    expect(getRetentionDays('ws1', makeStorage({ [retentionKey('ws1')]: '-5' }))).toBe(0)
+    expect(getRetentionDays('ws1', null)).toBe(0)
+    expect(getRetentionDays('', makeStorage())).toBe(0)
+    expect(
+      getRetentionDays('ws1', {
+        getItem() {
+          throw new Error('storage disabled')
+        },
+      })
+    ).toBe(0)
+  })
+
+  it('reports it could not record the choice', () => {
+    const throwing = {
+      setItem() {
+        throw new Error('full')
+      },
+      removeItem() {
+        throw new Error('full')
+      },
+    }
+
+    expect(setRetentionDays('ws1', 30, throwing)).toBe(false)
+    expect(setRetentionDays('ws1', 0, throwing)).toBe(false)
+    expect(setRetentionDays('ws1', 30, null)).toBe(false)
+    expect(setRetentionDays('', 30, makeStorage())).toBe(false)
+  })
+
+  it('offers keep-indefinitely first, and namespaces its key', () => {
+    expect(RETENTION_OPTIONS[0].days).toBe(0)
+    expect(RETENTION_OPTIONS.map((o) => o.days)).toEqual([0, 7, 30, 90])
+    expect(retentionKey('ws1')).toBe(`${RETENTION_PREFIX}ws1`)
+  })
+})
+
+describe('isExpired', () => {
+  it('expires a record older than the limit', () => {
+    expect(isExpired({ cachedAt: NOW - 8 * DAY }, 7, NOW)).toBe(true)
+    expect(isExpired({ cachedAt: NOW - 6 * DAY }, 7, NOW)).toBe(false)
+  })
+
+  it('never expires anything when the limit is indefinite', () => {
+    expect(isExpired({ cachedAt: 0 }, 0, NOW)).toBe(false)
+    expect(isExpired({ cachedAt: 0 }, undefined, NOW)).toBe(false)
+  })
+
+  it('treats a record written before this existed as current', () => {
+    // An upgrade must not delete someone's cache on its first run.
+    expect(isExpired({}, 7, NOW)).toBe(false)
+    expect(isExpired({ cachedAt: 'yesterday' }, 7, NOW)).toBe(false)
+    expect(isExpired(null, 7, NOW)).toBe(false)
+  })
+})
+
+describe('expiredRecords', () => {
+  it('applies each workspace its own limit', () => {
+    const records = [
+      { id: 'a', workspaceId: 'ws1', cachedAt: NOW - 10 * DAY },
+      { id: 'b', workspaceId: 'ws2', cachedAt: NOW - 10 * DAY },
+    ]
+    const limitFor = (id) => (id === 'ws1' ? 7 : 0)
+
+    expect(expiredRecords(records, limitFor, NOW).map((r) => r.id)).toEqual(['a'])
+  })
+
+  it('looks a limit up once per workspace, not once per record', () => {
+    // A sweep reads thousands of rows and would otherwise hit local storage for
+    // every one of them.
+    const limitFor = vi.fn(() => 7)
+    const records = Array.from({ length: 50 }, (_, i) => ({
+      id: `${i}`,
+      workspaceId: i % 2 ? 'ws1' : 'ws2',
+      cachedAt: NOW,
+    }))
+
+    expiredRecords(records, limitFor, NOW)
+
+    expect(limitFor).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores a record with no workspace to answer for', () => {
+    expect(expiredRecords([{ id: 'x', cachedAt: 0 }], () => 7, NOW)).toEqual([])
+  })
+
+  it('has nothing to expire from nothing', () => {
+    expect(expiredRecords([], () => 7, NOW)).toEqual([])
+    expect(expiredRecords(null, () => 7, NOW)).toEqual([])
+  })
+})
+
+describe('dueForSweep', () => {
+  it('is due when a day has passed, and not before', () => {
+    expect(dueForSweep(NOW - SWEEP_INTERVAL_MS, NOW)).toBe(true)
+    expect(dueForSweep(NOW - SWEEP_INTERVAL_MS + 1, NOW)).toBe(false)
+  })
+
+  it('is due when it has never run', () => {
+    expect(dueForSweep(null, NOW)).toBe(true)
+    expect(dueForSweep(undefined, NOW)).toBe(true)
+    expect(dueForSweep('never', NOW)).toBe(true)
+  })
+
+  it('is due when the clock has moved backwards', () => {
+    // A timezone change or a corrected system clock would otherwise park the
+    // sweep until the future caught up.
+    expect(dueForSweep(NOW + 5 * DAY, NOW)).toBe(true)
+  })
+
+  it('accepts a different interval', () => {
+    expect(dueForSweep(NOW - 100, NOW, 50)).toBe(true)
+    expect(dueForSweep(NOW - 10, NOW, 50)).toBe(false)
+  })
+})
+
+describe('readLastSweptAt and writeLastSweptAt', () => {
+  it('round-trips through the database rather than local storage', async () => {
+    // Kept beside the data it describes: clearing the cache and keeping the
+    // timestamp would skip the next sweep for a day over nothing.
+    const db = await openCache({ userId: 'u1', factory })
+
+    expect(await readLastSweptAt(db)).toBeNull()
+    expect(await writeLastSweptAt(db, NOW)).toBe(true)
+    expect(await readLastSweptAt(db)).toBe(NOW)
+    db.close()
+  })
+
+  it('says nothing rather than throwing without a database', async () => {
+    expect(await readLastSweptAt(null)).toBeNull()
+    expect(await writeLastSweptAt(null)).toBe(false)
+  })
+
+  it('says nothing rather than throwing on a closed connection', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+    db.close()
+
+    expect(await readLastSweptAt(db)).toBeNull()
+    expect(await writeLastSweptAt(db, NOW)).toBe(false)
+  })
+
+  it('says nothing when the read itself fails', async () => {
+    // The timestamp is an optimisation, so a failed read means "sweep now",
+    // not "give up".
+    const req = {}
+    const db = { transaction: () => ({ objectStore: () => ({ get: () => req }) }) }
+    const reading = readLastSweptAt(db)
+
+    req.onerror()
+
+    expect(await reading).toBeNull()
+  })
+
+  it('reports a failed or aborted write rather than claiming it swept', async () => {
+    // Claiming a sweep that did not happen would skip the next one for a day.
+    const errored = { objectStore: () => ({ put: () => {} }) }
+    const failing = writeLastSweptAt({ transaction: () => errored }, NOW)
+    errored.onerror()
+    expect(await failing).toBe(false)
+
+    const aborted = { objectStore: () => ({ put: () => {} }) }
+    const aborting = writeLastSweptAt({ transaction: () => aborted }, NOW)
+    aborted.onabort()
+    expect(await aborting).toBe(false)
+  })
+})
+
+describe('sweepExpired', () => {
+  it('removes what has outlived its limit and keeps the rest', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+    const storage = makeStorage()
+    setRetentionDays('ws1', 7, storage)
+    await cacheTask(db, makeTask({ id: 'stale' }), { storage: allOn })
+    await cacheTask(db, makeTask({ id: 'fresh' }), { storage: allOn })
+    // Both were stamped with the real clock, which is not `NOW`. Setting both
+    // explicitly is what makes this test about the limit rather than about how
+    // far the fixture's clock happens to sit from the machine's.
+    await setCachedAt(db, 'stale', NOW - 30 * DAY)
+    await setCachedAt(db, 'fresh', NOW - 1 * DAY)
+
+    expect(await sweepExpired(db, { storage, now: NOW, KeyRange: IDBKeyRange })).toBe(1)
+
+    expect(await getCachedTask(db, 'ws1', 'stale')).toBeNull()
+    expect(await getCachedTask(db, 'ws1', 'fresh')).not.toBeNull()
+    db.close()
+  })
+
+  it('removes the conversation with the task, not just the row', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+    const storage = makeStorage()
+    setRetentionDays('ws1', 1, storage)
+    await cacheTask(db, makeTask({ messages: [{ id: 'm1' }] }), { storage: allOn })
+
+    await sweepExpired(db, { storage, now: NOW + 10 * DAY, KeyRange: IDBKeyRange })
+
+    const threads = await new Promise((resolve) => {
+      const req = db.transaction('threads').objectStore('threads').getAll()
+      req.onsuccess = () => resolve(req.result)
+    })
+    expect(threads).toEqual([])
+    db.close()
+  })
+
+  it('does nothing when nothing has a limit', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+    await cacheTask(db, makeTask(), { storage: allOn })
+
+    expect(await sweepExpired(db, { storage: makeStorage(), now: NOW, KeyRange: IDBKeyRange })).toBe(0)
+    expect(await listAllCachedTasks(db)).toHaveLength(1)
+    db.close()
+  })
+
+  it('does nothing without a database', async () => {
+    expect(await sweepExpired(null, { storage: makeStorage() })).toBe(0)
+  })
+})
+
+describe('sweepIfDue', () => {
+  it('sweeps when due and records that it did', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+
+    const first = await sweepIfDue(db, { storage: makeStorage(), now: NOW, KeyRange: IDBKeyRange })
+
+    expect(first.swept).toBe(true)
+    expect(await readLastSweptAt(db)).toBe(NOW)
+    db.close()
+  })
+
+  it('skips the rest of the day', async () => {
+    // The guard is what makes this safe to call on every startup and on a
+    // timer: the work happens when due and is skipped the rest of the time.
+    const db = await openCache({ userId: 'u1', factory })
+    await sweepIfDue(db, { storage: makeStorage(), now: NOW, KeyRange: IDBKeyRange })
+
+    const again = await sweepIfDue(db, {
+      storage: makeStorage(),
+      now: NOW + 1000,
+      KeyRange: IDBKeyRange,
+    })
+
+    expect(again).toEqual({ swept: false, removed: 0 })
+    db.close()
+  })
+
+  it('sweeps again the next day', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+    await sweepIfDue(db, { storage: makeStorage(), now: NOW, KeyRange: IDBKeyRange })
+
+    const next = await sweepIfDue(db, {
+      storage: makeStorage(),
+      now: NOW + SWEEP_INTERVAL_MS,
+      KeyRange: IDBKeyRange,
+    })
+
+    expect(next.swept).toBe(true)
+    db.close()
+  })
+
+  it('reports how much it removed', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+    const storage = makeStorage()
+    setRetentionDays('ws1', 1, storage)
+    await cacheTask(db, makeTask(), { storage: allOn })
+
+    const result = await sweepIfDue(db, {
+      storage,
+      now: NOW + 10 * DAY,
+      KeyRange: IDBKeyRange,
+    })
+
+    expect(result).toEqual({ swept: true, removed: 1 })
+    db.close()
+  })
+
+  it('does nothing without a database', async () => {
+    expect(await sweepIfDue(null, {})).toEqual({ swept: false, removed: 0 })
+  })
+})
+
+describe('whenIdle', () => {
+  it('waits for the browser to be free when it can say', () => {
+    // A sweep competes with rendering, and there is never a reason for it to
+    // win — it is a day's tidying, not something anyone is waiting on.
+    const ran = []
+    const scheduler = (fn) => {
+      ran.push('scheduled')
+      fn()
+      return 7
+    }
+
+    expect(whenIdle(() => ran.push('swept'), scheduler)).toBe(7)
+    expect(ran).toEqual(['scheduled', 'swept'])
+  })
+
+  it('falls back to the next tick where idle time is not offered', async () => {
+    const ran = []
+
+    whenIdle(() => ran.push('swept'), undefined)
+    await new Promise((resolve) => setTimeout(resolve, 5))
+
+    expect(ran).toEqual(['swept'])
+  })
+})

--- a/frontend/test/localCache.test.js
+++ b/frontend/test/localCache.test.js
@@ -11,6 +11,7 @@ import {
   databaseName,
   destroyCache,
   getCachedTask,
+  deleteTasks,
   listAllCachedTasks,
   listCachedTasks,
   metaKey,
@@ -481,6 +482,44 @@ describe('listAllCachedTasks', () => {
 
   it('has nothing to scan without a database', async () => {
     expect(await listAllCachedTasks(null)).toEqual([])
+  })
+})
+
+describe('deleteTasks', () => {
+  it('removes the named tasks with their threads and attachment rows', async () => {
+    const db = await open()
+    await putTask(db, makeTask({ id: 'goes', attachments: [attachment('a1')] }))
+    await putTask(db, makeTask({ id: 'stays' }))
+
+    expect(await deleteTasks(db, [{ workspaceId: 'ws1', id: 'goes' }], IDBKeyRange)).toBe(1)
+
+    expect(await getCachedTask(db, 'ws1', 'goes')).toBeNull()
+    expect(await getCachedTask(db, 'ws1', 'stays')).not.toBeNull()
+    const atts = await new Promise((resolve) => {
+      const req = db.transaction(STORE_ATTACHMENTS).objectStore(STORE_ATTACHMENTS).getAll()
+      req.onsuccess = () => resolve(req.result)
+    })
+    expect(atts).toEqual([])
+    db.close()
+  })
+
+  it('has nothing to remove without a database or a list', async () => {
+    const db = await open()
+
+    expect(await deleteTasks(null, [{ workspaceId: 'ws1', id: 'x' }], IDBKeyRange)).toBe(0)
+    expect(await deleteTasks(db, [], IDBKeyRange)).toBe(0)
+    expect(await deleteTasks(db, undefined, IDBKeyRange)).toBe(0)
+    db.close()
+  })
+
+  it('reports nothing removed rather than throwing when the delete cannot run', async () => {
+    const broken = {
+      transaction() {
+        throw new Error('gone')
+      },
+    }
+
+    expect(await deleteTasks(broken, [{ workspaceId: 'ws1', id: 'x' }], IDBKeyRange)).toBe(0)
   })
 })
 

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -54,6 +54,7 @@ export default defineConfig({
         'src/composables/useCacheStorage.js',
         'src/composables/useCachedReads.js',
         'src/composables/useAttachmentCache.js',
+        'src/composables/useCacheRetention.js',
       ],
       reporter: ['text', 'lcov'],
       thresholds: {


### PR DESCRIPTION
> Based directly on `main`, which now has the whole local cache. No stack this time.

## What changed

Each workspace can now be told how long to keep its local copy — until you clear it, or 7, 30 or 90 days — and a daily sweep removes whatever has outlived that.

## Why changed

The local copy grows for as long as someone keeps working, and the only limits on it until now were the storage budget and a manual Clear button. A retention limit lets it bound itself, per workspace, on the device that holds it.

**The clock is when this device last kept the record, not when the server last changed the task.** That distinction is the whole design. Measuring against the server's timestamp would delete a task the instant after someone opened an old one — the opposite of what a cache is for. Measured this way, anything you keep coming back to stays, and anything you stop opening ages out. The setting says exactly that on screen, because "keep for 30 days" is otherwise ambiguous about which thirty days it means.

The control sits beside the on/off switch and follows the same rules: **per workspace, per device, never synced**, and stored only when it is not the default, so the default lives in one place rather than on every machine that ever opened the workspace. It appears only while the cache is on, because a retention limit on nothing is noise.

**An unreadable setting keeps data indefinitely rather than expiring it.** Holding slightly too long is a storage cost the budget already bounds; deleting someone's offline copy because a preference would not parse is a surprise they cannot undo.

The sweep runs at most once a day. Its marker lives in the cache's own store rather than in browser preferences — beside the data it describes, so clearing the cache cannot leave behind a marker that skips the next sweep for a day over nothing. A clock that has moved backwards counts as due, or a corrected system clock would park the sweep until the future caught up. It is scheduled for idle time, because a day's tidying has no business competing with a render.

**This is not an operating-system background job.** Browsers do not reliably offer one — the API that would provide it is single-vendor and gated on engagement heuristics nobody can predict — so the sweep runs while the app is open. That is enough for something whose only failure mode is holding data slightly longer than asked, and it is worth saying plainly rather than implying otherwise.

Attachments are deliberately untouched: they are already bounded by a per-file cap and a least-recently-used budget, and a second mechanism would be two answers to one question.

## Test coverage report

**New lines introduced: 100%.** The new module is on the enforced `coverage.include` list:

```
File                  | % Stmts | % Branch | % Funcs | % Lines
useCacheRetention.js  |     100 |      100 |     100 |     100
All files             |     100 |      100 |     100 |     100
```

**Total coverage impact: none — the suite stays at the 100% the config enforces.** 508 tests passing; 37 are new.

They cover the boundary either side of the limit, a record written before this existed being treated as current rather than as infinitely old, a limit looked up once per workspace rather than once per row, a backwards clock counting as due, the once-a-day guard skipping and then releasing, and the sweep removing a task's conversation and attachment rows rather than only its row.

## Other reports

Verified in a browser against an isolated backend:

- Records are stamped on write — 5 cached, every one carrying the timestamp
- Choosing "7 days" records it, and the panel reads *"Counted from the last time you opened a task, not from when it was written — so anything you keep coming back to stays."*
- Ageing two records past the limit and clearing the marker leaves them deleted after the next load, with the sweep recorded — and the result is stable across a further reload rather than flapping

`npm run build` is clean. No backend change and no new dependency.

TaskID: 0iEL2wfxKsb

🤖 Generated with [Claude Code](https://claude.com/claude-code)