### PR TITLE
chore: bump patch version to v0.5.4

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.5.3"
+	_appVersion   = "v0.5.4"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.5.3" {
-			t.Errorf("Expected version v0.5.3, got %s", s.Version())
+		if s.Version() != "v0.5.4" {
+			t.Errorf("Expected version v0.5.4, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.5.3",
+  "version": "0.5.4",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
## What changed

The project version moves from 0.5.3 to 0.5.4 across the desktop app, the frontend, and the backend.

## Why changed

To cut a security release: every open dependency advisory across all three packages is now fixed on main, and this is what ships them.

## Test coverage report

No new lines — the change is six version strings, so new-line coverage is not applicable and total coverage is unchanged. All three suites pass: backend `go test ./internal/...` clean, frontend 565 tests across 27 files, desktop 422 tests across 16 files.

Version sync verified both ways, including the form CI runs on a tag build:

```
$ node desktop/scripts/check-versions.mjs
✓ desktop, frontend and backend are all at 0.5.4

$ GITHUB_REF=refs/tags/v0.5.4 node desktop/scripts/check-versions.mjs
✓ desktop, frontend and backend are all at 0.5.4
✓ tag v0.5.4 matches version 0.5.4
```

## Other reports

**What this release contains** (everything since v0.5.3):

| | |
|---|---|
| #441 | frontend: `browserslist` and `fast-uri` advisories, both build-time only |
| #442 | desktop: Electron 38 → 44, nineteen advisories, `extract-zip` removed from the tree |
| #443 | backend: `golang.org/x/text` GO-2026-5970 and Fiber GHSA-gcfq-8gqf-4876 |
| #440 | the workspace accepts the agent models notification and reports `agentModels` |

**One user-facing consequence to be aware of before publishing:** #442 raises the floor to **macOS 13**. Electron 44 dropped macOS 12, so anyone still on it stops receiving updates at this version. No minimum was ever documented, so nothing is contradicted, but it is worth a line in the release notes.

**Two things this release knowingly does not fix**, both larger than a dependency bump and both better handled deliberately:

1. **32 Go standard-library advisories.** They need a newer build toolchain, not a dependency change. The Docker image floats on `golang:1.25-bookworm` and already picks them up; CI resolves the exact `go 1.25.0` directive and does not.
2. **The rate limiter and DDoS middleware trust client-supplied IP headers** — `X-Forwarded-For` and `X-Real-IP` are read with no trusted-proxy check, so varying one header per request yields a fresh bucket. Same class of problem as the Fiber advisory just patched, but in our own code.

**Lockfiles were edited by hand**, per the documented procedure — regenerating them pulls in unrelated churn and shifts resolution underneath a release. Agreement with `package.json` was confirmed by `npm ci --dry-run` in both packages (exit 0); a real `npm ci` was avoided so a running dev server's `node_modules` is untouched.

**Edits were line-scoped rather than find-and-replace.** `source-map-support@0.5.21` in both lockfiles and the version fixtures in `desktop/test/version.test.js`, `desktop/src/version.js` and the release workflow all contain version-shaped strings and are deliberately untouched.

**Merging alone publishes nothing** — the release is cut by tagging `main` and pushing the tag.

TaskID: 0iHFziBdCGv

🤖 Generated with [Claude Code](https://claude.com/claude-code)