### PR TITLE
chore: bump patch version to v0.5.7

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.5.6"
+	_appVersion   = "v0.5.7"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.5.6" {
-			t.Errorf("Expected version v0.5.6, got %s", s.Version())
+		if s.Version() != "v0.5.7" {
+			t.Errorf("Expected version v0.5.7, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.5.6",
+  "version": "0.5.7",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
## What changed

Bumps the project version from 0.5.6 to 0.5.7 across all six declaration sites, so the release build's version-sync gate passes.

## Why

Cuts a release containing the local-file-link fix. Merging alone publishes nothing — the release is built by tagging `main` with `v0.5.7` afterwards.

## Changes in this version

**fix**
- Links to local files are openable, and every link is copyable (#450). A `file:///…` link in a task or message used to render as text that looked like a link and did nothing, because the sanitiser strips `file:` hrefs. Clicking one is now a request the app answers: the desktop shell opens the file with its default application, and the browser — which can never reach the filesystem — copies the path instead. Anything that would run rather than be read is revealed in the file manager, never launched. Every link also gained a small copy button for its path or URL.

**test**
- Pin that a workspace delete stays inside its workspace (#449).

## Test coverage report

- **New lines: none** — this changes only version literals.
- **Total coverage impact: none.** The backend config test asserting the version string was updated alongside the constant; `go test ./internal/service/config/...` passes.

## Other reports

Version sync verified both ways, including the form CI runs on a tag build:

```
$ node desktop/scripts/check-versions.mjs
✓ desktop, frontend and backend are all at 0.5.7

$ GITHUB_REF=refs/tags/v0.5.7 node desktop/scripts/check-versions.mjs
✓ desktop, frontend and backend are all at 0.5.7
✓ tag v0.5.7 matches version 0.5.7
```

Lockfile version fields were edited by hand rather than regenerated, so no dependency resolution shifted underneath the release; `npm ci` still succeeds in both `desktop/` and `frontend/`. The unrelated `mkdirp@0.5.6` entry in `desktop/package-lock.json` was deliberately left alone.

TaskID: 0iHXHjiyCmn