### PR TITLE
chore: bump patch version to v0.5.3

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.5.2"
+	_appVersion   = "v0.5.3"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.5.2" {
-			t.Errorf("Expected version v0.5.2, got %s", s.Version())
+		if s.Version() != "v0.5.3" {
+			t.Errorf("Expected version v0.5.3, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
## What changed

The project version moves from 0.5.2 to 0.5.3 across the desktop app, the frontend, and the backend.

## Why changed

To cut the next patch release. The version-sync job rejects a tree whose versions disagree, so all six references move together.

## Test coverage report

No new lines — the change is six version strings, so new-line coverage is not applicable and total coverage is unchanged. Full suites pass: backend `go test ./internal/...` clean, frontend 565 tests across 27 files.

Version sync verified both ways, including the form CI runs on a tag build:

```
$ node desktop/scripts/check-versions.mjs
✓ desktop, frontend and backend are all at 0.5.3

$ GITHUB_REF=refs/tags/v0.5.3 node desktop/scripts/check-versions.mjs
✓ desktop, frontend and backend are all at 0.5.3
✓ tag v0.5.3 matches version 0.5.3
```

## Other reports

**Lockfiles edited by hand**, per the documented procedure — regenerating them pulls in unrelated bundled-dependency churn and shifts resolution underneath a release. Agreement with `package.json` was confirmed with `npm ci --dry-run` in both packages (exit 0). Dry-run rather than a real `npm ci` on purpose: a real one wipes `node_modules`, which a running dev server depends on.

**Edits were line-scoped rather than a blanket find-and-replace.** Two things in the tree legitimately contain `0.5.2`-shaped strings and are untouched: `source-map-support@0.5.21` in both lockfiles, and the worked examples in `desktop/test/version.test.js`, `desktop/src/version.js` and the desktop release workflow, which use version numbers as fixtures and illustrations rather than declarations.

**Changelog scope.** The commit body lists the search-duplication fix (#435) and the OpenAPI rewrite (#436), and deliberately omits the three documentation-only commits in this range (#433, #437, #438 — README and the new contribution guidelines). #436 is kept despite its `docs(api)` prefix because it changes a published contract and adds backend tests, so it is not static-file churn.

TaskID: 0iHEejGxqZl

🤖 Generated with [Claude Code](https://claude.com/claude-code)