### PR TITLE
chore: bump patch version to v0.5.6

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.5.5"
+	_appVersion   = "v0.5.6"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.5.5" {
-			t.Errorf("Expected version v0.5.5, got %s", s.Version())
+		if s.Version() != "v0.5.6" {
+			t.Errorf("Expected version v0.5.6, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.5.5",
+  "version": "0.5.6",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
## What changed

The project version moves from 0.5.5 to 0.5.6 across the desktop app, the frontend, and the backend.

## Why changed

To ship the task-deletion fix, which restores the ability to delete any task an agent has worked on.

## Test coverage report

No new lines — the change is six version strings, so new-line coverage is not applicable and total coverage is unchanged. All three suites pass: backend `go test ./internal/...` clean, frontend 565 tests across 27 files, desktop 422 tests across 16 files.

Version sync verified both ways, including the form CI runs on a tag build:

```
$ node desktop/scripts/check-versions.mjs
✓ desktop, frontend and backend are all at 0.5.6

$ GITHUB_REF=refs/tags/v0.5.6 node desktop/scripts/check-versions.mjs
✓ desktop, frontend and backend are all at 0.5.6
✓ tag v0.5.6 matches version 0.5.6
```

## Other reports

**One change in this release** (#447): deleting a task no longer fails with `violates foreign key constraint`. The delete cleared a task's messages but not its tool calls, and the remaining rows refused it — so in practice any task an agent had actually worked on could not be deleted. `DeleteWorkspace` had the same gap and is fixed with it.

**Worth a line in the release notes**, since anyone who hit this will want to know: it affected every task with tool-call history, not an unlucky subset, and no data was lost by it — the delete was refused rather than half-applied.

**Still true from v0.5.4 and not changed here**: the desktop floor is macOS 13, so anyone on macOS 12 is not receiving this release either.

**Lockfiles were edited by hand** per the documented procedure; agreement confirmed with `npm ci --dry-run` in both packages (exit 0), avoiding a real `npm ci` so a running dev server's `node_modules` is untouched. Edits were line-scoped, leaving the version-shaped strings in `source-map-support`, `desktop/test/version.test.js`, `desktop/src/version.js` and the release workflow alone.

**Merging alone publishes nothing** — the release is cut by tagging `main` and pushing the tag, which I will do once this is in.

TaskID: 0iHR6ntSbjN

🤖 Generated with [Claude Code](https://claude.com/claude-code)