### PR TITLE
chore: bump minor version to v0.5.0

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.4.18"
+	_appVersion   = "v0.5.0"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.4.18" {
-			t.Errorf("Expected version v0.4.18, got %s", s.Version())
+		if s.Version() != "v0.5.0" {
+			t.Errorf("Expected version v0.5.0, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.4.18",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.4.18",
+      "version": "0.5.0",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.4.18",
+  "version": "0.5.0",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.4.18",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.4.18",
+      "version": "0.5.0",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.4.18",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
**What changed**

The application version moves from 0.4.18 to 0.5.0 everywhere it is declared — the desktop shell, the web frontend and the backend.

**Why changed**

A minor rather than a patch, because this version adds a capability that was not there before: a workspace can now keep its tasks and attachments on the machine, search them without reaching the backend, and read them offline.

**What is in this version**

- **The local task cache** — per workspace, per profile, per machine. Tasks, message threads and attachment bytes are kept locally, searchable by title and description with no backend round trip, and readable while offline. Enabling it on one computer does not enable it on another. (#413, #414, #421 carrying #415–#419, #420)
- **Expiry** — a workspace can say how long its local copy is kept, and a daily background sweep drops what has aged out. (#422)
- **Deletion reaches the local copy** — deleting a task now clears its cached rows and its attachment bytes on both the web and desktop builds. (#423)
- **Keyboard shortcuts settled on one binding each** — the Cmd/Ctrl+Shift alternates were added and then removed, since in a browser most never arrived and the rest only repeated a single-letter shortcut that already worked. (#424, #426)

**Test coverage report**

- New lines introduced: none — this changes declared version strings only.
- Total coverage impact: none. The backend config suite passes, and the frontend suite is unaffected at 100%.

**Other reports**

- `node desktop/scripts/check-versions.mjs` reports all three sources agree at 0.5.0, and the tag form (`GITHUB_REF=refs/tags/v0.5.0`) additionally confirms the tag matches — this is the check CI runs before packaging.
- Lockfile version fields were edited by hand rather than regenerated, so no dependency resolution shifted. `npm ci` succeeds in both `frontend/` and `desktop/`.
- A version string used as a tokeniser test fixture was deliberately left alone; it is an illustration, not a declaration.

TaskID: 0iEdH4RUw0P