### PR TITLE
feat(cache): forget a deleted task's local copy and its attachments

### DIFF
--- a/desktop/src/main/attachment-store.js
+++ b/desktop/src/main/attachment-store.js
@@ -204,6 +204,25 @@ export function createAttachmentStore({ dir, fs, budget = budgetFor('desktop') }
     },
 
     /**
+     * Forget one task's attachments.
+     *
+     * A directory removal, because the task *is* a directory — the shape this
+     * store was given for exactly this reason. Deleting a task has to reach its
+     * bytes as well as its rows, or the bytes outlive the task that explained
+     * them.
+     */
+    async forgetTask(workspaceId, taskId) {
+      if (!workspaceId || !taskId) return false
+      if (!SAFE_ID.test(workspaceId) || !SAFE_ID.test(taskId)) return false
+      try {
+        await fs.rm(`${workspaceDir(workspaceId)}/${taskId}`, { recursive: true, force: true })
+        return true
+      } catch {
+        return false
+      }
+    },
+
+    /**
      * Forget one workspace's attachments, leaving every other workspace's alone.
      *
      * One directory removal, because the workspace *is* a directory. This is

--- a/desktop/src/main/index.js
+++ b/desktop/src/main/index.js
@@ -723,6 +723,9 @@ function registerIpc(getWindow) {
   ipcMain.handle('agentrq:attachments:forgetWorkspace', (_event, workspaceId) =>
     attachmentStoreFor(currentPartition()).forgetWorkspace(workspaceId)
   )
+  ipcMain.handle('agentrq:attachments:forgetTask', (_event, workspaceId, taskId) =>
+    attachmentStoreFor(currentPartition()).forgetTask(workspaceId, taskId)
+  )
   ipcMain.handle('agentrq:attachments:forgetAll', () =>
     attachmentStoreFor(currentPartition()).forgetAll()
   )

--- a/desktop/src/preload/index.js
+++ b/desktop/src/preload/index.js
@@ -14,6 +14,8 @@ contextBridge.exposeInMainWorld('agentrq', {
   attachments: {
     forgetWorkspace: (workspaceId) =>
       ipcRenderer.invoke('agentrq:attachments:forgetWorkspace', workspaceId),
+    forgetTask: (workspaceId, taskId) =>
+      ipcRenderer.invoke('agentrq:attachments:forgetTask', workspaceId, taskId),
     forgetAll: () => ipcRenderer.invoke('agentrq:attachments:forgetAll'),
   },
 

--- a/desktop/test/attachment-store.test.js
+++ b/desktop/test/attachment-store.test.js
@@ -304,6 +304,57 @@ describe('evict', () => {
   })
 })
 
+describe('forgetTask', () => {
+  it('removes one task and leaves the rest of the workspace', async () => {
+    // A directory removal, because the task is a directory — the shape this
+    // store was given for exactly this.
+    const fs = makeFs()
+    const s = store(fs)
+    const otherTask = '/api/v1/workspaces/0iCYS9XKlnN/tasks/0iCYVCihMfJ/attachments/0iCt6L19zvR'
+    await s.write(A, 'A', png)
+    await s.write(B, 'B', png)
+    await s.write(otherTask, 'C', png)
+
+    expect(await s.forgetTask('0iCYS9XKlnN', '0iCYTqxKOqv')).toBe(true)
+
+    expect(await s.read(A)).toBeNull()
+    expect(await s.read(B)).toBeNull()
+    expect(await s.read(otherTask)).not.toBeNull()
+  })
+
+  it('does not reach into another workspace holding the same task id', async () => {
+    const fs = makeFs()
+    const s = store(fs)
+    const sameTaskElsewhere = '/api/v1/workspaces/0aBcDeFgHiJ/tasks/0iCYTqxKOqv/attachments/0iCt6L19zvS'
+    await s.write(A, 'A', png)
+    await s.write(sameTaskElsewhere, 'B', png)
+
+    await s.forgetTask('0iCYS9XKlnN', '0iCYTqxKOqv')
+
+    expect(await s.read(sameTaskElsewhere)).not.toBeNull()
+  })
+
+  it('refuses ids that must not become a path', async () => {
+    const fs = makeFs()
+    await store(fs).write(A, 'A', png)
+
+    expect(await store(fs).forgetTask('../..', 't')).toBe(false)
+    expect(await store(fs).forgetTask('0iCYS9XKlnN', '../..')).toBe(false)
+    expect(await store(fs).forgetTask('', '0iCYTqxKOqv')).toBe(false)
+    expect(await store(fs).forgetTask('0iCYS9XKlnN', '')).toBe(false)
+    expect(await store(fs).read(A)).not.toBeNull()
+  })
+
+  it('reports failure rather than throwing', async () => {
+    const fs = makeFs()
+    fs.rm = async () => {
+      throw new Error('busy')
+    }
+
+    expect(await store(fs).forgetTask('0iCYS9XKlnN', '0iCYTqxKOqv')).toBe(false)
+  })
+})
+
 describe('forgetWorkspace', () => {
   it('removes one workspace and leaves the others', async () => {
     // One directory removal, because the workspace is a directory. This is what

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -395,7 +395,7 @@ import { useFormat } from './composables/useFormat'
 import { usePushNotifications } from './composables/usePushNotifications'
 import Toast from './components/Toast.vue'
 import { cacheTaskEvent, connectCache, sharedCache } from './composables/useCachedTasks'
-import { forgetEverything } from './composables/useCacheStorage'
+import { forgetCachedTask, forgetEverything } from './composables/useCacheStorage'
 import { SWEEP_INTERVAL_MS, sweepIfDue, whenIdle } from './composables/useCacheRetention'
 import CommandPalette from './components/CommandPalette.vue'
 import ShortcutsHelp from './components/ShortcutsHelp.vue'
@@ -574,6 +574,13 @@ watch(events, (newEvents) => {
   // stream carries tasks nobody has open to merge against. See useCachedTasks.
   if (event.type === 'task.created' || event.type === 'task.updated') {
     cacheTaskEvent(sharedCache(), event.payload)
+  }
+
+  // A deleted task must not outlive itself on this device. Driven by the event
+  // rather than by the button, so it also covers a task deleted from another
+  // device or by an agent.
+  if (event.type === 'task.deleted') {
+    forgetCachedTask(sharedCache(), event.payload?.id)
   }
 
   if (event.type === 'task.created' && event.payload.createdBy === 'agent') {

--- a/frontend/src/composables/useAttachmentCache.js
+++ b/frontend/src/composables/useAttachmentCache.js
@@ -115,6 +115,18 @@ export function evictionPlan(entries, budget) {
 }
 
 /**
+ * The cached attachment URLs belonging to one task.
+ *
+ * Deleting a task has to reach its bytes as well as its rows, and both ids are
+ * already in the path, so no bookkeeping is needed to find them.
+ */
+export function attachmentUrlsForTask(urls, workspaceId, taskId) {
+  if (!workspaceId || !taskId) return [];
+  const needle = `/workspaces/${workspaceId}/tasks/${taskId}/attachments/`;
+  return (Array.isArray(urls) ? urls : []).filter((url) => String(url).includes(needle));
+}
+
+/**
  * The cached attachment URLs belonging to one workspace.
  *
  * Clearing a workspace has to reach the bytes as well as the rows, and the

--- a/frontend/src/composables/useCacheStorage.js
+++ b/frontend/src/composables/useCacheStorage.js
@@ -1,5 +1,5 @@
 import { cacheSettingKey, resetSharedCache, SETTING_OFF } from './useCachedTasks';
-import { clearWorkspace, destroyCache } from './useLocalCache';
+import { clearWorkspace, deleteTasks, destroyCache, findCachedTaskById } from './useLocalCache';
 
 /**
  * Owning the local copy: turning it off, seeing what it costs, and getting rid
@@ -172,6 +172,58 @@ export async function tellShellToForgetAll(bridge = globalThis.window?.agentrq) 
   } catch {
     return false;
   }
+}
+
+/**
+ * Ask whichever layer holds attachment bytes to forget one task's.
+ *
+ * The browser has a service worker and the desktop app has a file store the
+ * shell owns; exactly one exists in any build, so both are asked and the absent
+ * one is already a no-op. Neither is awaited for its answer — a task whose rows
+ * are gone is deleted as far as anyone can tell, and bytes that outlive them by
+ * a moment are invisible.
+ */
+export function forgetTaskBytes(workspaceId, taskId, options = {}) {
+  const {
+    worker = globalThis.navigator?.serviceWorker,
+    bridge = globalThis.window?.agentrq,
+  } = options;
+
+  try {
+    worker?.controller?.postMessage({ type: 'FORGET_TASK', workspaceId, taskId });
+  } catch {
+    // A worker that has gone away holds nothing worth reaching.
+  }
+  try {
+    bridge?.attachments?.forgetTask?.(workspaceId, taskId);
+  } catch {
+    // Likewise for a shell that is not there.
+  }
+}
+
+/**
+ * Forget everything held for a task that no longer exists.
+ *
+ * Driven by the deletion event rather than by the button that caused it, so it
+ * covers a task deleted on another device or by an agent as well as one deleted
+ * here. The event carries only the task id, which is why the workspace is
+ * looked up from the record before anything is removed.
+ *
+ * A move publishes the same deletion for the workspace a task is leaving, and
+ * removing the local copy there is right: the matching creation event in the
+ * destination workspace writes it back under its new key.
+ *
+ * @returns {Promise<boolean>} whether anything was held to forget
+ */
+export async function forgetCachedTask(db, taskId, options = {}) {
+  if (!db || !taskId) return false;
+
+  const record = await findCachedTaskById(db, taskId);
+  if (!record) return false;
+
+  await deleteTasks(db, [record], options.KeyRange);
+  forgetTaskBytes(record.workspaceId, record.id, options);
+  return true;
 }
 
 /**

--- a/frontend/src/composables/useLocalCache.js
+++ b/frontend/src/composables/useLocalCache.js
@@ -389,6 +389,21 @@ export async function listAllCachedTasks(db) {
 }
 
 /**
+ * The cached record for a task id, whichever workspace holds it.
+ *
+ * Needed because a deletion is announced with the task id alone — the event
+ * envelope carries no workspace — while the store is keyed by both. Task ids
+ * are monoflakes and globally unique, so at most one record can match, and a
+ * scan is the honest way to find it: deletions are rare, and an index existing
+ * only for them would be paid for on every write.
+ */
+export async function findCachedTaskById(db, taskId) {
+  if (!db || !taskId) return null;
+  const rows = await listAllCachedTasks(db);
+  return rows.find((row) => String(row.id) === String(taskId)) ?? null;
+}
+
+/**
  * Forget specific tasks, wherever they live.
  *
  * Takes whole records rather than keys because the caller has just read them to

--- a/frontend/src/sw.js
+++ b/frontend/src/sw.js
@@ -4,6 +4,7 @@ import { CacheFirst, NetworkFirst } from 'workbox-strategies'
 import { CacheableResponsePlugin } from 'workbox-cacheable-response'
 
 import {
+  attachmentUrlsForTask,
   attachmentUrlsForWorkspace,
   budgetFor,
   evictionPlan,
@@ -18,6 +19,11 @@ self.addEventListener('message', event => {
   // worker can reach the cache they live in.
   if (event.data && event.data.type === 'FORGET_WORKSPACE') {
     event.waitUntil(forgetWorkspace(event.data.workspaceId))
+  }
+  // A deleted task's bytes outlive its rows unless something removes them, and
+  // only the worker can reach the cache they are in.
+  if (event.data && event.data.type === 'FORGET_TASK') {
+    event.waitUntil(forgetTask(event.data.workspaceId, event.data.taskId))
   }
 })
 
@@ -92,6 +98,13 @@ async function enforceBudget(cacheName) {
   // The platform is not knowable from inside the worker, and only the web build
   // registers one at all — so the web budget is the only one that applies here.
   for (const url of evictionPlan(entries, budgetFor('web'))) await cache.delete(url)
+}
+
+/** Forget one task's cached attachment bytes. */
+async function forgetTask(workspaceId, taskId) {
+  const cache = await caches.open(ATTACHMENT_CACHE)
+  const urls = (await cache.keys()).map(request => request.url)
+  for (const url of attachmentUrlsForTask(urls, workspaceId, taskId)) await cache.delete(url)
 }
 
 /** Forget one workspace's cached attachment bytes. */

--- a/frontend/test/attachmentCache.test.js
+++ b/frontend/test/attachmentCache.test.js
@@ -4,6 +4,7 @@ import {
   DESKTOP_BUDGET_BYTES,
   MAX_ATTACHMENT_BYTES,
   WEB_BUDGET_BYTES,
+  attachmentUrlsForTask,
   attachmentUrlsForWorkspace,
   budgetFor,
   evictionPlan,
@@ -150,6 +151,30 @@ describe('evictionPlan', () => {
     expect(evictionPlan([], 100)).toEqual([])
     expect(evictionPlan(null, 100)).toEqual([])
     expect(evictionPlan(undefined, 100)).toEqual([])
+  })
+})
+
+describe('attachmentUrlsForTask', () => {
+  const urls = [
+    'https://x/api/v1/workspaces/ws1/tasks/t1/attachments/a1',
+    'https://x/api/v1/workspaces/ws1/tasks/t1/attachments/a2',
+    'https://x/api/v1/workspaces/ws1/tasks/t2/attachments/a3',
+    'https://x/api/v1/workspaces/ws2/tasks/t1/attachments/a4',
+  ]
+
+  it('finds one task\'s attachments and no other task\'s', () => {
+    expect(attachmentUrlsForTask(urls, 'ws1', 't1')).toEqual([urls[0], urls[1]])
+  })
+
+  it('does not confuse the same task id in another workspace', () => {
+    expect(attachmentUrlsForTask(urls, 'ws2', 't1')).toEqual([urls[3]])
+  })
+
+  it('has nothing to find without both ids or a list', () => {
+    expect(attachmentUrlsForTask(urls, 'ws1', '')).toEqual([])
+    expect(attachmentUrlsForTask(urls, '', 't1')).toEqual([])
+    expect(attachmentUrlsForTask(null, 'ws1', 't1')).toEqual([])
+    expect(attachmentUrlsForTask(undefined, 'ws1', 't1')).toEqual([])
   })
 })
 

--- a/frontend/test/cacheStorage.test.js
+++ b/frontend/test/cacheStorage.test.js
@@ -4,6 +4,8 @@ import { IDBFactory, IDBKeyRange } from 'fake-indexeddb'
 import {
   clearWorkspaceData,
   estimateUsage,
+  forgetCachedTask,
+  forgetTaskBytes,
   forgetEverything,
   formatBytes,
   requestPersistence,
@@ -285,6 +287,81 @@ describe('tellWorkerToForget', () => {
     }
 
     expect(tellWorkerToForget('ws1', worker)).toBe(false)
+  })
+})
+
+describe('forgetTaskBytes', () => {
+  it('asks both layers, because exactly one exists in any build', () => {
+    const posted = []
+    const asked = []
+    const worker = { controller: { postMessage: (m) => posted.push(m) } }
+    const bridge = { attachments: { forgetTask: (w, t) => asked.push([w, t]) } }
+
+    forgetTaskBytes('ws1', 't1', { worker, bridge })
+
+    expect(posted).toEqual([{ type: 'FORGET_TASK', workspaceId: 'ws1', taskId: 't1' }])
+    expect(asked).toEqual([['ws1', 't1']])
+  })
+
+  it('is a no-op where neither exists, and never throws', () => {
+    // With nothing supplied it reads this device's own worker and shell, which
+    // in a plain browser test are simply absent.
+    expect(() => forgetTaskBytes('ws1', 't1')).not.toThrow()
+    expect(() => forgetTaskBytes('ws1', 't1', {})).not.toThrow()
+    expect(() => forgetTaskBytes('ws1', 't1', { worker: null, bridge: null })).not.toThrow()
+    expect(() => forgetTaskBytes('ws1', 't1', { worker: {}, bridge: {} })).not.toThrow()
+    expect(() =>
+      forgetTaskBytes('ws1', 't1', {
+        worker: {
+          controller: {
+            postMessage() {
+              throw new Error('worker gone')
+            },
+          },
+        },
+        bridge: {
+          attachments: {
+            forgetTask() {
+              throw new Error('shell gone')
+            },
+          },
+        },
+      })
+    ).not.toThrow()
+  })
+})
+
+describe('forgetCachedTask', () => {
+  it('removes the task and asks for its bytes, finding the workspace itself', async () => {
+    // The deletion event carries only the task id, so the workspace has to come
+    // from the record before anything can be removed.
+    const db = await openCache({ userId: 'u1', factory })
+    await cacheTask(db, makeTask({ id: 'goes' }), { storage: allOn })
+    await cacheTask(db, makeTask({ id: 'stays' }), { storage: allOn })
+    const posted = []
+    const worker = { controller: { postMessage: (m) => posted.push(m) } }
+
+    expect(await forgetCachedTask(db, 'goes', { worker, KeyRange: IDBKeyRange })).toBe(true)
+
+    expect(await listCachedTasks(db, 'ws1', IDBKeyRange)).toHaveLength(1)
+    expect(posted).toEqual([{ type: 'FORGET_TASK', workspaceId: 'ws1', taskId: 'goes' }])
+    db.close()
+  })
+
+  it('reports nothing held for a task this device never cached', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+
+    expect(await forgetCachedTask(db, 'never-seen', { KeyRange: IDBKeyRange })).toBe(false)
+    db.close()
+  })
+
+  it('does nothing without a database or a task id', async () => {
+    const db = await openCache({ userId: 'u1', factory })
+
+    expect(await forgetCachedTask(null, 't1', {})).toBe(false)
+    expect(await forgetCachedTask(db, '', {})).toBe(false)
+    expect(await forgetCachedTask(db, undefined, {})).toBe(false)
+    db.close()
   })
 })
 

--- a/frontend/test/localCache.test.js
+++ b/frontend/test/localCache.test.js
@@ -12,6 +12,7 @@ import {
   destroyCache,
   getCachedTask,
   deleteTasks,
+  findCachedTaskById,
   listAllCachedTasks,
   listCachedTasks,
   metaKey,
@@ -482,6 +483,28 @@ describe('listAllCachedTasks', () => {
 
   it('has nothing to scan without a database', async () => {
     expect(await listAllCachedTasks(null)).toEqual([])
+  })
+})
+
+describe('findCachedTaskById', () => {
+  it('finds a task without being told which workspace holds it', async () => {
+    // A deletion is announced with the task id alone — the event envelope
+    // carries no workspace — while the store is keyed by both.
+    const db = await open()
+    await putTask(db, makeTask({ id: 'here', workspaceId: 'ws2' }))
+
+    expect((await findCachedTaskById(db, 'here')).workspaceId).toBe('ws2')
+    db.close()
+  })
+
+  it('finds nothing for a task it has never seen', async () => {
+    const db = await open()
+    await putTask(db, makeTask())
+
+    expect(await findCachedTaskById(db, 'never')).toBeNull()
+    expect(await findCachedTaskById(db, '')).toBeNull()
+    expect(await findCachedTaskById(null, 'x')).toBeNull()
+    db.close()
   })
 })
 


### PR DESCRIPTION
> **Stacked on #422**, which it needs for the task-removal helper. Merge #422 first with "Squash and merge" + **"Delete branch"**, and this retargets to `main` on its own. One level only.

## What changed

A task deleted anywhere is now removed from this device too — its record, its conversation, its attachment details and the attachment files themselves.

## Why changed

Until now a deleted task lived on locally: it stayed searchable offline, and its attachments kept their space. That is wrong in the obvious way, and quietly so — the task is gone everywhere the user looks except the one place they cannot see.

**This is driven by the deletion event, not by the button that caused it.** That is what makes it cover a task deleted on another device or by an agent, not just one deleted in this window. It also covers a move: the workspace a task leaves publishes the same deletion, and dropping the local copy there is correct, because the matching creation event in the destination writes it back under its new key.

**The event carries only the task id.** The envelope has no workspace, while the local store is keyed by both — so the workspace is looked up from the record before anything is removed. Task ids are globally unique, so at most one record can match. A scan finds it rather than a dedicated index: deletions are rare, and an index existing only for them would be paid for on every single write.

The attachment files are reached differently in each build and asked for the same way. The browser messages its offline layer; the desktop app asks the shell, which removes a single directory — the store is laid out as workspace over task over attachment for exactly this reason, which is what that layout change bought. Both are asked rather than branching on which build is running: exactly one exists in any build, and asking the absent one is already a no-op.

Neither is waited on. A task whose records are gone is deleted as far as anyone can tell, and files that outlive them by a moment are invisible.

## Test coverage report

**New lines introduced: 100%**, across both packages, each enforcing it independently:

```
frontend    All files    100 | 100 | 100 | 100     518 tests
desktop     All files    100 | 100 | 100 | 100     422 tests
```

**Total coverage impact: none — both suites stay at the 100% their configs enforce.** 14 tests are new.

They cover finding a task without being told its workspace, both layers being asked and neither throwing when absent, a task this device never cached reporting nothing to forget, one task's files going without touching another task in the same workspace, the same task id in a *different* workspace being left alone, and ids that must not become a path being refused.

## Other reports

Verified in a browser against an isolated backend, reading the local store directly rather than trusting the UI:

- A task created and loaded is cached — 6 records, the new one among them
- Deleting it returns `204`, and the local copy drops to 5 with no trace of it
- No orphaned conversation row is left behind

Both packages build cleanly. No backend change and no new dependency.

TaskID: 0iENgFXVTUH

🤖 Generated with [Claude Code](https://claude.com/claude-code)