### PR TITLE
fix(ui): make the agent connection indicator live

### DIFF
--- a/backend/internal/controller/mcp/agent_connected_test.go
+++ b/backend/internal/controller/mcp/agent_connected_test.go
@@ -1,0 +1,88 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/mustafaturan/monoflake"
+
+	"github.com/agentrq/agentrq/backend/internal/service/eventbus"
+)
+
+// The agent.connected payload names the workspace the way the REST API does.
+//
+// It used to carry the raw int64 while view.Workspace exposes the base62 ID, so
+// no lookup on the client ever matched and the live connection indicator never
+// moved off whatever the last page load had fetched.
+func TestPublishAgentConnected_NamesTheWorkspaceInBase62(t *testing.T) {
+	const workspaceID int64 = 1234567890123
+	const userID = "0iAx25vra8v"
+
+	bus := eventbus.New()
+	sub := bus.Subscribe(workspaceID, "")
+	defer bus.Unsubscribe(workspaceID, "", sub)
+
+	ps := &WorkspaceServer{bus: bus, workspaceID: workspaceID, userID: userID}
+
+	for _, connected := range []bool{true, false} {
+		ps.publishAgentConnected(connected)
+
+		evt := readEvent(t, sub)
+		if evt.Type != "agent.connected" {
+			t.Fatalf("event type = %q, want agent.connected", evt.Type)
+		}
+		if got, want := evt.Payload["workspaceId"], monoflake.ID(workspaceID).String(); got != want {
+			t.Errorf("workspaceId = %#v, want %q", got, want)
+		}
+		if got := evt.Payload["connected"]; got != connected {
+			t.Errorf("connected = %#v, want %v", got, connected)
+		}
+	}
+}
+
+// The workspace owner's own stream carries it too: the sidebar subscribes
+// user-wide, not per workspace, and that is the indicator this bug was about.
+func TestPublishAgentConnected_ReachesTheUserWideStream(t *testing.T) {
+	const workspaceID int64 = 987654321
+	const userID = "0ZzhYQG2qtl"
+
+	bus := eventbus.New()
+	sub := bus.Subscribe(0, userID)
+	defer bus.Unsubscribe(0, userID, sub)
+
+	ps := &WorkspaceServer{bus: bus, workspaceID: workspaceID, userID: userID}
+	ps.publishAgentConnected(true)
+
+	evt := readEvent(t, sub)
+	if got, want := evt.Payload["workspaceId"], monoflake.ID(workspaceID).String(); got != want {
+		t.Errorf("workspaceId = %#v, want %q", got, want)
+	}
+}
+
+type busEvent struct {
+	Type    string         `json:"type"`
+	Payload map[string]any `json:"payload"`
+}
+
+// readEvent takes the next frame off an eventbus subscription and strips the
+// SSE framing the bus adds.
+func readEvent(t *testing.T, sub chan []byte) busEvent {
+	t.Helper()
+
+	select {
+	case line := <-sub:
+		const prefix = "data: "
+		if len(line) < len(prefix) || string(line[:len(prefix)]) != prefix {
+			t.Fatalf("frame is not SSE-framed: %q", line)
+		}
+		var evt busEvent
+		if err := json.Unmarshal(line[len(prefix):], &evt); err != nil {
+			t.Fatalf("unmarshal event: %v (frame %q)", err, line)
+		}
+		return evt
+	case <-time.After(time.Second):
+		t.Fatal("no event published")
+		return busEvent{}
+	}
+}

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -491,24 +491,34 @@ func (ps *WorkspaceServer) Handler() http.Handler {
 		if isSSE {
 			count := ps.agentConnections.Add(1)
 			if count == 1 {
-				ps.bus.Publish(ps.workspaceID, ps.userID, eventbus.Event{
-					Type:    "agent.connected",
-					Payload: map[string]any{"connected": true, "workspaceId": ps.workspaceID},
-				})
+				ps.publishAgentConnected(true)
 				ps.emitTelemetry(r.Context(), ActionMCPConnect, "connect", clientIdentityFromHTTPRequest(r))
 			}
 			defer func() {
 				if ps.agentConnections.Add(-1) == 0 {
-					ps.bus.Publish(ps.workspaceID, ps.userID, eventbus.Event{
-						Type:    "agent.connected",
-						Payload: map[string]any{"connected": false, "workspaceId": ps.workspaceID},
-					})
+					ps.publishAgentConnected(false)
 				}
 			}()
 		}
 
 		zlog.Debug().Str("method", r.Method).Str("path", r.URL.Path).Str("session_id", logID).Bool("sse", isSSE).Msg("MCP request")
 		ps.streamServer.ServeHTTP(w, r)
+	})
+}
+
+// publishAgentConnected tells the human clients whether an agent is attached.
+//
+// The workspace ID goes out base62-encoded, the way every other event on this
+// bus carries it: the REST API only ever names a workspace by its base62 ID
+// (see view.Workspace), so a raw int64 here matched nothing the frontend held
+// and the live indicator never moved off whatever the last page load fetched.
+func (ps *WorkspaceServer) publishAgentConnected(connected bool) {
+	ps.bus.Publish(ps.workspaceID, ps.userID, eventbus.Event{
+		Type: "agent.connected",
+		Payload: map[string]any{
+			"connected":   connected,
+			"workspaceId": monoflake.ID(ps.workspaceID).String(),
+		},
 	})
 }
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -550,13 +550,18 @@ const closeOverlaysOnEscape = (e) => {
 }
 
 // Setup Global Event Bus (Global stream receives events for all workspaces)
-const { connect, disconnect, events } = useEventBus()
+//
+// The shell owns this one subscription for the whole app: it is what keeps the
+// workspace store — and with it every agent-connection indicator on screen —
+// current, so a view never has to open a stream of its own just to learn that
+// an agent came online.
+//
+// Handled per event rather than by watching the buffer. Reacting to a
+// transition means seeing every event, and a watcher only ever showed the
+// handler the last one in the flush.
+const { connect, disconnect, isConnected, onEvent } = useEventBus(undefined, { buffer: false })
 
-// Watch for noteworthy events
-watch(events, (newEvents) => {
-  if (newEvents.length === 0) return
-  const event = newEvents[newEvents.length - 1]
-  
+onEvent((event) => {
   // Handle agent connection status updates globally
   if (event.type === 'agent.connected') {
     const { connected, workspaceId } = event.payload
@@ -567,7 +572,7 @@ watch(events, (newEvents) => {
   if (event.type === 'workspace.updated') {
     workspaceStore.updateWorkspaceMetadata(event.payload)
   }
-  
+
   // Keep the local copy current. Merged against what the cache already holds
   // rather than written straight through: a payload built without its relations
   // is indistinguishable from one whose relations are genuinely empty, and this
@@ -588,7 +593,7 @@ watch(events, (newEvents) => {
   } else if (event.type === 'task.updated') {
     const task = event.payload
     const lastMsg = task.messages?.[task.messages.length - 1]
-    
+
     // Check for permission requests
     if (lastMsg?.metadata?.type === 'permission_request' && lastMsg.metadata.status !== 'allow' && lastMsg.metadata.status !== 'deny') {
       notifyError(`Permission required: ${lastMsg.metadata.tool_name}`, 'Action Needed')
@@ -599,7 +604,15 @@ watch(events, (newEvents) => {
       notifyInfo(`Task "${task.title}" is now ${status}`)
     }
   }
-}, { deep: true })
+})
+
+// Nothing replays the events missed while the stream was down, and a dropped
+// `agent.connected` is invisible — the dot simply keeps showing the state from
+// before the drop, forever. Re-reading the list on every reconnect is what
+// bounds how long the indicator can be wrong to the length of the outage.
+watch(isConnected, (now, before) => {
+  if (now && before === false) workspaceStore.fetchWorkspaces()
+})
 
 onMounted(() => {
   themeStore.init()

--- a/frontend/src/stores/workspaceStore.js
+++ b/frontend/src/stores/workspaceStore.js
@@ -2,16 +2,29 @@ import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import { fetchWorkspaces as apiFetchWorkspaces } from '../api';
 
+/**
+ * The one copy of the workspace list every view reads.
+ *
+ * `agentConnected` in particular has to live in exactly one place. It changes
+ * from outside the app — an agent attaches or drops its MCP stream — and five
+ * separate surfaces render it: the sidebar dot, the Overview cards, the task
+ * list rows, the workspace header, and the reply box's disabled state. When a
+ * view kept its own copy, the copy it fetched on mount was the only value it
+ * ever showed, so the indicator went stale the moment an agent connected and
+ * stayed stale until that view was mounted again.
+ */
 export const useWorkspaceStore = defineStore('workspace', () => {
   const workspaces = ref([]);
   const loading = ref(false);
+
+  const byName = (a, b) => a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' });
 
   async function fetchWorkspaces() {
     loading.value = true;
     try {
       const res = await apiFetchWorkspaces();
       const list = res.workspaces || [];
-      workspaces.value = list.sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' }));
+      workspaces.value = list.sort(byName);
     } catch (err) {
       console.error('Failed to fetch workspaces:', err);
     } finally {
@@ -20,18 +33,43 @@ export const useWorkspaceStore = defineStore('workspace', () => {
   }
 
   function updateWorkspaceMetadata(updatedWs) {
-    const idx = workspaces.value.findIndex(w => w.id == updatedWs.id);
+    const idx = findIndex(updatedWs?.id);
     if (idx !== -1) {
       workspaces.value[idx] = { ...workspaces.value[idx], ...updatedWs };
-      workspaces.value.sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' }));
+      workspaces.value.sort(byName);
     }
   }
 
+  /**
+   * Record whether a workspace's agent is attached.
+   *
+   * IDs are compared as strings because they arrive from two directions: a
+   * route parameter is always a string, while a payload field is whatever the
+   * backend serialised. Coercing both sides is what keeps a mismatch from
+   * silently dropping the update, which is how this indicator broke before.
+   */
   function updateAgentStatus(workspaceId, connected) {
-    const ws = workspaces.value.find(w => w.id == workspaceId);
-    if (ws) {
-      ws.agentConnected = connected;
+    const idx = findIndex(workspaceId);
+    if (idx !== -1) {
+      workspaces.value[idx] = { ...workspaces.value[idx], agentConnected: connected };
     }
+  }
+
+  /** The workspace with this ID, or undefined. */
+  function getWorkspace(workspaceId) {
+    const idx = findIndex(workspaceId);
+    return idx === -1 ? undefined : workspaces.value[idx];
+  }
+
+  /** Whether this workspace's agent is attached right now. Unknown reads false. */
+  function isAgentConnected(workspaceId) {
+    return getWorkspace(workspaceId)?.agentConnected === true;
+  }
+
+  function findIndex(workspaceId) {
+    if (workspaceId === undefined || workspaceId === null) return -1;
+    const wanted = String(workspaceId);
+    return workspaces.value.findIndex(w => String(w.id) === wanted);
   }
 
   return {
@@ -39,6 +77,8 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     loading,
     fetchWorkspaces,
     updateWorkspaceMetadata,
-    updateAgentStatus
+    updateAgentStatus,
+    getWorkspace,
+    isAgentConnected
   };
 });

--- a/frontend/src/useEventBus.js
+++ b/frontend/src/useEventBus.js
@@ -1,4 +1,4 @@
-import { ref, onUnmounted, unref } from 'vue';
+import { ref, onUnmounted, unref, getCurrentInstance } from 'vue';
 import { API_BASE_URL } from './api';
 
 // Shared across all useEventBus instances — ensures only one auth check fires at a time
@@ -14,11 +14,44 @@ async function checkAuth() {
   return sharedAuthCheckPromise;
 }
 
-export function useEventBus(workspaceId) {
+/**
+ * Subscribe to the server's event stream.
+ *
+ * Two ways to read it, and they are not interchangeable:
+ *
+ * - `onEvent(fn)` delivers every event exactly once, as it arrives. Anything
+ *   that reacts to a *transition* — an agent connecting, a task being deleted —
+ *   has to use this. A Vue watcher on the array below is scheduled, so two
+ *   events landing in one flush collapse into a single callback and a handler
+ *   reading `events[events.length - 1]` silently loses the earlier one.
+ * - `events` is the running buffer, for views that re-render from the whole
+ *   list rather than acting on each item.
+ *
+ * `buffer: false` skips the buffer for long-lived subscribers. The shell holds
+ * its stream open for the life of the app — days, on the desktop build — and an
+ * array nobody reads would grow without bound, making every deep watcher over
+ * it a little slower for every event that had ever arrived.
+ *
+ * @param {string | import('vue').Ref<string>} [workspaceId]  scope to one workspace; omit for the user-wide stream
+ * @param {{ buffer?: boolean }} [options]
+ */
+export function useEventBus(workspaceId, { buffer = true } = {}) {
   const events = ref([]);
   const isConnected = ref(false);
+  const handlers = new Set();
   let eventSource = null;
   let reconnectDelay = 1000;
+
+  /**
+   * Call `fn` for each event from now on. Returns an unsubscribe function; the
+   * handler is also dropped when the owning component unmounts.
+   */
+  function onEvent(fn) {
+    handlers.add(fn);
+    const off = () => handlers.delete(fn);
+    if (getCurrentInstance()) onUnmounted(off);
+    return off;
+  }
 
   function connect() {
     if (eventSource) return;
@@ -56,11 +89,21 @@ export function useEventBus(workspaceId) {
     };
 
     eventSource.onmessage = (e) => {
+      let payload;
       try {
-        const payload = JSON.parse(e.data);
-        events.value.push(payload);
+        payload = JSON.parse(e.data);
       } catch (err) {
         console.error('Error parsing SSE data', err, e.data);
+        return;
+      }
+      if (buffer) events.value.push(payload);
+      // One bad handler must not stop the others from seeing the event.
+      for (const fn of handlers) {
+        try {
+          fn(payload);
+        } catch (err) {
+          console.error('SSE handler failed', err, payload);
+        }
       }
     };
   }
@@ -77,5 +120,5 @@ export function useEventBus(workspaceId) {
     disconnect();
   });
 
-  return { connect, disconnect, events, isConnected };
+  return { connect, disconnect, events, isConnected, onEvent };
 }

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -755,6 +755,7 @@ import { useSpeechToText } from '../composables/useSpeechToText';
 import { usePendingSend } from '../composables/usePendingSend';
 import { scrollToBottom as scrollContainerToBottom, shouldScrollOnViewChange } from '../composables/useChatScroll';
 import { useEventBus } from '../useEventBus';
+import { useWorkspaceStore } from '../stores/workspaceStore';
 import { renderMarkdown } from '../utils/markdown';
 import {
   contextGauge,
@@ -787,7 +788,15 @@ const router = useRouter();
 const workspaceId = computed(() => route.params.id || route.params.workspaceId);
 const taskId = computed(() => route.params.taskId);
 
-const workspace = ref(null);
+// Prefer the store's copy: it is the one the shell keeps current from the event
+// stream. A workspace fetched once at load meant `agentConnected` was frozen at
+// whatever it was then, so the reply box stayed disabled with "Waiting for
+// agent..." for as long as this view was open, however long ago the agent had
+// actually connected. The fetched copy is only the fallback for the moment
+// before the shell's workspace list has landed.
+const workspaceStore = useWorkspaceStore();
+const localWorkspace = ref(null);
+const workspace = computed(() => workspaceStore.getWorkspace(workspaceId.value) || localWorkspace.value);
 const task = ref(null);
 const user = ref(null);
 const descExpanded = ref(false);
@@ -1050,7 +1059,8 @@ async function load() {
 
     user.value = await fetchUser();
     const pRes = await getWorkspace(workspaceId.value);
-    workspace.value = pRes.workspace;
+    localWorkspace.value = pRes.workspace;
+    workspaceStore.updateWorkspaceMetadata(pRes.workspace);
     const tRes = await getTask(workspaceId.value, taskId.value);
     // Assigned, not merged. The cached copy may have painted the first frame
     // above, and the server's answer replaces it outright — a conversation is

--- a/frontend/src/views/TaskListView.vue
+++ b/frontend/src/views/TaskListView.vue
@@ -155,12 +155,13 @@
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { fetchGlobalTasks, fetchWorkspaces, sendPermissionVerdict, updateTaskAssignee, updateTaskStatus, updateTaskOrder } from '../api';
+import { fetchGlobalTasks, sendPermissionVerdict, updateTaskAssignee, updateTaskStatus, updateTaskOrder } from '../api';
 import { useToasts } from '../composables/useToasts';
 import { useTooltipStore } from '../stores/tooltipStore';
 import { useCron } from '../composables/useCron';
 import { buildTaskGroups, pendingOnHuman } from '../composables/useTaskGroups';
 import { useEventBus } from '../useEventBus';
+import { useWorkspaceStore } from '../stores/workspaceStore';
 import { useViewport } from '../composables/useViewport';
 import LoadingState from '../components/LoadingState.vue';
 import { cacheTasks, sharedCache } from '../composables/useCachedTasks';
@@ -173,7 +174,10 @@ const { notifySuccess, notifyError } = useToasts();
 const { isMobile } = useViewport();
 
 const tasks = ref([]);
-const workspaces = ref([]);
+// Read, never written: the shell keeps the store's agentConnected current from
+// the event stream, so the per-row dots below follow an agent coming and going
+// instead of freezing at whatever was true when this list was fetched.
+const workspaceStore = useWorkspaceStore();
 const loading = ref(false);
 const offset = ref(0);
 const limit = 10;
@@ -245,15 +249,9 @@ const activeTaskCount = computed(() => tasks.value.filter(t => t.status !== 'cro
 const scheduledCount = computed(() => tasks.value.filter(t => t.status === 'cron').length);
 const pendingInputCount = computed(() => pendingOnHuman(tasks.value).length);
 
-const getWorkspaceName = (workspaceId) => {
-  const ws = workspaces.value.find(w => w.id === workspaceId);
-  return ws ? ws.name : '...';
-};
+const getWorkspaceName = (workspaceId) => workspaceStore.getWorkspace(workspaceId)?.name || '...';
 
-const isAgentConnected = (workspaceId) => {
-  const ws = workspaces.value.find(w => w.id === workspaceId);
-  return ws ? ws.agentConnected : false;
-};
+const isAgentConnected = (workspaceId) => workspaceStore.isAgentConnected(workspaceId);
 
 const getLastMessageText = (task) => {
   if (!task.messages || task.messages.length === 0) return 'No message content available.';
@@ -337,8 +335,11 @@ const fetchInitial = async () => {
   }
 
   try {
-    const wsRes = await fetchWorkspaces();
-    workspaces.value = wsRes.workspaces;
+    // Only when the shell has not already filled it. This runs again on every
+    // task event, and re-fetching a list the store keeps live from the event
+    // stream would be a request per event plus a re-render everywhere it is
+    // rendered.
+    if (workspaceStore.workspaces.length === 0) await workspaceStore.fetchWorkspaces();
 
     await fetchNext();
   } catch (err) {

--- a/frontend/src/views/WorkspaceDetailView.vue
+++ b/frontend/src/views/WorkspaceDetailView.vue
@@ -199,7 +199,10 @@ const isFullPane = computed(() => !!sectionLabel.value);
 const isBoard = computed(() => route.path.endsWith('/board'));
 
 const workspaceStore = useWorkspaceStore();
-const workspace = computed(() => workspaceStore.workspaces.find(w => w.id == workspaceId.value) || localWorkspace.value);
+// The store first, because it is the copy the event stream keeps current. The
+// locally fetched one is only a fallback for the moment before the shell's
+// workspace list has landed.
+const workspace = computed(() => workspaceStore.getWorkspace(workspaceId.value) || localWorkspace.value);
 const localWorkspace = ref(null);
 const tasks = ref([]);
 const loading = ref(true);
@@ -223,7 +226,9 @@ const scheduledCount = computed(() => tasks.value.filter(t => t.status === 'cron
 const activeTaskCount = computed(() => tasks.value.length - scheduledCount.value);
 const pendingInputCount = computed(() => tasks.value.filter(t => t.createdBy === 'agent' && (t.status === 'notstarted')).length);
 
-const isAgentConnected = ref(false);
+// Derived, not stored. A ref set at load time is exactly what made this header
+// dot lie until the page was reloaded.
+const isAgentConnected = computed(() => workspace.value?.agentConnected === true);
 
 onMounted(() => {
   load();
@@ -263,17 +268,6 @@ watch(workspaceId, (newId) => {
   }
 });
 
-watch(events, (evts) => {
-  const last = evts[evts.length - 1];
-  if (!last) return;
-
-  if (last.type === 'agent.connected') {
-    if (last.payload && String(last.payload.workspaceId) === String(workspaceId.value)) {
-      isAgentConnected.value = last.payload.connected;
-    }
-  }
-}, { deep: true });
-
 watch(isConnected, (val, old) => {
   if (val && old === false) {
     // Re-fetch everything if reconnected
@@ -287,7 +281,6 @@ async function load(showLoading = true) {
     const pRes = await getWorkspace(workspaceId.value);
     localWorkspace.value = pRes.workspace;
     workspaceStore.updateWorkspaceMetadata(pRes.workspace);
-    isAgentConnected.value = workspace.value?.agentConnected;
     if (!isConnected.value) connect();
   } catch (err) {
     error.value = err.message;

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -239,11 +239,10 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onUnmounted, computed, watch } from 'vue';
+import { ref, onMounted, computed, watch } from 'vue';
 import { useRouter } from 'vue-router';
-import { fetchWorkspaces, createWorkspace, unarchiveWorkspace, fetchGlobalTasks, fetchGlobalTaskStats } from '../api';
+import { createWorkspace, unarchiveWorkspace, fetchGlobalTasks, fetchGlobalTaskStats } from '../api';
 import { useToasts } from '../composables/useToasts';
-import { useEventBus } from '../useEventBus';
 import { useWorkspaceStore } from '../stores/workspaceStore';
 import { useFormat } from '../composables/useFormat';
 import { useTooltipStore } from '../stores/tooltipStore';
@@ -437,36 +436,14 @@ function goToWorkspace(id) {
   router.push(`/workspaces/${id}`);
 }
 
-const { connect, disconnect, events } = useEventBus();
-
-watch(events, (newEvents) => {
-  if (newEvents.length === 0) return;
-  const event = newEvents[newEvents.length - 1];
-
-  if (event.type === 'agent.connected') {
-    const { connected, workspaceId } = event.payload;
-    const ws = workspaces.value.find(w => w.id === workspaceId);
-    if (ws) {
-      ws.agentConnected = connected;
-    }
-  }
-
-  if (event.type === 'workspace.updated') {
-    const updatedWs = event.payload;
-    const idx = workspaces.value.findIndex(w => w.id === updatedWs.id);
-    if (idx !== -1) {
-      workspaces.value[idx] = { ...workspaces.value[idx], ...updatedWs };
-    }
-  }
-}, { deep: true });
+// No event stream here on purpose. This view renders the workspace store, and
+// the shell already subscribes once for the whole app and writes agent
+// connection state and workspace metadata into that store. A second
+// subscription would be a second SSE connection per user doing the same work,
+// against a copy of the same list.
 
 onMounted(async () => {
   await loadWorkspaces();
-  connect();
-});
-
-onUnmounted(() => {
-  disconnect();
 });
 </script>
 

--- a/frontend/test/eventBus.test.js
+++ b/frontend/test/eventBus.test.js
@@ -1,0 +1,434 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createApp, defineComponent, h, ref } from 'vue'
+
+import { useEventBus } from '../src/useEventBus'
+
+/**
+ * A stand-in for the browser's EventSource that lets a test drive the stream:
+ * open it, push a message, fail it.
+ */
+class FakeEventSource {
+  static instances = []
+
+  constructor(url) {
+    this.url = url
+    this.closed = false
+    this.onopen = null
+    this.onerror = null
+    this.onmessage = null
+    FakeEventSource.instances.push(this)
+  }
+
+  close() {
+    this.closed = true
+  }
+
+  open() {
+    this.onopen?.()
+  }
+
+  send(payload) {
+    this.onmessage?.({ data: JSON.stringify(payload) })
+  }
+
+  sendRaw(data) {
+    this.onmessage?.({ data })
+  }
+
+  fail() {
+    this.onerror?.(new Error('stream died'))
+  }
+
+  static last() {
+    return FakeEventSource.instances[FakeEventSource.instances.length - 1]
+  }
+}
+
+const connectedEvent = (workspaceId, connected) => ({
+  type: 'agent.connected',
+  payload: { workspaceId, connected },
+})
+
+let fetchMock
+
+beforeEach(() => {
+  FakeEventSource.instances = []
+  vi.stubGlobal('EventSource', FakeEventSource)
+  fetchMock = vi.fn().mockResolvedValue({ status: 200 })
+  vi.stubGlobal('fetch', fetchMock)
+  delete window.__AGENTRQ_BASE_PATH__
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('useEventBus', () => {
+  describe('the URL it opens', () => {
+    it('uses the user-wide stream when no workspace is named', () => {
+      useEventBus().connect()
+
+      expect(FakeEventSource.last().url).toBe('/api/v1/events/stream')
+    })
+
+    it('scopes to one workspace when given an ID', () => {
+      useEventBus('0ZzhYQG2qtl').connect()
+
+      expect(FakeEventSource.last().url).toBe('/api/v1/workspaces/0ZzhYQG2qtl/events')
+    })
+
+    it('unwraps a ref, so a route param can be passed straight in', () => {
+      const id = ref('0iAx25vra8v')
+      useEventBus(id).connect()
+
+      expect(FakeEventSource.last().url).toBe('/api/v1/workspaces/0iAx25vra8v/events')
+    })
+
+    it('honours the base path the backend injects for a sub-path deployment', () => {
+      window.__AGENTRQ_BASE_PATH__ = '/agentrq/'
+
+      useEventBus().connect()
+
+      expect(FakeEventSource.last().url).toBe('/agentrq/api/v1/events/stream')
+    })
+
+    it('opens one stream however many times connect is called', () => {
+      const bus = useEventBus()
+
+      bus.connect()
+      bus.connect()
+
+      expect(FakeEventSource.instances).toHaveLength(1)
+    })
+  })
+
+  describe('onEvent', () => {
+    // The reason this exists. A Vue watcher on the buffer is scheduled, so two
+    // events arriving in one flush collapse into a single callback and a
+    // handler reading the last element loses the earlier one — which for
+    // `agent.connected` means an indicator that never moves.
+    it('delivers every event, not just the last of a burst', () => {
+      const bus = useEventBus()
+      const seen = []
+      bus.onEvent((e) => seen.push(e))
+      bus.connect()
+
+      FakeEventSource.last().send(connectedEvent('a', true))
+      FakeEventSource.last().send(connectedEvent('b', true))
+
+      expect(seen.map(e => e.payload.workspaceId)).toEqual(['a', 'b'])
+    })
+
+    it('delivers to every handler', () => {
+      const bus = useEventBus()
+      const first = vi.fn()
+      const second = vi.fn()
+      bus.onEvent(first)
+      bus.onEvent(second)
+      bus.connect()
+
+      FakeEventSource.last().send(connectedEvent('a', true))
+
+      expect(first).toHaveBeenCalledOnce()
+      expect(second).toHaveBeenCalledOnce()
+    })
+
+    it('stops delivering once unsubscribed', () => {
+      const bus = useEventBus()
+      const handler = vi.fn()
+      const off = bus.onEvent(handler)
+      bus.connect()
+
+      off()
+      FakeEventSource.last().send(connectedEvent('a', true))
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('keeps the other handlers running when one throws', () => {
+      const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const bus = useEventBus()
+      const survivor = vi.fn()
+      bus.onEvent(() => { throw new Error('handler blew up') })
+      bus.onEvent(survivor)
+      bus.connect()
+
+      FakeEventSource.last().send(connectedEvent('a', true))
+
+      expect(survivor).toHaveBeenCalledOnce()
+      expect(err).toHaveBeenCalled()
+    })
+
+    it('drops a malformed frame without reaching the handlers', () => {
+      const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const bus = useEventBus()
+      const handler = vi.fn()
+      bus.onEvent(handler)
+      bus.connect()
+
+      FakeEventSource.last().sendRaw('not json')
+
+      expect(handler).not.toHaveBeenCalled()
+      expect(bus.events.value).toEqual([])
+      expect(err).toHaveBeenCalled()
+    })
+  })
+
+  describe('the buffer', () => {
+    it('collects events for views that render the whole list', () => {
+      const bus = useEventBus()
+      bus.connect()
+
+      FakeEventSource.last().send(connectedEvent('a', true))
+
+      expect(bus.events.value).toEqual([connectedEvent('a', true)])
+    })
+
+    // The shell holds its stream open for the life of the app. An array nobody
+    // reads would grow for every event that had ever arrived.
+    it('stays empty when the subscriber asked not to buffer', () => {
+      const bus = useEventBus(undefined, { buffer: false })
+      const handler = vi.fn()
+      bus.onEvent(handler)
+      bus.connect()
+
+      FakeEventSource.last().send(connectedEvent('a', true))
+
+      expect(bus.events.value).toEqual([])
+      expect(handler).toHaveBeenCalledOnce()
+    })
+
+    it('starts clean on a reconnect, so nothing is replayed as new', () => {
+      const bus = useEventBus()
+      bus.connect()
+      FakeEventSource.last().send(connectedEvent('a', true))
+
+      bus.disconnect()
+      bus.connect()
+
+      expect(bus.events.value).toEqual([])
+    })
+  })
+
+  describe('connection state', () => {
+    it('reports connected once the stream opens', () => {
+      const bus = useEventBus()
+      bus.connect()
+      expect(bus.isConnected.value).toBe(false)
+
+      FakeEventSource.last().open()
+
+      expect(bus.isConnected.value).toBe(true)
+    })
+
+    it('reports disconnected on failure', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const bus = useEventBus()
+      bus.connect()
+      FakeEventSource.last().open()
+
+      FakeEventSource.last().fail()
+
+      expect(bus.isConnected.value).toBe(false)
+    })
+
+    it('reports disconnected when closed deliberately', () => {
+      const bus = useEventBus()
+      bus.connect()
+      FakeEventSource.last().open()
+
+      bus.disconnect()
+
+      expect(bus.isConnected.value).toBe(false)
+      expect(FakeEventSource.instances[0].closed).toBe(true)
+    })
+
+    it('does nothing when disconnecting a stream that was never opened', () => {
+      const bus = useEventBus()
+
+      bus.disconnect()
+
+      expect(FakeEventSource.instances).toHaveLength(0)
+    })
+  })
+
+  describe('inside a component', () => {
+    /** Mount a component that runs `setup`, and return a function to unmount it. */
+    const mount = (setup) => {
+      const app = createApp(defineComponent({ setup, render: () => h('div') }))
+      app.mount(document.createElement('div'))
+      return () => app.unmount()
+    }
+
+    it('closes the stream when the component goes away', () => {
+      let bus
+      const unmount = mount(() => {
+        bus = useEventBus()
+        bus.connect()
+      })
+
+      unmount()
+
+      expect(FakeEventSource.instances[0].closed).toBe(true)
+      expect(bus.isConnected.value).toBe(false)
+    })
+
+    it('drops a handler registered in a component that has unmounted', () => {
+      const handler = vi.fn()
+      let bus
+      const unmount = mount(() => {
+        bus = useEventBus()
+        bus.onEvent(handler)
+        bus.connect()
+      })
+      const source = FakeEventSource.instances[0]
+
+      unmount()
+      source.send(connectedEvent('a', true))
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('reconnection', () => {
+    it('retries after a second, then backs off', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const bus = useEventBus()
+      bus.connect()
+
+      FakeEventSource.last().fail()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(FakeEventSource.instances).toHaveLength(1)
+
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(FakeEventSource.instances).toHaveLength(2)
+
+      FakeEventSource.last().fail()
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(FakeEventSource.instances).toHaveLength(2)
+
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(FakeEventSource.instances).toHaveLength(3)
+    })
+
+    it('caps the backoff at thirty seconds', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const bus = useEventBus()
+      bus.connect()
+
+      // 1s, 2s, 4s, 8s, 16s, 30s, 30s...
+      for (const delay of [1000, 2000, 4000, 8000, 16000, 30000]) {
+        FakeEventSource.last().fail()
+        await vi.advanceTimersByTimeAsync(0)
+        const before = FakeEventSource.instances.length
+        await vi.advanceTimersByTimeAsync(delay)
+        expect(FakeEventSource.instances.length).toBe(before + 1)
+      }
+
+      FakeEventSource.last().fail()
+      await vi.advanceTimersByTimeAsync(0)
+      const before = FakeEventSource.instances.length
+      await vi.advanceTimersByTimeAsync(30000)
+      expect(FakeEventSource.instances.length).toBe(before + 1)
+    })
+
+    it('resets the backoff once a stream opens again', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const bus = useEventBus()
+      bus.connect()
+
+      FakeEventSource.last().fail()
+      await vi.advanceTimersByTimeAsync(1000)
+      FakeEventSource.last().fail()
+      await vi.advanceTimersByTimeAsync(2000)
+      FakeEventSource.last().open()
+
+      FakeEventSource.last().fail()
+      await vi.advanceTimersByTimeAsync(0)
+      const before = FakeEventSource.instances.length
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(FakeEventSource.instances.length).toBe(before + 1)
+    })
+
+    it('stops retrying and goes to the login page when the session is gone', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      fetchMock.mockResolvedValue({ status: 401 })
+      const href = vi.fn()
+      vi.stubGlobal('location', { pathname: '/workspaces/a', set href(v) { href(v) } })
+
+      const bus = useEventBus()
+      bus.connect()
+      FakeEventSource.last().fail()
+      await vi.advanceTimersByTimeAsync(60000)
+
+      expect(href).toHaveBeenCalledWith('/login')
+      expect(FakeEventSource.instances).toHaveLength(1)
+      expect(warn).toHaveBeenCalled()
+    })
+
+    it('keeps the base path when redirecting to login', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+      window.__AGENTRQ_BASE_PATH__ = '/agentrq/'
+      fetchMock.mockResolvedValue({ status: 401 })
+      const href = vi.fn()
+      vi.stubGlobal('location', { pathname: '/agentrq/workspaces/a', set href(v) { href(v) } })
+
+      useEventBus().connect()
+      FakeEventSource.last().fail()
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(href).toHaveBeenCalledWith('/agentrq/login')
+    })
+
+    it('does not navigate when already on the login page', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+      fetchMock.mockResolvedValue({ status: 401 })
+      const href = vi.fn()
+      vi.stubGlobal('location', { pathname: '/login', set href(v) { href(v) } })
+
+      useEventBus().connect()
+      FakeEventSource.last().fail()
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(href).not.toHaveBeenCalled()
+    })
+
+    it('keeps retrying when the auth check itself cannot be reached', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      fetchMock.mockRejectedValue(new Error('offline'))
+
+      useEventBus().connect()
+      FakeEventSource.last().fail()
+      await vi.advanceTimersByTimeAsync(1000)
+
+      expect(FakeEventSource.instances).toHaveLength(2)
+    })
+
+    // Every stream errors at once when the backend restarts. One auth check
+    // between them, not one per stream.
+    it('shares a single auth check across simultaneous failures', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      let resolveAuth
+      fetchMock.mockReturnValue(new Promise((r) => { resolveAuth = r }))
+
+      const first = useEventBus()
+      const second = useEventBus('0ZzhYQG2qtl')
+      first.connect()
+      second.connect()
+      FakeEventSource.instances[0].fail()
+      FakeEventSource.instances[1].fail()
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(fetchMock).toHaveBeenCalledOnce()
+
+      resolveAuth({ status: 200 })
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+  })
+})

--- a/frontend/test/workspaceStore.test.js
+++ b/frontend/test/workspaceStore.test.js
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const fetchWorkspaces = vi.fn()
+vi.mock('../src/api', () => ({ fetchWorkspaces: (...args) => fetchWorkspaces(...args) }))
+
+const { useWorkspaceStore } = await import('../src/stores/workspaceStore')
+
+const ws = (id, name, extra = {}) => ({ id, name, agentConnected: false, ...extra })
+
+describe('workspaceStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    fetchWorkspaces.mockReset()
+  })
+
+  describe('fetchWorkspaces', () => {
+    it('sorts the list by name, so the sidebar order never depends on the server', async () => {
+      fetchWorkspaces.mockResolvedValue({ workspaces: [ws('b', 'zeta'), ws('a', 'alpha')] })
+      const store = useWorkspaceStore()
+
+      await store.fetchWorkspaces()
+
+      expect(store.workspaces.map(w => w.name)).toEqual(['alpha', 'zeta'])
+      expect(store.loading).toBe(false)
+    })
+
+    it('sorts numerically, so agent-10 comes after agent-2', async () => {
+      fetchWorkspaces.mockResolvedValue({ workspaces: [ws('a', 'agent-10'), ws('b', 'agent-2')] })
+      const store = useWorkspaceStore()
+
+      await store.fetchWorkspaces()
+
+      expect(store.workspaces.map(w => w.name)).toEqual(['agent-2', 'agent-10'])
+    })
+
+    it('treats a response with no list as an empty one', async () => {
+      fetchWorkspaces.mockResolvedValue({})
+      const store = useWorkspaceStore()
+
+      await store.fetchWorkspaces()
+
+      expect(store.workspaces).toEqual([])
+    })
+
+    it('keeps what it had when the request fails, and stops loading', async () => {
+      fetchWorkspaces.mockResolvedValueOnce({ workspaces: [ws('a', 'alpha')] })
+      const store = useWorkspaceStore()
+      await store.fetchWorkspaces()
+
+      const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+      fetchWorkspaces.mockRejectedValueOnce(new Error('offline'))
+      await store.fetchWorkspaces()
+      err.mockRestore()
+
+      expect(store.workspaces.map(w => w.id)).toEqual(['a'])
+      expect(store.loading).toBe(false)
+    })
+  })
+
+  describe('updateAgentStatus', () => {
+    beforeEach(async () => {
+      fetchWorkspaces.mockResolvedValue({ workspaces: [ws('0ZzhYQG2qtl', 'alpha'), ws('0iAx25vra8v', 'beta')] })
+      await useWorkspaceStore().fetchWorkspaces()
+    })
+
+    it('marks the named workspace connected and leaves the others alone', () => {
+      const store = useWorkspaceStore()
+
+      store.updateAgentStatus('0ZzhYQG2qtl', true)
+
+      expect(store.isAgentConnected('0ZzhYQG2qtl')).toBe(true)
+      expect(store.isAgentConnected('0iAx25vra8v')).toBe(false)
+    })
+
+    it('marks it disconnected again', () => {
+      const store = useWorkspaceStore()
+      store.updateAgentStatus('0ZzhYQG2qtl', true)
+
+      store.updateAgentStatus('0ZzhYQG2qtl', false)
+
+      expect(store.isAgentConnected('0ZzhYQG2qtl')).toBe(false)
+    })
+
+    // The bug this store exists to prevent: the backend used to publish the
+    // workspace ID as a raw int64 while the API names workspaces in base62, so
+    // no lookup ever matched and the indicator never moved.
+    it('ignores an ID that names no workspace it holds', () => {
+      const store = useWorkspaceStore()
+
+      store.updateAgentStatus(1234567890123, true)
+
+      expect(store.workspaces.some(w => w.agentConnected)).toBe(false)
+    })
+
+    it('matches an ID that arrives as a number rather than a string', () => {
+      fetchWorkspaces.mockResolvedValue({ workspaces: [ws(42, 'numeric')] })
+      const store = useWorkspaceStore()
+      store.workspaces = [ws(42, 'numeric')]
+
+      store.updateAgentStatus('42', true)
+
+      expect(store.isAgentConnected(42)).toBe(true)
+    })
+
+    it('ignores a missing ID rather than matching the first row', () => {
+      const store = useWorkspaceStore()
+
+      store.updateAgentStatus(undefined, true)
+      store.updateAgentStatus(null, true)
+
+      expect(store.workspaces.some(w => w.agentConnected)).toBe(false)
+    })
+  })
+
+  describe('updateWorkspaceMetadata', () => {
+    beforeEach(async () => {
+      fetchWorkspaces.mockResolvedValue({ workspaces: [ws('a', 'alpha'), ws('b', 'beta')] })
+      await useWorkspaceStore().fetchWorkspaces()
+    })
+
+    it('merges the new fields over the old ones', () => {
+      const store = useWorkspaceStore()
+
+      store.updateWorkspaceMetadata({ id: 'a', description: 'now described' })
+
+      expect(store.getWorkspace('a')).toMatchObject({ name: 'alpha', description: 'now described' })
+    })
+
+    it('re-sorts, because a rename can change the order', () => {
+      const store = useWorkspaceStore()
+
+      store.updateWorkspaceMetadata({ id: 'a', name: 'zulu' })
+
+      expect(store.workspaces.map(w => w.name)).toEqual(['beta', 'zulu'])
+    })
+
+    it('ignores a workspace it does not hold', () => {
+      const store = useWorkspaceStore()
+
+      store.updateWorkspaceMetadata({ id: 'never-seen', name: 'ghost' })
+
+      expect(store.workspaces).toHaveLength(2)
+    })
+
+    it('ignores an update with no workspace in it', () => {
+      const store = useWorkspaceStore()
+
+      store.updateWorkspaceMetadata(undefined)
+
+      expect(store.workspaces).toHaveLength(2)
+    })
+  })
+
+  describe('reads', () => {
+    it('returns undefined for a workspace it does not hold', () => {
+      expect(useWorkspaceStore().getWorkspace('nope')).toBeUndefined()
+    })
+
+    // False, not undefined: every caller renders this as a boolean, and an
+    // unknown workspace has to read the same as an offline one.
+    it('reports an unknown workspace as offline', () => {
+      expect(useWorkspaceStore().isAgentConnected('nope')).toBe(false)
+    })
+
+    it('reports a workspace with no connection field yet as offline', () => {
+      const store = useWorkspaceStore()
+      store.workspaces = [{ id: 'a', name: 'alpha' }]
+
+      expect(store.isAgentConnected('a')).toBe(false)
+    })
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -34,7 +34,9 @@ export default defineConfig({
       provider: 'v8',
       include: [
         'src/app.js',
+        'src/useEventBus.js',
         'src/stores/platformStore.js',
+        'src/stores/workspaceStore.js',
         'src/desktop/*.js',
         'src/composables/useChatScroll.js',
         'src/composables/useTaskGroups.js',


### PR DESCRIPTION
**What changed**

The agent connection indicator now updates the moment an agent connects or drops, everywhere it appears — the sidebar dot, the Overview card, the task list rows and the workspace header — instead of only when a page is refreshed or revisited. The reply box on an open task also unlocks as soon as its agent comes online, rather than staying stuck on "Waiting for agent..." until a reload.

**Why changed**

The connection event named the workspace by its internal numeric identifier while the rest of the API names it by its public short code, so no view ever recognised which workspace the event was about — the indicator moved only when a page happened to re-read the workspace list from the server. Four views also kept their own private copy of that list, two of them never listened for the event at all, and nothing re-read anything after the live connection dropped, so a missed change stayed wrong indefinitely. They now share one copy that a single subscription keeps current.

**Test coverage report**

- New lines introduced: **100%**. Both files added to the frontend's enforced-100% coverage set (`useEventBus`, the workspace store) report 100% statements/branches/functions/lines, and the new backend helper reports 100%.
- Total coverage impact:
  - Frontend: 41 new tests (520 → 561). The suite's global 100% threshold still passes with two previously-uncovered source files now inside it — this is a net widening of what the threshold guards, not just more tests over the same code.
  - Backend: `internal/controller/mcp` 67.3% → 67.4%. Full suite (`go test ./internal/...`) green across 28 packages.
  - Desktop: 422 tests green, unchanged.

**Other reports**

Reproduced and verified in a real browser before and after, driving an actual MCP session rather than a stubbed one — on an isolated backend and its own sqlite file, so nothing touched a running dev instance.

*Before* (this branch's parent): with an agent genuinely attached (`agentConnected = True` server-side), the Overview card still read `OFFLINE` and the reply box stayed `disabled=true / "Waiting for agent..."`.

*After*: the same page, never reloaded, followed the agent in both directions —

```
agent connects → card=LIVE    | sidebarDot=Agent Online | sameMarker=load-1788591951400
agent drops    → card=OFFLINE | sidebarDot=Agent Offline | sameMarker=load-1788591951400
reply box      → disabled=false | "Type instructions... (Cmd ⌘ + Enter to send)"
```

`sameMarker` is a value written to `window` before the agent connected; it surviving is what proves no reload or re-navigation occurred.

The backend test was mutation-checked: restoring the old payload fails it with `workspaceId = 1.234567890123e+12, want "0000LjaL3EZ"`, so the assertion bites rather than passing vacuously.

Two latent bugs in the same path are fixed alongside, both of which could lose an update on their own: nothing re-synchronised after the live stream dropped, and event handlers read only the last event of a batch from a scheduled watcher, so a burst arriving together silently discarded all but one.

No GitHub issue tracks this one — it came in as an AgentRQ task, so there is no `Closes:` link to add. Happy to file one retroactively if you would rather have it referenced.

TaskID: 0iEpCS3seBt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
