### PR TITLE
fix(ui): make links to local files openable, and copyable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,17 @@ Consequences worth knowing before changing anything here:
 - Desktop-only capabilities reach the renderer through the narrow `window.agentrq`
   bridge in `desktop/src/preload/`. Components branch on `usePlatformStore()`,
   never on user-agent sniffing or probing for `window.agentrq`.
+- **Never make a `file:` URL followable.** `classifyLink` blocks the scheme on
+  purpose — message bodies are agent-written, and a followed `file:` link is how
+  one reaches the machine. Rendered markdown therefore strips the href and
+  parks the URL in `data-file-url` (`frontend/src/utils/markdown.js`); clicking
+  it is a bridge request answered by `desktop/src/main/files.js`, which opens
+  only file types that are read rather than run and reveals everything else in
+  the file manager.
+- **Copying from the renderer goes through the shell on desktop.**
+  `navigator.clipboard.writeText` throws in a window that is not frontmost, so
+  `writeClipboard` prefers `window.agentrq.clipboard` and falls back to the
+  browser API only where there is no shell.
 
 ### Three traps that are invisible in source
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -77,12 +77,13 @@ still works.
 
 ## Verifying the architecture
 
-Two scripts, both kept so the claims stay reproducible:
+Scripts, all kept so the claims stay reproducible:
 
 ```bash
 npm run spike:eventsource                    # is EventSource allowed on app://?
 AGENTRQ_SERVER_URL=http://localhost:3999 \
 AGENTRQ_ROOT_TOKEN=... npx electron scripts/verify-e2e.mjs
+npm run build && npx electron scripts/verify-markdown-links.mjs  # needs no backend
 ```
 
 `verify:e2e` runs the real protocol handler against a real backend and checks
@@ -92,7 +93,21 @@ connects. `verify:connection` starts from nothing stored and drives the
 first-run screen: a bad URL is refused with a reason and nothing is saved; a
 good one is probed, stored, and reachable through the proxy.
 
-Both assert a *computed* style rather than DOM presence alone — see the Tailwind
+`verify:markdown-links` needs no backend: it boots the app, drops a rendered
+link into the running window and clicks it, then checks that the click crossed
+the bridge, that a document was opened, that a script was *revealed* rather than
+run, that a missing file said which one, and that the copy button put the path
+on the real clipboard. The `shell.openPath` / `showItemInFolder` calls are
+recorded rather than made — a passing run would otherwise launch an editor and a
+Finder window on whoever ran it — and the clipboard is put back afterwards.
+
+That last check is why copies go through the shell at all:
+`navigator.clipboard.writeText` throws *"Document is not focused"* in a window
+that is not frontmost, with or without a user gesture behind it. A copy button
+that works only when nothing has stolen focus is the same silent nothing as the
+bug it was added for.
+
+The first two assert a *computed* style rather than DOM presence alone — see the Tailwind
 note below for why that check earns its place.
 
 ### Spike result: EventSource works over `app://`

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -14,6 +14,7 @@
     "spike:eventsource": "npm run build && electron scripts/spike-eventsource.mjs",
     "verify:e2e": "npm run build && electron scripts/verify-e2e.mjs",
     "verify:connection": "npm run build && electron scripts/verify-connection.mjs",
+    "verify:markdown-links": "npm run build && electron scripts/verify-markdown-links.mjs",
     "check:versions": "node scripts/check-versions.mjs",
     "package": "npm run build && electron-builder --publish never",
     "package:dir": "npm run build && electron-builder --dir"

--- a/desktop/scripts/verify-markdown-links.mjs
+++ b/desktop/scripts/verify-markdown-links.mjs
@@ -1,0 +1,254 @@
+/**
+ * End-to-end check of the two things a link in a message body can be clicked
+ * for: copying where it points, and — for a local file — opening it.
+ *
+ * Unit tests cover the two decisions — what the markdown renderer emits, and
+ * which files may be handed to their default application — but not the path
+ * between them, which is where this bug lived: a sanitised anchor, a delegated
+ * click in the real App.vue, the preload bridge, and the shell's answer coming
+ * back as a toast. That path only exists inside a running Electron window.
+ *
+ * Needs no backend: the app boots from app://, fails its first API call and
+ * lands on the login screen, which is enough — the click handler is bound at
+ * the application root, above any route.
+ *
+ * The one thing left stubbed is `shell.openPath` / `shell.showItemInFolder`
+ * themselves, recorded here rather than called: a passing run would otherwise
+ * launch an editor and a Finder window on whoever ran it. Everything on either
+ * side of them is the real thing.
+ *
+ * The clipboard check uses the real system clipboard, so it puts back whatever
+ * was on it before.
+ *
+ *   npm run build && npx electron scripts/verify-markdown-links.mjs
+ */
+import { app, BrowserWindow, clipboard, ipcMain, net, protocol } from 'electron'
+import { readFile, access, mkdtemp, mkdir, stat, writeFile } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { createAppProtocolHandler } from '../src/main/protocol.js'
+import { FileOpenAction, fileOpenAction, localPathFromFileUrl } from '../src/main/files.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const RENDERER_ROOT = join(__dirname, '../dist/renderer')
+const PRELOAD = join(__dirname, '../dist/preload/index.cjs')
+
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: 'app',
+    privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true, corsEnabled: true },
+  },
+])
+
+async function fileExists(pathname) {
+  try {
+    await access(join(RENDERER_ROOT, pathname), constants.R_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** What the shell was asked to do, in place of actually doing it. */
+const shellCalls = []
+
+/**
+ * Mirrors the handler in src/main/index.js. Repeated rather than imported
+ * because index.js takes over the Electron app lifecycle at import time; the
+ * logic it leans on — files.js — is the real thing, and so is the IPC channel
+ * the renderer reaches it through.
+ */
+function registerFileHandler() {
+  ipcMain.handle('agentrq:files:open', async (_event, rawUrl) => {
+    const path = localPathFromFileUrl(rawUrl)
+    if (!path) return { ok: false, error: 'That link does not point at a file on this computer.' }
+
+    let stats
+    try {
+      stats = await stat(path)
+    } catch {
+      return { ok: false, error: `No such file: ${path}` }
+    }
+
+    if (fileOpenAction(path, { isDirectory: stats.isDirectory() }) === FileOpenAction.Reveal) {
+      shellCalls.push({ call: 'showItemInFolder', path })
+      return { ok: true, revealed: true }
+    }
+    shellCalls.push({ call: 'openPath', path })
+    return { ok: true, revealed: false }
+  })
+}
+
+/**
+ * Drives one click, in the window, against the markup `renderMarkdown`
+ * produces for a link — pinned to that renderer by its own unit tests.
+ *
+ * The click is dispatched inside the injected markup and left to bubble:
+ * reaching the handler bound at the application root is precisely what is
+ * being checked.
+ */
+const clickScript = (fileUrl, { copyText = '' } = {}) => `(async () => {
+  // index.html's mount point and App.vue's own root element both carry
+  // id="app". The inner one is the Vue tree; appending to the outer would put
+  // the link outside the delegated handler, which is not where message bodies
+  // are rendered and would prove nothing.
+  const root = document.querySelector('#app #app') ?? document.querySelector('#app');
+  document.querySelectorAll('#verify-md').forEach((n) => n.remove());
+
+  const fileUrl = ${JSON.stringify(fileUrl)};
+  const copyText = ${JSON.stringify(copyText)};
+
+  const holder = document.createElement('div');
+  holder.id = 'verify-md';
+  const anchor = document.createElement('a');
+  anchor.className = 'md-file-link';
+  anchor.setAttribute('data-file-url', fileUrl);
+  anchor.setAttribute('role', 'link');
+  anchor.tabIndex = 0;
+  anchor.textContent = 'plan';
+  holder.append(anchor);
+
+  // The copy button carries an icon, so the click lands on a child of it —
+  // which is the case the handler has to walk up from.
+  let icon = null;
+  if (copyText) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'md-copy-link';
+    button.setAttribute('data-copy-text', copyText);
+    icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    button.append(icon);
+    holder.append(button);
+  }
+  root.appendChild(holder);
+
+  const before = document.body.innerText;
+  (icon ?? anchor).dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+  // The handler is async: the bridge round-trip and any toast land after it.
+  await new Promise((r) => setTimeout(r, 400));
+
+  const added = document.body.innerText.replace(before, '');
+  holder.remove();
+  return { hasHref: anchor.hasAttribute('href'), added: added.trim() };
+})()`
+
+setTimeout(() => {
+  console.error('✗ verification timed out')
+  app.exit(3)
+}, 60000)
+
+app.whenReady().then(async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'agentrq-file-links-'))
+  const plan = join(dir, 'skills support plan.md')
+  const script = join(dir, 'install.sh')
+  const folder = join(dir, 'brain')
+  await writeFile(plan, '# plan\n')
+  await writeFile(script, '#!/bin/sh\necho hi\n')
+  await mkdir(folder)
+
+  registerFileHandler()
+  // The connection screen would otherwise take the window; this run is about
+  // what happens inside the app, not how it got pointed at a server.
+  ipcMain.handle('agentrq:connection:get', () => ({ configured: true, serverUrl: 'http://localhost:3999', locked: true }))
+  ipcMain.handle('agentrq:update:get', () => ({ status: 'idle', detail: '', version: '', enabled: false }))
+  ipcMain.handle('agentrq:theme:set', () => ({ source: 'system', color: '#fafafa' }))
+  ipcMain.handle('agentrq:profiles:get', () => ({ activeProfileId: '', profiles: [] }))
+  ipcMain.handle('agentrq:notifications:get', () => ({ supported: false, mutedWorkspaces: [] }))
+  // The real one, mirroring src/main/index.js: this check is about the
+  // clipboard actually being written, so nothing here is stubbed.
+  ipcMain.handle('agentrq:clipboard:write', (_e, text) => {
+    clipboard.writeText(String(text ?? ''))
+    return true
+  })
+
+  protocol.handle(
+    'app',
+    createAppProtocolHandler({
+      serverUrl: () => 'http://localhost:3999',
+      netFetch: net.fetch,
+      fileExists,
+      readFile: (pathname) => readFile(join(RENDERER_ROOT, pathname)),
+    })
+  )
+
+  // The webPreferences the real window uses, preload included — otherwise this
+  // would be checking a window the app never creates.
+  const win = new BrowserWindow({
+    show: false,
+    webPreferences: { preload: PRELOAD, contextIsolation: true, nodeIntegration: false, sandbox: true },
+  })
+  await win.loadURL('app://agentrq/')
+  await new Promise((r) => setTimeout(r, 1500))
+
+  const results = []
+  const record = (name, pass, detail) => results.push({ name, pass, detail })
+
+  const bridge = await win.webContents.executeJavaScript(
+    "typeof window.agentrq?.files?.open === 'function'"
+  )
+  record('the bridge exposes files.open', bridge === true, String(bridge))
+
+  const asUrl = (path) => 'file://' + encodeURI(path)
+
+  const document = await win.webContents.executeJavaScript(clickScript(asUrl(plan)))
+  record('the anchor carries no href to navigate to', document.hasHref === false, 'href present: ' + document.hasHref)
+  record(
+    'clicking a document asks the shell to open it',
+    shellCalls.at(-1)?.call === 'openPath' && shellCalls.at(-1)?.path === plan,
+    JSON.stringify(shellCalls.at(-1))
+  )
+  record('opening quietly says nothing', document.added === '', JSON.stringify(document.added))
+
+  const executable = await win.webContents.executeJavaScript(clickScript(asUrl(script)))
+  record(
+    'clicking a script reveals it instead of running it',
+    shellCalls.at(-1)?.call === 'showItemInFolder' && shellCalls.at(-1)?.path === script,
+    JSON.stringify(shellCalls.at(-1))
+  )
+  record(
+    'and the app says so',
+    executable.added.includes('file manager') && executable.added.includes(script),
+    JSON.stringify(executable.added)
+  )
+
+  await win.webContents.executeJavaScript(clickScript(asUrl(folder)))
+  record(
+    'clicking a folder opens it',
+    shellCalls.at(-1)?.call === 'openPath' && shellCalls.at(-1)?.path === folder,
+    JSON.stringify(shellCalls.at(-1))
+  )
+
+  const callsBefore = shellCalls.length
+  const missing = await win.webContents.executeJavaScript(clickScript(asUrl(join(dir, 'gone.md'))))
+  record('a file that is not there reaches the shell and no further', shellCalls.length === callsBefore, 'no shell call')
+  record(
+    'and the person is told which file',
+    missing.added.includes('gone.md'),
+    JSON.stringify(missing.added)
+  )
+
+  // Copying a link's target. The real clipboard, so it is put back afterwards.
+  //
+  // This is the check that found the reason copies go through the shell at all:
+  // `navigator.clipboard.writeText` throws "Document is not focused" in a
+  // window that is not frontmost, gesture or no gesture, and this window never
+  // is. A copy button that works only when nothing has stolen focus is the same
+  // silent nothing as the bug being fixed.
+  const clipboardBefore = clipboard.readText()
+  const copied = await win.webContents.executeJavaScript(
+    clickScript(asUrl(plan), { copyText: plan })
+  )
+  record('clicking the copy button copies the path', clipboard.readText() === plan, clipboard.readText())
+  record('and says what it copied', copied.added.includes('Copied'), JSON.stringify(copied.added))
+  clipboard.writeText(clipboardBefore)
+
+  console.log('\n─── links in a message body, in a real window ───')
+  for (const r of results) console.log(`${r.pass ? '✓' : '✗'} ${r.name} — ${r.detail}`)
+  const failed = results.filter((r) => !r.pass)
+  console.log(failed.length === 0 ? '\n✓ all checks passed' : `\n✗ ${failed.length} check(s) failed`)
+  app.exit(failed.length === 0 ? 0 : 1)
+})

--- a/desktop/src/main/files.js
+++ b/desktop/src/main/files.js
@@ -1,0 +1,111 @@
+/**
+ * Opening a local file that a message linked to.
+ *
+ * The renderer never navigates to a `file:` URL — it asks the shell to open
+ * one, and this is the part that decides what "open" is allowed to mean.
+ *
+ * That decision matters because the link came from message content, which is
+ * written by an agent and can therefore be wrong or hostile. Handing any path
+ * to `shell.openPath` would mean a link labelled `plan.md` could point at a
+ * `.command` file and run it on click. So only file types that are *read* by
+ * their default application open that way; everything else is revealed in the
+ * file manager, where the person can see what it actually is and decide for
+ * themselves. A revealed file has been shown, not run.
+ *
+ * The list is therefore an allowlist. An unknown extension is not assumed
+ * harmless — the interesting case is always the one nobody thought about.
+ *
+ * Kept apart from index.js because that module needs a live Electron to import,
+ * and this decision is the part worth testing.
+ */
+
+export const FileOpenAction = {
+  /** Hand to the default application. */
+  Open: 'open',
+  /** Show in the file manager without opening it. */
+  Reveal: 'reveal',
+}
+
+/**
+ * Extensions whose default application displays the file rather than executing
+ * it. Notably absent, and deliberately:
+ *
+ * - `.html`/`.svg`, which open in a browser and can carry script and markup a
+ *   message author chose;
+ * - `.sh`, `.command`, `.app`, `.exe`, `.bat`, `.scpt` and friends, which run;
+ * - archives, which invite a double-click on whatever is inside them;
+ * - no extension at all, where the platform decides based on metadata this
+ *   process has not looked at.
+ */
+const READABLE_EXTENSIONS = new Set([
+  // Text and source
+  'txt', 'md', 'markdown', 'rst', 'adoc', 'org', 'log', 'csv', 'tsv',
+  'json', 'jsonl', 'yaml', 'yml', 'toml', 'ini', 'cfg', 'conf', 'env', 'xml',
+  'go', 'mod', 'sum', 'js', 'mjs', 'cjs', 'jsx', 'ts', 'tsx', 'vue', 'svelte',
+  'py', 'rb', 'rs', 'java', 'kt', 'swift', 'c', 'h', 'cc', 'cpp', 'hpp', 'cs',
+  'php', 'sql', 'graphql', 'proto', 'diff', 'patch', 'css', 'scss', 'less',
+  // Documents
+  'pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'odt', 'ods', 'odp',
+  'rtf', 'pages', 'numbers', 'key', 'epub',
+  // Media
+  'png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'tif', 'tiff', 'heic', 'avif',
+  'mp3', 'wav', 'm4a', 'flac', 'aac', 'ogg',
+  'mp4', 'mov', 'm4v', 'webm', 'mkv', 'avi',
+])
+
+/**
+ * The filesystem path a `file:` URL names.
+ *
+ * Returns '' for anything that is not a local file URL, including
+ * `file://server/share/x` — that names a machine which is not this one, and
+ * reaching for it would hang on a network mount at best.
+ *
+ * @param {string} rawUrl
+ * @returns {string}
+ */
+export function localPathFromFileUrl(rawUrl) {
+  let url
+  try {
+    url = new URL(String(rawUrl ?? ''))
+  } catch {
+    return ''
+  }
+  if (url.protocol !== 'file:') return ''
+  if (url.host && url.host !== 'localhost') return ''
+
+  let path
+  try {
+    path = decodeURIComponent(url.pathname)
+  } catch {
+    // A stray `%` in a filename is not a reason to refuse the whole path.
+    path = url.pathname
+  }
+
+  // Windows drive paths arrive as `/C:/Users/…`; the leading slash belongs to
+  // the URL form, not the path.
+  if (/^\/[A-Za-z]:/.test(path)) path = path.slice(1)
+
+  // A NUL byte truncates the path inside the platform's own file APIs, so what
+  // gets opened would not be what was inspected here.
+  return path.includes('\0') ? '' : path
+}
+
+/**
+ * What may be done with a path, from its name alone.
+ *
+ * @param {string} path
+ * @param {{ isDirectory?: boolean }} [stat]
+ * @returns {typeof FileOpenAction[keyof typeof FileOpenAction]}
+ */
+export function fileOpenAction(path, { isDirectory = false } = {}) {
+  // A folder has no default application to run; opening one shows its contents.
+  if (isDirectory) return FileOpenAction.Open
+
+  const name = String(path ?? '').split(/[\\/]/).pop()
+  const dot = name.lastIndexOf('.')
+  // A leading dot is `.zshrc` — a name, not an extension.
+  if (dot <= 0) return FileOpenAction.Reveal
+
+  const extension = name.slice(dot + 1).toLowerCase()
+  return READABLE_EXTENSIONS.has(extension) ? FileOpenAction.Open : FileOpenAction.Reveal
+}

--- a/desktop/src/main/index.js
+++ b/desktop/src/main/index.js
@@ -4,6 +4,7 @@ import {
   Menu,
   Notification,
   Tray,
+  clipboard,
   dialog,
   globalShortcut,
   ipcMain,
@@ -35,6 +36,7 @@ import { QUICK_CREATE_ACCELERATOR, buildMenuTemplate } from './menu.js'
 import { badgeFor, createNotificationGate, createUnreadCounter, mapEventToNotification } from './notifications.js'
 import { createEventStreamClient } from './sse.js'
 import { LinkTarget, classifyLink, linkWindowBounds } from './links.js'
+import { FileOpenAction, fileOpenAction, localPathFromFileUrl } from './files.js'
 import { UpdateStatus, createUpdater } from './updater.js'
 // Externalised by the build, so this resolves from node_modules at runtime.
 // Importing it is inert; the dev guard is about never *using* it against a
@@ -716,6 +718,52 @@ function registerIpc(getWindow) {
 
     if (result.canceled) return ''
     return result.filePaths?.[0] ?? ''
+  })
+
+  // Opening a local file a message linked to.
+  //
+  // The renderer cannot do this itself: a `file:` URL is unnavigable there by
+  // design, which is the whole reason the click comes across the bridge as a
+  // request instead. What arrives is the URL, never a path the renderer
+  // composed — and `files.js` decides whether the thing it names may be handed
+  // to its default application or only shown in the file manager, because the
+  // link was written by an agent and a `.command` file dressed up as `plan.md`
+  // must not run on a click.
+  ipcMain.handle('agentrq:files:open', async (_event, rawUrl) => {
+    const path = localPathFromFileUrl(rawUrl)
+    if (!path) return { ok: false, error: 'That link does not point at a file on this computer.' }
+
+    let stats
+    try {
+      stats = await fsPromises.stat(path)
+    } catch {
+      // Deliberately not distinguishing "gone" from "cannot look": the path is
+      // the useful half of the message either way.
+      return { ok: false, error: `No such file: ${path}` }
+    }
+
+    if (fileOpenAction(path, { isDirectory: stats.isDirectory() }) === FileOpenAction.Reveal) {
+      shell.showItemInFolder(path)
+      return { ok: true, revealed: true }
+    }
+
+    // `openPath` resolves to a message on failure and an empty string on
+    // success — a no-permission or no-handler case that would otherwise look
+    // like nothing happened at all.
+    const failure = await shell.openPath(path)
+    if (failure) return { ok: false, error: failure }
+    return { ok: true, revealed: false }
+  })
+
+  // Copying a link's target out of a message body.
+  //
+  // The renderer could reach `navigator.clipboard`, but that refuses to write
+  // from a document which is not focused — a condition the shell's clipboard
+  // does not have, and one nobody would think to blame for a copy button that
+  // does nothing.
+  ipcMain.handle('agentrq:clipboard:write', (_event, text) => {
+    clipboard.writeText(String(text ?? ''))
+    return true
   })
 
   // Profiles. Only names and servers cross the bridge — never a session, a

--- a/desktop/src/preload/index.js
+++ b/desktop/src/preload/index.js
@@ -75,6 +75,36 @@ contextBridge.exposeInMainWorld('agentrq', {
     remove: (id) => ipcRenderer.invoke('agentrq:profiles:remove', id),
   },
 
+  files: {
+    /**
+     * Open a local file that a message linked to.
+     *
+     * The `file:` URL crosses as-is; the shell decides what may be opened and
+     * what is only revealed, because that judgement must not live on the side
+     * of the boundary that renders message content.
+     *
+     * @param {string} fileUrl
+     * @returns {Promise<{ok: boolean, revealed?: boolean, error?: string}>}
+     *          `revealed` is true when the file was shown in the file manager
+     *          rather than opened, so the app can say which happened.
+     */
+    open: (fileUrl) => ipcRenderer.invoke('agentrq:files:open', fileUrl),
+  },
+
+  clipboard: {
+    /**
+     * Put text on the system clipboard.
+     *
+     * The renderer has `navigator.clipboard`, but that one refuses to write
+     * from a document which is not focused. The shell's has no such condition,
+     * so a copy here always lands.
+     *
+     * @param {string} text
+     * @returns {Promise<boolean>}
+     */
+    write: (text) => ipcRenderer.invoke('agentrq:clipboard:write', text),
+  },
+
   dialog: {
     /**
      * Ask the shell to show the platform's folder chooser.

--- a/desktop/test/files.test.js
+++ b/desktop/test/files.test.js
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+
+import { FileOpenAction, fileOpenAction, localPathFromFileUrl } from '../src/main/files.js'
+
+describe('localPathFromFileUrl', () => {
+  it('reads an ordinary local file URL', () => {
+    expect(localPathFromFileUrl('file:///Users/mt/brain/skills_support_plan.md'))
+      .toBe('/Users/mt/brain/skills_support_plan.md')
+  })
+
+  it('decodes percent-escapes, so the path is the one on disk', () => {
+    expect(localPathFromFileUrl('file:///Users/mt/My%20Notes/a%2Bb.md')).toBe('/Users/mt/My Notes/a+b.md')
+  })
+
+  it('accepts localhost, which is this machine spelled out', () => {
+    expect(localPathFromFileUrl('file://localhost/etc/hosts')).toBe('/etc/hosts')
+  })
+
+  it('refuses a host that is another machine', () => {
+    // Reaching for it would block on a network mount at best.
+    expect(localPathFromFileUrl('file://fileserver/share/report.pdf')).toBe('')
+  })
+
+  it('refuses every other scheme', () => {
+    expect(localPathFromFileUrl('https://example.com/a.md')).toBe('')
+    expect(localPathFromFileUrl('app://agentrq/tasks/1')).toBe('')
+    expect(localPathFromFileUrl('javascript:alert(1)')).toBe('')
+  })
+
+  it('refuses junk', () => {
+    expect(localPathFromFileUrl('/Users/mt/plan.md')).toBe('')
+    expect(localPathFromFileUrl('')).toBe('')
+    expect(localPathFromFileUrl(null)).toBe('')
+  })
+
+  it('refuses a path carrying a NUL byte', () => {
+    // The platform's file APIs truncate there, so what got opened would not be
+    // what was inspected.
+    expect(localPathFromFileUrl('file:///Users/mt/plan.md%00.command')).toBe('')
+  })
+
+  it('keeps a malformed escape rather than refusing the file', () => {
+    expect(localPathFromFileUrl('file:///tmp/100%.md')).toBe('/tmp/100%.md')
+  })
+
+  it('drops the slash the URL form adds to a Windows drive path', () => {
+    expect(localPathFromFileUrl('file:///C:/Users/mt/plan.md')).toBe('C:/Users/mt/plan.md')
+  })
+})
+
+describe('fileOpenAction', () => {
+  const action = (path, stat) => fileOpenAction(path, stat)
+
+  it('opens the documents people actually link to', () => {
+    for (const path of [
+      '/Users/mt/skills_support_plan.md',
+      '/Users/mt/notes.txt',
+      '/Users/mt/report.pdf',
+      '/Users/mt/data.csv',
+      '/Users/mt/main.go',
+      '/Users/mt/screenshot.png',
+      '/Users/mt/demo.mp4',
+      '/Users/mt/deck.pptx',
+    ]) {
+      expect(action(path), path).toBe(FileOpenAction.Open)
+    }
+  })
+
+  it('is not fooled by an uppercase extension', () => {
+    expect(action('/Users/mt/PLAN.MD')).toBe(FileOpenAction.Open)
+  })
+
+  it('reveals anything that would run rather than open it', () => {
+    // The link text is written by an agent; `plan.md` may well point here.
+    for (const path of [
+      '/Users/mt/install.sh',
+      '/Users/mt/setup.command',
+      '/Applications/Calculator.app',
+      '/Users/mt/setup.exe',
+      '/Users/mt/go.bat',
+      '/Users/mt/thing.scpt',
+    ]) {
+      expect(action(path), path).toBe(FileOpenAction.Reveal)
+    }
+  })
+
+  it('reveals markup that opens in a browser', () => {
+    // An .html or .svg file carries script and markup its author chose.
+    expect(action('/Users/mt/report.html')).toBe(FileOpenAction.Reveal)
+    expect(action('/Users/mt/icon.svg')).toBe(FileOpenAction.Reveal)
+  })
+
+  it('reveals an archive rather than inviting a click on what is inside', () => {
+    expect(action('/Users/mt/bundle.zip')).toBe(FileOpenAction.Reveal)
+  })
+
+  it('reveals an extension nobody listed', () => {
+    // An allowlist, because the interesting case is the one not thought about.
+    expect(action('/Users/mt/thing.wat')).toBe(FileOpenAction.Reveal)
+  })
+
+  it('reveals a file with no extension, where the platform decides', () => {
+    expect(action('/Users/mt/Makefile')).toBe(FileOpenAction.Reveal)
+  })
+
+  it('treats a leading dot as a name, not an extension', () => {
+    expect(action('/Users/mt/.zshrc')).toBe(FileOpenAction.Reveal)
+  })
+
+  it('does not read an extension out of a directory name', () => {
+    expect(action('/Users/mt/notes.md/run')).toBe(FileOpenAction.Reveal)
+  })
+
+  it('opens a folder, which has nothing to run', () => {
+    expect(action('/Users/mt/brain', { isDirectory: true })).toBe(FileOpenAction.Open)
+    expect(action('/Users/mt/scripts.sh', { isDirectory: true })).toBe(FileOpenAction.Open)
+  })
+
+  it('reads the extension off a Windows path too', () => {
+    expect(action('C:\\Users\\mt\\plan.md')).toBe(FileOpenAction.Open)
+    expect(action('C:\\Users\\mt\\setup.exe')).toBe(FileOpenAction.Reveal)
+  })
+
+  it('reveals nothing it cannot name', () => {
+    expect(action('')).toBe(FileOpenAction.Reveal)
+    expect(action(null)).toBe(FileOpenAction.Reveal)
+  })
+})

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -134,6 +134,21 @@ agentrq://workflows
 
 Useful in a Slack message, a calendar invite, or a script.
 
+**Local file links.** A `file:///…` link in a task or a message is clickable
+here. Documents, images, source files and media open in whatever application you
+normally use for them. Anything that would *run* — a script, a `.app`, an `.exe`,
+an archive, an `.html` page, or a file with no extension at all — is shown in
+Finder or your file manager instead, and the app says so. AgentRQ never runs a
+file because a message linked to it.
+
+In the browser the same link cannot be opened at all — no web page may reach
+your filesystem — so clicking it copies the path to your clipboard instead.
+
+**Copying a link.** Every link in a task or a message has a small copy button
+beside it, in both the desktop app and the browser. It puts the link's target on
+your clipboard: the plain filesystem path for a local file, the URL for anything
+else.
+
 **Window state.** Position and size are remembered between launches — and
 checked against the displays you currently have, so the window never reopens on
 a monitor you have unplugged.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,7 @@
 <template>
   <div id="app"
+       @click="onMarkdownLinkActivate"
+       @keydown="onMarkdownLinkActivate"
        :class="[
          'flex flex-col md:flex-row h-[100dvh] bg-zinc-100 dark:bg-zinc-950 font-inter overflow-hidden',
          isMacDesktop ? 'pt-10' : ''
@@ -388,6 +390,13 @@ import { useToasts } from './composables/useToasts'
 import { useEventBus } from './useEventBus'
 import { profileDisplay } from './composables/useProfileDisplay'
 import { usePlatformStore } from './stores/platformStore'
+import {
+  copyLinkTarget,
+  copyTargetFromEvent,
+  fileLinkFromEvent,
+  followFileLink,
+  writeClipboard,
+} from './composables/useMarkdownLinks'
 import { useThemeStore } from './stores/themeStore'
 import { useTooltipStore } from './stores/tooltipStore'
 import { useWorkspaceStore } from './stores/workspaceStore'
@@ -428,6 +437,45 @@ const user = ref(null)
 const isUserMenuOpen = ref(false)
 
 const platformStore = usePlatformStore()
+
+/** The clipboard, through the shell where there is one. */
+const copyText = (text) =>
+  writeClipboard(text, { bridge: window.agentrq?.clipboard, clipboard: navigator.clipboard })
+
+/**
+ * Acting on a link in rendered markdown: copying where it points, or — for a
+ * `file:///…` link — following it.
+ *
+ * Delegated from the app root, so one wiring serves every view that injects a
+ * message body as HTML. Enter and space are bound as well as click because a
+ * file link is an anchor with no href — see `useMarkdownLinks` for why — and
+ * something standing in for a link owes that to a person not using a mouse.
+ */
+async function onMarkdownLinkActivate(event) {
+  const copyTarget = copyTargetFromEvent(event)
+  if (copyTarget) {
+    event.preventDefault()
+    const copied = await copyLinkTarget(copyTarget, { copyText })
+    const notify = copied.tone === 'error' ? notifyError : notifySuccess
+    notify(copied.message, copied.title)
+    return
+  }
+
+  const fileUrl = fileLinkFromEvent(event)
+  if (!fileUrl) return
+  event.preventDefault()
+
+  const { tone, message } = await followFileLink(fileUrl, {
+    isDesktop: platformStore.isDesktop,
+    bridge: window.agentrq?.files,
+    copyText,
+  })
+
+  // A file that simply opened says so by opening; a toast would only be noise.
+  if (!message) return
+  if (tone === 'error') notifyError(message, 'Could not open file')
+  else notifyInfo(message)
+}
 
 // Signed-in profiles. Each is its own session in the desktop shell, so the
 // browser build has nothing to show and the section stays hidden there.

--- a/frontend/src/composables/useMarkdownLinks.js
+++ b/frontend/src/composables/useMarkdownLinks.js
@@ -1,0 +1,199 @@
+/**
+ * Links inside rendered message content: following one to a local file, and
+ * copying any of them.
+ *
+ * A `file:` href cannot simply be left on the anchor. DOMPurify's default URI
+ * allowlist has no `file:` in it, so the sanitiser strips the href and leaves
+ * `<a>plan.md</a>` — text that looks like a link and does nothing. Relaxing the
+ * allowlist would not help either: a browser tab refuses to navigate to
+ * `file://` from an http page, and in the desktop shell a `file:` URL arriving
+ * from a message body is exactly the shape of link that must never be followed
+ * (`classifyLink` blocks it, deliberately).
+ *
+ * So the path rides in a `data-file-url` attribute, which survives sanitising,
+ * and the anchor carries no href. Clicking it is a request the app answers
+ * here, not a navigation — which also means the answer can differ by platform
+ * without the markdown differing.
+ */
+
+/** Where `renderMarkdown` parks the URL, and what the click handler looks for. */
+export const FILE_LINK_ATTR = 'data-file-url';
+export const FILE_LINK_SELECTOR = `[${FILE_LINK_ATTR}]`;
+
+/**
+ * The file URL a click or keypress asked for, or '' when it asked for nothing.
+ *
+ * Message bodies are injected as HTML in half a dozen views, so activation is
+ * delegated from the app root rather than bound per view — which means this
+ * sees every click and every keystroke in the application and must decide
+ * quickly that almost all of them are not its business. Space in particular
+ * cannot be swallowed up front: that would stop people typing.
+ *
+ * @param {Event} event
+ * @returns {string}
+ */
+export function fileLinkFromEvent(event) {
+  if (event?.type === 'keydown' && event.key !== 'Enter' && event.key !== ' ') return '';
+  // `closest` walks up from the click target, which is usually a text node's
+  // parent inside the anchor rather than the anchor itself.
+  const anchor = event?.target?.closest?.(FILE_LINK_SELECTOR);
+  return anchor?.getAttribute(FILE_LINK_ATTR) || '';
+}
+
+/**
+ * Where `renderMarkdown` parks the text a link's copy button puts on the
+ * clipboard — the decoded path for a local file, the URL for anything else.
+ */
+export const COPY_TEXT_ATTR = 'data-copy-text';
+export const COPY_SELECTOR = `[${COPY_TEXT_ATTR}]`;
+
+/**
+ * The text a copy button was clicked for, or '' when the click was not one.
+ *
+ * Buttons fire a click of their own on Enter and space, so unlike a file link
+ * this needs no keyboard case.
+ *
+ * @param {Event} event
+ * @returns {string}
+ */
+export function copyTargetFromEvent(event) {
+  if (event?.type !== 'click') return '';
+  return event?.target?.closest?.(COPY_SELECTOR)?.getAttribute(COPY_TEXT_ATTR) || '';
+}
+
+/**
+ * Put text on the clipboard.
+ *
+ * The desktop shell is asked first, because the browser's Clipboard API
+ * refuses to write from a document that is not focused — true of the window
+ * behind a dialog, and true again the moment anything steals focus between the
+ * click and the write. The shell's clipboard has no such condition. In the
+ * browser there is nothing else to use.
+ *
+ * @param {string} text
+ * @param {{ bridge?: unknown, clipboard?: Clipboard }} context
+ */
+export async function writeClipboard(text, { bridge, clipboard }) {
+  if (typeof bridge?.write === 'function') {
+    await bridge.write(text);
+    return;
+  }
+  await clipboard.writeText(text);
+}
+
+/**
+ * Put a link's target on the clipboard.
+ *
+ * @param {string} text
+ * @param {{ copyText?: (text: string) => Promise<void> }} context
+ * @returns {Promise<{ tone: 'success'|'error', title: string, message: string }>}
+ *          the target is the message either way — on success so it is clear
+ *          *what* was copied, and on failure so it can still be read off the
+ *          screen and selected by hand.
+ */
+export async function copyLinkTarget(text, { copyText }) {
+  try {
+    await copyText?.(text);
+    return { tone: 'success', title: 'Copied', message: text };
+  } catch {
+    // Denied permission, or no secure context.
+    return { tone: 'error', title: 'Could not copy', message: text };
+  }
+}
+
+/** What following the link can do, given where the app is running. */
+export const FileLinkAction = {
+  /** Ask the desktop shell to open or reveal it. */
+  Open: 'open',
+  /** No shell to ask: hand the person the path so they can open it themselves. */
+  Copy: 'copy',
+};
+
+/**
+ * The filesystem path a `file:` URL names, decoded for display.
+ *
+ * Returns '' for anything that is not a local file URL — including
+ * `file://server/share/x`, which names a machine that is not this one.
+ *
+ * @param {string} rawUrl
+ * @returns {string}
+ */
+export function filePathFromUrl(rawUrl) {
+  let url;
+  try {
+    url = new URL(String(rawUrl ?? ''));
+  } catch {
+    return '';
+  }
+  if (url.protocol !== 'file:') return '';
+  // An empty host is the ordinary `file:///path`; "localhost" is the same thing
+  // spelled out. Any other host is a remote share this app cannot reach.
+  if (url.host && url.host !== 'localhost') return '';
+
+  let path;
+  try {
+    path = decodeURIComponent(url.pathname);
+  } catch {
+    // A stray `%` in a filename is not a reason to lose the whole link.
+    path = url.pathname;
+  }
+
+  // Windows drive paths arrive as `/C:/Users/…`; the leading slash is an
+  // artefact of the URL form and not part of the path.
+  return /^\/[A-Za-z]:/.test(path) ? path.slice(1) : path;
+}
+
+/**
+ * Which of the two things a click can do here.
+ *
+ * The bridge is checked as well as the platform because those are different
+ * questions: a desktop build whose preload predates this feature is still
+ * "desktop", and calling a method it does not have would fail silently — the
+ * very bug this is fixing. Copying the path is the honest fallback.
+ *
+ * @param {{ isDesktop: boolean, bridge: unknown }} context
+ */
+export function fileLinkAction({ isDesktop, bridge }) {
+  return isDesktop && typeof bridge?.open === 'function' ? FileLinkAction.Open : FileLinkAction.Copy;
+}
+
+/**
+ * Follow a local file link.
+ *
+ * @param {string} rawUrl the `file:` URL from the anchor
+ * @param {{ isDesktop: boolean, bridge?: unknown, copyText?: (text: string) => Promise<void> }} context
+ * @returns {Promise<{ tone: 'success'|'info'|'error', message: string }>} `message`
+ *          is '' when the outcome speaks for itself — the file opened, and a
+ *          toast saying so would only be in the way.
+ */
+export async function followFileLink(rawUrl, { isDesktop, bridge, copyText }) {
+  const path = filePathFromUrl(rawUrl);
+  if (!path) {
+    return { tone: 'error', message: 'That link does not point at a file on this computer.' };
+  }
+
+  if (fileLinkAction({ isDesktop, bridge }) === FileLinkAction.Open) {
+    let result;
+    try {
+      result = await bridge.open(rawUrl);
+    } catch (err) {
+      return { tone: 'error', message: err?.message || `Could not open ${path}` };
+    }
+    if (!result?.ok) return { tone: 'error', message: result?.error || `Could not open ${path}` };
+    // Programs and scripts are shown rather than run, so say which happened —
+    // otherwise a file manager appearing instead of the editor looks like a bug.
+    return result.revealed
+      ? { tone: 'info', message: `AgentRQ does not run files, so ${path} is shown in your file manager instead.` }
+      : { tone: 'success', message: '' };
+  }
+
+  const preamble = 'A browser cannot open a file on your computer.';
+  try {
+    await copyText?.(path);
+    return { tone: 'info', message: `${preamble} The path is on your clipboard: ${path}` };
+  } catch {
+    // Clipboard access is denied often enough (no permission, no secure
+    // context) that the path itself has to be the fallback.
+    return { tone: 'info', message: `${preamble} The file is at ${path}` };
+  }
+}

--- a/frontend/src/utils/markdown.js
+++ b/frontend/src/utils/markdown.js
@@ -1,6 +1,8 @@
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 
+import { COPY_TEXT_ATTR, FILE_LINK_ATTR, filePathFromUrl } from '../composables/useMarkdownLinks';
+
 function escapeHtml(text) {
   return text
     .replace(/&/g, '&amp;')
@@ -17,6 +19,72 @@ function escapeHtml(text) {
 // visible text instead of being rendered as markup.
 marked.use({ renderer: { html({ text }) { return escapeHtml(text); } } });
 
+const FILE_SCHEME = /^file:/i;
+
+// A link to a local file gets no href at all: DOMPurify would strip a `file:`
+// one anyway, and both builds refuse to navigate to it — see `useMarkdownLinks`,
+// which turns the surviving `data-file-url` back into an open request. Every
+// other scheme falls through to marked's own anchor, which is why this returns
+// false rather than rendering one itself.
+marked.use({
+  renderer: {
+    link(token) {
+      if (!FILE_SCHEME.test(token.href)) return false;
+      const path = filePathFromUrl(token.href);
+      // The tooltip is the decoded path, because the link text is usually just
+      // a filename and where the file actually lives is the useful part.
+      const title = escapeHtml(token.title || path || token.href);
+      return (
+        `<a class="md-file-link" ${FILE_LINK_ATTR}="${escapeHtml(token.href)}"` +
+        ` role="link" tabindex="0" title="${title}">${this.parser.parseInline(token.tokens)}</a>`
+      );
+    },
+  },
+});
+
+// A clipboard, drawn at the text's own size so it sits on the line rather than
+// beside it. Inline because an <img> would be a request per link.
+const COPY_ICON =
+  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"' +
+  ' stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+  '<rect x="9" y="9" width="11" height="11" rx="2"></rect>' +
+  '<path d="M5 15V5a2 2 0 0 1 2-2h10"></path></svg>';
+
+/**
+ * Give every link a button that copies where it points.
+ *
+ * Done *after* sanitising, on the DOM rather than on a string: these nodes are
+ * the app's own, so building them here means no attribute of theirs is ever
+ * assembled out of message text — the escaping question simply does not arise.
+ *
+ * @param {DocumentFragment} fragment
+ */
+function addCopyButtons(fragment) {
+  for (const anchor of fragment.querySelectorAll('a')) {
+    // A local file link has no href by then; the useful thing to copy is the
+    // path it names, not the URL form of it.
+    const fileUrl = anchor.getAttribute(FILE_LINK_ATTR);
+    const target = fileUrl ? filePathFromUrl(fileUrl) || fileUrl : anchor.getAttribute('href');
+    if (!target) continue;
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'md-copy-link';
+    button.setAttribute(COPY_TEXT_ATTR, target);
+    button.title = `Copy ${target}`;
+    button.setAttribute('aria-label', `Copy ${target}`);
+    button.innerHTML = COPY_ICON;
+    anchor.after(button);
+  }
+}
+
 export function renderMarkdown(text) {
-  return DOMPurify.sanitize(marked.parse(text || '', { breaks: true }));
+  const clean = DOMPurify.sanitize(marked.parse(text || '', { breaks: true }), {
+    RETURN_DOM_FRAGMENT: true,
+  });
+  addCopyButtons(clean);
+
+  const holder = document.createElement('div');
+  holder.append(clean);
+  return holder.innerHTML;
 }

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -1442,6 +1442,15 @@ function stripNote(body) {
 .md-body blockquote p { margin: 0.2em 0; }
 .md-body a { text-decoration: underline; }
 .md-body a:hover { opacity: 0.75; }
+/* A link to a local file carries no href — the app opens it rather than the
+   browser navigating to it — so the pointer cursor has to be asked for. */
+.md-body a.md-file-link { cursor: pointer; text-decoration-style: dotted; text-underline-offset: 2px; }
+/* Every link gets a button that copies where it points. Faint until wanted, so
+   a paragraph of links does not read as a row of icons. */
+.md-body .md-copy-link { display: inline-flex; vertical-align: -0.12em; margin: 0 0.05em 0 0.2em; padding: 0.1em; border-radius: 4px; border: none; background: none; color: currentColor; opacity: 0.4; cursor: pointer; transition: opacity 0.15s, background-color 0.15s; }
+.md-body .md-copy-link svg { width: 0.95em; height: 0.95em; }
+.md-body .md-copy-link:hover, .md-body .md-copy-link:focus-visible { opacity: 1; background: rgba(0,0,0,0.06); }
+.dark .md-body .md-copy-link:hover, .dark .md-body .md-copy-link:focus-visible { background: rgba(255,255,255,0.12); }
 .md-body strong { font-weight: 700; }
 .md-body em { font-style: italic; }
 .md-body hr { border: none; border-top: 1px solid #e5e7eb; margin: 0.85em 0; }

--- a/frontend/test/markdownLinks.test.js
+++ b/frontend/test/markdownLinks.test.js
@@ -1,0 +1,436 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  COPY_TEXT_ATTR,
+  FILE_LINK_ATTR,
+  FileLinkAction,
+  copyLinkTarget,
+  copyTargetFromEvent,
+  writeClipboard,
+  fileLinkAction,
+  fileLinkFromEvent,
+  filePathFromUrl,
+  followFileLink,
+} from '../src/composables/useMarkdownLinks';
+import { renderMarkdown } from '../src/utils/markdown';
+
+describe('filePathFromUrl', () => {
+  it('decodes an ordinary local file URL', () => {
+    expect(filePathFromUrl('file:///Users/mt/.gemini/brain/skills_support_plan.md'))
+      .toBe('/Users/mt/.gemini/brain/skills_support_plan.md');
+  });
+
+  it('decodes percent-escapes so the path is the one on disk', () => {
+    expect(filePathFromUrl('file:///Users/mt/My%20Notes/a%2Bb.md')).toBe('/Users/mt/My Notes/a+b.md');
+  });
+
+  it('treats localhost as this machine', () => {
+    expect(filePathFromUrl('file://localhost/etc/hosts')).toBe('/etc/hosts');
+  });
+
+  it('refuses a URL naming another machine', () => {
+    expect(filePathFromUrl('file://fileserver/share/report.pdf')).toBe('');
+  });
+
+  it('refuses schemes that are not file', () => {
+    expect(filePathFromUrl('https://example.com/a.md')).toBe('');
+    expect(filePathFromUrl('javascript:alert(1)')).toBe('');
+  });
+
+  it('returns empty for junk', () => {
+    expect(filePathFromUrl('not a url')).toBe('');
+    expect(filePathFromUrl(null)).toBe('');
+    expect(filePathFromUrl(undefined)).toBe('');
+  });
+
+  it('keeps a malformed escape rather than losing the link', () => {
+    expect(filePathFromUrl('file:///tmp/100%.md')).toBe('/tmp/100%.md');
+  });
+
+  it('drops the slash the URL form adds to a Windows drive path', () => {
+    expect(filePathFromUrl('file:///C:/Users/mt/plan.md')).toBe('C:/Users/mt/plan.md');
+  });
+});
+
+describe('fileLinkAction', () => {
+  it('opens through the shell on the desktop', () => {
+    expect(fileLinkAction({ isDesktop: true, bridge: { open: () => {} } })).toBe(FileLinkAction.Open);
+  });
+
+  it('copies in the browser, which cannot open a local file', () => {
+    expect(fileLinkAction({ isDesktop: false, bridge: undefined })).toBe(FileLinkAction.Copy);
+  });
+
+  it('copies on a desktop build whose bridge predates the feature', () => {
+    expect(fileLinkAction({ isDesktop: true, bridge: {} })).toBe(FileLinkAction.Copy);
+  });
+});
+
+describe('followFileLink', () => {
+  const desktop = (open) => ({ isDesktop: true, bridge: { open } });
+
+  it('opens the file and says nothing when it worked', async () => {
+    const open = vi.fn().mockResolvedValue({ ok: true, revealed: false });
+    const result = await followFileLink('file:///Users/mt/plan.md', desktop(open));
+
+    expect(open).toHaveBeenCalledWith('file:///Users/mt/plan.md');
+    expect(result).toEqual({ tone: 'success', message: '' });
+  });
+
+  it('explains when the shell revealed the file instead of opening it', async () => {
+    const result = await followFileLink(
+      'file:///Users/mt/install.sh',
+      desktop(vi.fn().mockResolvedValue({ ok: true, revealed: true }))
+    );
+
+    expect(result.tone).toBe('info');
+    expect(result.message).toContain('/Users/mt/install.sh');
+    expect(result.message).toContain('file manager');
+  });
+
+  it('reports what the shell said went wrong', async () => {
+    const result = await followFileLink(
+      'file:///Users/mt/gone.md',
+      desktop(vi.fn().mockResolvedValue({ ok: false, error: 'No such file: /Users/mt/gone.md' }))
+    );
+
+    expect(result).toEqual({ tone: 'error', message: 'No such file: /Users/mt/gone.md' });
+  });
+
+  it('reports a bridge that threw', async () => {
+    const result = await followFileLink(
+      'file:///Users/mt/plan.md',
+      desktop(vi.fn().mockRejectedValue(new Error('bridge is gone')))
+    );
+
+    expect(result).toEqual({ tone: 'error', message: 'bridge is gone' });
+  });
+
+  it('names the file when the bridge threw something with no message', async () => {
+    const result = await followFileLink(
+      'file:///Users/mt/plan.md',
+      desktop(vi.fn().mockRejectedValue('nope'))
+    );
+
+    expect(result.tone).toBe('error');
+    expect(result.message).toContain('/Users/mt/plan.md');
+  });
+
+  it('falls back to a generic message when the shell gave no reason', async () => {
+    const result = await followFileLink(
+      'file:///Users/mt/plan.md',
+      desktop(vi.fn().mockResolvedValue({ ok: false }))
+    );
+
+    expect(result.tone).toBe('error');
+    expect(result.message).toContain('/Users/mt/plan.md');
+  });
+
+  it('copies the path in the browser and says where it went', async () => {
+    const copyText = vi.fn().mockResolvedValue(undefined);
+    const result = await followFileLink('file:///Users/mt/plan.md', { isDesktop: false, copyText });
+
+    expect(copyText).toHaveBeenCalledWith('/Users/mt/plan.md');
+    expect(result.tone).toBe('info');
+    expect(result.message).toContain('clipboard');
+    expect(result.message).toContain('/Users/mt/plan.md');
+  });
+
+  it('still shows the path when the clipboard is denied', async () => {
+    const result = await followFileLink('file:///Users/mt/plan.md', {
+      isDesktop: false,
+      copyText: vi.fn().mockRejectedValue(new Error('denied')),
+    });
+
+    expect(result.tone).toBe('info');
+    expect(result.message).toContain('/Users/mt/plan.md');
+  });
+
+  it('refuses a link that names no local file', async () => {
+    const open = vi.fn();
+    const result = await followFileLink('file://fileserver/share/x.md', desktop(open));
+
+    expect(open).not.toHaveBeenCalled();
+    expect(result.tone).toBe('error');
+  });
+});
+
+describe('renderMarkdown', () => {
+  it('keeps a local file link reachable, which the sanitizer would otherwise strip', () => {
+    const html = renderMarkdown('[plan](file:///Users/mt/skills%20support.md)');
+
+    // The bug: DOMPurify drops a `file:` href, leaving an anchor that does nothing.
+    expect(html).not.toContain('href');
+    expect(html).toContain(`${FILE_LINK_ATTR}="file:///Users/mt/skills%20support.md"`);
+    expect(html).toContain('class="md-file-link"');
+    expect(html).toContain('>plan</a>');
+  });
+
+  it('titles the link with the path, since the text is usually just a filename', () => {
+    expect(renderMarkdown('[plan](file:///Users/mt/deep/skills%20support.md)'))
+      .toContain('title="/Users/mt/deep/skills support.md"');
+  });
+
+  it('renders markdown inside the link text', () => {
+    expect(renderMarkdown('[**plan**](file:///a.md)')).toContain('<strong>plan</strong>');
+  });
+
+  it('leaves ordinary links to the default renderer', () => {
+    const html = renderMarkdown('[docs](https://agentrq.com/docs)');
+
+    expect(html).toContain('href="https://agentrq.com/docs"');
+    expect(html).not.toContain(FILE_LINK_ATTR);
+  });
+
+  it('still refuses a javascript: link', () => {
+    expect(renderMarkdown('[x](javascript:alert(1))')).not.toContain('javascript:');
+  });
+
+  it('escapes a quote in the file URL rather than breaking out of the attribute', () => {
+    const html = renderMarkdown('[x](file:///tmp/a"onmouseover="alert(1).md)');
+
+    // The quote has to stay inside the attribute value; escaped, the rest of
+    // the URL is an odd filename and not a second attribute.
+    const anchor = new DOMParser().parseFromString(html, 'text/html').querySelector('a');
+    expect(anchor.getAttributeNames()).not.toContain('onmouseover');
+    expect(anchor.getAttribute(FILE_LINK_ATTR)).toBe('file:///tmp/a"onmouseover="alert(1).md');
+  });
+
+  it('leaves plain text alone', () => {
+    expect(renderMarkdown('just words')).toContain('just words');
+  });
+
+  it('renders nothing for nothing', () => {
+    expect(renderMarkdown('')).toBe('');
+    expect(renderMarkdown(null)).toBe('');
+    expect(renderMarkdown(undefined)).toBe('');
+  });
+
+  it('shows angle-bracket text rather than swallowing it as markup', () => {
+    // CommonMark reads `<Item>` as raw inline HTML, which the sanitizer then
+    // drops as an unknown tag.
+    expect(renderMarkdown('a List<Item> of things')).toContain('List&lt;Item&gt;');
+  });
+
+  it('prefers the title the markdown itself gives the link', () => {
+    expect(renderMarkdown('[plan](file:///Users/mt/plan.md "The plan")'))
+      .toContain('title="The plan"');
+  });
+
+  it('titles a file link on another machine with the URL, having no path', () => {
+    // `file://fileserver/share/x.md` names no path on this computer, so there
+    // is nothing better to show than the URL itself.
+    const html = renderMarkdown('[report](file://fileserver/share/report.pdf)');
+
+    expect(html).toContain('title="file://fileserver/share/report.pdf"');
+  });
+});
+
+describe('fileLinkFromEvent', () => {
+  // Driven through real rendered markdown, so the delegation is tested against
+  // the markup the app actually produces rather than a hand-written anchor.
+  const mount = (markdown) => {
+    document.body.innerHTML = `<div id="root">${renderMarkdown(markdown)}</div>`;
+    return document.querySelector('a');
+  };
+
+  it('finds the file link a click landed on', () => {
+    const anchor = mount('[plan](file:///Users/mt/plan.md)');
+
+    expect(fileLinkFromEvent({ type: 'click', target: anchor })).toBe('file:///Users/mt/plan.md');
+  });
+
+  it('finds it from a click on the text inside the link', () => {
+    const anchor = mount('[**plan**](file:///Users/mt/plan.md)');
+
+    expect(fileLinkFromEvent({ type: 'click', target: anchor.querySelector('strong') }))
+      .toBe('file:///Users/mt/plan.md');
+  });
+
+  it('ignores a click on an ordinary link, which the browser handles', () => {
+    const anchor = mount('[docs](https://agentrq.com/docs)');
+
+    expect(fileLinkFromEvent({ type: 'click', target: anchor })).toBe('');
+  });
+
+  it('ignores a click on anything else in the app', () => {
+    mount('some words');
+
+    expect(fileLinkFromEvent({ type: 'click', target: document.querySelector('#root') })).toBe('');
+  });
+
+  it('follows the link on Enter and space, as a link should', () => {
+    const anchor = mount('[plan](file:///Users/mt/plan.md)');
+
+    expect(fileLinkFromEvent({ type: 'keydown', key: 'Enter', target: anchor })).toBe('file:///Users/mt/plan.md');
+    expect(fileLinkFromEvent({ type: 'keydown', key: ' ', target: anchor })).toBe('file:///Users/mt/plan.md');
+  });
+
+  it('lets every other keystroke past, including space outside a link', () => {
+    const anchor = mount('[plan](file:///Users/mt/plan.md)');
+
+    expect(fileLinkFromEvent({ type: 'keydown', key: 'a', target: anchor })).toBe('');
+    // Delegation puts this handler in front of every keystroke in the app;
+    // claiming space anywhere else would stop people typing.
+    document.body.innerHTML = '<textarea></textarea>';
+    expect(fileLinkFromEvent({ type: 'keydown', key: ' ', target: document.querySelector('textarea') })).toBe('');
+  });
+
+  it('survives an event with nothing useful on it', () => {
+    expect(fileLinkFromEvent(undefined)).toBe('');
+    expect(fileLinkFromEvent({ type: 'click', target: null })).toBe('');
+  });
+});
+
+describe('copy buttons', () => {
+  const buttons = (markdown) => {
+    document.body.innerHTML = `<div id="root">${renderMarkdown(markdown)}</div>`;
+    return [...document.querySelectorAll('button')];
+  };
+
+  it('offers to copy the URL of an ordinary link', () => {
+    const [button] = buttons('[docs](https://agentrq.com/docs)');
+
+    expect(button.getAttribute(COPY_TEXT_ATTR)).toBe('https://agentrq.com/docs');
+    expect(button.previousElementSibling.tagName).toBe('A');
+  });
+
+  it('offers the path, not the URL form, for a local file link', () => {
+    const [button] = buttons('[plan](file:///Users/mt/skills%20support.md)');
+
+    expect(button.getAttribute(COPY_TEXT_ATTR)).toBe('/Users/mt/skills support.md');
+  });
+
+  it('gives every link its own button', () => {
+    const found = buttons('[a](https://a.test) and [b](file:///b.md) and [c](https://c.test)');
+
+    expect(found.map((b) => b.getAttribute(COPY_TEXT_ATTR))).toEqual([
+      'https://a.test',
+      '/b.md',
+      'https://c.test',
+    ]);
+  });
+
+  it('names what it copies, for a tooltip and for a screen reader', () => {
+    const [button] = buttons('[plan](file:///Users/mt/plan.md)');
+
+    expect(button.getAttribute('title')).toBe('Copy /Users/mt/plan.md');
+    expect(button.getAttribute('aria-label')).toBe('Copy /Users/mt/plan.md');
+    // Inside a form it must not submit anything.
+    expect(button.getAttribute('type')).toBe('button');
+  });
+
+  it('adds nothing where there is no link', () => {
+    expect(buttons('just words and `code`')).toHaveLength(0);
+  });
+
+  it('falls back to the URL when a file link names no local path', () => {
+    const [button] = buttons('[report](file://fileserver/share/report.pdf)');
+
+    expect(button.getAttribute(COPY_TEXT_ATTR)).toBe('file://fileserver/share/report.pdf');
+  });
+
+  it('adds nothing to a link the sanitizer emptied', () => {
+    // `javascript:` is rendered as plain text, so there is no anchor at all.
+    expect(buttons('[x](javascript:alert(1))')).toHaveLength(0);
+  });
+
+  it('cannot be built out of message text', () => {
+    // The buttons are DOM nodes made after sanitising, so a quote in the URL
+    // stays a character in an attribute value rather than becoming markup.
+    const [button] = buttons('[x](file:///tmp/a"onmouseover="alert(1).md)');
+
+    expect(button.getAttributeNames()).not.toContain('onmouseover');
+  });
+});
+
+describe('copyTargetFromEvent', () => {
+  const mount = (markdown) => {
+    document.body.innerHTML = `<div id="root">${renderMarkdown(markdown)}</div>`;
+    return document.querySelector('button');
+  };
+
+  it('finds what a clicked button copies', () => {
+    const button = mount('[docs](https://agentrq.com/docs)');
+
+    expect(copyTargetFromEvent({ type: 'click', target: button })).toBe('https://agentrq.com/docs');
+  });
+
+  it('finds it from a click on the icon inside the button', () => {
+    const button = mount('[docs](https://agentrq.com/docs)');
+
+    expect(copyTargetFromEvent({ type: 'click', target: button.querySelector('svg') }))
+      .toBe('https://agentrq.com/docs');
+  });
+
+  it('ignores a click on the link itself, which is a different action', () => {
+    mount('[plan](file:///Users/mt/plan.md)');
+
+    expect(copyTargetFromEvent({ type: 'click', target: document.querySelector('a') })).toBe('');
+  });
+
+  it('leaves keystrokes alone, since a button clicks itself on Enter and space', () => {
+    const button = mount('[docs](https://agentrq.com/docs)');
+
+    expect(copyTargetFromEvent({ type: 'keydown', key: 'Enter', target: button })).toBe('');
+  });
+
+  it('survives an event with nothing useful on it', () => {
+    expect(copyTargetFromEvent(undefined)).toBe('');
+    expect(copyTargetFromEvent({ type: 'click', target: null })).toBe('');
+  });
+});
+
+describe('copyLinkTarget', () => {
+  it('copies and reports what went to the clipboard', async () => {
+    const copyText = vi.fn().mockResolvedValue(undefined);
+    const result = await copyLinkTarget('/Users/mt/plan.md', { copyText });
+
+    expect(copyText).toHaveBeenCalledWith('/Users/mt/plan.md');
+    expect(result).toEqual({ tone: 'success', title: 'Copied', message: '/Users/mt/plan.md' });
+  });
+
+  it('still shows the text when the clipboard is denied', async () => {
+    const result = await copyLinkTarget('/Users/mt/plan.md', {
+      copyText: vi.fn().mockRejectedValue(new Error('denied')),
+    });
+
+    expect(result).toEqual({ tone: 'error', title: 'Could not copy', message: '/Users/mt/plan.md' });
+  });
+});
+
+describe('writeClipboard', () => {
+  it('uses the shell where there is one', async () => {
+    const write = vi.fn().mockResolvedValue(true);
+    const writeText = vi.fn();
+
+    await writeClipboard('/Users/mt/plan.md', { bridge: { write }, clipboard: { writeText } });
+
+    // Not the browser's: it refuses to write from an unfocused document, which
+    // is a copy button that silently does nothing.
+    expect(write).toHaveBeenCalledWith('/Users/mt/plan.md');
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('uses the browser clipboard when there is no shell', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    await writeClipboard('/Users/mt/plan.md', { clipboard: { writeText } });
+
+    expect(writeText).toHaveBeenCalledWith('/Users/mt/plan.md');
+  });
+
+  it('falls back on a desktop build whose bridge predates the feature', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    await writeClipboard('/x.md', { bridge: {}, clipboard: { writeText } });
+
+    expect(writeText).toHaveBeenCalledWith('/x.md');
+  });
+
+  it('lets a failure through to the caller, which reports it', async () => {
+    await expect(
+      writeClipboard('/x.md', { clipboard: { writeText: vi.fn().mockRejectedValue(new Error('denied')) } })
+    ).rejects.toThrow('denied');
+  });
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -57,6 +57,8 @@ export default defineConfig({
         'src/composables/useCachedReads.js',
         'src/composables/useAttachmentCache.js',
         'src/composables/useCacheRetention.js',
+        'src/composables/useMarkdownLinks.js',
+        'src/utils/markdown.js',
       ],
       reporter: ['text', 'lcov'],
       thresholds: {


### PR DESCRIPTION
## What changed

A link to a file on your own computer used to render as text that looked like a link and did nothing when clicked. It now works: in the desktop app it opens the file in whatever application you normally use for that kind of file, and in the browser — which is never allowed to reach your filesystem — it copies the path to your clipboard and says why it cannot open it. Anything that would *run* rather than be read (a script, an app bundle, an installer, an archive, a web page, or a file with no extension) is shown in Finder or your file manager instead of being launched, and the app tells you that is what happened.

Every link in a task or message also gains a small copy button beside it, in both builds, which puts the plain filesystem path or the URL on your clipboard.

## Why

The sanitiser that protects rendered message content strips `file:` URLs, so the link arrived with nothing behind it. Simply putting it back would not have been safe or sufficient: a browser tab cannot navigate to a local file at all, and message bodies are written by agents, so a link labelled like a document could point at something executable. Following the link is therefore a request the application answers rather than a navigation the browser performs, which is what lets the two builds each do the right thing and lets the shell refuse to run anything.

The copy button was added on request in the same task, and it made a second problem visible: the browser clipboard API refuses to write from a window that is not frontmost, so on the desktop copies go through the shell instead. Otherwise the button would have silently done nothing any time something had stolen focus — the same failure the original bug was.

## Test coverage report

- **New lines: 100%.** Frontend and desktop both enforce a 100% line/branch/function threshold, and the new modules are inside it. The two new files were also added to the frontend's explicit coverage include list, which they would otherwise have sat outside.
- **Total coverage impact: none — both suites remain at 100%.** Frontend 622 tests passing (up from 591), desktop 443 passing.

## Other reports

Verified end-to-end in a real Electron window, not only in unit tests — a new `npm run verify:markdown-links` (needs no backend) injects a rendered link into the running app, clicks it, and checks the whole path through the delegated handler, the preload bridge and the shell:

```
✓ the bridge exposes files.open
✓ the anchor carries no href to navigate to
✓ clicking a document asks the shell to open it
✓ opening quietly says nothing
✓ clicking a script reveals it instead of running it
✓ clicking a folder opens it
✓ a file that is not there reaches the shell and no further, and says which file
✓ clicking the copy button copies the path to the real clipboard
```

The `shell.openPath` / `showItemInFolder` calls are recorded rather than made, so a passing run does not launch an editor and a Finder window on whoever ran it; the clipboard is restored afterwards.

Documented in `docs/DESKTOP.md`, `desktop/README.md`, and as two new invariants in `AGENTS.md`.

TaskID: 0iHXHjiyCmn