### PR TITLE
refactor(shortcuts): drop the Cmd/Ctrl+Shift alternates

### DIFF
--- a/frontend/src/components/ShortcutsHelp.vue
+++ b/frontend/src/components/ShortcutsHelp.vue
@@ -9,7 +9,6 @@
 import { computed } from 'vue';
 
 import { SHORTCUTS, formatShortcut } from '../composables/useKeyboardShortcuts';
-import { usePlatformStore } from '../stores/platformStore';
 
 const props = defineProps({
   show: Boolean,
@@ -17,8 +16,6 @@ const props = defineProps({
   mac: Boolean,
 });
 const emit = defineEmits(['close']);
-
-const platformStore = usePlatformStore();
 
 const GROUPS = [
   { scope: 'global', title: 'Anywhere' },
@@ -31,14 +28,6 @@ const groups = computed(() =>
     items: SHORTCUTS.filter((s) => s.scope === group.scope).map((s) => ({
       ...s,
       combo: formatShortcut(s, { mac: props.mac }),
-      // Only where it can actually fire. In a browser these chords are taken
-      // by the browser's own menu — reopen closed tab, private window, switch
-      // profile — and never reach the page, so advertising them there would be
-      // advertising nothing.
-      alsoCombo:
-        platformStore.isDesktop && s.withModifier
-          ? formatShortcut(s, { mac: props.mac, modifier: true })
-          : '',
     })),
   }))
 );
@@ -71,10 +60,6 @@ const groups = computed(() =>
                 </span>
                 <span class="shrink-0 flex items-center gap-1.5">
                   <kbd class="text-[10px] font-mono text-gray-700 dark:text-zinc-200 border border-gray-200 dark:border-zinc-700 rounded px-1.5 py-0.5">{{ item.combo }}</kbd>
-                  <template v-if="item.alsoCombo">
-                    <span class="text-[10px] text-gray-400 dark:text-zinc-600">or</span>
-                    <kbd class="text-[10px] font-mono text-gray-700 dark:text-zinc-200 border border-gray-200 dark:border-zinc-700 rounded px-1.5 py-0.5">{{ item.alsoCombo }}</kbd>
-                  </template>
                 </span>
               </li>
             </ul>

--- a/frontend/src/composables/useKeyboardShortcuts.js
+++ b/frontend/src/composables/useKeyboardShortcuts.js
@@ -25,24 +25,23 @@ import { onMounted, onUnmounted } from 'vue';
  * to the page, and a bare letter collides with nothing at all as long as it is
  * suppressed while the user is typing (see `isTypingTarget`).
  *
- * ## The modifier alternates, and where they are real
+ * ## Why there is no Cmd/Ctrl+Shift alternate
  *
- * The three action shortcuts also answer to **Cmd/Ctrl+Shift+key**, which is
- * what people reach for first. Those chords are bound, but they are not
- * available everywhere, and the difference is not ours to fix:
+ * There was one, on the theory that a chord is what people reach for first. It
+ * earned its keep nowhere:
  *
- * - **In the desktop app they work.** It owns its own menu bar, so nothing
- *   above the page claims them. Cmd/Ctrl+Shift+N already opened the task form
- *   there through the application menu before this existed.
- * - **In a browser most of them never arrive.** Cmd+Shift+T reopens the last
- *   closed tab, Cmd+Shift+N opens a private window, and Cmd+Shift+M switches
- *   profile in Chrome. The browser's own menu takes those before the page is
- *   offered the event.
+ * - **In a browser most of those chords never arrive.** Cmd+Shift+T reopens the
+ *   last closed tab and Cmd+Shift+N opens a private window; the browser's own
+ *   menu takes both before the page is offered the event.
+ * - **The ones that did arrive were redundant.** The bare letter was already
+ *   there, and was what the help sheet advertised.
+ * - **On the desktop the one chord worth having is not the page's to bind.**
+ *   Cmd/Ctrl+Shift+N opens the task form through the application menu and a
+ *   global shortcut, both in the main process, so it works whether or not the
+ *   window even has focus — see `desktop/src/main/menu.js`.
  *
- * So the bare letters stay, and stay the advertised binding on the web. They
- * are the ones that work in every build. The help sheet shows the chord only
- * where it can actually fire, because advertising a shortcut that silently
- * does nothing is worse than not having one.
+ * So a bare letter is the whole scheme: one binding to explain, and one thing
+ * that can break.
  */
 export const SHORTCUTS = [
   {
@@ -61,7 +60,6 @@ export const SHORTCUTS = [
     label: 'New task',
     hint: 'Opens the task form for the workspace you are in',
     scope: 'global',
-    withModifier: true,
   },
   {
     id: 'show-help',
@@ -78,7 +76,6 @@ export const SHORTCUTS = [
     label: 'Chat view',
     hint: 'The message thread',
     scope: 'task',
-    withModifier: true,
   },
   {
     id: 'trajectory-view',
@@ -86,7 +83,6 @@ export const SHORTCUTS = [
     label: 'Trajectory view',
     hint: "The agent's reasoning and tool calls",
     scope: 'task',
-    withModifier: true,
   },
 ];
 
@@ -164,13 +160,13 @@ export function matchShortcut(event, { mac = false, shortcuts = SHORTCUTS } = {}
       // Cmd+Shift+K is not silently the same shortcut.
       if (s.mod) return modPressed && clean && !shift;
 
-      // The modifier alternate: the same action reached as Cmd/Ctrl+Shift+key.
-      // Held with the modifier it is unambiguous, so it fires while typing too.
-      if (modPressed) return Boolean(s.withModifier) && clean && shift;
-
+      // A bare letter is only ever bare. A held modifier means the keystroke
+      // belongs to the browser or the system — Cmd+M minimises a window — and
+      // answering to it here would fire the shortcut on the way past.
+      //
       // `?` is Shift+/ on most layouts, so Shift is judged by the resulting
       // character rather than by the flag.
-      return !typing && clean;
+      return !modPressed && !typing && clean;
     }) ?? null
   );
 }
@@ -183,13 +179,10 @@ export function matchShortcut(event, { mac = false, shortcuts = SHORTCUTS } = {}
  * `+`.
  *
  * @param {{ key: string, mod?: boolean }} shortcut
- * @param {{ mac?: boolean, modifier?: boolean }} [options]
- *        `modifier` renders the Cmd/Ctrl+Shift alternate rather than the key
- *        on its own.
+ * @param {{ mac?: boolean }} [options]
  */
-export function formatShortcut(shortcut, { mac = false, modifier = false } = {}) {
+export function formatShortcut(shortcut, { mac = false } = {}) {
   const key = shortcut.key.toUpperCase();
-  if (modifier) return mac ? `⌘⇧${key}` : `Ctrl+Shift+${key}`;
   if (!shortcut.mod) return key;
   return mac ? `⌘${key}` : `Ctrl+${key}`;
 }

--- a/frontend/test/keyboardShortcuts.test.js
+++ b/frontend/test/keyboardShortcuts.test.js
@@ -49,15 +49,6 @@ describe('SHORTCUTS', () => {
     expect(claimed).toEqual(['k'])
   })
 
-  it('offers a modifier alternate for the actions, and only for those', () => {
-    // Cmd/Ctrl+Shift+key is what people reach for first, and it works in the
-    // desktop app, which owns its own menu bar. The help sheet is what decides
-    // whether to advertise it.
-    const withChord = SHORTCUTS.filter((s) => s.withModifier).map((s) => s.id)
-
-    expect(withChord.sort()).toEqual(['chat-view', 'new-task', 'trajectory-view'])
-  })
-
   it('gives every shortcut an id, a key and a scope the help sheet groups by', () => {
     for (const s of SHORTCUTS) {
       expect(s.id).toBeTruthy()
@@ -128,30 +119,19 @@ describe('matchShortcut', () => {
     expect(matchShortcut(press('k'))).toBeNull()
   })
 
-  it('reads the modifier alternate for the actions that declare one', () => {
-    expect(matchShortcut(press('n', { metaKey: true, shiftKey: true }), { mac: true }).id).toBe(
-      'new-task'
-    )
-    expect(matchShortcut(press('m', { ctrlKey: true, shiftKey: true })).id).toBe('chat-view')
-    expect(matchShortcut(press('t', { ctrlKey: true, shiftKey: true })).id).toBe('trajectory-view')
-  })
-
-  it('fires the modifier alternate even while typing', () => {
-    // Held with a modifier it cannot be mistaken for text, unlike the bare key.
-    const inReply = { target: { tagName: 'TEXTAREA' }, ctrlKey: true, shiftKey: true }
-
-    expect(matchShortcut(press('m', inReply)).id).toBe('chat-view')
-  })
-
-  it('needs the shift for the alternate, and refuses it for a declared chord', () => {
-    // Cmd+M alone is Minimize on macOS and would never arrive; matching it
-    // would be claiming a key we do not get. And Cmd+Shift+K is not Cmd+K.
+  it('leaves a bare letter alone whenever a modifier is held', () => {
+    // Those keystrokes belong to the browser or the system — Cmd+M minimises a
+    // window, Cmd+Shift+T reopens a tab — and most never arrive at all.
+    // Answering to them would fire the shortcut on the way past.
     expect(matchShortcut(press('m', { ctrlKey: true }))).toBeNull()
-    expect(matchShortcut(press('k', { ctrlKey: true, shiftKey: true }))).toBeNull()
+    expect(matchShortcut(press('m', { ctrlKey: true, shiftKey: true }))).toBeNull()
+    expect(matchShortcut(press('t', { metaKey: true, shiftKey: true }), { mac: true })).toBeNull()
+    expect(matchShortcut(press('n', { metaKey: true, shiftKey: true }), { mac: true })).toBeNull()
   })
 
-  it('offers no alternate for a shortcut that did not ask for one', () => {
-    expect(matchShortcut(press('?', { ctrlKey: true, shiftKey: true }))).toBeNull()
+  it('refuses a shifted version of a declared chord', () => {
+    // Cmd+Shift+K is not Cmd+K.
+    expect(matchShortcut(press('k', { ctrlKey: true, shiftKey: true }))).toBeNull()
   })
 
   it('reads the bare letters', () => {
@@ -209,10 +189,6 @@ describe('formatShortcut', () => {
     expect(formatShortcut({ key: '?' })).toBe('?')
   })
 
-  it('writes the modifier alternate when asked for it', () => {
-    expect(formatShortcut({ key: 'm' }, { mac: true, modifier: true })).toBe('⌘⇧M')
-    expect(formatShortcut({ key: 'm' }, { modifier: true })).toBe('Ctrl+Shift+M')
-  })
 })
 
 describe('dispatchShortcut', () => {


### PR DESCRIPTION
**What changed**

The two-key combinations for new task, messages and trajectory are gone. Every shortcut is now the single letter the help sheet already showed, and holding a modifier no longer triggers one.

**Why changed**

They were solving a problem that did not exist. In a browser most of those combinations never reached the app — the browser uses them to reopen a tab or open a private window — and the ones that did reach it only repeated a single-key shortcut that already worked. Creating a task from the keyboard on the desktop app is handled by the application menu and a global shortcut rather than by the page, so nothing is lost there either.

**Test coverage report**

- New lines introduced: 100%
- Total coverage impact: none — the frontend suite stays at 100% statements / 100% branches / 100% functions / 100% lines across every gated file. 518 tests pass.
- Net 77 lines removed against 31 added.

**Other reports**

- Production build succeeds.
- Behaviour change worth noting: a single-letter shortcut is now ignored while any modifier is held. Previously `Cmd+M` and similar could still match on the way past to the browser or window manager.

TaskID: 0iEZ0zyltOj