### PR TITLE
docs: add Search & Keyboard Shortcuts to the README feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ Give a workspace a countdown — 3s, 5s, 10s, 15s, 30s or 60s — and every chat
 
 </td>
 </tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Search & Keyboard Shortcuts
+
+<kbd>⌘K</kbd> (<kbd>Ctrl+K</kbd> off macOS) opens a task finder that matches any word in a title or description, straight from the copy your device already saved — so it answers offline, and tells you how far it looked. Everything else is a bare letter: <kbd>N</kbd> for a new task, <kbd>M</kbd> and <kbd>T</kbd> to flip between a task's chat and its trajectory, <kbd>?</kbd> for the list. Nothing to configure, and nothing to memorise.
+
+</td>
+<td width="50%"><img src="https://agentrq.com/assets/feature-keyboard-shortcuts.gif" alt="AgentRQ task finder and keyboard shortcuts sheet" width="320" /></td>
+</tr>
 </table>
 
 See the full list at [agentrq.com/features](https://agentrq.com/features).


### PR DESCRIPTION
## What changed

The README's feature gallery now covers the task finder and the keyboard shortcuts, so both are discoverable from the repository itself rather than only from the website. One new row, keeping the alternating text/image layout the table already uses.

## Why changed

The feature shipped, but the README's feature list stopped short of it — the only description of it lived on agentrq.com.

## Test coverage report

Docs-only change. No executable lines were added or changed, so new-line coverage is not applicable and total coverage is unaffected. No test run was needed or performed.

## Other reports

The copy was written against the implementation rather than the marketing page, and the two differ:

- The five bindings and their scopes come from `SHORTCUTS` in `frontend/src/composables/useKeyboardShortcuts.js` — `M` and `T` are `scope: 'task'`, hence "a task's chat and its trajectory".
- "Any word in a title or description" holds because `frontend/src/composables/useLocalCache.js` indexes both `title` and `body`; `searchCachedTasks` reads IndexedDB with no request, hence "answers offline".
- "Tells you how far it looked" is the `titlesReach` indicator in `frontend/src/components/CommandPalette.vue` ("saved here" vs. "N recent").
- The features page describes a "three-tier lookup". That is not quite what the code does: `canResolveId` offers the cross-workspace ID lookup only when the text search returns nothing *and* the query looks like an ID. Rather than compress that into something inaccurate, the row omits it and the linked features page covers it.
- The image is `feature-keyboard-shortcuts.gif`, verified to return `200 image/gif`, matching the gif convention of every other row.

`README.zh-CN.md` is deliberately untouched — it carries no feature gallery, and the precedent commit bff7bd4 (Message Send Delay) likewise touched only `README.md`.

TaskID: 0iEuENA63er

🤖 Generated with [Claude Code](https://claude.com/claude-code)