### PR TITLE
docs: remove the outdated YouTube demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@
   <a href="README.zh-CN.md">简体中文</a>
   <br />
   <br />
-  <a href="https://www.youtube.com/watch?v=GBAoSpuCzrU">Watch on YouTube in HD</a>
-  <br />
-  <br />
   <a href="https://discord.gg/xFSMaEA2b2">
     <img src="https://img.shields.io/badge/Discord-Join%20Community-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" />
   </a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,9 +4,6 @@
   <a href="README.md">English</a>
   <br />
   <br />
-  <a href="https://www.youtube.com/watch?v=GBAoSpuCzrU">Watch on YouTube in HD</a>
-  <br />
-  <br />
   <a href="https://discord.gg/xFSMaEA2b2">
     <img src="https://img.shields.io/badge/Discord-Join%20Community-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" />
   </a>


### PR DESCRIPTION
**What changed**

The "Watch on YouTube in HD" link has been taken out of the header of both the English and Chinese landing docs, leaving the language switcher and the Discord badge in place.

**Why changed**

The linked walkthrough no longer reflects how AgentRQ looks or works, so pointing new visitors at it hurts more than it helps. It stays out until a fresh demo is recorded.

**Test coverage report**

Documentation-only change — no executable lines added or removed, so there are no new lines to cover and total coverage is unchanged.

**Other reports**

Grepped the whole repo (`.md`, `.vue`, `.js`, `.go`, `.html`, `.json`) for `youtube`/`youtu.be`: the two header lines removed here were the only occurrences. Both files were edited together because their header blocks are mirror copies and would otherwise drift.

TaskID: 0iEf86IZCXB

🤖 Generated with [Claude Code](https://claude.com/claude-code)