### PR TITLE
docs: contribution guidelines and the proposals folders

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to AgentRQ
+
+Contributions come in three forms. There is no fourth.
+
+| Your intent | What to do |
+|---|---|
+| **Bug report or security issue** | [Open a GitHub issue](https://github.com/agentrq/agentrq/issues/new). No PR. |
+| **Feature request** | Add a proposal at `proposals/feature/<YYYYMMDD>-<slug>.md` |
+| **Architectural change** | Add a proposal at `proposals/adr/<YYYYMMDD>-<slug>.md` |
+
+Both kinds of proposal are submitted the same way: a pull request that adds one
+`.md` file to the relevant folder.
+
+## Why we work this way
+
+Given that coding agents write most of the underlying code now, we'd prefer
+feature and ADR PRs in the form of human-written text. This can be quite
+informal too — just run your idea by us the same way you would a coworker or a
+friend, say, over Discord. If we're aligned on the change, we're happy to burn
+our tokens on the underlying implementation.
+
+**Please do not have AI artificially expand what you'd like to do into a formal
+proposal.** A few honest paragraphs beat a generated document with headings for
+"Motivation", "Non-Goals" and "Alternatives Considered". We are reading for the
+idea, not the format.
+
+## Bugs
+
+Just open an issue. We appreciate this a lot, and will credit you as reporter.
+
+## Writing a proposal
+
+The file name is `<YYYYMMDD>-<slug>.md` — the date you opened it, then a short
+hyphenated name. For example, `20260905-per-workspace-quiet-hours.md`.
+
+There is no template. Say what you want and why; that is the whole ask. If it
+helps to know what we tend to wonder about while reading:
+
+- What problem are you hitting, and what do you do about it today?
+- Roughly what should happen instead?
+- Anything that would obviously break, if you can see it from where you sit?
+
+Skip any of those that don't apply. A three-sentence proposal is a perfectly
+good proposal.
+
+See [`proposals/feature/README.md`](proposals/feature/README.md) and
+[`proposals/adr/README.md`](proposals/adr/README.md) for which folder yours
+belongs in.
+
+## What happens next
+
+We read it and reply on the PR. If we're aligned, we merge the proposal and
+pick up the implementation ourselves — you do not need to write the code. If
+we're not, we'll say so on the PR and why; the proposal still stays useful as a
+record of something we considered.

--- a/proposals/adr/README.md
+++ b/proposals/adr/README.md
@@ -1,0 +1,43 @@
+# Architecture decision records
+
+A change to how AgentRQ is built, rather than to what it does.
+
+**File name:** `<YYYYMMDD>-<slug>.md` — e.g. `20260905-move-attachments-to-object-storage.md`
+
+**How to submit:** a PR adding one `.md` file to this folder. See
+[CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## What belongs here
+
+Decisions that are expensive to reverse and that later work has to build on:
+swapping a storage engine, changing how the agent and the server talk, adding
+or removing a layer, a new dependency that everything ends up importing.
+
+The test is roughly: *would someone reading the code in a year wonder why it
+was done this way?* If yes, it wants a record.
+
+If it's a capability a user would notice, it's a feature — put it in
+[`../feature`](../feature) instead. Not sure which? Pick either; we'll move it
+if it's in the wrong place.
+
+## Writing one
+
+Same as anywhere else here: informal, human-written, as long as it needs to be
+and no longer. **Please don't have AI inflate it into a formal document.**
+
+What's actually useful in an ADR, if you have it:
+
+- What forced the decision — the constraint, the limit you hit, the thing that
+  stopped working.
+- What you'd do about it.
+- What you gave up by choosing that. This is the part future readers want most,
+  and the part that's hardest to reconstruct later.
+
+A record that says "we did X because Y, and it costs us Z" has done its job.
+
+## A note on records that didn't happen
+
+Merged does not mean shipped. A proposal we agreed with is still a record of
+what we thought at the time, so an ADR that was superseded stays in place — add
+a new one that says what changed and link back to it, rather than editing the
+old file into agreement with the present.

--- a/proposals/feature/README.md
+++ b/proposals/feature/README.md
@@ -1,0 +1,35 @@
+# Feature proposals
+
+Something AgentRQ should do that it doesn't do yet.
+
+**File name:** `<YYYYMMDD>-<slug>.md` — e.g. `20260905-per-workspace-quiet-hours.md`
+
+**How to submit:** a PR adding one `.md` file to this folder. See
+[CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## What belongs here
+
+A new capability, or a change to how an existing one behaves — a filter on the
+task board, a notification channel, a new MCP tool, a setting that isn't there.
+If a user could notice the difference, it's a feature.
+
+If it changes how the system is *built* rather than what it does — the storage
+engine, the transport between agent and server, how a whole layer is
+structured — it's an ADR. Put it in [`../adr`](../adr) instead.
+
+Not sure which? Pick either. We'll move it if it's in the wrong place, and
+that costs nobody anything.
+
+## Writing one
+
+Informal is fine and preferred. Tell us what you're running into and what you'd
+like instead, the way you'd explain it to a coworker. Three sentences is a
+perfectly good proposal.
+
+**Please don't have AI expand a small idea into a formal document.** We are
+reading for the idea. A generated proposal with sections for "Motivation" and
+"Alternatives Considered" is harder to read than the two paragraphs it was
+grown from, and we'd rather have the two paragraphs.
+
+You don't need to propose an implementation, and you don't need to write one.
+If we agree on the change, we'll build it.


### PR DESCRIPTION
## What changed

The repository now states how to contribute: bugs go to an issue, while feature requests and architectural changes go through a short written proposal. Each proposal folder has its own README explaining what belongs in it and how to name the file.

## Why changed

There was nothing written down, so the three ways in were only known to people who already knew them.

## Test coverage report

Docs-only change. No executable lines added or changed, so new-line coverage is not applicable and total coverage is unaffected. Relative links were checked programmatically — all six resolve to real paths.

## Other reports

**Kept short on purpose.** The guidelines ask contributors not to have AI inflate an idea into a formal proposal, which would read badly sitting next to pages of generated scaffolding. The three files come to 134 lines total, and there is no proposal template — the text says explicitly that a three-sentence proposal is a perfectly good one.

**One correction to the spec.** The task described the naming convention as `<YYYYMMDD>-<slag>.md`; that reads as a typo for `slug`, which is what the files use throughout. Easy to change if it was deliberate.

**Two small additions beyond the literal text,** both to answer questions the guidelines would otherwise leave open:

- **What separates a feature from an ADR**, since the split only helps if people can tell which is which. Each README says what belongs in it, and both say to pick either when unsure because we'll move it — a contributor should not stall on filing.
- **What happens after you open a proposal** — we reply on the PR, and if we agree we implement it ourselves. The "we're happy to burn our tokens on the implementation" promise is the unusual part of this model, so it is worth being explicit that no code is expected from the contributor.

No link was added from README.md: GitHub surfaces CONTRIBUTING.md on its own in the issue and PR flows and in the repository sidebar.

TaskID: 0iGesgMpF7B

🤖 Generated with [Claude Code](https://claude.com/claude-code)