### PR TITLE
docs(codex): set Codex up through the ACP gateway's registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,77 +297,36 @@ The gateway will automatically:
 - Spawn the agent subprocess and bridge standard I/O.
 - Forward task assignments, messages, and permission requests in real-time.
 
-## 🌌 Codex Gateway (Bridge for OpenAI Codex)
+## 🌌 Codex (via the ACP Gateway)
 
-Similar to the ACP Gateway, the `@agentrq/codex-gateway` connects [OpenAI Codex](https://github.com/openai/codex) to AgentRQ workspaces by bridging the Model Context Protocol (MCP) with the Codex app-server protocol.
+[OpenAI Codex](https://github.com/openai/codex) connects through the same
+[ACP Gateway](#-acp-gateway-bridge-for-acp-agents) as every other agent. The
+gateway resolves `codex-acp` from the [ACP registry](https://github.com/agentclientprotocol/registry)
+and runs it for you, so there is nothing to install and nothing to configure
+beyond the `.mcp.json` the gateway reads.
 
-### Installation
-
-```bash
-npm install -g @agentrq/codex-gateway@latest
-```
+> Earlier releases used a separate `@agentrq/codex-gateway` package and a
+> `.codex/config.toml`. Neither is needed now.
 
 ### Setup
 
-**1. Configure agentrq MCP server for Codex (project-level)**
-
-Codex reads project-level MCP server config from `.codex/config.toml`. Create this file so the Codex agent can use agentrq tools directly during task execution (replace `<WORKSPACEID>` and `<TOKEN>` with your values from the agentrq dashboard):
-
-```bash
-mkdir -p .codex
-cat >> .codex/config.toml << 'EOF'
-
-[mcp_servers.agentrq-workspace]
-url = "https://<WORKSPACEID>.mcp.agentrq.com/?token=<TOKEN>"
-
-[mcp_servers.agentrq-<ID>.tools.updateTaskStatus]
-approval_mode = "approve"
-
-[mcp_servers.agentrq-<ID>.tools.getWorkspace]
-approval_mode = "approve"
-
-[mcp_servers.agentrq-<ID>.tools.reply]
-approval_mode = "approve"
-
-[mcp_servers.agentrq-<ID>.tools.createTask]
-approval_mode = "approve"
-
-[mcp_servers.agentrq-<ID>.tools.downloadAttachment]
-approval_mode = "approve"
-
-[mcp_servers.agentrq-<ID>.tools.getTask]
-approval_mode = "approve"
-EOF
-```
-
-**2. Configure the gateway's agentrq connection**
-
-Create a `.mcp.json` in your project root so `codex-gateway` can connect to the same agentrq workspace:
-
-```json
-{
-  "mcpServers": {
-    "agentrq": {
-      "type": "http",
-      "url": "https://<WORKSPACEID>.mcp.agentrq.com/mcp?token=<TOKEN>"
-    }
-  }
-}
-```
-
-> **Note:** `.mcp.json` is used by `codex-gateway` to receive tasks. `.codex/config.toml` is used by the Codex agent itself to call agentrq tools (e.g. `reply`, `updateTaskStatus`) during execution.
-
-### Usage
-
-Run `codex-gateway` from your agentrq workspace root (the directory containing `.mcp.json`):
+1. Ensure you have a [`.mcp.json`](#step-1--mcpjson) in your project root.
+2. Log in — Codex will not open a session until you have. The first run fetches
+   the agent, then hands you its login:
 
 ```bash
-# Default: runs `codex app-server`
-codex-gateway
-
-# Custom codex command
-codex-gateway -- codex app-server
+npx @agentrq/acp-gateway@latest --login --agent codex-acp
 ```
+
+3. Start the bridge. Run it from the same directory as `.mcp.json`:
+
+```bash
+npx @agentrq/acp-gateway@latest --agent codex-acp
+```
+
+Sign out again with `--logout` in place of `--login`. The registry publishes
+Codex as an npm package, so npx fetches it on first use and keeps it current —
+unlike the binary agents, it needs no `--allow-unverified-agent`.
 
 ## 👑 Supervisor (CoreMCP)
 

--- a/frontend/src/views/WorkspaceSettingsView.vue
+++ b/frontend/src/views/WorkspaceSettingsView.vue
@@ -197,20 +197,6 @@
                     </div>
                   </section>
 
-                  <section v-if="activeConnectionTab === 'codex'" class="space-y-4 min-w-0 w-full overflow-hidden">
-                    <h3 class="text-[10px] font-bold text-gray-400 dark:text-zinc-500 uppercase tracking-widest ml-1">2. Codex Config</h3>
-                    <p class="text-[11px] text-gray-500 dark:text-zinc-400 font-medium px-1">Add this to <code class="bg-gray-100 dark:bg-zinc-800 px-1 py-0.5 rounded text-gray-900 dark:text-white">.codex/config.toml</code> to allow tool usage.</p>
-                    <div class="bg-gray-50 dark:bg-zinc-800/50 rounded-sm p-5 relative group border border-gray-200 dark:border-zinc-800 w-full max-w-full overflow-hidden">
-                      <div class="flex justify-between items-center mb-4">
-                        <span class="text-[10px] font-semibold text-gray-500 dark:text-zinc-500 font-mono">config.toml</span>
-                        <button type="button" @click="copyToClipboard(codexConfigToml, 'codexConfig')" class="text-[10px] font-bold text-gray-400 hover:text-black dark:text-zinc-400 dark:hover:text-white transition-colors uppercase tracking-widest">
-                          {{ copiedState.codexConfig ? 'Copied!' : 'Copy Config' }}
-                        </button>
-                      </div>
-                      <pre class="text-[11px] text-gray-800 dark:text-zinc-300 font-mono leading-relaxed p-1 overflow-x-auto custom-scrollbar whitespace-pre max-w-full block"><code>{{ codexConfigToml }}</code></pre>
-                    </div>
-                  </section>
-
                   <section v-if="activeConnectionTab === 'deepseek'" class="space-y-3 min-w-0 w-full overflow-hidden">
                     <h3 class="text-[10px] font-bold text-gray-400 dark:text-zinc-500 uppercase tracking-widest ml-1">Entry point</h3>
                     <div class="flex gap-2">
@@ -276,17 +262,30 @@
                     </div>
 
                     <div v-else-if="activeConnectionTab === 'codex'" class="space-y-4 min-w-0">
+                      <p class="text-[11px] text-gray-500 dark:text-zinc-400 font-medium">Codex will not open a session until it has been logged in to, so that comes first. Run both from this workspace's directory — the one holding the <code class="bg-gray-100 dark:bg-zinc-800 px-1 py-0.5 rounded text-gray-900 dark:text-white">.mcp.json</code> above.</p>
                       <div class="space-y-2">
-                        <p class="text-[11px] text-gray-600 dark:text-zinc-400 font-medium">Start the bridge — npx fetches the latest version each run, so there's nothing to install or upgrade separately:</p>
+                        <p class="text-[11px] text-gray-600 dark:text-zinc-400 font-medium">1. Log in. The first run fetches the agent, then hands you its login — pick a method when asked:</p>
                         <div class="bg-white dark:bg-zinc-900 p-3 rounded-sm border border-gray-200 dark:border-zinc-700 flex items-center justify-between group shadow-sm overflow-hidden">
                           <div class="flex-1 min-w-0 overflow-x-auto no-scrollbar">
-                            <code class="text-[10px] text-gray-900 dark:text-white font-bold whitespace-nowrap">npx @agentrq/acp-gateway@latest --max-concurrency 1 -- npx @agentclientprotocol/codex-acp</code>
+                            <code class="text-[10px] text-gray-900 dark:text-white font-bold whitespace-nowrap">{{ codexLoginCommand }}</code>
                           </div>
-                          <button type="button" @click="copyToClipboard('npx @agentrq/acp-gateway@latest --max-concurrency 1 -- npx @agentclientprotocol/codex-acp', 'codexStart')" class="text-[9px] font-bold uppercase tracking-widest pl-4 shrink-0 transition-colors" :class="copiedState.codexStart ? 'text-green-500' : 'text-gray-400 hover:text-black dark:hover:text-white'">
+                          <button type="button" @click="copyToClipboard(codexLoginCommand, 'codexLogin')" class="text-[9px] font-bold uppercase tracking-widest pl-4 shrink-0 transition-colors" :class="copiedState.codexLogin ? 'text-green-500' : 'text-gray-400 hover:text-black dark:hover:text-white'">
+                            {{ copiedState.codexLogin ? 'Copied!' : 'Copy' }}
+                          </button>
+                        </div>
+                      </div>
+                      <div class="space-y-2">
+                        <p class="text-[11px] text-gray-600 dark:text-zinc-400 font-medium">2. Start the bridge. Tasks assigned to this workspace's agent arrive from here:</p>
+                        <div class="bg-white dark:bg-zinc-900 p-3 rounded-sm border border-gray-200 dark:border-zinc-700 flex items-center justify-between group shadow-sm overflow-hidden">
+                          <div class="flex-1 min-w-0 overflow-x-auto no-scrollbar">
+                            <code class="text-[10px] text-gray-900 dark:text-white font-bold whitespace-nowrap">{{ codexStartCommand }}</code>
+                          </div>
+                          <button type="button" @click="copyToClipboard(codexStartCommand, 'codexStart')" class="text-[9px] font-bold uppercase tracking-widest pl-4 shrink-0 transition-colors" :class="copiedState.codexStart ? 'text-green-500' : 'text-gray-400 hover:text-black dark:hover:text-white'">
                             {{ copiedState.codexStart ? 'Copied!' : 'Copy' }}
                           </button>
                         </div>
                       </div>
+                      <p class="text-[11px] text-gray-500 dark:text-zinc-400 font-medium">The registry publishes Codex as an npm package, so npx fetches it on the first run and there is nothing to install or upgrade separately. Sign out again with <code class="bg-gray-100 dark:bg-zinc-800 px-1 py-0.5 rounded text-gray-900 dark:text-white">--logout</code> in place of <code class="bg-gray-100 dark:bg-zinc-800 px-1 py-0.5 rounded text-gray-900 dark:text-white">--login</code>.</p>
                     </div>
 
                     <div v-else-if="activeConnectionTab === 'deepseek'" class="space-y-4 min-w-0">
@@ -916,7 +915,7 @@ const copiedState = ref({
   gatewayInstalled: false,
   antigravityLogin: false,
   antigravityStart: false,
-  codexConfig: false,
+  codexLogin: false,
   codexStart: false,
   dshEnv: false,
   dshInstall: false,
@@ -961,6 +960,12 @@ const acpInstalledAgentCommand = `${ACP_GATEWAY} -- harn serve acp`;
 // on every command, since leaving either off is an error rather than a
 // different behaviour.
 const ANTIGRAVITY_AGENT = '--agent antigravity-acp --allow-unverified-agent';
+// Codex ships through the registry as an npm package, so unlike Antigravity
+// it needs no --allow-unverified-agent: the gateway only checksums binary
+// downloads, and an npx distribution never reaches that path.
+const CODEX_AGENT = '--agent codex-acp';
+const codexLoginCommand = `${ACP_GATEWAY} --login ${CODEX_AGENT}`;
+const codexStartCommand = `${ACP_GATEWAY} ${CODEX_AGENT}`;
 const antigravityLoginCommand = `${ACP_GATEWAY} --login ${ANTIGRAVITY_AGENT}`;
 const antigravityStartCommand = `${ACP_GATEWAY} ${ANTIGRAVITY_AGENT}`;
 
@@ -1002,32 +1007,6 @@ const permissionsConfig = computed(() => ({
 }));
 
 const permissionsConfigJson = computed(() => JSON.stringify(permissionsConfig.value, null, 2));
-
-const codexConfigToml = computed(() => {
-  return `[mcp_servers.${serverName.value}]
-url = "${authenticatedUrl.value}"
-
-[mcp_servers.${serverName.value}.tools.updateTaskStatus]
-approval_mode = "approve"
-
-[mcp_servers.${serverName.value}.tools.getWorkspace]
-approval_mode = "approve"
-
-[mcp_servers.${serverName.value}.tools.reply]
-approval_mode = "approve"
-
-[mcp_servers.${serverName.value}.tools.createTask]
-approval_mode = "approve"
-
-[mcp_servers.${serverName.value}.tools.downloadAttachment]
-approval_mode = "approve"
-
-[mcp_servers.${serverName.value}.tools.getTask]
-approval_mode = "approve"
-
-[mcp_servers.${serverName.value}.tools.publishEvent]
-approval_mode = "approve"`;
-});
 
 // DeepSeek Harness installs the AgentRQ bundle rather than an MCP config file:
 // the bundle's own patch mounts both the MCP bridge and the delivery plugin,


### PR DESCRIPTION
## What changed

Codex is now set up the same way as every other agent — one login command and one start command through the ACP gateway — instead of needing its own package and a separate config file. The extra configuration step is gone from both the workspace setup screen and the README.

## Why changed

Codex is published in the ACP registry, so the gateway can fetch and run it directly. The old instructions predated that and told people to install and configure things that are no longer needed.

## Test coverage report

No new lines — the change is documentation and setup copy, so new-line coverage is not applicable and total coverage is unchanged. Frontend suite passes (565 tests across 27 files) and `npm run build` succeeds, which matters because the setup screen is a Vue component and a broken template would fail there.

## Other reports

**This closes #207, and the fix is real rather than incidental.** That issue reported that the Codex launch command fails on Windows PowerShell with `spawn ... ENOENT`. The old command reached the agent through `-- npx @agentclientprotocol/codex-acp`, and the gateway spawns whatever follows `--` verbatim — so on Windows it looked for `npx` and found only `npx.cmd`. `--agent codex-acp` goes through the registry path instead, which rewrites `npx` to `npx.cmd` on win32. The fix already existed inside the gateway; our instructions simply pointed at the path that lacked it.

Reported by **@zZacharyz**, credited as reporter in the commit — thank you for the report, and for including the exact failing invocation and the working workaround, which is what made the cause identifiable.

**Two claims worth checking rather than trusting:**

- `codex-acp` is genuinely a published registry id — confirmed against `https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json`, distributed as the npm package `@agentclientprotocol/codex-acp`.
- It needs **no** `--allow-unverified-agent`, unlike Antigravity. The gateway only checksums binary downloads, and `resolveLaunchSpec` returns the npx launch spec before it ever reaches that path.

**One honest caveat on the Windows fix.** There may be a second failure behind the one this removes: since Node 20.12.2, spawning a `.cmd` with `shell: false` throws `EINVAL`. If that still holds, the registry path could fail too, for a different reason. I have no Windows machine and could not test it — so this is verified by reading the gateway's source, not by running it. Worth one confirmation from a Windows user before #207 is called done.

**One behavioural change to be aware of.** The old setup command carried `--max-concurrency 1`; the requested new command does not, and the gateway's default is 2. Both spellings of the flag parse, so the old value was taking effect — Codex will now run two tasks at once where it ran one. Easy to add back if that limit was deliberate.

TaskID: 0iHMqtd9qvR

🤖 Generated with [Claude Code](https://claude.com/claude-code)