### PR TITLE
chore: bump patch version to v0.5.5

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.5.4"
+	_appVersion   = "v0.5.5"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.5.4" {
-			t.Errorf("Expected version v0.5.4, got %s", s.Version())
+		if s.Version() != "v0.5.5" {
+			t.Errorf("Expected version v0.5.5, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.5.4",
+  "version": "0.5.5",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
## What changed

The project version moves from 0.5.4 to 0.5.5 across the desktop app, the frontend, and the backend.

## Why changed

To ship the corrected Codex setup instructions, which fix a launch command that failed on Windows.

## Test coverage report

No new lines — the change is six version strings, so new-line coverage is not applicable and total coverage is unchanged. All three suites pass: backend `go test ./internal/...` clean, frontend 565 tests across 27 files, desktop 422 tests across 16 files.

Version sync verified both ways, including the form CI runs on a tag build:

```
$ node desktop/scripts/check-versions.mjs
✓ desktop, frontend and backend are all at 0.5.5

$ GITHUB_REF=refs/tags/v0.5.5 node desktop/scripts/check-versions.mjs
✓ desktop, frontend and backend are all at 0.5.5
✓ tag v0.5.5 matches version 0.5.5
```

## Other reports

**One change in this release** (#445): Codex is now set up through the ACP gateway's registry — a login command and a start command — rather than a separate package and its own config file. That also fixes #207: the old command reached the agent after `--`, which the gateway spawns verbatim, so Windows looked for `npx` and found only `npx.cmd`; `--agent codex-acp` takes the registry path, which resolves that correctly.

**Credit, per CONTRIBUTING.md.** #207 was reported by **@zZacharyz**, credited as reporter with a `Reported-by:` trailer on both the fix and this bump. The report named the exact failing invocation and the working workaround, which is what made the cause identifiable rather than guesswork.

**Worth carrying into the release notes**: the Windows fix is verified by reading the gateway's source, not by running it on Windows. There may be a second failure behind the one this removes — since Node 20.12.2, spawning a `.cmd` with `shell: false` throws `EINVAL` — so a confirmation from a Windows user is still worth having before #207 is considered settled.

**Unchanged from the previous release and still true**: v0.5.4 raised the desktop floor to macOS 13, so anyone on macOS 12 is not receiving this either.

**Lockfiles were edited by hand** per the documented procedure; agreement was confirmed with `npm ci --dry-run` in both packages (exit 0), avoiding a real `npm ci` so a running dev server's `node_modules` is untouched. Edits were line-scoped, leaving the version-shaped strings in `source-map-support`, `desktop/test/version.test.js`, `desktop/src/version.js` and the release workflow alone.

**Merging alone publishes nothing** — the release is cut by tagging `main` and pushing the tag.

TaskID: 0iHMqtd9qvR

🤖 Generated with [Claude Code](https://claude.com/claude-code)