### PR TITLE
feat(mcp): accept the agent models notification

### DIFF
--- a/backend/internal/controller/mcp/agent_models.go
+++ b/backend/internal/controller/mcp/agent_models.go
@@ -1,0 +1,183 @@
+package mcp
+
+import (
+	"context"
+
+	zlog "github.com/rs/zerolog/log"
+)
+
+// AgentModelsNotificationMethod is the channel notification a gateway sends to
+// say which models the agent behind it can switch between.
+//
+// It arrives whenever the agent's session config changes, so the newest one for
+// a session replaces the previous rather than adding to it.
+const AgentModelsNotificationMethod = "notifications/claude/channel/models"
+
+// AgentModel is one model the connected agent offers.
+type AgentModel struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Current     bool   `json:"current,omitempty"`
+	Group       string `json:"group,omitempty"`
+}
+
+// AgentModelsParams is the payload of a models notification.
+//
+// snake_case, unlike the REST surface: this is the wire format the gateways
+// already send (acp-gateway's `sendModelsToWorkspace`), and renaming the fields
+// here would break every gateway in the field to satisfy a convention that
+// governs the HTTP API rather than this channel.
+type AgentModelsParams struct {
+	TaskID       string       `json:"task_id"`
+	SessionID    string       `json:"session_id"`
+	ConfigID     string       `json:"config_id"`
+	CurrentModel string       `json:"current_model"`
+	Models       []AgentModel `json:"models"`
+}
+
+// AgentModelsSnapshot is what one connected session last reported.
+//
+// ConfigID is carried through because selecting a model means writing back to
+// the same session config option the agent advertised it under; a snapshot
+// without it describes models nobody can switch to. SessionID is the *agent's*
+// session — see the note on keying in HandleAgentModels — and is kept for the
+// same reason: a future "use this model" has to name it.
+type AgentModelsSnapshot struct {
+	SessionID    string
+	ConfigID     string
+	CurrentModel string
+	Models       []AgentModel
+}
+
+// currentModelID is the model the payload says is selected.
+//
+// The top-level field is preferred, falling back to whichever entry carries the
+// agent's own `current` flag: gateways send one or the other, and a picker with
+// nothing selected is worse than either.
+func (p AgentModelsParams) currentModelID() string {
+	if p.CurrentModel != "" {
+		return p.CurrentModel
+	}
+	for _, m := range p.Models {
+		if m.Current {
+			return m.ID
+		}
+	}
+	return ""
+}
+
+// HandleAgentModels records the models a session reports it can switch between.
+//
+// Recorded rather than relayed into the chat: unlike agent telemetry, this is
+// not something that happened during a turn — it is a standing fact about the
+// connected agent, and it belongs beside the other live capabilities the
+// dashboard reads off the workspace.
+func (ps *WorkspaceServer) HandleAgentModels(ctx context.Context, sessionID string, p AgentModelsParams) {
+	// Keyed by the MCP transport session, deliberately, and *not* by the
+	// payload's session_id.
+	//
+	// The two are different namespaces: the transport session is this server's
+	// connection to the gateway, while `session_id` is the gateway's own ACP
+	// session with the agent behind it. Keying on the payload would put entries
+	// under IDs that liveSessionIDs never reports, so every snapshot would look
+	// as though it belonged to a session that had gone and none would ever be
+	// advertised. sessionTasks next door keys the same way for the same reason.
+	//
+	// An empty key is fine rather than something to reject: some transports
+	// leave the session ID blank, and the reader filters against the same list
+	// this is keyed on, so the two stay consistent either way.
+	//
+	// An empty model list is recorded rather than dropped: it is how a session
+	// says it has stopped offering a choice, and keeping the old list would
+	// leave a picker showing models the agent no longer accepts.
+	snapshot := AgentModelsSnapshot{
+		SessionID:    p.SessionID,
+		ConfigID:     p.ConfigID,
+		CurrentModel: p.currentModelID(),
+		Models:       p.Models,
+	}
+
+	ps.agentModelsMu.Lock()
+	ps.agentModels[sessionID] = snapshot
+	pruneAgentModels(ps.agentModels, ps.liveSessionIDs())
+	ps.agentModelsMu.Unlock()
+
+	zlog.Debug().
+		Str("session_id", sessionID).
+		Int("models", len(p.Models)).
+		Str("current_model", snapshot.CurrentModel).
+		Msg("recorded the models the agent offers")
+}
+
+// AgentModels reports what the connected agent can switch between, or nil when
+// nothing connected has said.
+func (ps *WorkspaceServer) AgentModels() *AgentModelsSnapshot {
+	ps.agentModelsMu.RLock()
+	defer ps.agentModelsMu.RUnlock()
+	return pickAgentModels(ps.agentModels, ps.liveSessionIDs())
+}
+
+// liveSessionIDs lists the sessions currently connected to this workspace.
+func (ps *WorkspaceServer) liveSessionIDs() []string {
+	if ps.mcpServer == nil {
+		return nil
+	}
+	var ids []string
+	for sess := range ps.mcpServer.Sessions() {
+		ids = append(ids, sess.ID())
+	}
+	return ids
+}
+
+// pickAgentModels chooses the snapshot to report from what sessions have said.
+//
+// Only live sessions count. The snapshot arrives by notification and is
+// therefore cached, so without this filter a workspace would go on advertising
+// the models of an agent that disconnected hours ago, and a picker built on it
+// would offer a choice nothing could act on.
+//
+// A session that reported an empty list is skipped rather than returned: it has
+// withdrawn its offer, and another session may still have one worth showing.
+// `live` is iterated rather than the map so the answer follows the session
+// order the server reports rather than Go's randomised map order, which would
+// otherwise make the choice differ between two identical calls.
+func pickAgentModels(snapshots map[string]AgentModelsSnapshot, live []string) *AgentModelsSnapshot {
+	for _, id := range live {
+		snapshot, ok := snapshots[id]
+		if !ok || len(snapshot.Models) == 0 {
+			continue
+		}
+		return &snapshot
+	}
+	return nil
+}
+
+// pruneAgentModels drops the snapshots of sessions that have gone away.
+//
+// There is no disconnect hook to hang this on, and pickAgentModels already
+// ignores dead sessions, so this is about the map rather than about
+// correctness: a long-lived workspace whose agent reconnects repeatedly would
+// otherwise accumulate one snapshot per session for the life of the process.
+//
+// No live sessions at all means the server is between connections rather than
+// that every snapshot is stale — and dropping them there would discard the very
+// notification being recorded, since a test or an early call can observe the
+// map before the session is visible.
+//
+// The caller must hold the write lock.
+func pruneAgentModels(snapshots map[string]AgentModelsSnapshot, live []string) {
+	if len(live) == 0 {
+		return
+	}
+
+	keep := make(map[string]bool, len(live))
+	for _, id := range live {
+		keep[id] = true
+	}
+	for id := range snapshots {
+		if !keep[id] {
+			delete(snapshots, id)
+		}
+	}
+}

--- a/backend/internal/controller/mcp/agent_models_test.go
+++ b/backend/internal/controller/mcp/agent_models_test.go
@@ -1,0 +1,376 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// The notification this file handles used to be rejected outright — the SDK
+// answered "JSON RPC not handled" and the gateway logged a transport error at
+// the user. These tests pin both halves of the fix: that the payload the
+// gateways actually send is understood, and that a snapshot never outlives the
+// session that reported it.
+
+func newModelsServer() *WorkspaceServer {
+	return &WorkspaceServer{agentModels: make(map[string]AgentModelsSnapshot)}
+}
+
+// The exact frame acp-gateway puts on the wire (src/acpClient.ts), so a rename
+// on either side fails here rather than in production.
+const gatewayModelsFrame = `{
+  "jsonrpc": "2.0",
+  "method": "notifications/claude/channel/models",
+  "params": {
+    "task_id": "0iF1U1qQwS1",
+    "session_id": "01a07404-01a7-7033-a58f-47b119036378",
+    "config_id": "model",
+    "current_model": "gemini-2.5-pro",
+    "models": [
+      {"id": "gemini-2.5-pro", "name": "Gemini 2.5 Pro", "description": "Most capable", "current": true, "group": "Google"},
+      {"id": "gemini-2.5-flash", "name": "Gemini 2.5 Flash"}
+    ]
+  }
+}`
+
+func TestAgentModelsParamsMatchesTheGatewayWireFormat(t *testing.T) {
+	var frame struct {
+		Method string            `json:"method"`
+		Params AgentModelsParams `json:"params"`
+	}
+	if err := json.Unmarshal([]byte(gatewayModelsFrame), &frame); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if frame.Method != AgentModelsNotificationMethod {
+		t.Errorf("method = %q, want %q", frame.Method, AgentModelsNotificationMethod)
+	}
+
+	p := frame.Params
+	if p.TaskID != "0iF1U1qQwS1" {
+		t.Errorf("task_id = %q", p.TaskID)
+	}
+	if p.SessionID != "01a07404-01a7-7033-a58f-47b119036378" {
+		t.Errorf("session_id = %q", p.SessionID)
+	}
+	if p.ConfigID != "model" {
+		t.Errorf("config_id = %q", p.ConfigID)
+	}
+	if p.CurrentModel != "gemini-2.5-pro" {
+		t.Errorf("current_model = %q", p.CurrentModel)
+	}
+	if len(p.Models) != 2 {
+		t.Fatalf("models = %d, want 2", len(p.Models))
+	}
+	want := AgentModel{
+		ID: "gemini-2.5-pro", Name: "Gemini 2.5 Pro",
+		Description: "Most capable", Current: true, Group: "Google",
+	}
+	if !reflect.DeepEqual(p.Models[0], want) {
+		t.Errorf("models[0] = %+v, want %+v", p.Models[0], want)
+	}
+	if p.Models[1].Description != "" || p.Models[1].Current || p.Models[1].Group != "" {
+		t.Errorf("optional fields should stay zero when absent: %+v", p.Models[1])
+	}
+}
+
+func TestHandleCustomNotificationRoutesModels(t *testing.T) {
+	ps := newModelsServer()
+	ps.HandleCustomNotification(context.Background(), "transport-session", []byte(gatewayModelsFrame))
+
+	// Keyed by the MCP transport session — the namespace liveSessionIDs
+	// reports — and not by the ACP session the payload names.
+	got, ok := ps.agentModels["transport-session"]
+	if !ok {
+		t.Fatalf("models were not recorded; map = %+v", ps.agentModels)
+	}
+	if _, wrong := ps.agentModels["01a07404-01a7-7033-a58f-47b119036378"]; wrong {
+		t.Error("keyed by the payload's ACP session, which liveSessionIDs never reports")
+	}
+	if len(got.Models) != 2 || got.ConfigID != "model" {
+		t.Errorf("recorded = %+v", got)
+	}
+	if got.SessionID != "01a07404-01a7-7033-a58f-47b119036378" {
+		t.Errorf("the agent's session should be kept on the snapshot, got %q", got.SessionID)
+	}
+}
+
+func TestHandleAgentModels(t *testing.T) {
+	t.Run("records what the session reported", func(t *testing.T) {
+		ps := newModelsServer()
+		ps.HandleAgentModels(context.Background(), "sess-1", AgentModelsParams{
+			ConfigID:     "model",
+			CurrentModel: "b",
+			Models:       []AgentModel{{ID: "a"}, {ID: "b"}},
+		})
+
+		got := ps.agentModels["sess-1"]
+		if got.ConfigID != "model" || got.CurrentModel != "b" || len(got.Models) != 2 {
+			t.Errorf("recorded = %+v", got)
+		}
+	})
+
+	t.Run("keys on the transport session, not the agent's", func(t *testing.T) {
+		// The payload's session_id is the gateway's ACP session; the key has to
+		// be the MCP transport session, because that is the namespace
+		// liveSessionIDs reports and therefore the one the reader filters on.
+		// Keying on the payload would file every snapshot under an ID that
+		// never appears live, and none would ever be advertised.
+		ps := newModelsServer()
+		ps.HandleAgentModels(context.Background(), "mcp-session", AgentModelsParams{
+			SessionID: "acp-session",
+			Models:    []AgentModel{{ID: "a"}},
+		})
+
+		if _, ok := ps.agentModels["mcp-session"]; !ok {
+			t.Errorf("expected the transport session as the key, got %+v", ps.agentModels)
+		}
+		if _, ok := ps.agentModels["acp-session"]; ok {
+			t.Error("must not key on the agent's own session id")
+		}
+		if got := ps.agentModels["mcp-session"].SessionID; got != "acp-session" {
+			t.Errorf("the agent's session should still be recorded on the snapshot, got %q", got)
+		}
+	})
+
+	t.Run("records against a blank transport session rather than dropping it", func(t *testing.T) {
+		// Some transports leave the session ID empty. The reader filters
+		// against the same list this is keyed on, so "" is internally
+		// consistent — and dropping it would lose the models outright.
+		ps := newModelsServer()
+		ps.HandleAgentModels(context.Background(), "", AgentModelsParams{Models: []AgentModel{{ID: "a"}}})
+
+		if _, ok := ps.agentModels[""]; !ok {
+			t.Errorf("expected the models recorded under the blank key, got %+v", ps.agentModels)
+		}
+		if got := pickAgentModels(ps.agentModels, []string{""}); got == nil {
+			t.Error("a blank-keyed snapshot must still be readable for a blank live session")
+		}
+	})
+
+	t.Run("the newest report replaces the previous one", func(t *testing.T) {
+		ps := newModelsServer()
+		ps.HandleAgentModels(context.Background(), "sess-1", AgentModelsParams{Models: []AgentModel{{ID: "a"}, {ID: "b"}}})
+		ps.HandleAgentModels(context.Background(), "sess-1", AgentModelsParams{Models: []AgentModel{{ID: "c"}}})
+
+		got := ps.agentModels["sess-1"]
+		if len(got.Models) != 1 || got.Models[0].ID != "c" {
+			t.Errorf("expected the second report to win, got %+v", got)
+		}
+	})
+
+	t.Run("an empty list is recorded, because it withdraws the choice", func(t *testing.T) {
+		ps := newModelsServer()
+		ps.HandleAgentModels(context.Background(), "sess-1", AgentModelsParams{Models: []AgentModel{{ID: "a"}}})
+		ps.HandleAgentModels(context.Background(), "sess-1", AgentModelsParams{Models: nil})
+
+		got, ok := ps.agentModels["sess-1"]
+		if !ok {
+			t.Fatal("the withdrawal should still be recorded")
+		}
+		if len(got.Models) != 0 {
+			t.Errorf("expected the list cleared, got %+v", got.Models)
+		}
+	})
+
+	t.Run("falls back to the per-model current flag", func(t *testing.T) {
+		// Gateways send the top-level field or the flag, not always both.
+		ps := newModelsServer()
+		ps.HandleAgentModels(context.Background(), "sess-1", AgentModelsParams{
+			Models: []AgentModel{{ID: "a"}, {ID: "b", Current: true}},
+		})
+
+		if got := ps.agentModels["sess-1"].CurrentModel; got != "b" {
+			t.Errorf("CurrentModel = %q, want %q", got, "b")
+		}
+	})
+
+	t.Run("leaves the current model empty when nothing claims to be it", func(t *testing.T) {
+		ps := newModelsServer()
+		ps.HandleAgentModels(context.Background(), "sess-1", AgentModelsParams{Models: []AgentModel{{ID: "a"}}})
+
+		if got := ps.agentModels["sess-1"].CurrentModel; got != "" {
+			t.Errorf("CurrentModel = %q, want empty", got)
+		}
+	})
+
+	t.Run("the top-level field beats the flag when both are set", func(t *testing.T) {
+		ps := newModelsServer()
+		ps.HandleAgentModels(context.Background(), "sess-1", AgentModelsParams{
+			CurrentModel: "a",
+			Models:       []AgentModel{{ID: "b", Current: true}},
+		})
+
+		if got := ps.agentModels["sess-1"].CurrentModel; got != "a" {
+			t.Errorf("CurrentModel = %q, want %q", got, "a")
+		}
+	})
+}
+
+func TestPickAgentModels(t *testing.T) {
+	snapshots := map[string]AgentModelsSnapshot{
+		"live":     {ConfigID: "model", Models: []AgentModel{{ID: "a"}}},
+		"dead":     {ConfigID: "stale", Models: []AgentModel{{ID: "z"}}},
+		"withdrew": {ConfigID: "empty"},
+	}
+
+	t.Run("reports what a live session offers", func(t *testing.T) {
+		got := pickAgentModels(snapshots, []string{"live"})
+		if got == nil || got.ConfigID != "model" {
+			t.Fatalf("got %+v", got)
+		}
+	})
+
+	t.Run("never reports a disconnected session's models", func(t *testing.T) {
+		// The whole reason for the filter: the snapshot is cached, so a
+		// workspace would otherwise advertise the models of an agent that left.
+		if got := pickAgentModels(snapshots, []string{"dead-gone"}); got != nil {
+			t.Errorf("got %+v, want nil", got)
+		}
+		if got := pickAgentModels(snapshots, nil); got != nil {
+			t.Errorf("got %+v, want nil", got)
+		}
+	})
+
+	t.Run("skips a session that withdrew its offer", func(t *testing.T) {
+		if got := pickAgentModels(snapshots, []string{"withdrew"}); got != nil {
+			t.Errorf("got %+v, want nil", got)
+		}
+	})
+
+	t.Run("passes over an empty offer to find a real one", func(t *testing.T) {
+		got := pickAgentModels(snapshots, []string{"withdrew", "live"})
+		if got == nil || got.ConfigID != "model" {
+			t.Fatalf("got %+v", got)
+		}
+	})
+
+	t.Run("follows session order rather than map order", func(t *testing.T) {
+		// Two identical calls must not disagree, which iterating the map would
+		// allow.
+		for i := 0; i < 50; i++ {
+			got := pickAgentModels(snapshots, []string{"dead", "live"})
+			if got == nil || got.ConfigID != "stale" {
+				t.Fatalf("call %d got %+v, want the first live session's", i, got)
+			}
+		}
+	})
+
+	t.Run("has nothing to report when nothing was recorded", func(t *testing.T) {
+		if got := pickAgentModels(map[string]AgentModelsSnapshot{}, []string{"live"}); got != nil {
+			t.Errorf("got %+v, want nil", got)
+		}
+		if got := pickAgentModels(nil, []string{"live"}); got != nil {
+			t.Errorf("got %+v, want nil", got)
+		}
+	})
+}
+
+func TestPruneAgentModels(t *testing.T) {
+	t.Run("drops the sessions that have gone", func(t *testing.T) {
+		snapshots := map[string]AgentModelsSnapshot{"a": {}, "b": {}, "c": {}}
+		pruneAgentModels(snapshots, []string{"b"})
+
+		if len(snapshots) != 1 {
+			t.Fatalf("snapshots = %+v, want only b", snapshots)
+		}
+		if _, ok := snapshots["b"]; !ok {
+			t.Errorf("kept the wrong one: %+v", snapshots)
+		}
+	})
+
+	t.Run("keeps everything when nothing is connected", func(t *testing.T) {
+		// No live sessions means "between connections", not "all stale" —
+		// pruning there would discard the notification being recorded.
+		snapshots := map[string]AgentModelsSnapshot{"a": {}}
+		pruneAgentModels(snapshots, nil)
+
+		if len(snapshots) != 1 {
+			t.Errorf("snapshots = %+v, want a kept", snapshots)
+		}
+	})
+}
+
+func TestAgentModelsWithoutAnMCPServer(t *testing.T) {
+	// No server means no live sessions, so there is nothing to advertise even
+	// though something was recorded earlier.
+	ps := newModelsServer()
+	ps.agentModels["sess-1"] = AgentModelsSnapshot{Models: []AgentModel{{ID: "a"}}}
+
+	if got := ps.AgentModels(); got != nil {
+		t.Errorf("AgentModels() = %+v, want nil", got)
+	}
+	if got := ps.liveSessionIDs(); got != nil {
+		t.Errorf("liveSessionIDs() = %v, want nil", got)
+	}
+}
+
+// The end-to-end shape: a real session connects, reports its models, and the
+// workspace advertises them only for as long as that session is there. The
+// pure functions above cover the rules; this covers the wiring to the SDK.
+func TestAgentModelsWithAConnectedSession(t *testing.T) {
+	replies := 0
+	ps := permissionServer(t, &replies)
+	ps.agentModels = make(map[string]AgentModelsSnapshot)
+	sessionID := connectedServer(t, ps, "acp-gateway")
+
+	if got := ps.liveSessionIDs(); len(got) != 1 || got[0] != sessionID {
+		t.Fatalf("liveSessionIDs() = %v, want [%s]", got, sessionID)
+	}
+
+	// Nothing reported yet, so there is nothing to advertise.
+	if got := ps.AgentModels(); got != nil {
+		t.Errorf("AgentModels() = %+v before any report, want nil", got)
+	}
+
+	ps.HandleAgentModels(context.Background(), sessionID, AgentModelsParams{
+		ConfigID:     "model",
+		CurrentModel: "gemini-2.5-pro",
+		Models:       []AgentModel{{ID: "gemini-2.5-pro"}, {ID: "gemini-2.5-flash"}},
+	})
+
+	got := ps.AgentModels()
+	if got == nil {
+		t.Fatal("AgentModels() = nil after the session reported")
+	}
+	if got.ConfigID != "model" || got.CurrentModel != "gemini-2.5-pro" || len(got.Models) != 2 {
+		t.Errorf("AgentModels() = %+v", got)
+	}
+}
+
+// A snapshot recorded by a session that is no longer connected is never
+// advertised, even though it is still cached — the case the live-session filter
+// exists for.
+func TestAgentModelsIgnoresADepartedSession(t *testing.T) {
+	replies := 0
+	ps := permissionServer(t, &replies)
+	ps.agentModels = map[string]AgentModelsSnapshot{
+		"a-session-that-left": {ConfigID: "model", Models: []AgentModel{{ID: "a"}}},
+	}
+	connectedServer(t, ps, "acp-gateway")
+
+	if got := ps.AgentModels(); got != nil {
+		t.Errorf("AgentModels() = %+v, want nil for a departed session", got)
+	}
+}
+
+// Recording a new session's models evicts a departed one's, so the map does not
+// grow for the life of the process.
+func TestHandleAgentModelsPrunesDepartedSessions(t *testing.T) {
+	replies := 0
+	ps := permissionServer(t, &replies)
+	ps.agentModels = map[string]AgentModelsSnapshot{
+		"a-session-that-left": {Models: []AgentModel{{ID: "old"}}},
+	}
+	sessionID := connectedServer(t, ps, "acp-gateway")
+
+	ps.HandleAgentModels(context.Background(), sessionID, AgentModelsParams{Models: []AgentModel{{ID: "new"}}})
+
+	if _, ok := ps.agentModels["a-session-that-left"]; ok {
+		t.Errorf("the departed session should have been pruned: %+v", ps.agentModels)
+	}
+	if _, ok := ps.agentModels[sessionID]; !ok {
+		t.Errorf("the live session's models should have been kept: %+v", ps.agentModels)
+	}
+}

--- a/backend/internal/controller/mcp/manager.go
+++ b/backend/internal/controller/mcp/manager.go
@@ -91,6 +91,18 @@ func (m *Manager) SupportsStop(workspaceID int64) bool {
 	return srv.SupportsStop()
 }
 
+// AgentModels reports the models the workspace's connected agent offers, or nil
+// when there is no server running for it or nothing has reported any.
+func (m *Manager) AgentModels(workspaceID int64) *AgentModelsSnapshot {
+	m.mu.RLock()
+	srv, ok := m.servers[workspaceID]
+	m.mu.RUnlock()
+	if !ok || srv == nil {
+		return nil
+	}
+	return srv.AgentModels()
+}
+
 // SendChannelNotification forwards a channel notification to the appropriate WorkspaceServer.
 func (m *Manager) SendChannelNotification(ctx context.Context, workspaceID int64, userID string, taskID int64, content string) {
 	m.mu.RLock()

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -128,15 +128,20 @@ type WorkspaceServer struct {
 	// each revision rewrites that message instead of appending another one.
 	agentTelemetryMessagesMu sync.RWMutex
 	agentTelemetryMessages   map[string]int64 // taskID:kind[:planID] -> messageID
-	elicitationsMu           sync.Mutex
-	elicitations             map[string]chan elicitationResponse // requestID -> channel the waiting elicit tool call blocks on
-	metadataMu               sync.RWMutex
-	icon                     string
-	name                     string
-	description              string
-	archivedAt               *time.Time
-	lastUpdateCheckAt        time.Time
-	agentConnections         atomic.Int32
+	// What each connected session says it can switch between. Cached because it
+	// only ever arrives by notification, and read back filtered to live
+	// sessions so a disconnected agent stops advertising its models.
+	agentModelsMu     sync.RWMutex
+	agentModels       map[string]AgentModelsSnapshot // sessionID -> models last reported
+	elicitationsMu    sync.Mutex
+	elicitations      map[string]chan elicitationResponse // requestID -> channel the waiting elicit tool call blocks on
+	metadataMu        sync.RWMutex
+	icon              string
+	name              string
+	description       string
+	archivedAt        *time.Time
+	lastUpdateCheckAt time.Time
+	agentConnections  atomic.Int32
 
 	// done is closed by Close to stop the StartPing/StartPoller ticker goroutines, so a
 	// removed workspace server does not leak them for the lifetime of the process.
@@ -357,6 +362,7 @@ func NewWorkspaceServer(
 		undeliveredVerdicts:    make(map[string]string),
 		toolCallIDs:            make(map[string]int64),
 		agentTelemetryMessages: make(map[string]int64),
+		agentModels:            make(map[string]AgentModelsSnapshot),
 		elicitations:           make(map[string]chan elicitationResponse),
 		icon:                   icon,
 		name:                   name,
@@ -2070,6 +2076,18 @@ func (ps *WorkspaceServer) HandleCustomNotification(ctx context.Context, session
 			return
 		}
 		ps.HandleAgentTelemetry(ctx, sessionID, telemetry.Params)
+		return
+	}
+
+	if msg.Method == AgentModelsNotificationMethod {
+		var models struct {
+			Params AgentModelsParams `json:"params"`
+		}
+		if err := json.Unmarshal(data, &models); err != nil {
+			zlog.Error().Err(err).Str("session_id", sessionID).Msg("Failed to unmarshal agent models notification")
+			return
+		}
+		ps.HandleAgentModels(ctx, sessionID, models.Params)
 		return
 	}
 

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -31,6 +31,7 @@ type (
 		NotificationSettings  *NotificationSettings
 		AgentConnected        bool
 		AgentSupportsStop     bool
+		AgentModels           *AgentModels
 		AutoAllowedTools      []string
 		AllowAllCommands      bool
 		SelfLearningLoopNote  string
@@ -40,6 +41,25 @@ type (
 	}
 
 	// SlackConfig holds the Slack channel linked to a workspace.
+	// AgentModels is what the workspace's connected agent says it can switch
+	// between. Live state read off the MCP session rather than a stored column,
+	// so it is absent whenever no agent is connected or none has reported any.
+	AgentModels struct {
+		// ConfigID names the session config option the agent advertised these
+		// under, which is what a selection has to be written back to.
+		ConfigID     string
+		CurrentModel string
+		Models       []AgentModel
+	}
+
+	AgentModel struct {
+		ID          string
+		Name        string
+		Description string
+		Current     bool
+		Group       string
+	}
+
 	SlackConfig struct {
 		Enabled     bool   `json:"enabled"`
 		Installed   bool   `json:"installed"`

--- a/backend/internal/data/view/api/view.go
+++ b/backend/internal/data/view/api/view.go
@@ -19,6 +19,7 @@ type (
 		NotificationSettings  *NotificationSettings `json:"notificationSettings,omitempty"`
 		AgentConnected        bool                  `json:"agentConnected"`
 		AgentSupportsStop     bool                  `json:"agentSupportsStop"`
+		AgentModels           *AgentModels          `json:"agentModels,omitempty"`
 		MCPURL                string                `json:"mcpUrl"`
 		MCPToken              string                `json:"mcpToken,omitempty"`
 		AutoAllowedTools      []string              `json:"autoAllowedTools,omitempty"`
@@ -27,6 +28,23 @@ type (
 		InputSendDelaySeconds int                   `json:"inputSendDelaySeconds"`
 		WorkingDirectory      string                `json:"workingDirectory,omitempty"`
 		Slack                 *SlackConfig          `json:"slack,omitempty"`
+	}
+
+	// AgentModels is what the connected agent can switch between. Omitted
+	// entirely when no agent is connected or none has reported any, so a client
+	// can treat its presence as "a choice exists".
+	AgentModels struct {
+		ConfigID     string       `json:"configId"`
+		CurrentModel string       `json:"currentModel,omitempty"`
+		Models       []AgentModel `json:"models"`
+	}
+
+	AgentModel struct {
+		ID          string `json:"id"`
+		Name        string `json:"name"`
+		Description string `json:"description,omitempty"`
+		Current     bool   `json:"current,omitempty"`
+		Group       string `json:"group,omitempty"`
 	}
 
 	SlackConfig struct {

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -612,6 +612,7 @@ func (h *handler) createWorkspace() fiber.Handler {
 		}
 		rs.Workspace.AgentConnected = h.mcpManager.IsAgentConnected(rs.Workspace.ID)
 		rs.Workspace.AgentSupportsStop = h.mcpManager.SupportsStop(rs.Workspace.ID)
+		rs.Workspace.AgentModels = agentModelsEntity(h.mcpManager.AgentModels(rs.Workspace.ID))
 		h.enrichWorkspaceSlack(ctx, &rs.Workspace)
 
 		c.Status(http.StatusCreated)
@@ -640,6 +641,7 @@ func (h *handler) getWorkspace() fiber.Handler {
 		}
 		rs.Workspace.AgentConnected = h.mcpManager.IsAgentConnected(rs.Workspace.ID)
 		rs.Workspace.AgentSupportsStop = h.mcpManager.SupportsStop(rs.Workspace.ID)
+		rs.Workspace.AgentModels = agentModelsEntity(h.mcpManager.AgentModels(rs.Workspace.ID))
 		h.enrichWorkspaceSlack(ctx, &rs.Workspace)
 
 		c.Status(http.StatusOK)
@@ -667,6 +669,7 @@ func (h *handler) listWorkspaces() fiber.Handler {
 		for i := range rs.Workspaces {
 			rs.Workspaces[i].AgentConnected = h.mcpManager.IsAgentConnected(rs.Workspaces[i].ID)
 			rs.Workspaces[i].AgentSupportsStop = h.mcpManager.SupportsStop(rs.Workspaces[i].ID)
+			rs.Workspaces[i].AgentModels = agentModelsEntity(h.mcpManager.AgentModels(rs.Workspaces[i].ID))
 			h.enrichWorkspaceSlack(ctx, &rs.Workspaces[i])
 		}
 
@@ -774,6 +777,7 @@ func (h *handler) updateWorkspace() fiber.Handler {
 		}
 		rs.Workspace.AgentConnected = h.mcpManager.IsAgentConnected(rq.Workspace.ID)
 		rs.Workspace.AgentSupportsStop = h.mcpManager.SupportsStop(rq.Workspace.ID)
+		rs.Workspace.AgentModels = agentModelsEntity(h.mcpManager.AgentModels(rq.Workspace.ID))
 		h.enrichWorkspaceSlack(ctx, &rs.Workspace)
 
 		c.Status(http.StatusOK)
@@ -939,5 +943,30 @@ func (h *handler) enrichWorkspaceSlack(ctx context.Context, ws *entity.Workspace
 	cfg, err := h.slackCtrl.GetWorkspaceSlackConfig(ctx, ws.ID)
 	if err == nil && cfg != nil {
 		ws.Slack = cfg
+	}
+}
+
+// agentModelsEntity converts a live MCP snapshot into the entity the workspace
+// carries, so the API layer keeps its own shape rather than exposing the MCP
+// controller's type through the view.
+func agentModelsEntity(s *mcpctrl.AgentModelsSnapshot) *entity.AgentModels {
+	if s == nil {
+		return nil
+	}
+
+	models := make([]entity.AgentModel, len(s.Models))
+	for i, m := range s.Models {
+		models[i] = entity.AgentModel{
+			ID:          m.ID,
+			Name:        m.Name,
+			Description: m.Description,
+			Current:     m.Current,
+			Group:       m.Group,
+		}
+	}
+	return &entity.AgentModels{
+		ConfigID:     s.ConfigID,
+		CurrentModel: s.CurrentModel,
+		Models:       models,
 	}
 }

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -31,6 +31,7 @@ import (
 var customNotificationMethods = []string{
 	"notifications/claude/channel/permission_request",
 	mcpctrl.AgentTelemetryNotificationMethod,
+	mcpctrl.AgentModelsNotificationMethod,
 }
 
 type Params struct {

--- a/backend/internal/mapper/api/workspace.go
+++ b/backend/internal/mapper/api/workspace.go
@@ -152,6 +152,7 @@ func fromEntityWorkspaceToView(p entity.Workspace, mcpURL string) view.Workspace
 		NotificationSettings:  fromEntityNotificationSettingsToView(p.NotificationSettings),
 		AgentConnected:        p.AgentConnected,
 		AgentSupportsStop:     p.AgentSupportsStop,
+		AgentModels:           fromEntityAgentModelsToView(p.AgentModels),
 		MCPURL:                mcpURL,
 		AutoAllowedTools:      p.AutoAllowedTools,
 		AllowAllCommands:      p.AllowAllCommands,
@@ -198,5 +199,32 @@ func fromViewNotificationSettingsToEntity(p *view.NotificationSettings) *entity.
 		WorkspaceArchived:   p.WorkspaceArchived,
 		WorkspaceUnarchived: p.WorkspaceUnarchived,
 		Channels:            p.Channels,
+	}
+}
+
+// fromEntityAgentModelsToView renders the models the connected agent offers.
+//
+// nil rather than an empty object when nothing is connected or nothing was
+// reported: the field is omitted from the response entirely, so a client can
+// read its presence as "there is a choice to make here".
+func fromEntityAgentModelsToView(m *entity.AgentModels) *view.AgentModels {
+	if m == nil {
+		return nil
+	}
+
+	models := make([]view.AgentModel, len(m.Models))
+	for i, one := range m.Models {
+		models[i] = view.AgentModel{
+			ID:          one.ID,
+			Name:        one.Name,
+			Description: one.Description,
+			Current:     one.Current,
+			Group:       one.Group,
+		}
+	}
+	return &view.AgentModels{
+		ConfigID:     m.ConfigID,
+		CurrentModel: m.CurrentModel,
+		Models:       models,
 	}
 }

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1622,6 +1622,12 @@ components:
           type: boolean
           description: Whether an agent currently holds an MCP session.
         agentSupportsStop: { type: boolean }
+        agentModels:
+          allOf: [{ $ref: '#/components/schemas/AgentModels' }]
+          description: |
+            What the connected agent can switch between. Absent when no agent is
+            connected, or when the connected one has not reported any, so its
+            presence means a choice exists.
         mcpUrl: { type: string }
         mcpToken:
           type: string
@@ -1638,6 +1644,35 @@ components:
             agent. 0 disables the delay.
         workingDirectory: { type: string }
         slack: { $ref: '#/components/schemas/SlackConfig' }
+
+    AgentModels:
+      type: object
+      description: |
+        Live state read off the workspace's MCP session rather than a stored
+        column: it arrives as a `notifications/claude/channel/models`
+        notification from the gateway and is reported only while the session
+        that sent it is still connected.
+      properties:
+        configId:
+          type: string
+          description: |
+            The agent session config option these were advertised under, which
+            is what a selection would have to be written back to.
+        currentModel: { type: string }
+        models:
+          type: array
+          items: { $ref: '#/components/schemas/AgentModel' }
+
+    AgentModel:
+      type: object
+      properties:
+        id: { type: string }
+        name: { type: string }
+        description: { type: string }
+        current: { type: boolean }
+        group:
+          type: string
+          description: Optional grouping, e.g. the provider name.
 
     SlackConfig:
       type: object


### PR DESCRIPTION
## What changed

The workspace now accepts the notification a gateway sends listing the models its agent can switch between, and reports them on the workspace so a client can show which model is in use and what else is available.

## Why changed

That notification was not recognised, so every one was answered "JSON RPC not handled" and the gateway logged a transport error where the user could see it.

## Test coverage report

New lines: 100%. Every function in the new file is at 100% statement coverage — `HandleAgentModels`, `AgentModels`, `liveSessionIDs`, `pickAgentModels`, `pruneAgentModels`, `currentModelID`. Full backend suite passes, including the OpenAPI drift tests after documenting the new field.

23 tests, including one that decodes the exact JSON frame the gateway puts on the wire, so a rename on either side fails here rather than in production.

## Other reports

**More than a one-line fix, deliberately.** Adding the method to the allowlist alone would stop the error and throw the payload away. Instead the models are kept and surfaced as `agentModels` on the workspace object, beside `agentConnected` and `agentSupportsStop`, which are live capabilities read the same way. A model picker can be built on it with no further backend work.

**A bug caught by writing the tests, worth recording.** The first version keyed each snapshot by the payload's `session_id`. That is the gateway's own ACP session — a different namespace from the MCP transport session that the live-session list reports. Snapshots would have been filed under IDs that never appear as live, so nothing would ever have been read back and the feature would have looked like it worked while always returning nothing. It now keys on the transport session, as `sessionTasks` next door already does, and keeps the agent's session id on the snapshot, since selecting a model later has to name it. A test pins the distinction.

**Only live sessions are reported.** The data arrives by notification and is therefore cached, so without that filter a workspace would go on advertising the models of an agent that disconnected hours ago, and a picker built on it would offer a choice nothing could act on. Snapshots for departed sessions are also pruned on write, since there is no disconnect hook to do it.

**Scope: this is read-only.** Nothing here lets anyone choose a model. That needs a notification in the opposite direction and a handler in the gateway — which already has the ACP call for it (`setSessionModel` → `session/set_config_option`) but nothing to trigger it, since the workspace→gateway channel currently carries only `task`, `cancel`, `verdict` and `reconnected`.

**Wire format left in snake_case.** `task_id` / `session_id` / `config_id` / `current_model` is what gateways already send; renaming them would break every deployed gateway to satisfy a convention that governs the HTTP API. The REST surface added here is camelCase as required.

TaskID: 0iHFPT12O6D

🤖 Generated with [Claude Code](https://claude.com/claude-code)