### PR TITLE
feat(frontend): offer the interface to browser agents over WebMCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,24 @@ Named signals that let one workspace trigger tasks in another.
 - **`EventTrigger.emitEventId`**: optional field that chains events — when the trigger's spawned task completes it publishes this second event. The consumer appends the same `publishEvent` instruction to the task body. Triggered tasks always start as `notstarted` (no cron scheduling).
 - **Frontend**: `/events` list + `/events/:id` detail (triggers CRUD + resulting tasks, 10 shown with load-more). Both the task-creation form and the trigger-creation form have an optional "Emit event on completion" selector.
 
+## WebMCP (`frontend/src/webmcp/`)
+
+The interface offers itself to a browser agent as WebMCP tools — 52 of them,
+registered on sign-in and withdrawn on sign-out.
+
+- `modelContext.js` is the browser seam (finds `document.modelContext`, falling
+  back to the deprecated `navigator.modelContext`); `tools.js` is the pure
+  catalogue; `composables/useWebMCP.js` is the only Vue-aware part.
+- **The catalogue mirrors `frontend/src/api.js` function for function.** That is
+  what makes "anything the UI can do" checkable, and
+  `frontend/test/webmcpTools.test.js` enforces it: add an API function without a
+  tool and it fails. Exemptions live in that test with a reason.
+- Tools act as the signed-in user with their cookie, so they inherit exactly the
+  user's permissions. The registration is withdrawn on logout because the page
+  is not reloaded in between.
+- User-facing documentation is `docs/WEBMCP.md`; `cd desktop && npm run
+  verify:webmcp` drives the whole path in a real browser with no backend.
+
 ## Commit convention
 
 Include `Task: <taskID>` in the commit body for traceability.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,19 @@ certificates are in place — the install command above is the way around both.
 Connecting to a server and troubleshooting are covered in the
 [Desktop Guide](docs/DESKTOP.md).
 
+## Driving AgentRQ from a browser agent
+
+If your browser supports [WebMCP](https://github.com/webmachinelearning/webmcp),
+an AI agent you talk to there can use AgentRQ directly — list your workspaces,
+open a task, reply in it, build a workflow. Everything the interface can do is
+offered as a tool, including asking which page you are on, so "reply to this
+task" resolves to the task you have open.
+
+The tools run in the page as you, with your session, so an agent gets exactly
+your permissions and nothing more, and they are withdrawn when you sign out.
+Nothing to install or configure; a browser without WebMCP simply sees no tools.
+See the [WebMCP Guide](docs/WEBMCP.md).
+
 To run it from source:
 
 ```bash

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -15,6 +15,7 @@
     "verify:e2e": "npm run build && electron scripts/verify-e2e.mjs",
     "verify:connection": "npm run build && electron scripts/verify-connection.mjs",
     "verify:markdown-links": "npm run build && electron scripts/verify-markdown-links.mjs",
+    "verify:webmcp": "npm run build && electron scripts/verify-webmcp.mjs",
     "check:versions": "node scripts/check-versions.mjs",
     "package": "npm run build && electron-builder --publish never",
     "package:dir": "npm run build && electron-builder --dir"

--- a/desktop/scripts/verify-webmcp.mjs
+++ b/desktop/scripts/verify-webmcp.mjs
@@ -1,0 +1,224 @@
+/**
+ * End-to-end check that the WebMCP catalogue reaches a real browser.
+ *
+ * The unit tests prove the catalogue is right and that registration is driven
+ * correctly. What they cannot prove is the part that only exists in a browser:
+ * that the app finds `document.modelContext` at all, registers against it once
+ * the user is signed in, that a tool invoked through that object really calls
+ * the interface's own API, and that signing out withdraws the tools rather than
+ * leaving an agent holding the last person's session.
+ *
+ * No WebMCP-capable browser is required: this installs a stub `modelContext`
+ * before the app boots, which is exactly what the page sees from a real one.
+ * The agent side of the protocol is the browser's job, not AgentRQ's — what is
+ * under test here is what AgentRQ hands it.
+ *
+ *   npm run build && npx electron scripts/verify-webmcp.mjs
+ */
+import { app, BrowserWindow, ipcMain, net, protocol } from 'electron'
+import { readFile, access } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { createAppProtocolHandler } from '../src/main/protocol.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const RENDERER_ROOT = join(__dirname, '../dist/renderer')
+const PRELOAD = join(__dirname, '../dist/preload/index.cjs')
+
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: 'app',
+    privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true, corsEnabled: true },
+  },
+])
+
+async function fileExists(pathname) {
+  try {
+    await access(join(RENDERER_ROOT, pathname), constants.R_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * A stand-in for the API the app is pointed at.
+ *
+ * Every request the page makes is answered here, so a tool invocation can be
+ * observed as the HTTP call it becomes — which is the claim worth checking:
+ * that a WebMCP tool drives the same interface a click does.
+ */
+const requests = []
+function apiResponse(url, method) {
+  const { pathname, search } = new URL(url)
+  requests.push({ method, pathname, search })
+
+  if (pathname.endsWith('/auth/user')) return { id: 'u1', name: 'QA', email: 'qa@example.com' }
+  if (pathname.endsWith('/workspaces')) return [{ id: 'ws1', name: 'Ops', description: 'Run things' }]
+  if (pathname.endsWith('/tasks')) return { id: 't9', title: 'From an agent' }
+  if (pathname.endsWith('/auth/logout')) return {}
+  return []
+}
+
+/** The stub the page will find, mirroring what a WebMCP browser exposes. */
+const STUB = `
+  (() => {
+    // Idempotent on purpose: 'did-start-loading' fires more than once per
+    // document, and reinstalling would hand the page a fresh empty registry
+    // while the app held tools registered against the old one.
+    if (document.modelContext) return;
+    const tools = new Map();
+    Object.defineProperty(document, 'modelContext', {
+      configurable: true,
+      value: {
+        registerTool(tool, options = {}) {
+          if (tools.has(tool.name)) return Promise.reject(new Error('InvalidStateError'));
+          tools.set(tool.name, tool);
+          options.signal?.addEventListener('abort', () => tools.delete(tool.name));
+          return Promise.resolve();
+        },
+        getTools: () => Promise.resolve([...tools.values()]),
+      },
+    });
+    window.__stubTools = tools;
+  })();
+`
+
+setTimeout(() => {
+  console.error('✗ verification timed out')
+  app.exit(3)
+}, 60000)
+
+app.whenReady().then(async () => {
+  ipcMain.handle('agentrq:connection:get', () => ({ configured: true, serverUrl: 'http://stub', locked: true }))
+  ipcMain.handle('agentrq:update:get', () => ({ status: 'idle', detail: '', version: '', enabled: false }))
+  ipcMain.handle('agentrq:theme:set', () => ({ source: 'system', color: '#fafafa' }))
+  ipcMain.handle('agentrq:profiles:get', () => ({ activeProfileId: '', profiles: [] }))
+  ipcMain.handle('agentrq:notifications:get', () => ({ supported: false, mutedWorkspaces: [] }))
+
+  const staticHandler = createAppProtocolHandler({
+    serverUrl: () => 'http://stub',
+    netFetch: net.fetch,
+    fileExists,
+    readFile: (pathname) => readFile(join(RENDERER_ROOT, pathname)),
+  })
+
+  // The API is answered here rather than proxied, so this run needs no backend
+  // and every call a tool makes is observable.
+  protocol.handle('app', (request) => {
+    const { pathname } = new URL(request.url)
+    if (pathname.startsWith('/api/')) {
+      return new Response(JSON.stringify(apiResponse(request.url, request.method)), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+    return staticHandler(request)
+  })
+
+  const win = new BrowserWindow({
+    show: false,
+    webPreferences: { preload: PRELOAD, contextIsolation: true, nodeIntegration: false, sandbox: true },
+  })
+
+  // Before any page script runs: the app looks for the API while it boots.
+  win.webContents.on('did-start-loading', () => {
+    win.webContents.executeJavaScript(STUB).catch(() => {})
+  })
+
+  await win.loadURL('app://agentrq/')
+  await new Promise((r) => setTimeout(r, 2500))
+
+  const results = []
+  const record = (name, pass, detail) => results.push({ name, pass, detail })
+
+  const registered = await win.webContents.executeJavaScript(
+    '(async () => [...(await document.modelContext.getTools())].map((t) => t.name))()'
+  )
+  record('the app registers its catalogue with the browser', registered.length > 40, registered.length + ' tools')
+  record(
+    'including the tools only a page can offer',
+    registered.includes('getCurrentPage') && registered.includes('navigate'),
+    'getCurrentPage/navigate present: ' + registered.includes('getCurrentPage')
+  )
+  record(
+    'and the ones that mirror the interface',
+    ['listWorkspaces', 'createTask', 'replyToTask', 'updateTaskStatus'].every((n) => registered.includes(n)),
+    registered.slice(0, 4).join(', ') + ', …'
+  )
+
+  // A tool, invoked the way an agent would: through the object the browser owns.
+  const before = requests.length
+  const created = await win.webContents.executeJavaScript(`
+    (async () => {
+      const tool = window.__stubTools.get('createTask');
+      return tool.execute({ workspaceId: 'ws1', title: 'From an agent', body: 'Body' }, { signal: undefined });
+    })()
+  `)
+  const call = requests.slice(before).find((r) => r.method === 'POST')
+  record(
+    'invoking a tool drives the interface\'s own API',
+    call?.pathname === '/api/v1/workspaces/ws1/tasks',
+    call ? call.method + ' ' + call.pathname : 'no request was made'
+  )
+  record('and the tool returns what the API said', created?.id === 't9', JSON.stringify(created))
+
+  const page = await win.webContents.executeJavaScript(
+    "window.__stubTools.get('getCurrentPage').execute({}, {})"
+  )
+  record('getCurrentPage answers with the live route', typeof page?.path === 'string', JSON.stringify(page))
+
+  await win.webContents.executeJavaScript(
+    "window.__stubTools.get('navigate').execute({ path: '/events' }, {})"
+  )
+  await new Promise((r) => setTimeout(r, 400))
+  const movedTo = await win.webContents.executeJavaScript('location.pathname')
+  record('the navigate tool moves the user', movedTo === '/events', 'now at ' + movedTo)
+
+  const annotations = await win.webContents.executeJavaScript(`
+    (async () => {
+      const tools = await document.modelContext.getTools();
+      const byName = Object.fromEntries(tools.map((t) => [t.name, t.annotations]));
+      return { read: byName.listWorkspaces, remove: byName.deleteWorkspace };
+    })()
+  `)
+  record(
+    'reads and deletions are annotated for the agent',
+    annotations.read?.readOnlyHint === true && annotations.remove?.destructiveHint === true,
+    JSON.stringify(annotations)
+  )
+
+  // Signing out must withdraw the tools: the page is not reloaded, so anything
+  // left registered would still be acting as the person who just left.
+  const clicked = await win.webContents.executeJavaScript(`
+    (async () => {
+      const find = (label) =>
+        [...document.querySelectorAll('button')].find((b) => b.textContent.trim() === label);
+      // Log Out lives inside the user menu, so it has to be opened first —
+      // driving this the way a person does rather than calling the handler,
+      // which would prove only that the function exists.
+      const menu = find('Q');
+      if (!menu) return 'no user menu';
+      menu.click();
+      await new Promise((r) => setTimeout(r, 300));
+      const logout = find('Logout');
+      if (!logout) return 'no Logout in the open menu';
+      logout.click();
+      return 'clicked';
+    })()
+  `)
+  record('the Logout control was reachable', clicked === 'clicked', JSON.stringify(clicked))
+  await new Promise((r) => setTimeout(r, 1500))
+  const afterLogout = await win.webContents.executeJavaScript(
+    '(async () => (await document.modelContext.getTools()).length)()'
+  )
+  record('signing out withdraws every tool', afterLogout === 0, afterLogout + ' tools left registered')
+
+  console.log('\n─── WebMCP, in a real browser ───')
+  for (const r of results) console.log(`${r.pass ? '✓' : '✗'} ${r.name} — ${r.detail}`)
+  const failed = results.filter((r) => !r.pass)
+  console.log(failed.length === 0 ? '\n✓ all checks passed' : `\n✗ ${failed.length} check(s) failed`)
+  app.exit(failed.length === 0 ? 0 : 1)
+})

--- a/docs/WEBMCP.md
+++ b/docs/WEBMCP.md
@@ -1,0 +1,115 @@
+# WebMCP: driving AgentRQ from a browser agent
+
+AgentRQ offers its own interface to an AI agent running in your browser. If your
+browser supports [WebMCP](https://github.com/webmachinelearning/webmcp), an
+agent you talk to there can list your workspaces, open a task, reply in it,
+change a status, build a workflow — anything you can do by clicking, it can do
+by calling a tool.
+
+Nothing to install and nothing to configure. Open AgentRQ, sign in, and the
+tools are there.
+
+---
+
+## What it is
+
+WebMCP is a browser API that lets a *page* hand the agent a set of typed tools.
+It is the same idea as an MCP server, with one difference that matters: the
+tools run inside the page you already have open, as you, in your session. The
+agent never needs a token, never sees your credentials, and can do exactly what
+your account can do — no more.
+
+That last point is worth being concrete about. A tool call is the same HTTP
+request the interface itself makes, carrying the same cookie. If you cannot
+delete a workspace, neither can the agent.
+
+## What you can ask for
+
+Every capability of the interface, grouped roughly as the app is:
+
+| Area | Examples |
+|---|---|
+| **Where you are** | `getCurrentPage`, `navigate` |
+| **Workspaces** | list, read, create, update, archive, unarchive, delete, stats, Slack channel, connection token |
+| **Tasks** | list, read, create, reply, respond, status, assignee, order, move, stop, delete, permission verdicts, elicitation answers, scheduled-task template, counts |
+| **Events** | list, read, create, update, delete, triggers (list/create/update/delete), tasks an event spawned |
+| **Workflows** | list, read, create, update, delete, steps, tasks, and the whole workflow as editable text |
+
+`getCurrentPage` is the one to know about. It tells the agent which page you are
+looking at and the IDs in the URL, which is what turns "reply to this task" into
+a real call. Without it the agent would have to ask you for IDs you should never
+have to read.
+
+Two things in the interface are deliberately **not** tools:
+
+- **Attachments.** Their URLs are rendered by the page and fetched by the
+  browser with your session; there is nothing an agent can usefully do with one.
+- **Telemetry.** The app records a little about its own use. That is not an
+  action you take, so it is not something to offer.
+
+## Reading the annotations
+
+Every tool says what kind of thing it is, so an agent can decide what to do
+without asking you and what to check first:
+
+- **`readOnlyHint`** — reads nothing but data. `listWorkspaces`, `getTask`,
+  `getCurrentPage` and the rest of the read side.
+- **`destructiveHint`** — removes something that does not come back:
+  `deleteWorkspace`, `deleteTask`, `deleteEvent`, `deleteEventTrigger`,
+  `deleteWorkflow`, `deleteWorkflowStep`, and `replaceWorkflowFromText`, which
+  drops anything not in the text you give it.
+
+A good agent will confirm a destructive call with you first. AgentRQ marks them
+so it can.
+
+## Which browsers
+
+WebMCP is new and support is uneven. AgentRQ looks for it in both places the
+specification has used — `document.modelContext` (current) and
+`navigator.modelContext` (deprecated in Chromium 150) — and if neither is there,
+does nothing at all. The app is unchanged; there are simply no tools.
+
+The API also requires a secure context, so it will not appear on a plain `http://`
+page. Serve AgentRQ over HTTPS, or use `http://localhost`, which browsers treat
+as secure.
+
+This works the same way in the desktop app, which runs the same interface.
+
+## Signing out
+
+The tools are registered when you sign in and withdrawn the moment you sign out.
+Because they act as you, leaving them registered would leave an agent holding a
+session that has ended — so it does not happen, and there is a test that fails
+if it ever starts.
+
+---
+
+## For contributors
+
+Three files, and the split between them is deliberate:
+
+- `frontend/src/webmcp/modelContext.js` — the browser seam. Finds the API,
+  registers tools one at a time so a refusal costs one tool rather than the
+  page, and reports why nothing registered. No Vue.
+- `frontend/src/webmcp/tools.js` — the catalogue. Pure: it takes the API client
+  and a router and returns descriptors.
+- `frontend/src/composables/useWebMCP.js` — the wiring, and the only part that
+  knows about Vue.
+
+**The invariant to keep:** the catalogue mirrors `frontend/src/api.js`. That
+module is the interface's capability surface, so mirroring it is what makes
+"anything you can do in the UI" checkable. `frontend/test/webmcpTools.test.js`
+enforces it — it drives every tool against a recording stub and asserts that
+every exported API function was reached. Add a function to `api.js` without
+adding a tool and that test fails, which is the intent.
+
+Verify the whole path in a real browser with:
+
+```bash
+cd desktop && npm run verify:webmcp
+```
+
+It needs no backend: it installs a stub `document.modelContext` exactly as a
+supporting browser would, answers the API itself so each tool call is
+observable, and checks registration, invocation, navigation, annotations and
+withdrawal on sign-out.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -386,9 +386,13 @@ import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useRegisterSW } from 'virtual:pwa-register/vue'
 import { fetchUser, fetchWorkspaces, API_BASE_URL } from './api'
+// The whole module, because the WebMCP catalogue mirrors it function for
+// function — naming each one here would be a second list to keep in step.
+import * as api from './api'
 import { useToasts } from './composables/useToasts'
 import { useEventBus } from './useEventBus'
 import { profileDisplay } from './composables/useProfileDisplay'
+import { connectWebMCP } from './composables/useWebMCP'
 import { usePlatformStore } from './stores/platformStore'
 import {
   copyLinkTarget,
@@ -681,7 +685,15 @@ const hideTooltip = () => {
   tooltipStore.hide();
 }
 
+/** The registration handle, so the tools can be withdrawn on sign-out. */
+let webmcp = null
+
 async function logout() {
+  // Before anything else: these tools act as the signed-in user, and the page
+  // is not reloaded on sign-out, so leaving them registered would leave an
+  // agent holding the last person's session.
+  webmcp?.unregister()
+  webmcp = null
   await unsubscribePush()
   // Unconditional, and before the request: a browser several people use must
   // not leave one person's task titles readable by the next, and that has to
@@ -705,9 +717,28 @@ const loadUser = async () => {
     if (user.value?.id) {
       const db = await connectCache(user.value.id)
       startRetentionSweep(db)
+      offerWebMCPTools()
     }
   } catch (err) {
     console.error('Failed to fetch user:', err)
+  }
+}
+
+/**
+ * Hand the interface's own capabilities to an agent running in this browser.
+ *
+ * Only once signed in: the tools act as this user, with their cookie and their
+ * permissions, so there is nothing to offer before we know who that is. The
+ * browser is usually one without WebMCP at all, which is not a failure — the
+ * catalogue is simply not registered and nothing else changes.
+ */
+async function offerWebMCPTools() {
+  if (webmcp) return
+  try {
+    webmcp = await connectWebMCP({ api, router })
+  } catch (err) {
+    // An agent-facing extra must never cost the person their interface.
+    console.error('Failed to register WebMCP tools:', err)
   }
 }
 

--- a/frontend/src/composables/useWebMCP.js
+++ b/frontend/src/composables/useWebMCP.js
@@ -1,0 +1,56 @@
+/**
+ * Offering the AgentRQ interface to an agent running in the browser.
+ *
+ * This is the wiring: it builds the catalogue in `src/webmcp/tools.js` with the
+ * live API client and router, hands it to the browser, and withdraws it again
+ * when the session ends. The two halves it joins are deliberately framework-free
+ * — this file is the only part that knows about Vue.
+ *
+ * Registration is tied to being signed in, and that is a security property
+ * rather than tidiness. Every tool acts as the signed-in user, with the same
+ * cookie and therefore exactly the same permissions the interface itself has:
+ * no more, and none at all once they log out. Withdrawing the tools on sign-out
+ * is what keeps that true, because the page is not reloaded in between.
+ */
+import { createToolCatalogue } from '../webmcp/tools'
+import { registerTools } from '../webmcp/modelContext'
+
+/**
+ * A description of where the person is, in the terms the tools speak.
+ *
+ * Route params are what an agent needs to turn "this task" into IDs, so they
+ * are handed over as they are rather than being summarised into prose.
+ *
+ * @param {import('vue-router').RouteLocationNormalized} route
+ */
+export function describePage(route) {
+  return {
+    path: route?.path ?? '/',
+    params: { ...(route?.params ?? {}) },
+    query: { ...(route?.query ?? {}) },
+  }
+}
+
+/**
+ * Register the catalogue, and return the means to withdraw it.
+ *
+ * @param {object} deps
+ * @param {object} deps.api the API client
+ * @param {import('vue-router').Router} deps.router
+ * @returns {Promise<{ status: string, registered: string[], refused: Array<object>, unregister: () => void }>}
+ */
+export async function connectWebMCP({ api, router, context }) {
+  const controller = new AbortController()
+
+  const tools = createToolCatalogue({
+    api,
+    navigate: (path) => router.push(path),
+    // Read at call time, not at registration: the person moves around the app
+    // while the tools stay registered, and a snapshot would answer for the page
+    // they happened to be on when they signed in.
+    currentPage: () => describePage(router.currentRoute.value),
+  })
+
+  const result = await registerTools(tools, { context, signal: controller.signal })
+  return { ...result, unregister: () => controller.abort() }
+}

--- a/frontend/src/webmcp/modelContext.js
+++ b/frontend/src/webmcp/modelContext.js
@@ -1,0 +1,90 @@
+/**
+ * The seam between AgentRQ and the browser's WebMCP implementation.
+ *
+ * WebMCP lets a page hand an agent running *in the browser* a set of typed
+ * tools, so the agent drives the application the way a person does rather than
+ * guessing at its HTTP API. The catalogue of tools is `./tools.js`; this module
+ * is only concerned with reaching the browser API at all, and with doing it in
+ * a way that cannot break the app when the API is absent, moved, or refuses.
+ *
+ * Three things about that API make a seam worth having:
+ *
+ * - **It moved.** The accessor was `navigator.modelContext` when WebMCP first
+ *   shipped and is `document.modelContext` since the May 2026 draft, with the
+ *   old one deprecated rather than removed. Both are checked, newest first.
+ * - **It is usually not there.** Only some browsers implement it, and only in a
+ *   secure context. Absence is the ordinary case, not an error, so it is
+ *   reported as a reason rather than thrown.
+ * - **Registration can be refused.** A permissions policy, a duplicate name or
+ *   a malformed schema rejects the promise. One bad tool must not take the
+ *   others down with it, so each is registered on its own.
+ *
+ * Nothing here imports Vue: this is the part that talks to the browser, and
+ * keeping it free of the framework is what makes it testable without one.
+ */
+
+/** Why the page has no tools registered. */
+export const WebMCPStatus = {
+  /** Tools are registered and the agent can see them. */
+  Registered: 'registered',
+  /** The browser does not implement WebMCP, or the page is not a secure context. */
+  Unsupported: 'unsupported',
+  /** Supported, but every tool was refused. */
+  Refused: 'refused',
+}
+
+/**
+ * The page's model context, or null when this browser has none.
+ *
+ * `document` first: `navigator.modelContext` is the deprecated spelling, kept
+ * only so a browser that has not yet moved is still served.
+ *
+ * @param {{ document?: object, navigator?: object }} [globals] injectable for tests
+ * @returns {object|null}
+ */
+export function getModelContext({ document: doc = globalThis.document, navigator: nav = globalThis.navigator } = {}) {
+  const context = doc?.modelContext ?? nav?.modelContext ?? null
+  // A stub that cannot register a tool is no more useful than no API at all,
+  // and treating it as present would mean reporting tools that do not exist.
+  return context && typeof context.registerTool === 'function' ? context : null
+}
+
+/**
+ * Register a catalogue of tools with the browser.
+ *
+ * Every tool is registered against the same `AbortSignal`, which is how WebMCP
+ * spells "unregister": aborting the controller withdraws them all at once. That
+ * matters here because the tools act as the signed-in user — when the session
+ * ends they have to stop being offered.
+ *
+ * Registration is per-tool and failures are collected rather than thrown: a
+ * schema the browser dislikes should cost the app that one tool, not the whole
+ * catalogue and not the page.
+ *
+ * @param {Array<object>} tools from `./tools.js`
+ * @param {{ context?: object|null, signal?: AbortSignal }} [options]
+ * @returns {Promise<{ status: string, registered: string[], refused: Array<{ name: string, reason: string }> }>}
+ */
+export async function registerTools(tools, { context = getModelContext(), signal } = {}) {
+  if (!context) return { status: WebMCPStatus.Unsupported, registered: [], refused: [] }
+
+  const registered = []
+  const refused = []
+
+  for (const tool of tools) {
+    try {
+      // `signal` goes in the options bag, not the descriptor: it is how the
+      // registration is withdrawn, not something the agent sees.
+      await context.registerTool(tool, signal ? { signal } : {})
+      registered.push(tool.name)
+    } catch (err) {
+      refused.push({ name: tool.name, reason: err?.message || String(err) })
+    }
+  }
+
+  // Nothing registered out of a non-empty catalogue means the browser said no
+  // to all of it — a permissions policy, most likely. Worth distinguishing from
+  // "this browser has no WebMCP", because only one of the two is fixable.
+  const status = registered.length === 0 && tools.length > 0 ? WebMCPStatus.Refused : WebMCPStatus.Registered
+  return { status, registered, refused }
+}

--- a/frontend/src/webmcp/tools.js
+++ b/frontend/src/webmcp/tools.js
@@ -1,0 +1,641 @@
+/**
+ * The WebMCP tool catalogue: everything the AgentRQ interface can do, offered
+ * to an agent running in the browser.
+ *
+ * The rule this file follows is that the catalogue mirrors `src/api.js`. That
+ * module *is* the interface's capability surface — every button in the app
+ * ends up calling one of its functions — so mirroring it is what makes
+ * "anything you can do in the UI" a checkable claim rather than an aspiration.
+ * A new API function without a tool here is a gap; that is the invariant to
+ * keep.
+ *
+ * Two tools have no API function behind them, and they are the reason this is
+ * WebMCP rather than a published HTTP API: `getCurrentPage` and `navigate` let
+ * an agent see and change what the person is actually looking at. "Reply to the
+ * task I have open" is answerable here and nowhere else.
+ *
+ * Everything is injected — the API client and the router — so the catalogue is
+ * a pure function of its dependencies and can be tested without a browser, a
+ * network or a Vue app.
+ *
+ * Naming follows the MCP server in `backend/internal/controller/mcp`: an agent
+ * that can see both surfaces sees one vocabulary, and `createTask` means the
+ * same thing on each. Field names are camelCase, as every other AgentRQ API
+ * surface is.
+ */
+
+/** JSON Schema fragments, named once so the catalogue reads as intent. */
+const str = (description) => ({ type: 'string', description })
+const bool = (description) => ({ type: 'boolean', description })
+const int = (description) => ({ type: 'integer', description })
+
+const WORKSPACE_ID = str('The workspace ID (base62), as it appears in the URL.')
+const TASK_ID = str('The task ID (base62), as it appears in the URL.')
+
+/**
+ * Build a WebMCP tool descriptor.
+ *
+ * `readOnly` and `destructive` become the annotations an agent uses to decide
+ * what it may do unattended. They are set from the operation itself rather than
+ * left to each entry to remember: a tool that only reads is annotated as such,
+ * and anything that removes data says so.
+ */
+function tool({ name, description, properties = {}, required = [], readOnly = false, destructive = false, run }) {
+  return {
+    name,
+    description,
+    inputSchema: { type: 'object', properties, required },
+    annotations: {
+      readOnlyHint: readOnly,
+      // Both spellings: MCP annotates removal with `destructiveHint`, while the
+      // WebMCP draft asks whether an action is consequential. Unknown members
+      // are ignored, and being understood by both is worth more than guessing.
+      destructiveHint: destructive,
+      consequentialHint: !readOnly,
+    },
+    execute: run,
+  }
+}
+
+/**
+ * Everything the interface can do.
+ *
+ * @param {object} deps
+ * @param {object} deps.api the `src/api.js` module, or a stand-in
+ * @param {(path: string) => Promise<unknown>} deps.navigate router push
+ * @param {() => { path: string, params: object, query: object }} deps.currentPage
+ *        where the person is right now
+ * @returns {Array<object>} descriptors ready for `registerTools`
+ */
+export function createToolCatalogue({ api, navigate, currentPage }) {
+  return [
+    // ---- Where the person is, and taking them elsewhere --------------------
+    tool({
+      name: 'getCurrentPage',
+      description:
+        'Where the user is right now in the AgentRQ interface: the route path and its parameters. ' +
+        'Call this first to resolve phrases like "this task" or "the workspace I am looking at" ' +
+        'into the IDs the other tools need.',
+      readOnly: true,
+      run: () => currentPage(),
+    }),
+    tool({
+      name: 'navigate',
+      description:
+        'Open a page in the AgentRQ interface, moving the user there. Paths are the ones in the ' +
+        'address bar, for example "/", "/tasks/ongoing", "/workspaces/<workspaceId>/board", ' +
+        '"/workspaces/<workspaceId>/tasks/<taskId>", "/events", "/workflows".',
+      properties: { path: str('An in-app path beginning with "/".') },
+      required: ['path'],
+      run: async ({ path }) => {
+        await navigate(path)
+        return { navigatedTo: path }
+      },
+    }),
+
+    tool({
+      name: 'getCurrentUser',
+      description: 'Who is signed in. Everything else these tools do is done as this user.',
+      readOnly: true,
+      run: () => api.fetchUser(),
+    }),
+
+    // ---- Workspaces --------------------------------------------------------
+    tool({
+      name: 'listWorkspaces',
+      description: 'Every workspace the signed-in user can see.',
+      properties: { includeArchived: bool('Include archived workspaces. Defaults to false.') },
+      readOnly: true,
+      run: ({ includeArchived = false } = {}) => api.fetchWorkspaces(includeArchived),
+    }),
+    tool({
+      name: 'getWorkspace',
+      description: 'One workspace, including its mission description and settings.',
+      properties: { workspaceId: WORKSPACE_ID },
+      required: ['workspaceId'],
+      readOnly: true,
+      run: ({ workspaceId }) => api.getWorkspace(workspaceId),
+    }),
+    tool({
+      name: 'createWorkspace',
+      description: 'Create a workspace. The description is the mission agents are given.',
+      properties: {
+        name: str('Display name.'),
+        description: str('The mission: what agents in this workspace are for.'),
+        icon: str('Optional emoji shown beside the name.'),
+        selfLearningLoopNote: str('Optional standing note appended to every task in this workspace.'),
+        workingDirectory: str('Optional absolute path agents run in.'),
+      },
+      required: ['name', 'description'],
+      run: ({ name, description, icon = '', selfLearningLoopNote = '', workingDirectory = '' }) =>
+        api.createWorkspace(name, description, icon, selfLearningLoopNote, workingDirectory),
+    }),
+    tool({
+      name: 'updateWorkspace',
+      description: 'Change a workspace. Only the fields given are altered.',
+      properties: {
+        workspaceId: WORKSPACE_ID,
+        name: str('New display name.'),
+        description: str('New mission description.'),
+        icon: str('New emoji.'),
+        selfLearningLoopNote: str('New standing note.'),
+        workingDirectory: str('New working directory.'),
+      },
+      required: ['workspaceId'],
+      run: ({ workspaceId, ...fields }) => api.updateWorkspace(workspaceId, fields),
+    }),
+    tool({
+      name: 'archiveWorkspace',
+      description: 'Archive a workspace, hiding it from the default list without deleting anything.',
+      properties: { workspaceId: WORKSPACE_ID },
+      required: ['workspaceId'],
+      run: ({ workspaceId }) => api.archiveWorkspace(workspaceId),
+    }),
+    tool({
+      name: 'unarchiveWorkspace',
+      description: 'Restore an archived workspace to the default list.',
+      properties: { workspaceId: WORKSPACE_ID },
+      required: ['workspaceId'],
+      run: ({ workspaceId }) => api.unarchiveWorkspace(workspaceId),
+    }),
+    tool({
+      name: 'deleteWorkspace',
+      description:
+        'Permanently delete a workspace and everything in it. This cannot be undone — prefer ' +
+        'archiveWorkspace unless the user has asked for deletion in so many words.',
+      properties: { workspaceId: WORKSPACE_ID },
+      required: ['workspaceId'],
+      destructive: true,
+      run: ({ workspaceId }) => api.deleteWorkspace(workspaceId),
+    }),
+    tool({
+      name: 'getWorkspaceToken',
+      description:
+        'The workspace token an agent uses to connect to this workspace over MCP. ' +
+        'This is a credential: show it to the user, never paste it into anything else.',
+      properties: { workspaceId: WORKSPACE_ID },
+      required: ['workspaceId'],
+      readOnly: true,
+      run: ({ workspaceId }) => api.getWorkspaceToken(workspaceId),
+    }),
+    tool({
+      name: 'getWorkspaceStats',
+      description: 'Activity statistics for a workspace over a time range.',
+      properties: {
+        workspaceId: WORKSPACE_ID,
+        range: str('Range such as "7d" or "30d". Defaults to "7d".'),
+        from: int('Optional start as a Unix timestamp.'),
+        to: int('Optional end as a Unix timestamp.'),
+      },
+      required: ['workspaceId'],
+      readOnly: true,
+      run: ({ workspaceId, range = '7d', from = 0, to = 0 }) =>
+        api.fetchWorkspaceStats(workspaceId, range, from, to),
+    }),
+    tool({
+      name: 'setWorkspaceSlackChannel',
+      description: 'Connect a workspace to a Slack channel so its activity is posted there.',
+      properties: {
+        workspaceId: WORKSPACE_ID,
+        channelId: str('Slack channel ID.'),
+        channelName: str('Slack channel name, for display.'),
+      },
+      required: ['workspaceId', 'channelId', 'channelName'],
+      run: ({ workspaceId, channelId, channelName }) =>
+        api.setWorkspaceSlackChannel(workspaceId, channelId, channelName),
+    }),
+    tool({
+      name: 'removeWorkspaceSlackChannel',
+      description: 'Disconnect a workspace from its Slack channel.',
+      properties: { workspaceId: WORKSPACE_ID },
+      required: ['workspaceId'],
+      run: ({ workspaceId }) => api.removeWorkspaceSlackChannel(workspaceId),
+    }),
+
+    // ---- Tasks -------------------------------------------------------------
+    tool({
+      name: 'listTasks',
+      description:
+        'Tasks in one workspace, or across every workspace when workspaceId is omitted. ' +
+        'Statuses are notstarted, ongoing, completed, rejected, cron and blocked.',
+      properties: {
+        workspaceId: str('Restrict to one workspace. Omit for all workspaces.'),
+        status: str('Filter by status.'),
+        filter: str('Named filter, as used by the /tasks/<filter> pages.'),
+        limit: int('How many to return. Defaults to 10.'),
+        offset: int('How many to skip, for paging.'),
+      },
+      readOnly: true,
+      run: ({ workspaceId, ...options } = {}) =>
+        workspaceId ? api.fetchTasks(workspaceId, options) : api.fetchGlobalTasks(options),
+    }),
+    tool({
+      name: 'getTask',
+      description: 'One task in full, including its conversation.',
+      properties: { workspaceId: WORKSPACE_ID, taskId: TASK_ID },
+      required: ['workspaceId', 'taskId'],
+      readOnly: true,
+      run: ({ workspaceId, taskId }) => api.getTask(workspaceId, taskId),
+    }),
+    tool({
+      name: 'createTask',
+      description:
+        'Create a task in a workspace. Assign it to an agent to have it worked on, or to a human ' +
+        'to make it a to-do. A cronSchedule makes it recurring, and must be hourly at coarsest: ' +
+        'the minute field is a single fixed number.',
+      properties: {
+        workspaceId: WORKSPACE_ID,
+        title: str('Short title.'),
+        body: str('The task itself, in markdown.'),
+        assignee: str('"agent" or "human". Defaults to "agent".'),
+        status: str('Initial status. Defaults to "notstarted".'),
+        cronSchedule: str('Optional cron expression, making this a recurring task.'),
+        allowAllCommands: bool('Let the agent run commands without asking each time.'),
+        eventId: str('Optional event this task publishes when it completes.'),
+        workflowId: str('Optional workflow this task belongs to.'),
+      },
+      required: ['workspaceId', 'title', 'body'],
+      run: ({
+        workspaceId,
+        title,
+        body,
+        assignee = 'agent',
+        status = 'notstarted',
+        cronSchedule = '',
+        allowAllCommands = false,
+        eventId = '',
+        workflowId = '',
+      }) =>
+        api.createTask(
+          workspaceId,
+          title,
+          body,
+          assignee,
+          [],
+          status,
+          cronSchedule,
+          allowAllCommands,
+          eventId,
+          workflowId
+        ),
+    }),
+    tool({
+      name: 'replyToTask',
+      description: 'Send a message in a task conversation, as the signed-in user.',
+      properties: { workspaceId: WORKSPACE_ID, taskId: TASK_ID, text: str('The message.') },
+      required: ['workspaceId', 'taskId', 'text'],
+      run: ({ workspaceId, taskId, text }) => api.replyToTask(workspaceId, taskId, text),
+    }),
+    tool({
+      name: 'respondToTask',
+      description:
+        'Answer a task that is waiting on the user — accepting or rejecting what was proposed.',
+      properties: {
+        workspaceId: WORKSPACE_ID,
+        taskId: TASK_ID,
+        action: str('The response action, such as "accept" or "reject".'),
+        text: str('Optional message to send with it.'),
+      },
+      required: ['workspaceId', 'taskId', 'action'],
+      run: ({ workspaceId, taskId, action, text = '' }) =>
+        api.respondToTask(workspaceId, taskId, action, text),
+    }),
+    tool({
+      name: 'updateTaskStatus',
+      description:
+        'Set a task\'s status: notstarted, ongoing, completed, rejected, cron or blocked.',
+      properties: { workspaceId: WORKSPACE_ID, taskId: TASK_ID, status: str('The new status.') },
+      required: ['workspaceId', 'taskId', 'status'],
+      run: ({ workspaceId, taskId, status }) => api.updateTaskStatus(workspaceId, taskId, status),
+    }),
+    tool({
+      name: 'updateTaskAssignee',
+      description: 'Hand a task to the agent or back to a human.',
+      properties: { workspaceId: WORKSPACE_ID, taskId: TASK_ID, assignee: str('"agent" or "human".') },
+      required: ['workspaceId', 'taskId', 'assignee'],
+      run: ({ workspaceId, taskId, assignee }) => api.updateTaskAssignee(workspaceId, taskId, assignee),
+    }),
+    tool({
+      name: 'updateTaskOrder',
+      description: 'Reorder a task on the board.',
+      properties: { workspaceId: WORKSPACE_ID, taskId: TASK_ID, order: int('The new position.') },
+      required: ['workspaceId', 'taskId', 'order'],
+      run: ({ workspaceId, taskId, order }) => api.updateTaskOrder(workspaceId, taskId, order),
+    }),
+    tool({
+      name: 'moveTask',
+      description: 'Move a task to a different workspace.',
+      properties: {
+        workspaceId: WORKSPACE_ID,
+        taskId: TASK_ID,
+        destinationWorkspaceId: str('The workspace to move it into.'),
+      },
+      required: ['workspaceId', 'taskId', 'destinationWorkspaceId'],
+      run: ({ workspaceId, taskId, destinationWorkspaceId }) =>
+        api.moveTask(workspaceId, taskId, destinationWorkspaceId),
+    }),
+    tool({
+      name: 'updateTaskAllowAllCommands',
+      description:
+        'Turn off (or back on) the per-command permission prompts for one task. Turning it on ' +
+        'lets the agent run anything in that task without asking, so confirm with the user first.',
+      properties: {
+        workspaceId: WORKSPACE_ID,
+        taskId: TASK_ID,
+        allowAllCommands: bool('Whether the agent may run commands unprompted.'),
+      },
+      required: ['workspaceId', 'taskId', 'allowAllCommands'],
+      run: ({ workspaceId, taskId, allowAllCommands }) =>
+        api.updateTaskAllowAllCommands(workspaceId, taskId, allowAllCommands),
+    }),
+    tool({
+      name: 'stopTask',
+      description: 'Interrupt a running task. Refuses when whatever is connected has no stop.',
+      properties: { workspaceId: WORKSPACE_ID, taskId: TASK_ID },
+      required: ['workspaceId', 'taskId'],
+      run: ({ workspaceId, taskId }) => api.stopTask(workspaceId, taskId),
+    }),
+    tool({
+      name: 'deleteTask',
+      description: 'Permanently delete a task and its conversation. This cannot be undone.',
+      properties: { workspaceId: WORKSPACE_ID, taskId: TASK_ID },
+      required: ['workspaceId', 'taskId'],
+      destructive: true,
+      run: ({ workspaceId, taskId }) => api.deleteTask(workspaceId, taskId),
+    }),
+    tool({
+      name: 'sendPermissionVerdict',
+      description:
+        'Answer an agent asking permission to run something. This is the prompt the user sees in ' +
+        'the task; only answer it on their instruction.',
+      properties: {
+        workspaceId: WORKSPACE_ID,
+        taskId: TASK_ID,
+        requestId: str('The permission request being answered.'),
+        behavior: str('The verdict, such as "allow" or "deny".'),
+      },
+      required: ['workspaceId', 'taskId', 'requestId', 'behavior'],
+      run: ({ workspaceId, taskId, requestId, behavior }) =>
+        api.sendPermissionVerdict(workspaceId, taskId, requestId, behavior),
+    }),
+    tool({
+      name: 'respondToElicitation',
+      description: 'Answer a question an agent asked the user inside a task.',
+      properties: {
+        workspaceId: WORKSPACE_ID,
+        taskId: TASK_ID,
+        requestId: str('The question being answered.'),
+        action: str('"accept", "decline" or "cancel".'),
+        content: { type: 'object', description: 'The answer, shaped by the question that was asked.' },
+      },
+      required: ['workspaceId', 'taskId', 'requestId', 'action'],
+      run: ({ workspaceId, taskId, requestId, action, content = {} }) =>
+        api.respondToElicitation(workspaceId, taskId, requestId, action, content),
+    }),
+    tool({
+      name: 'updateScheduledTask',
+      description:
+        'Change the template of a recurring task — what each future run will be given. ' +
+        'The cron schedule must stay hourly at coarsest.',
+      properties: {
+        workspaceId: WORKSPACE_ID,
+        taskId: TASK_ID,
+        title: str('New title.'),
+        body: str('New body.'),
+        assignee: str('"agent" or "human".'),
+        cronSchedule: str('New cron expression.'),
+        allowAllCommands: bool('Whether runs may execute commands unprompted.'),
+      },
+      required: ['workspaceId', 'taskId', 'title', 'body', 'assignee', 'cronSchedule'],
+      run: ({ workspaceId, taskId, title, body, assignee, cronSchedule, allowAllCommands = false }) =>
+        api.updateScheduledTask(workspaceId, taskId, title, body, assignee, cronSchedule, allowAllCommands),
+    }),
+    tool({
+      name: 'getTaskCounts',
+      description: 'How many tasks a workspace has in each status.',
+      properties: { workspaceId: WORKSPACE_ID },
+      required: ['workspaceId'],
+      readOnly: true,
+      run: ({ workspaceId }) => api.fetchTaskCounts(workspaceId),
+    }),
+    tool({
+      name: 'getGlobalTaskStats',
+      description: 'Task statistics across every workspace the user can see.',
+      readOnly: true,
+      run: () => api.fetchGlobalTaskStats(),
+    }),
+
+    // ---- Events ------------------------------------------------------------
+    tool({
+      name: 'listEvents',
+      description:
+        'Named signals that let a task in one workspace start tasks in another.',
+      readOnly: true,
+      run: () => api.fetchEvents(),
+    }),
+    tool({
+      name: 'getEvent',
+      description: 'One event, with its payload guidelines.',
+      properties: { eventId: str('The event ID.') },
+      required: ['eventId'],
+      readOnly: true,
+      run: ({ eventId }) => api.getEvent(eventId),
+    }),
+    tool({
+      name: 'createEvent',
+      description: 'Create a named event that tasks can publish.',
+      properties: {
+        name: str('Event name, as agents will publish it.'),
+        payloadGuidelines: str('What a publisher should put in the payload.'),
+      },
+      required: ['name'],
+      run: ({ name, payloadGuidelines = '' }) => api.createEvent(name, payloadGuidelines),
+    }),
+    tool({
+      name: 'updateEvent',
+      description: 'Change an event\'s payload guidelines.',
+      properties: { eventId: str('The event ID.'), payloadGuidelines: str('New guidelines.') },
+      required: ['eventId', 'payloadGuidelines'],
+      run: ({ eventId, payloadGuidelines }) => api.updateEvent(eventId, payloadGuidelines),
+    }),
+    tool({
+      name: 'deleteEvent',
+      description: 'Permanently delete an event and its triggers.',
+      properties: { eventId: str('The event ID.') },
+      required: ['eventId'],
+      destructive: true,
+      run: ({ eventId }) => api.deleteEvent(eventId),
+    }),
+    tool({
+      name: 'listEventTriggers',
+      description: 'The triggers on an event: what each publish creates, and where.',
+      properties: { eventId: str('The event ID.') },
+      required: ['eventId'],
+      readOnly: true,
+      run: ({ eventId }) => api.fetchEventTriggers(eventId),
+    }),
+    tool({
+      name: 'createEventTrigger',
+      description:
+        'Add a trigger, so publishing this event creates a task. In the body, {{EVENT_PAYLOAD}} ' +
+        'and {{EVENT_FAQ}} are replaced with what the publisher sent; the title is always literal.',
+      properties: {
+        eventId: str('The event to trigger on.'),
+        workspaceId: str('Where the task is created.'),
+        title: str('Task title. Substitutions are not applied here.'),
+        body: str('Task body, which may use {{EVENT_PAYLOAD}} and {{EVENT_FAQ}}.'),
+        assignee: str('"agent" or "human". Defaults to "agent".'),
+        cronSchedule: str('Optional cron expression.'),
+        allowAllCommands: bool('Let the created task run commands unprompted.'),
+        emitEventId: str('Optional second event published when the created task completes.'),
+      },
+      required: ['eventId', 'workspaceId', 'title'],
+      run: ({ eventId, ...trigger }) => api.createEventTrigger(eventId, trigger),
+    }),
+    tool({
+      name: 'updateEventTrigger',
+      description: 'Change what a trigger creates.',
+      properties: {
+        eventId: str('The event the trigger belongs to.'),
+        triggerId: str('The trigger being changed.'),
+        workspaceId: str('Where the task is created.'),
+        title: str('Task title.'),
+        body: str('Task body.'),
+        assignee: str('"agent" or "human".'),
+        cronSchedule: str('Optional cron expression.'),
+        allowAllCommands: bool('Let the created task run commands unprompted.'),
+        emitEventId: str('Optional second event published on completion.'),
+      },
+      required: ['eventId', 'triggerId', 'workspaceId', 'title'],
+      run: ({ eventId, triggerId, ...trigger }) => api.updateEventTrigger(eventId, triggerId, trigger),
+    }),
+    tool({
+      name: 'deleteEventTrigger',
+      description: 'Remove a trigger, so this event stops creating that task.',
+      properties: { eventId: str('The event ID.'), triggerId: str('The trigger ID.') },
+      required: ['eventId', 'triggerId'],
+      destructive: true,
+      run: ({ eventId, triggerId }) => api.deleteEventTrigger(eventId, triggerId),
+    }),
+    tool({
+      name: 'listEventTasks',
+      description: 'Tasks that were spawned by an event.',
+      properties: { eventId: str('The event ID.') },
+      required: ['eventId'],
+      readOnly: true,
+      run: ({ eventId }) => api.fetchEventTasks(eventId),
+    }),
+
+    // ---- Workflows ---------------------------------------------------------
+    tool({
+      name: 'listWorkflows',
+      description: 'Workflows: chains of events and the tasks they create.',
+      readOnly: true,
+      run: () => api.fetchWorkflows(),
+    }),
+    tool({
+      name: 'getWorkflow',
+      description: 'One workflow, with its layout and starting event.',
+      properties: { workflowId: str('The workflow ID.') },
+      required: ['workflowId'],
+      readOnly: true,
+      run: ({ workflowId }) => api.getWorkflow(workflowId),
+    }),
+    tool({
+      name: 'createWorkflow',
+      description:
+        'Create a workflow: a named chain in which one event\'s task publishes the next event. ' +
+        'Add its steps with createWorkflowStep, or write the whole thing with replaceWorkflowFromText.',
+      properties: {
+        name: str('Workflow name.'),
+        description: str('What the workflow is for.'),
+        startEventId: str('Optional event that starts it.'),
+      },
+      required: ['name'],
+      run: ({ name, description = '', startEventId = '' }) =>
+        api.createWorkflow({ name, description, startEventId }),
+    }),
+    tool({
+      name: 'updateWorkflow',
+      description: 'Change a workflow. Only the fields given are altered.',
+      properties: {
+        workflowId: str('The workflow ID.'),
+        name: str('New name.'),
+        description: str('New description.'),
+        startEventId: str('New starting event.'),
+      },
+      required: ['workflowId'],
+      run: ({ workflowId, ...fields }) => api.updateWorkflow(workflowId, fields),
+    }),
+    tool({
+      name: 'deleteWorkflow',
+      description: 'Permanently delete a workflow and its steps.',
+      properties: { workflowId: str('The workflow ID.') },
+      required: ['workflowId'],
+      destructive: true,
+      run: ({ workflowId }) => api.deleteWorkflow(workflowId),
+    }),
+    tool({
+      name: 'listWorkflowSteps',
+      description: 'The steps of a workflow: which event creates which task, where.',
+      properties: { workflowId: str('The workflow ID.') },
+      required: ['workflowId'],
+      readOnly: true,
+      run: ({ workflowId }) => api.fetchWorkflowSteps(workflowId),
+    }),
+    tool({
+      name: 'createWorkflowStep',
+      description:
+        'Add a step: when the given event fires, create this task. Refused when it would ' +
+        'introduce a cycle, and the refusal says which connection was rejected.',
+      properties: {
+        workflowId: str('The workflow ID.'),
+        eventId: str('The event this step listens for.'),
+        workspaceId: str('Where the task is created.'),
+        title: str('Task title.'),
+        body: str('Task body.'),
+        assignee: str('"agent" or "human". Defaults to "agent".'),
+        allowAllCommands: bool('Let the created task run commands unprompted.'),
+        emitEventId: str('Optional event published when the created task completes.'),
+      },
+      required: ['workflowId', 'eventId', 'workspaceId', 'title'],
+      run: ({ workflowId, ...step }) => api.createWorkflowStep(workflowId, step),
+    }),
+    tool({
+      name: 'deleteWorkflowStep',
+      description: 'Remove one step from a workflow.',
+      properties: { workflowId: str('The workflow ID.'), stepId: str('The step ID.') },
+      required: ['workflowId', 'stepId'],
+      destructive: true,
+      run: ({ workflowId, stepId }) => api.deleteWorkflowStep(workflowId, stepId),
+    }),
+    tool({
+      name: 'listWorkflowTasks',
+      description: 'Tasks a workflow has created.',
+      properties: { workflowId: str('The workflow ID.') },
+      required: ['workflowId'],
+      readOnly: true,
+      run: ({ workflowId }) => api.fetchWorkflowTasks(workflowId),
+    }),
+    tool({
+      name: 'getWorkflowText',
+      description:
+        'A workflow as editable text — the whole thing in one document, which is usually easier ' +
+        'to reason about than the steps one at a time.',
+      properties: { workflowId: str('The workflow ID.') },
+      required: ['workflowId'],
+      readOnly: true,
+      run: ({ workflowId }) => api.fetchWorkflowText(workflowId),
+    }),
+    tool({
+      name: 'replaceWorkflowFromText',
+      description:
+        'Replace a workflow with the one described by this text. Everything not in the text is ' +
+        'removed, so read it with getWorkflowText and edit that rather than composing from scratch.',
+      properties: { workflowId: str('The workflow ID.'), text: str('The full workflow document.') },
+      required: ['workflowId', 'text'],
+      destructive: true,
+      run: ({ workflowId, text }) => api.replaceWorkflowFromText(workflowId, text),
+    }),
+  ]
+}

--- a/frontend/test/useWebMCP.test.js
+++ b/frontend/test/useWebMCP.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ref } from 'vue';
+
+import { connectWebMCP, describePage } from '../src/composables/useWebMCP';
+import { WebMCPStatus } from '../src/webmcp/modelContext';
+
+const routerAt = (route) => ({ push: vi.fn().mockResolvedValue(undefined), currentRoute: ref(route) });
+
+describe('describePage', () => {
+  it('hands over the route params, which are what an agent needs', () => {
+    const page = describePage({
+      path: '/workspaces/ws1/tasks/t1',
+      params: { id: 'ws1', taskId: 't1' },
+      query: { tab: 'trajectory' },
+    });
+
+    expect(page).toEqual({
+      path: '/workspaces/ws1/tasks/t1',
+      params: { id: 'ws1', taskId: 't1' },
+      query: { tab: 'trajectory' },
+    });
+  });
+
+  it('copies rather than exposing the router\'s own objects', () => {
+    const params = { id: 'ws1' };
+
+    const page = describePage({ path: '/', params, query: {} });
+    params.id = 'ws2';
+
+    expect(page.params.id).toBe('ws1');
+  });
+
+  it('describes something sane before the router has a route', () => {
+    expect(describePage(undefined)).toEqual({ path: '/', params: {}, query: {} });
+  });
+});
+
+describe('connectWebMCP', () => {
+  const context = () => ({ registerTool: vi.fn().mockResolvedValue(undefined) });
+
+  it('registers the whole catalogue', async () => {
+    const ctx = context();
+
+    const result = await connectWebMCP({ api: {}, router: routerAt({ path: '/' }), context: ctx });
+
+    expect(result.status).toBe(WebMCPStatus.Registered);
+    expect(result.registered).toContain('createTask');
+    expect(result.registered).toContain('getCurrentPage');
+    expect(ctx.registerTool).toHaveBeenCalledTimes(result.registered.length);
+  });
+
+  it('routes the navigate tool through the app\'s own router', async () => {
+    const ctx = context();
+    const router = routerAt({ path: '/' });
+    await connectWebMCP({ api: {}, router, context: ctx });
+
+    const navigate = ctx.registerTool.mock.calls.map(([t]) => t).find((t) => t.name === 'navigate');
+    await navigate.execute({ path: '/events' }, {});
+
+    // Not location.href: a full page load would drop the SPA's state.
+    expect(router.push).toHaveBeenCalledWith('/events');
+  });
+
+  it('answers getCurrentPage from where the user is now, not where they were', async () => {
+    const ctx = context();
+    const router = routerAt({ path: '/', params: {}, query: {} });
+    await connectWebMCP({ api: {}, router, context: ctx });
+
+    const currentPage = ctx.registerTool.mock.calls.map(([t]) => t).find((t) => t.name === 'getCurrentPage');
+    // The tools stay registered while the person moves around the app.
+    router.currentRoute.value = { path: '/workspaces/ws1/board', params: { id: 'ws1' }, query: {} };
+
+    expect(await currentPage.execute({}, {})).toEqual({
+      path: '/workspaces/ws1/board',
+      params: { id: 'ws1' },
+      query: {},
+    });
+  });
+
+  it('withdraws every tool at once when the session ends', async () => {
+    const ctx = context();
+    const result = await connectWebMCP({ api: {}, router: routerAt({ path: '/' }), context: ctx });
+
+    // The signal each tool was registered against is the unregister mechanism.
+    const signals = ctx.registerTool.mock.calls.map(([, options]) => options.signal);
+    expect(new Set(signals).size).toBe(1);
+    expect(signals[0].aborted).toBe(false);
+
+    result.unregister();
+
+    expect(signals[0].aborted).toBe(true);
+  });
+
+  it('reports an unsupported browser without touching anything', async () => {
+    const result = await connectWebMCP({ api: {}, router: routerAt({ path: '/' }), context: null });
+
+    expect(result.status).toBe(WebMCPStatus.Unsupported);
+    expect(result.registered).toEqual([]);
+    // Still safe to call, so the caller needs no branch of its own.
+    expect(() => result.unregister()).not.toThrow();
+  });
+});

--- a/frontend/test/webmcpModelContext.test.js
+++ b/frontend/test/webmcpModelContext.test.js
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { WebMCPStatus, getModelContext, registerTools } from '../src/webmcp/modelContext';
+
+const workingContext = () => ({ registerTool: vi.fn().mockResolvedValue(undefined) });
+
+describe('getModelContext', () => {
+  it('prefers document.modelContext, the current spelling', () => {
+    const onDocument = workingContext();
+    const onNavigator = workingContext();
+
+    expect(getModelContext({ document: { modelContext: onDocument }, navigator: { modelContext: onNavigator } }))
+      .toBe(onDocument);
+  });
+
+  it('still finds navigator.modelContext, which older browsers have', () => {
+    // Deprecated in Chromium 150, but a browser that has not moved yet is
+    // still a browser with WebMCP.
+    const onNavigator = workingContext();
+
+    expect(getModelContext({ document: {}, navigator: { modelContext: onNavigator } })).toBe(onNavigator);
+  });
+
+  it('reports nothing where the browser has no WebMCP', () => {
+    // The ordinary case, and not an error.
+    expect(getModelContext({ document: {}, navigator: {} })).toBeNull();
+  });
+
+  it('survives a context with neither global, as in a worker', () => {
+    expect(getModelContext({ document: undefined, navigator: undefined })).toBeNull();
+  });
+
+  it('rejects an object that cannot register a tool', () => {
+    // Reporting tools against a stub would claim capabilities that do not exist.
+    expect(getModelContext({ document: { modelContext: {} }, navigator: {} })).toBeNull();
+    expect(getModelContext({ document: { modelContext: { registerTool: 'nope' } }, navigator: {} })).toBeNull();
+  });
+});
+
+describe('registerTools', () => {
+  const tools = [
+    { name: 'listWorkspaces', execute: () => {} },
+    { name: 'createTask', execute: () => {} },
+  ];
+
+  it('registers every tool and says which', async () => {
+    const context = workingContext();
+
+    const result = await registerTools(tools, { context });
+
+    expect(result.status).toBe(WebMCPStatus.Registered);
+    expect(result.registered).toEqual(['listWorkspaces', 'createTask']);
+    expect(result.refused).toEqual([]);
+    expect(context.registerTool).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes the abort signal, which is how a tool is withdrawn', async () => {
+    const context = workingContext();
+    const signal = new AbortController().signal;
+
+    await registerTools(tools, { context, signal });
+
+    expect(context.registerTool).toHaveBeenCalledWith(tools[0], { signal });
+  });
+
+  it('omits the options bag when there is no signal to pass', async () => {
+    const context = workingContext();
+
+    await registerTools([tools[0]], { context });
+
+    expect(context.registerTool).toHaveBeenCalledWith(tools[0], {});
+  });
+
+  it('does nothing at all where WebMCP is unsupported', async () => {
+    const result = await registerTools(tools, { context: null });
+
+    expect(result).toEqual({ status: WebMCPStatus.Unsupported, registered: [], refused: [] });
+  });
+
+  it('keeps the rest of the catalogue when one tool is refused', async () => {
+    // A schema the browser dislikes should cost that one tool, not the page.
+    const context = {
+      registerTool: vi.fn()
+        .mockRejectedValueOnce(new Error('InvalidStateError: bad schema'))
+        .mockResolvedValueOnce(undefined),
+    };
+
+    const result = await registerTools(tools, { context });
+
+    expect(result.status).toBe(WebMCPStatus.Registered);
+    expect(result.registered).toEqual(['createTask']);
+    expect(result.refused).toEqual([{ name: 'listWorkspaces', reason: 'InvalidStateError: bad schema' }]);
+  });
+
+  it('describes a thrown non-error too', async () => {
+    const context = { registerTool: vi.fn().mockRejectedValue('nope') };
+
+    const { refused } = await registerTools([tools[0]], { context });
+
+    expect(refused).toEqual([{ name: 'listWorkspaces', reason: 'nope' }]);
+  });
+
+  it('separates a browser that refused everything from one that has no WebMCP', async () => {
+    // Only one of the two is something the deployment can fix.
+    const context = { registerTool: vi.fn().mockRejectedValue(new Error('NotAllowedError')) };
+
+    const result = await registerTools(tools, { context });
+
+    expect(result.status).toBe(WebMCPStatus.Refused);
+    expect(result.registered).toEqual([]);
+  });
+
+  it('is not "refused" when there was nothing to register', async () => {
+    const result = await registerTools([], { context: workingContext() });
+
+    expect(result.status).toBe(WebMCPStatus.Registered);
+  });
+
+  it('looks the browser up itself when given no context', async () => {
+    // The production path: no injection, so it must find document.modelContext.
+    const context = workingContext();
+    document.modelContext = context;
+    try {
+      const result = await registerTools([tools[0]]);
+      expect(result.registered).toEqual(['listWorkspaces']);
+    } finally {
+      delete document.modelContext;
+    }
+  });
+});

--- a/frontend/test/webmcpTools.test.js
+++ b/frontend/test/webmcpTools.test.js
@@ -1,0 +1,430 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { createToolCatalogue } from '../src/webmcp/tools';
+import * as api from '../src/api';
+
+/**
+ * An input carrying every field any tool asks for, so one object can drive the
+ * whole catalogue. Tools destructure what they need and ignore the rest.
+ */
+const EVERY_FIELD = {
+  workspaceId: 'ws1',
+  taskId: 't1',
+  destinationWorkspaceId: 'ws2',
+  eventId: 'e1',
+  triggerId: 'tr1',
+  workflowId: 'wf1',
+  stepId: 'st1',
+  requestId: 'req1',
+  path: '/events',
+  name: 'a name',
+  title: 'a title',
+  body: 'a body',
+  text: 'some text',
+  description: 'a description',
+  status: 'ongoing',
+  assignee: 'agent',
+  behavior: 'allow',
+  action: 'accept',
+  content: { answer: 'yes' },
+  order: 3,
+  allowAllCommands: true,
+  cronSchedule: '0 9 * * *',
+  channelId: 'C1',
+  channelName: 'general',
+  payloadGuidelines: 'what to send',
+  startEventId: 'e0',
+  emitEventId: 'e2',
+  includeArchived: true,
+  range: '30d',
+};
+
+/** An API stand-in that records what the catalogue asked of it. */
+function recordingApi() {
+  const calls = [];
+  const stub = new Proxy(
+    {},
+    {
+      get: (_target, method) => (...args) => {
+        calls.push({ method, args });
+        return Promise.resolve({ ok: true });
+      },
+    }
+  );
+  return { stub, calls };
+}
+
+const build = (overrides = {}) =>
+  createToolCatalogue({
+    api: recordingApi().stub,
+    navigate: vi.fn().mockResolvedValue(undefined),
+    currentPage: () => ({ path: '/', params: {}, query: {} }),
+    ...overrides,
+  });
+
+describe('the catalogue as a whole', () => {
+  const catalogue = build();
+
+  it('offers a substantial set of tools', () => {
+    expect(catalogue.length).toBeGreaterThan(40);
+  });
+
+  it('names every tool exactly once', () => {
+    const names = catalogue.map((t) => t.name);
+
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('describes every tool well enough for an agent to choose it', () => {
+    for (const t of catalogue) {
+      expect(t.name, `${t.name} name`).toMatch(/^[a-zA-Z][a-zA-Z0-9_]*$/);
+      expect(t.description.length, `${t.name} description`).toBeGreaterThan(20);
+      expect(typeof t.execute, `${t.name} execute`).toBe('function');
+    }
+  });
+
+  it('gives every tool an object schema listing its required fields', () => {
+    for (const t of catalogue) {
+      expect(t.inputSchema.type, t.name).toBe('object');
+      for (const field of t.inputSchema.required) {
+        expect(t.inputSchema.properties, `${t.name} requires ${field}`).toHaveProperty(field);
+      }
+    }
+  });
+
+  it('describes every property, since the description is what the agent reads', () => {
+    for (const t of catalogue) {
+      for (const [field, schema] of Object.entries(t.inputSchema.properties)) {
+        expect(schema.description, `${t.name}.${field}`).toBeTruthy();
+      }
+    }
+  });
+
+  it('annotates reads as read-only and nothing else', () => {
+    const readOnly = catalogue.filter((t) => t.annotations.readOnlyHint).map((t) => t.name);
+
+    expect(readOnly).toContain('listWorkspaces');
+    expect(readOnly).toContain('getTask');
+    expect(readOnly).toContain('getCurrentPage');
+    expect(readOnly).not.toContain('createTask');
+    expect(readOnly).not.toContain('deleteWorkspace');
+  });
+
+  it('marks everything that removes data as destructive', () => {
+    const destructive = catalogue.filter((t) => t.annotations.destructiveHint).map((t) => t.name);
+
+    expect(destructive.sort()).toEqual(
+      [
+        'deleteEvent',
+        'deleteEventTrigger',
+        'deleteTask',
+        'deleteWorkflow',
+        'deleteWorkflowStep',
+        'deleteWorkspace',
+        'replaceWorkflowFromText',
+      ].sort()
+    );
+  });
+
+  it('never marks a tool both read-only and consequential', () => {
+    for (const t of catalogue) {
+      expect(t.annotations.consequentialHint, t.name).toBe(!t.annotations.readOnlyHint);
+    }
+  });
+
+  it('uses camelCase field names, as every other AgentRQ surface does', () => {
+    for (const t of catalogue) {
+      for (const field of Object.keys(t.inputSchema.properties)) {
+        expect(field, `${t.name}.${field}`).not.toMatch(/_/);
+      }
+    }
+  });
+});
+
+describe('parity with the interface', () => {
+  /**
+   * Functions in `api.js` that deliberately have no tool. Anything else must,
+   * because the promise of this feature is that whatever the UI can do, an
+   * agent can do — and `api.js` is what the UI can do.
+   */
+  const NOT_TOOLS = {
+    // Instrumentation the app records about itself, not an action a person takes.
+    recordTelemetry: 'internal telemetry, not a UI capability',
+    // Builds a URL for an <img>/<a>; the bytes are fetched by the browser with
+    // the session cookie, which an agent cannot replay outside the page.
+    getAttachmentUrl: 'returns a URL the page renders, not an action',
+  };
+
+  const apiFunctions = Object.entries(api)
+    .filter(([, value]) => typeof value === 'function')
+    .map(([name]) => name)
+    .filter((name) => !(name in NOT_TOOLS));
+
+  /**
+   * Drive every tool and collect which API functions the catalogue used.
+   *
+   * Twice over: some tools choose between two API calls depending on what they
+   * were given — `listTasks` is per-workspace or global — so a single input
+   * would leave one of the two branches unvisited and the parity claim
+   * unproven. The empty run is expected to throw for tools with required
+   * fields, and those throws are not what is being measured.
+   */
+  const used = (() => {
+    const { stub, calls } = recordingApi();
+    const catalogue = createToolCatalogue({
+      api: stub,
+      navigate: vi.fn().mockResolvedValue(undefined),
+      currentPage: () => ({ path: '/', params: {}, query: {} }),
+    });
+    const drive = (input) =>
+      Promise.all(catalogue.map((t) => Promise.resolve().then(() => t.execute(input, {})).catch(() => {})));
+    return drive(EVERY_FIELD)
+      .then(() => drive({}))
+      .then(() => new Set(calls.map((c) => c.method)));
+  })();
+
+  it.each(apiFunctions)('exposes %s', async (name) => {
+    expect(await used).toContain(name);
+  });
+
+  it('exempts only what it documents', () => {
+    // Guards the exemption list itself: a name removed from api.js must be
+    // removed from here too, or the list silently stops meaning anything.
+    for (const name of Object.keys(NOT_TOOLS)) {
+      expect(api, name).toHaveProperty(name);
+    }
+  });
+});
+
+describe('each tool calls the interface the way the UI does', () => {
+  /**
+   * One row per tool: the input an agent might send, and the API call it must
+   * turn into. Positional arguments are the point — a misplaced one is a bug
+   * no schema catches.
+   */
+  const CASES = [
+    ['getCurrentUser', {}, 'fetchUser', []],
+    ['listWorkspaces', { includeArchived: true }, 'fetchWorkspaces', [true]],
+    ['listWorkspaces', {}, 'fetchWorkspaces', [false]],
+    ['getWorkspace', { workspaceId: 'ws1' }, 'getWorkspace', ['ws1']],
+    [
+      'createWorkspace',
+      { name: 'Ops', description: 'Run things' },
+      'createWorkspace',
+      ['Ops', 'Run things', '', '', ''],
+    ],
+    [
+      'createWorkspace',
+      { name: 'Ops', description: 'Run things', icon: '🛠', selfLearningLoopNote: 'note', workingDirectory: '/srv' },
+      'createWorkspace',
+      ['Ops', 'Run things', '🛠', 'note', '/srv'],
+    ],
+    ['updateWorkspace', { workspaceId: 'ws1', name: 'New' }, 'updateWorkspace', ['ws1', { name: 'New' }]],
+    ['archiveWorkspace', { workspaceId: 'ws1' }, 'archiveWorkspace', ['ws1']],
+    ['unarchiveWorkspace', { workspaceId: 'ws1' }, 'unarchiveWorkspace', ['ws1']],
+    ['deleteWorkspace', { workspaceId: 'ws1' }, 'deleteWorkspace', ['ws1']],
+    ['getWorkspaceToken', { workspaceId: 'ws1' }, 'getWorkspaceToken', ['ws1']],
+    ['getWorkspaceStats', { workspaceId: 'ws1' }, 'fetchWorkspaceStats', ['ws1', '7d', 0, 0]],
+    [
+      'getWorkspaceStats',
+      { workspaceId: 'ws1', range: '30d', from: 1, to: 2 },
+      'fetchWorkspaceStats',
+      ['ws1', '30d', 1, 2],
+    ],
+    [
+      'setWorkspaceSlackChannel',
+      { workspaceId: 'ws1', channelId: 'C1', channelName: 'general' },
+      'setWorkspaceSlackChannel',
+      ['ws1', 'C1', 'general'],
+    ],
+    ['removeWorkspaceSlackChannel', { workspaceId: 'ws1' }, 'removeWorkspaceSlackChannel', ['ws1']],
+
+    ['listTasks', { workspaceId: 'ws1', status: 'ongoing' }, 'fetchTasks', ['ws1', { status: 'ongoing' }]],
+    ['listTasks', { status: 'ongoing' }, 'fetchGlobalTasks', [{ status: 'ongoing' }]],
+    ['listTasks', {}, 'fetchGlobalTasks', [{}]],
+    ['getTask', { workspaceId: 'ws1', taskId: 't1' }, 'getTask', ['ws1', 't1']],
+    [
+      'createTask',
+      { workspaceId: 'ws1', title: 'T', body: 'B' },
+      'createTask',
+      ['ws1', 'T', 'B', 'agent', [], 'notstarted', '', false, '', ''],
+    ],
+    [
+      'createTask',
+      {
+        workspaceId: 'ws1',
+        title: 'T',
+        body: 'B',
+        assignee: 'human',
+        status: 'ongoing',
+        cronSchedule: '0 9 * * *',
+        allowAllCommands: true,
+        eventId: 'e1',
+        workflowId: 'wf1',
+      },
+      'createTask',
+      ['ws1', 'T', 'B', 'human', [], 'ongoing', '0 9 * * *', true, 'e1', 'wf1'],
+    ],
+    ['replyToTask', { workspaceId: 'ws1', taskId: 't1', text: 'hi' }, 'replyToTask', ['ws1', 't1', 'hi']],
+    [
+      'respondToTask',
+      { workspaceId: 'ws1', taskId: 't1', action: 'accept' },
+      'respondToTask',
+      ['ws1', 't1', 'accept', ''],
+    ],
+    [
+      'respondToTask',
+      { workspaceId: 'ws1', taskId: 't1', action: 'reject', text: 'no' },
+      'respondToTask',
+      ['ws1', 't1', 'reject', 'no'],
+    ],
+    [
+      'updateTaskStatus',
+      { workspaceId: 'ws1', taskId: 't1', status: 'completed' },
+      'updateTaskStatus',
+      ['ws1', 't1', 'completed'],
+    ],
+    [
+      'updateTaskAssignee',
+      { workspaceId: 'ws1', taskId: 't1', assignee: 'human' },
+      'updateTaskAssignee',
+      ['ws1', 't1', 'human'],
+    ],
+    ['updateTaskOrder', { workspaceId: 'ws1', taskId: 't1', order: 4 }, 'updateTaskOrder', ['ws1', 't1', 4]],
+    [
+      'moveTask',
+      { workspaceId: 'ws1', taskId: 't1', destinationWorkspaceId: 'ws2' },
+      'moveTask',
+      ['ws1', 't1', 'ws2'],
+    ],
+    [
+      'updateTaskAllowAllCommands',
+      { workspaceId: 'ws1', taskId: 't1', allowAllCommands: true },
+      'updateTaskAllowAllCommands',
+      ['ws1', 't1', true],
+    ],
+    ['stopTask', { workspaceId: 'ws1', taskId: 't1' }, 'stopTask', ['ws1', 't1']],
+    ['deleteTask', { workspaceId: 'ws1', taskId: 't1' }, 'deleteTask', ['ws1', 't1']],
+    [
+      'sendPermissionVerdict',
+      { workspaceId: 'ws1', taskId: 't1', requestId: 'r1', behavior: 'allow' },
+      'sendPermissionVerdict',
+      ['ws1', 't1', 'r1', 'allow'],
+    ],
+    [
+      'respondToElicitation',
+      { workspaceId: 'ws1', taskId: 't1', requestId: 'r1', action: 'accept', content: { a: 1 } },
+      'respondToElicitation',
+      ['ws1', 't1', 'r1', 'accept', { a: 1 }],
+    ],
+    [
+      'respondToElicitation',
+      { workspaceId: 'ws1', taskId: 't1', requestId: 'r1', action: 'decline' },
+      'respondToElicitation',
+      ['ws1', 't1', 'r1', 'decline', {}],
+    ],
+    [
+      'updateScheduledTask',
+      { workspaceId: 'ws1', taskId: 't1', title: 'T', body: 'B', assignee: 'agent', cronSchedule: '0 9 * * *' },
+      'updateScheduledTask',
+      ['ws1', 't1', 'T', 'B', 'agent', '0 9 * * *', false],
+    ],
+    ['getTaskCounts', { workspaceId: 'ws1' }, 'fetchTaskCounts', ['ws1']],
+    ['getGlobalTaskStats', {}, 'fetchGlobalTaskStats', []],
+
+    ['listEvents', {}, 'fetchEvents', []],
+    ['getEvent', { eventId: 'e1' }, 'getEvent', ['e1']],
+    ['createEvent', { name: 'built' }, 'createEvent', ['built', '']],
+    ['createEvent', { name: 'built', payloadGuidelines: 'what' }, 'createEvent', ['built', 'what']],
+    ['updateEvent', { eventId: 'e1', payloadGuidelines: 'what' }, 'updateEvent', ['e1', 'what']],
+    ['deleteEvent', { eventId: 'e1' }, 'deleteEvent', ['e1']],
+    ['listEventTriggers', { eventId: 'e1' }, 'fetchEventTriggers', ['e1']],
+    [
+      'createEventTrigger',
+      { eventId: 'e1', workspaceId: 'ws1', title: 'T', body: 'B' },
+      'createEventTrigger',
+      ['e1', { workspaceId: 'ws1', title: 'T', body: 'B' }],
+    ],
+    [
+      'updateEventTrigger',
+      { eventId: 'e1', triggerId: 'tr1', workspaceId: 'ws1', title: 'T' },
+      'updateEventTrigger',
+      ['e1', 'tr1', { workspaceId: 'ws1', title: 'T' }],
+    ],
+    ['deleteEventTrigger', { eventId: 'e1', triggerId: 'tr1' }, 'deleteEventTrigger', ['e1', 'tr1']],
+    ['listEventTasks', { eventId: 'e1' }, 'fetchEventTasks', ['e1']],
+
+    ['listWorkflows', {}, 'fetchWorkflows', []],
+    ['getWorkflow', { workflowId: 'wf1' }, 'getWorkflow', ['wf1']],
+    [
+      'createWorkflow',
+      { name: 'Ship it' },
+      'createWorkflow',
+      [{ name: 'Ship it', description: '', startEventId: '' }],
+    ],
+    [
+      'createWorkflow',
+      { name: 'Ship it', description: 'D', startEventId: 'e0' },
+      'createWorkflow',
+      [{ name: 'Ship it', description: 'D', startEventId: 'e0' }],
+    ],
+    ['updateWorkflow', { workflowId: 'wf1', name: 'New' }, 'updateWorkflow', ['wf1', { name: 'New' }]],
+    ['deleteWorkflow', { workflowId: 'wf1' }, 'deleteWorkflow', ['wf1']],
+    ['listWorkflowSteps', { workflowId: 'wf1' }, 'fetchWorkflowSteps', ['wf1']],
+    [
+      'createWorkflowStep',
+      { workflowId: 'wf1', eventId: 'e1', workspaceId: 'ws1', title: 'T' },
+      'createWorkflowStep',
+      ['wf1', { eventId: 'e1', workspaceId: 'ws1', title: 'T' }],
+    ],
+    ['deleteWorkflowStep', { workflowId: 'wf1', stepId: 'st1' }, 'deleteWorkflowStep', ['wf1', 'st1']],
+    ['listWorkflowTasks', { workflowId: 'wf1' }, 'fetchWorkflowTasks', ['wf1']],
+    ['getWorkflowText', { workflowId: 'wf1' }, 'fetchWorkflowText', ['wf1']],
+    [
+      'replaceWorkflowFromText',
+      { workflowId: 'wf1', text: 'the doc' },
+      'replaceWorkflowFromText',
+      ['wf1', 'the doc'],
+    ],
+  ];
+
+  it.each(CASES)('%s(%o) calls %s', async (toolName, input, method, args) => {
+    const { stub, calls } = recordingApi();
+    const catalogue = build({ api: stub });
+    const found = catalogue.find((t) => t.name === toolName);
+
+    await found.execute(input, { signal: undefined });
+
+    expect(calls).toEqual([{ method, args }]);
+  });
+});
+
+describe('the tools that only WebMCP can offer', () => {
+  it('reports where the user is, so "this task" can be resolved', async () => {
+    const page = { path: '/workspaces/ws1/tasks/t1', params: { id: 'ws1', taskId: 't1' }, query: {} };
+    const catalogue = build({ currentPage: () => page });
+
+    const result = await catalogue.find((t) => t.name === 'getCurrentPage').execute({}, {});
+
+    expect(result).toEqual(page);
+  });
+
+  it('moves the user to a page and confirms where it went', async () => {
+    const navigate = vi.fn().mockResolvedValue(undefined);
+    const catalogue = build({ navigate });
+
+    const result = await catalogue.find((t) => t.name === 'navigate').execute({ path: '/events' }, {});
+
+    expect(navigate).toHaveBeenCalledWith('/events');
+    expect(result).toEqual({ navigatedTo: '/events' });
+  });
+
+  it('lets an API failure reach the agent rather than swallowing it', async () => {
+    // The agent has to be told the difference between "done" and "refused".
+    const catalogue = build({ api: { getTask: () => Promise.reject(new Error('Failed to fetch task')) } });
+
+    await expect(
+      catalogue.find((t) => t.name === 'getTask').execute({ workspaceId: 'ws1', taskId: 't1' }, {})
+    ).rejects.toThrow('Failed to fetch task');
+  });
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -58,7 +58,9 @@ export default defineConfig({
         'src/composables/useAttachmentCache.js',
         'src/composables/useCacheRetention.js',
         'src/composables/useMarkdownLinks.js',
+        'src/composables/useWebMCP.js',
         'src/utils/markdown.js',
+        'src/webmcp/*.js',
       ],
       reporter: ['text', 'lcov'],
       thresholds: {


### PR DESCRIPTION
## What changed

An AI agent running in your browser can now use AgentRQ directly — list workspaces, open a task, reply in it, change a status, build a workflow. Everything the interface can do is offered as a tool, including asking which page you are on, so "reply to this task" resolves to the task you actually have open.

## Why

WebMCP lets a page hand tools to an agent in the browser. Doing it this way rather than publishing another API means the agent acts inside your existing session, as you: it needs no token, never sees a credential, and can do exactly what your account can do and nothing more.

## Test coverage report

- **New lines: 100%.** All three new modules are inside the frontend's 100% line/branch/function threshold, and were added to the explicit coverage include list so they are genuinely counted.
- **Total coverage impact: none — the suite stays at 100%.** Frontend 768 tests passing (up from 622); desktop 443 unchanged.

The headline test is a parity check rather than a unit test: it imports every export of the frontend's API client, drives the whole tool catalogue against a recording stub, and asserts each API function was reached. That is what makes "anything you can do in the UI" enforceable — add an API function without a tool and the suite goes red. Two exemptions are documented in the test itself: telemetry, which is not a user action, and attachment URLs, which the page renders rather than acts on.

## Other reports

Verified end-to-end in a real browser, not only in unit tests — `npm run verify:webmcp` in `desktop/` needs no backend, installs a stub model context exactly as a supporting browser would, and answers the API itself so every tool call is observable:

```
✓ the app registers its catalogue with the browser — 52 tools
✓ including the tools only a page can offer — getCurrentPage/navigate present
✓ and the ones that mirror the interface
✓ invoking a tool drives the interface's own API — POST /api/v1/workspaces/ws1/tasks
✓ and the tool returns what the API said
✓ getCurrentPage answers with the live route
✓ the navigate tool moves the user — now at /events
✓ reads and deletions are annotated for the agent
✓ the Logout control was reachable
✓ signing out withdraws every tool — 0 tools left registered
```

That last check is the security property: the tools act as the signed-in user and the page is not reloaded on sign-out, so the registration is withdrawn rather than left behind. Writing it caught two false passes in the harness itself before it earned a green.

Notes for reviewers:

- Reads are annotated `readOnlyHint`; the seven tools that remove data are annotated `destructiveHint`, so an agent can tell what to confirm first.
- The browser API moved between drafts, so both accessors are checked — `document.modelContext` first, then the deprecated `navigator.modelContext`. A browser with neither registers nothing and is otherwise unaffected, which is also why the desktop build needs no platform fork.
- User documentation is `docs/WEBMCP.md`, linked from the README; the parity invariant is recorded in `AGENTS.md`.

TaskID: 0iHmqLyWWtF