### PR TITLE
docs: point the README at CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,10 @@ Copy the filled-in commands and config block from **Workspace Settings → Setup
 AgentRQ supports multi-tenant Slack integration for real-time task creation, thread replies sync, and agent permission requests:
 - [Slack Integration Setup & Usage Guide](integrations/slack/README.md)
 
+## 🙌 Contributing
+
+Bug reports go in a [GitHub issue](https://github.com/agentrq/agentrq/issues/new) and feature or architecture ideas go in a short written proposal — see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## 🤝 Credits
 
 - [AgentRQ](https://agentrq.com) — The official Agent-Human collaboration platform.


### PR DESCRIPTION
## What changed

The README now points readers at the contribution guidelines, in one sentence just before the credits.

## Why changed

The guidelines merged with nothing linking to them from the front page.

## Test coverage report

Docs-only change. No executable lines added or changed, so new-line coverage is not applicable and total coverage is unaffected. No test run was needed or performed.

## Other reports

Four lines: a heading, a blank line, one sentence, a blank line. A heading rather than a bare sentence because every other topic in this README has one, and a loose line between Integrations and Credits would read as orphaned; the sentence itself is the single sentence that was asked for. It uses a different emoji from the Credits section immediately below it, which already holds 🤝.

The link target was verified to exist on `main` — the guidelines merged shortly before this branch was cut, so it resolves rather than 404ing.

TaskID: 0iGesgMpF7B

🤖 Generated with [Claude Code](https://claude.com/claude-code)