### PR TITLE
chore: bump patch version to v0.5.2

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.5.1"
+	_appVersion   = "v0.5.2"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.5.1" {
-			t.Errorf("Expected version v0.5.1, got %s", s.Version())
+		if s.Version() != "v0.5.2" {
+			t.Errorf("Expected version v0.5.2, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
**What changed**

Bumps the project to **v0.5.2** across all six version references — desktop and frontend `package.json` plus their lockfiles, the backend's `_appVersion` constant, and its test assertion.

**Why changed**

To cut a release containing the agent connection indicator fix. The version-sync check runs before any packaging and rejects a tree whose versions disagree, so all six have to move together.

**Changelog since v0.5.1**

*Fixes*
- **fix(ui): make the agent connection indicator live (#431)** — the indicator now updates the moment an agent connects or drops, everywhere it appears: the sidebar dot, the Overview card, the task list rows and the workspace header. It previously only changed on a refresh or a revisit, because the connection event named the workspace by its internal numeric identifier while the rest of the API uses the public short code, so no view recognised which workspace the event was about. The reply box on an open task also unlocks as soon as its agent comes online rather than staying stuck on "Waiting for agent..." until a reload. Two latent ways a live update could be lost are fixed alongside: nothing re-read state after the event stream dropped, and handlers only saw the last event of a batch.

**Test coverage report**

No new lines of product code, so no new coverage to report. Verification run:

- `node desktop/scripts/check-versions.mjs` → `✓ desktop, frontend and backend are all at 0.5.2`
- `GITHUB_REF=refs/tags/v0.5.2 node desktop/scripts/check-versions.mjs` (the form CI runs on a tag build) → also `✓ tag v0.5.2 matches version 0.5.2`
- `go test ./internal/service/config/` green with the updated assertion
- `npm ci` succeeds in both `desktop/` and `frontend/`, confirming the hand-edited lockfiles are still installable

**Other reports**

Lockfile version fields were edited by hand rather than regenerated, so no unrelated dependency resolution shifted underneath the release — the diff is exactly nine lines across six files. Version strings used as fixtures or worked examples (`desktop/test/version.test.js`, `desktop/src/version.js`, `.github/workflows/desktop-release.yml`) were deliberately left alone.

TaskID: 0iEpCS3seBt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
