### PR TITLE
chore: bump patch version to v0.5.1

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.5.0"
+	_appVersion   = "v0.5.1"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.5.0" {
-			t.Errorf("Expected version v0.5.0, got %s", s.Version())
+		if s.Version() != "v0.5.1" {
+			t.Errorf("Expected version v0.5.1, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
**What changed**

The application version moves from 0.5.0 to 0.5.1 everywhere it is declared — the desktop and web packages, their lockfiles, and the backend.

**Why changed**

To cut a patch release carrying the two scheduler fixes and the README cleanup landed since 0.5.0. The version-sync job rejects a tree whose declarations disagree, so all of them move together.

**Test coverage report**

- New lines introduced: none — this is a version-string change only, so there is nothing new to cover.
- Total coverage impact: unchanged. The backend config test asserting the version was updated alongside it and passes.

**Other reports**

Verified with `node desktop/scripts/check-versions.mjs` in both forms CI uses:

```
✓ desktop, frontend and backend are all at 0.5.1
✓ tag v0.5.1 matches version 0.5.1
```

Lockfile version fields were edited by hand rather than regenerated, so no dependency resolution shifted under the release; `npm ci` still succeeds.

**Changelog since v0.5.0**

- fix: carry the whole completion choice onto scheduled runs (#429)
- fix: preserve eventId when spawning task from cron template (#279)
- docs: remove the outdated YouTube demo link (#428)

TaskID: 0iEiDlbQY2T

🤖 Generated with [Claude Code](https://claude.com/claude-code)