### PR TITLE
feat: count how the interface itself is used

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,27 @@ registered on sign-in and withdrawn on sign-out.
 - User-facing documentation is `docs/WEBMCP.md`; `cd desktop && npm run
   verify:webmcp` drives the whole path in a real browser with no backend.
 
+## Telemetry
+
+Most actions are emitted by the backend right after it does the work, which
+makes them self-evidently true. A few happen entirely in the browser and are
+*reported* by it instead — the local-AI features, and interface usage
+(shortcuts, search, copies, the trajectory view).
+
+- The allowlist in `entity.ClientReportableAction` is the security boundary for
+  `POST /api/v1/telemetry`: only names in it may be reported, and the controller
+  additionally checks the caller owns the workspace.
+- Adding one means four places, or it reads as zero: the `Action` constant and
+  its `String()`, the allowlist, the `model.ActionID*` constant (**append only**
+  — the value is stored), and the mapping in `controller/telemetry`.
+- `frontend/src/composables/useUiTelemetry.js` resolves the workspace from the
+  route and **drops the report when there is none**, rather than guessing one.
+  Interface counts are therefore actions-with-a-workspace-in-context.
+- The route is rate limited per user. It was raised to 60/minute when interface
+  usage was added; ordinary use passes the old ceiling of 10 easily, and being
+  short there loses reports silently and starves the local-AI metrics that share
+  the bucket.
+
 ## Commit convention
 
 Include `Task: <taskID>` in the commit body for traceability.

--- a/backend/internal/controller/crud/telemetry_test.go
+++ b/backend/internal/controller/crud/telemetry_test.go
@@ -15,11 +15,22 @@ import (
 
 const testWorkspaceID int64 = 42
 
-func TestClientReportableActionAllowsOnlyTheNamedTwo(t *testing.T) {
-	for name, want := range map[string]entity.Action{
-		"local_ai_title_generate": entity.ActionLocalAITitleGenerate,
-		"local_ai_recording_end":  entity.ActionLocalAIRecordingEnd,
-	} {
+// The allowlist is the security boundary for the ingest route, so it is
+// spelled out here in full: a name added to the switch without a line here is
+// a name nobody decided to accept.
+var clientReportable = map[string]entity.Action{
+	"local_ai_title_generate": entity.ActionLocalAITitleGenerate,
+	"local_ai_recording_end":  entity.ActionLocalAIRecordingEnd,
+	"ui_shortcut_use":         entity.ActionUIShortcutUse,
+	"ui_search":               entity.ActionUISearch,
+	"ui_search_open":          entity.ActionUISearchOpen,
+	"ui_copy_link":            entity.ActionUICopyLink,
+	"ui_copy_markdown":        entity.ActionUICopyMarkdown,
+	"ui_trajectory_view":      entity.ActionUITrajectoryView,
+}
+
+func TestClientReportableActionAllowsOnlyTheNamedActions(t *testing.T) {
+	for name, want := range clientReportable {
 		got, ok := entity.ClientReportableAction(name)
 		if !ok || got != want {
 			t.Errorf("%s: got (%v, %v), want (%v, true)", name, got, ok, want)
@@ -38,6 +49,9 @@ func TestClientReportableActionAllowsOnlyTheNamedTwo(t *testing.T) {
 		"",
 		"unknown",
 		"LOCAL_AI_TITLE_GENERATE",
+		"UI_SEARCH",
+		"ui_",
+		"task_allow_all_commands_toggle",
 	} {
 		if _, ok := entity.ClientReportableAction(name); ok {
 			t.Errorf("%q must not be client-reportable", name)
@@ -45,14 +59,26 @@ func TestClientReportableActionAllowsOnlyTheNamedTwo(t *testing.T) {
 	}
 }
 
-// Both new actions have to stringify, or they land in telemetry as "unknown"
-// and cannot be told apart when the counts are read back.
-func TestLocalAIActionsStringify(t *testing.T) {
-	if got := entity.ActionLocalAITitleGenerate.String(); got != "local_ai_title_generate" {
-		t.Errorf("got %q", got)
+// Every client-reportable action has to stringify back to the name it was
+// reported under, or it lands in telemetry as "unknown" and the counts cannot
+// be told apart when they are read back.
+func TestClientReportableActionsStringify(t *testing.T) {
+	for name, action := range clientReportable {
+		if got := action.String(); got != name {
+			t.Errorf("%v: got %q, want %q", action, got, name)
+		}
 	}
-	if got := entity.ActionLocalAIRecordingEnd.String(); got != "local_ai_recording_end" {
-		t.Errorf("got %q", got)
+}
+
+// Distinct values, because they are stored as the action column: two actions
+// sharing a number would be indistinguishable rows forever after.
+func TestClientReportableActionsAreDistinct(t *testing.T) {
+	seen := map[entity.Action]string{}
+	for name, action := range clientReportable {
+		if other, clash := seen[action]; clash {
+			t.Errorf("%s and %s are both %v", name, other, action)
+		}
+		seen[action] = name
 	}
 }
 

--- a/backend/internal/controller/telemetry/telemetry.go
+++ b/backend/internal/controller/telemetry/telemetry.go
@@ -167,6 +167,18 @@ func (c *controller) recordCRUD(event entity.CRUDEvent) {
 		action = model.ActionIDLocalAITitleGenerate
 	case entity.ActionLocalAIRecordingEnd:
 		action = model.ActionIDLocalAIRecordingEnd
+	case entity.ActionUIShortcutUse:
+		action = model.ActionIDUIShortcutUse
+	case entity.ActionUISearch:
+		action = model.ActionIDUISearch
+	case entity.ActionUISearchOpen:
+		action = model.ActionIDUISearchOpen
+	case entity.ActionUICopyLink:
+		action = model.ActionIDUICopyLink
+	case entity.ActionUICopyMarkdown:
+		action = model.ActionIDUICopyMarkdown
+	case entity.ActionUITrajectoryView:
+		action = model.ActionIDUITrajectoryView
 	default:
 		return
 	}

--- a/backend/internal/controller/telemetry/telemetry_test.go
+++ b/backend/internal/controller/telemetry/telemetry_test.go
@@ -282,3 +282,93 @@ func TestLocalAIActionsPersistScopedToUserAndWorkspace(t *testing.T) {
 		t.Error("the two local-AI actions share an id")
 	}
 }
+
+// Every interface-usage action must reach a stored row with its own id.
+//
+// The mapping is a switch with a silent `default: return`, so an action added
+// to the allowlist but not to that switch is accepted by the API, reported by
+// the browser, and then dropped — a metric that reads as zero rather than as
+// broken. This is the test that fails instead.
+func TestUIActionsPersistWithDistinctIDs(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	if err := db.AutoMigrate(&model.Telemetry{}); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockPubSub := mock_pubsub.NewMockService(ctrl)
+	crudChan := make(chan any, 10)
+	mcpChan := make(chan any, 10)
+	mockPubSub.EXPECT().Subscribe(gomock.Any(), pubsub.SubscribeRequest{PubSubID: entity.PubSubTopicCRUD}).
+		Return(&pubsub.SubscribeResponse{Events: crudChan}, nil)
+	mockPubSub.EXPECT().Subscribe(gomock.Any(), pubsub.SubscribeRequest{PubSubID: entity.PubSubTopicMCP}).
+		Return(&pubsub.SubscribeResponse{Events: mcpChan}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := New(Params{
+		DB:        &testDBConn{db: db},
+		PubSub:    mockPubSub,
+		BatchSize: 2,
+		Interval:  50 * time.Millisecond,
+	})
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+
+	cases := []struct {
+		action entity.Action
+		stored uint8
+		name   string
+	}{
+		{entity.ActionUIShortcutUse, model.ActionIDUIShortcutUse, "shortcut use"},
+		{entity.ActionUISearch, model.ActionIDUISearch, "search"},
+		{entity.ActionUISearchOpen, model.ActionIDUISearchOpen, "search open"},
+		{entity.ActionUICopyLink, model.ActionIDUICopyLink, "copy link"},
+		{entity.ActionUICopyMarkdown, model.ActionIDUICopyMarkdown, "copy markdown"},
+		{entity.ActionUITrajectoryView, model.ActionIDUITrajectoryView, "trajectory view"},
+	}
+
+	for _, tc := range cases {
+		crudChan <- entity.CRUDEvent{
+			UserID: 7, WorkspaceID: 70,
+			Action: tc.action, Actor: entity.ActorHuman,
+		}
+	}
+
+	time.Sleep(400 * time.Millisecond)
+	c.Close()
+
+	seen := map[uint8]string{}
+	for _, tc := range cases {
+		var rows []model.Telemetry
+		if err := db.Where("action = ?", tc.stored).Find(&rows).Error; err != nil {
+			t.Fatalf("%s: query failed: %v", tc.name, err)
+		}
+		if len(rows) != 1 {
+			t.Fatalf("%s: expected 1 row, got %d", tc.name, len(rows))
+		}
+		if rows[0].UserID != 7 || rows[0].WorkspaceID != 70 {
+			t.Errorf("%s: expected user 7 / workspace 70, got user %d / workspace %d",
+				tc.name, rows[0].UserID, rows[0].WorkspaceID)
+		}
+		if other, clash := seen[tc.stored]; clash {
+			t.Errorf("%s and %s share stored id %d", tc.name, other, tc.stored)
+		}
+		seen[tc.stored] = tc.name
+	}
+
+	// And they must not collide with the actions already stored, which would
+	// silently merge two metrics that were never the same thing.
+	for _, existing := range []uint8{model.ActionIDLocalAITitleGenerate, model.ActionIDLocalAIRecordingEnd, model.ActionIDTaskCreate} {
+		if _, clash := seen[existing]; clash {
+			t.Errorf("a UI action reuses stored id %d", existing)
+		}
+	}
+}

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -905,6 +905,15 @@ const (
 	// allowlist of what a browser is permitted to claim.
 	ActionLocalAITitleGenerate Action = 40
 	ActionLocalAIRecordingEnd  Action = 41
+	// Interface usage, reported by the browser for the same reason: a keypress,
+	// a search and a copy all begin and end in the tab, so the report is the
+	// only evidence there is. Same allowlist, same ownership check.
+	ActionUIShortcutUse    Action = 50
+	ActionUISearch         Action = 51
+	ActionUISearchOpen     Action = 52
+	ActionUICopyLink       Action = 53
+	ActionUICopyMarkdown   Action = 54
+	ActionUITrajectoryView Action = 55
 )
 
 // ClientReportableAction resolves an action name a browser is allowed to
@@ -921,6 +930,18 @@ func ClientReportableAction(name string) (Action, bool) {
 		return ActionLocalAITitleGenerate, true
 	case "local_ai_recording_end":
 		return ActionLocalAIRecordingEnd, true
+	case "ui_shortcut_use":
+		return ActionUIShortcutUse, true
+	case "ui_search":
+		return ActionUISearch, true
+	case "ui_search_open":
+		return ActionUISearchOpen, true
+	case "ui_copy_link":
+		return ActionUICopyLink, true
+	case "ui_copy_markdown":
+		return ActionUICopyMarkdown, true
+	case "ui_trajectory_view":
+		return ActionUITrajectoryView, true
 	}
 	return 0, false
 }
@@ -971,6 +992,18 @@ func (a Action) String() string {
 		return "local_ai_title_generate"
 	case ActionLocalAIRecordingEnd:
 		return "local_ai_recording_end"
+	case ActionUIShortcutUse:
+		return "ui_shortcut_use"
+	case ActionUISearch:
+		return "ui_search"
+	case ActionUISearchOpen:
+		return "ui_search_open"
+	case ActionUICopyLink:
+		return "ui_copy_link"
+	case ActionUICopyMarkdown:
+		return "ui_copy_markdown"
+	case ActionUITrajectoryView:
+		return "ui_trajectory_view"
 	}
 	return "unknown"
 }

--- a/backend/internal/data/model/model.go
+++ b/backend/internal/data/model/model.go
@@ -272,4 +272,13 @@ const (
 	// the end: inserting above would silently reinterpret every existing row.
 	ActionIDLocalAITitleGenerate
 	ActionIDLocalAIRecordingEnd
+	// Interface usage, also browser-reported: which of the shortcuts, the
+	// finder and the copy affordances people actually reach for. Nothing
+	// server-side sees any of them.
+	ActionIDUIShortcutUse
+	ActionIDUISearch
+	ActionIDUISearchOpen
+	ActionIDUICopyLink
+	ActionIDUICopyMarkdown
+	ActionIDUITrajectoryView
 )

--- a/backend/internal/handler/api/telemetry_test.go
+++ b/backend/internal/handler/api/telemetry_test.go
@@ -74,10 +74,51 @@ func TestRecordTelemetryAcceptsAnAllowlistedAction(t *testing.T) {
 	}
 }
 
+// Each interface-usage name has to survive the whole edge — JSON, allowlist,
+// workspace parse — and arrive at the controller as its own action. A name the
+// frontend sends that dies here is a metric that silently reads zero.
+func TestRecordTelemetryAcceptsEachUIAction(t *testing.T) {
+	for name, want := range map[string]entity.Action{
+		"ui_shortcut_use":    entity.ActionUIShortcutUse,
+		"ui_search":          entity.ActionUISearch,
+		"ui_search_open":     entity.ActionUISearchOpen,
+		"ui_copy_link":       entity.ActionUICopyLink,
+		"ui_copy_markdown":   entity.ActionUICopyMarkdown,
+		"ui_trajectory_view": entity.ActionUITrajectoryView,
+	} {
+		ctrl := &mockTelemetryCrud{}
+		app := newTelemetryApp(ctrl)
+
+		resp := postTelemetry(app, fmt.Sprintf(`{"action":%q,"workspaceId":%q}`, name, testTelemetryWorkspaceID))
+
+		if resp.StatusCode != http.StatusNoContent {
+			t.Errorf("%s: expected 204, got %d", name, resp.StatusCode)
+			continue
+		}
+		if len(ctrl.calls) != 1 {
+			t.Errorf("%s: expected one controller call, got %d", name, len(ctrl.calls))
+			continue
+		}
+		if got := ctrl.calls[0].Action; got != want {
+			t.Errorf("%s: action got %v, want %v", name, got, want)
+		}
+		// Still the session's user, never the body's — same rule as every
+		// other action on this route.
+		if got := ctrl.calls[0].UserID; got != "user1" {
+			t.Errorf("%s: userID got %q, want the session's user", name, got)
+		}
+	}
+}
+
 // The allowlist is the security boundary for this route: an action the server
 // emits for real work must never be settable by a client.
 func TestRecordTelemetryRejectsActionsOutsideTheAllowlist(t *testing.T) {
-	for _, action := range []string{"task_create", "message_create", "mcp_tool_call", "", "nonsense"} {
+	for _, action := range []string{
+		"task_create", "message_create", "mcp_tool_call", "", "nonsense",
+		// Near-misses for the new names, so the allowlist stays a list of
+		// exact strings rather than anything prefix-shaped.
+		"ui_", "ui_search_", "UI_SEARCH", "task_allow_all_commands_toggle",
+	} {
 		ctrl := &mockTelemetryCrud{}
 		app := newTelemetryApp(ctrl)
 

--- a/backend/internal/service/ratelimit/ratelimit.go
+++ b/backend/internal/service/ratelimit/ratelimit.go
@@ -76,13 +76,23 @@ func (l *limiter) AllowMessage(userID int64) bool {
 	return allow(rb, now, 5, 60)
 }
 
-// AllowTelemetry caps client-reported telemetry at 10 per rolling minute.
+// AllowTelemetry caps client-reported telemetry at 60 per rolling minute.
 //
 // Unlike the other buckets this guards a route whose whole job is to be called
 // from the browser on a click, so the ceiling is what stops a page — buggy or
-// hostile — from inflating the counters it feeds. Two per second rather than
-// one leaves room for the genuine case of two different features being used in
-// the same second, which the per-minute cap still bounds.
+// hostile — from inflating the counters it feeds.
+//
+// It was 2/second and 10/minute when the only client-reported actions were two
+// rare local-AI events. Interface usage is a different traffic profile
+// altogether: shortcuts, searches and copies are ordinary interactions, and an
+// engaged user passes ten a minute without trying. Left at ten, the new counts
+// would be silently short *and* would starve the local-AI metrics that share
+// this bucket — a change that quietly degrades a metric which works today.
+//
+// Sixty a minute is one a second sustained, which no honest interface exceeds
+// and which still bounds a hostile page to sixty small rows per user per
+// minute. The per-second burst of five covers a genuine flurry — a shortcut
+// that switches view and is counted as both — without letting a loop run away.
 func (l *limiter) AllowTelemetry(userID int64) bool {
 	l.Lock()
 	defer l.Unlock()
@@ -94,7 +104,7 @@ func (l *limiter) AllowTelemetry(userID int64) bool {
 		l.telemetryRequests[userID] = rb
 	}
 
-	return allow(rb, now, 2, 10)
+	return allow(rb, now, 5, 60)
 }
 
 func allow(rb *rotatingBucket, now int64, maxSec int, maxMin int) bool {

--- a/backend/internal/service/ratelimit/ratelimit_test.go
+++ b/backend/internal/service/ratelimit/ratelimit_test.go
@@ -184,16 +184,41 @@ func TestTelemetryAllowsTenPerMinute(t *testing.T) {
 	}
 }
 
-// Two different local-AI features can genuinely be used in the same second, so
-// the per-second burst allows a pair while the minute cap still bounds it.
-func TestTelemetryAllowsAPairInOneSecondButNotAThird(t *testing.T) {
+// A burst is allowed because one interaction can be two metrics — a shortcut
+// that also switches view — while the per-second ceiling still bounds a loop.
+func TestTelemetryAllowsABurstInOneSecondButNotBeyondIt(t *testing.T) {
 	rb := &rotatingBucket{}
 
-	if !allow(rb, 100, 2, 10) || !allow(rb, 100, 2, 10) {
-		t.Fatal("two calls in the same second should be allowed")
+	for i := 0; i < 5; i++ {
+		if !allow(rb, 100, 5, 60) {
+			t.Fatalf("call %d in the same second should be allowed", i+1)
+		}
 	}
-	if allow(rb, 100, 2, 10) {
-		t.Error("a third call in the same second must be blocked")
+	if allow(rb, 100, 5, 60) {
+		t.Error("a sixth call in the same second must be blocked")
+	}
+}
+
+// The budget has to fit ordinary interface use. Ten a minute was sized for two
+// rare local-AI events; shortcuts, searches and copies pass that without
+// trying, and being short here loses reports silently.
+func TestTelemetryBudgetFitsAMinuteOfInterfaceUse(t *testing.T) {
+	rb := &rotatingBucket{}
+
+	// Synthetic timestamps, because the limiter reads the real clock: a loop
+	// calling AllowTelemetry lands entirely inside one second and would measure
+	// the burst ceiling instead of the minute budget.
+	allowed := 0
+	for second := 0; second < 30; second++ {
+		for i := 0; i < 2; i++ {
+			if allow(rb, int64(100+second), 5, 60) {
+				allowed++
+			}
+		}
+	}
+
+	if allowed < 60 {
+		t.Errorf("a minute of interface use should fit: only %d of 60 reports allowed", allowed)
 	}
 }
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -84,6 +84,8 @@ npm run spike:eventsource                    # is EventSource allowed on app://?
 AGENTRQ_SERVER_URL=http://localhost:3999 \
 AGENTRQ_ROOT_TOKEN=... npx electron scripts/verify-e2e.mjs
 npm run build && npx electron scripts/verify-markdown-links.mjs  # needs no backend
+AGENTRQ_SERVER_URL=http://localhost:3997 AGENTRQ_QA_DB=… \
+AGENTRQ_QA_WORKSPACE=… npx electron scripts/verify-ui-telemetry.mjs
 ```
 
 `verify:e2e` runs the real protocol handler against a real backend and checks
@@ -101,7 +103,22 @@ on the real clipboard. The `shell.openPath` / `showItemInFolder` calls are
 recorded rather than made — a passing run would otherwise launch an editor and a
 Finder window on whoever ran it — and the clipboard is put back afterwards.
 
-That last check is why copies go through the shell at all:
+`verify:ui-telemetry` drives the real interface against a scratch backend and
+checks that a keypress, a copy, a search and a view switch each report exactly
+once, attributed to the workspace they happened in — and that an action taken
+where no workspace is in context reports nothing rather than guessing one.
+
+It watches the report the *page* makes rather than the row the server stores,
+and the reason is worth knowing before changing it: three delays sit between a
+click and a row — `keepalive` sends the renderer defers until the document
+unloads, a rate limit that drops a script's burst with a 429, and the
+controller's five-second batch. Reading the table after each click measures the
+browser's send schedule, not the application. That a report becomes a row is
+covered by the Go tests instead, and the script still closes the window at the
+end to force delivery and read one row back, so the two halves are known to be
+connected.
+
+That copy-link check is why copies go through the shell at all:
 `navigator.clipboard.writeText` throws *"Document is not focused"* in a window
 that is not frontmost, with or without a user gesture behind it. A copy button
 that works only when nothing has stolen focus is the same silent nothing as the

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -16,6 +16,7 @@
     "verify:connection": "npm run build && electron scripts/verify-connection.mjs",
     "verify:markdown-links": "npm run build && electron scripts/verify-markdown-links.mjs",
     "verify:webmcp": "npm run build && electron scripts/verify-webmcp.mjs",
+    "verify:ui-telemetry": "npm run build && electron scripts/verify-ui-telemetry.mjs",
     "check:versions": "node scripts/check-versions.mjs",
     "package": "npm run build && electron-builder --publish never",
     "package:dir": "npm run build && electron-builder --dir"

--- a/desktop/scripts/verify-ui-telemetry.mjs
+++ b/desktop/scripts/verify-ui-telemetry.mjs
@@ -1,0 +1,412 @@
+/**
+ * End-to-end check that the interface reports what people do with it.
+ *
+ * The unit tests prove each link — the allowlist, the entity-to-row mapping,
+ * the workspace resolution — and the Go tests prove that a reported action
+ * becomes a stored row. What none of them can prove is the part that only
+ * exists in a browser: that pressing a key, copying something or searching
+ * actually causes a report, attributed to the right workspace, exactly once.
+ *
+ * So this drives the real interface against a real backend and watches what the
+ * page reports.
+ *
+ * ## Why it watches the page rather than the database
+ *
+ * It read the telemetry table at first, and every check failed while the
+ * feature worked. Three delays sit between a click and a row: `recordTelemetry`
+ * sends with `keepalive`, which this renderer defers until the document
+ * unloads; the ingest route allows five reports a second and drops the rest
+ * with a 429, which a script trips and a person never does; and the controller
+ * batches rows on a five-second timer. Measuring through all three measures the
+ * browser's send schedule, not the application.
+ *
+ * The seam that matters here is what the interface *decides to report*, so that
+ * is what this observes — the fetch the page makes, captured in the page. That
+ * a report becomes a row is the backend's contract, and is covered by
+ * `TestRecordTelemetryAcceptsEachUIAction` and
+ * `TestUIActionsPersistWithDistinctIDs`. One row is still read back at the end,
+ * as a smoke check that the two halves are really connected.
+ *
+ * Needs a scratch backend, never your dev instance:
+ *   AGENTRQ_SERVER_URL=http://localhost:3997 \
+ *   AGENTRQ_QA_DB=/path/to/qa.db \
+ *   AGENTRQ_QA_WORKSPACE=<id> npx electron scripts/verify-ui-telemetry.mjs
+ */
+import { app, BrowserWindow, ipcMain, net, protocol, session } from 'electron'
+import { readFile, access } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { createAppProtocolHandler } from '../src/main/protocol.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const RENDERER_ROOT = join(__dirname, '../dist/renderer')
+const PRELOAD = join(__dirname, '../dist/preload/index.cjs')
+const serverUrl = process.env.AGENTRQ_SERVER_URL ?? 'http://localhost:3997'
+const dbPath = process.env.AGENTRQ_QA_DB ?? ''
+const workspaceId = process.env.AGENTRQ_QA_WORKSPACE ?? ''
+const rootToken = process.env.AGENTRQ_ROOT_TOKEN ?? 'qa-root-token'
+
+// The stored action ids, from backend/internal/data/model/model.go. Written out
+// rather than imported because they are Go constants; the numbers are what the
+// database actually holds, so reading them back is the point.
+const ACTION = {
+  uiShortcutUse: 22,
+  uiSearch: 23,
+  uiSearchOpen: 24,
+  uiCopyLink: 25,
+  uiCopyMarkdown: 26,
+  uiTrajectoryView: 27,
+}
+
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: 'app',
+    privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true, corsEnabled: true },
+  },
+])
+
+async function fileExists(pathname) {
+  try {
+    await access(join(RENDERER_ROOT, pathname), constants.R_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Counts per action, straight out of the telemetry table. */
+function telemetryCounts() {
+  const out = execFileSync('sqlite3', [dbPath, 'SELECT action, COUNT(*) FROM telemetries GROUP BY action;'], {
+    encoding: 'utf8',
+  })
+  const counts = {}
+  for (const line of out.trim().split('\n').filter(Boolean)) {
+    const [action, count] = line.split('|')
+    counts[Number(action)] = Number(count)
+  }
+  return counts
+}
+
+/**
+ * Long enough for the server to write what it was told.
+ *
+ * The telemetry controller batches and flushes on a 5s timer, so a report is
+ * accepted by the API well before it is a row. Reading the table sooner finds
+ * nothing and says the feature is broken when it is only in flight.
+ */
+/**
+ * Wait until the server has stored what the page reported, or give up.
+ *
+ * Polling rather than sleeping, because three separate delays sit between a
+ * click and a row and only the last is predictable: `recordTelemetry` sends
+ * with `keepalive`, which the browser may defer; the ingest route is rate
+ * limited, so a burst earns a 429 and is dropped; and the telemetry controller
+ * batches on a 5s timer. A fixed sleep either flakes or is slower than it needs
+ * to be, and a fixed sleep that is too short reports a working feature as
+ * broken — which is exactly what it did while this script was being written.
+ *
+ * @param {(counts: Record<number, number>) => boolean} satisfied
+ * @param {number} [timeoutMs]
+ */
+async function waitFor(satisfied, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    const counts = telemetryCounts()
+    if (satisfied(counts) || Date.now() > deadline) return counts
+    await new Promise((r) => setTimeout(r, 500))
+  }
+}
+
+/**
+ * A gap between actions.
+ *
+ * The ingest route allows a burst of five reports a second. A person clicking
+ * never approaches that; a script driving six features does, and the reports it
+ * loses to a 429 look exactly like a feature that never reported.
+ */
+const pace = () => new Promise((r) => setTimeout(r, 1500))
+
+setTimeout(() => {
+  console.error('✗ verification timed out')
+  app.exit(3)
+}, 180000)
+
+app.whenReady().then(async () => {
+  if (!dbPath || !workspaceId) {
+    console.error('✗ AGENTRQ_QA_DB and AGENTRQ_QA_WORKSPACE are required')
+    app.exit(2)
+    return
+  }
+
+  ipcMain.handle('agentrq:connection:get', () => ({ configured: true, serverUrl, locked: true }))
+  ipcMain.handle('agentrq:update:get', () => ({ status: 'idle', detail: '', version: '', enabled: false }))
+  ipcMain.handle('agentrq:theme:set', () => ({ source: 'system', color: '#fafafa' }))
+  ipcMain.handle('agentrq:profiles:get', () => ({ activeProfileId: '', profiles: [] }))
+  ipcMain.handle('agentrq:notifications:get', () => ({ supported: false, mutedWorkspaces: [] }))
+  ipcMain.handle('agentrq:clipboard:write', () => true)
+
+  protocol.handle(
+    'app',
+    createAppProtocolHandler({
+      serverUrl: () => serverUrl,
+      netFetch: net.fetch,
+      fileExists,
+      readFile: (pathname) => readFile(join(RENDERER_ROOT, pathname)),
+    })
+  )
+
+  const win = new BrowserWindow({
+    show: false,
+    webPreferences: { preload: PRELOAD, contextIsolation: true, nodeIntegration: false, sandbox: true },
+  })
+  await win.loadURL('app://agentrq/')
+  await new Promise((r) => setTimeout(r, 1200))
+
+  // Sign in the way the app does, so the cookie lands in this window's jar and
+  // every report below is made as a real session.
+  await win.webContents.executeJavaScript(`
+    fetch('/api/v1/auth/root/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rootToken: ${JSON.stringify(rootToken)} }),
+    }).then((r) => r.status)
+  `)
+
+  const results = []
+  const record = (name, pass, detail) => results.push({ name, pass, detail })
+
+  const signedIn = await win.webContents.executeJavaScript(
+    "fetch('/api/v1/auth/user').then((r) => r.status)"
+  )
+  record('the QA session is signed in', signedIn === 200, 'GET /auth/user -> ' + signedIn)
+
+  const before = telemetryCounts()
+  const gained = (counts, action) => (counts[action] ?? 0) - (before[action] ?? 0)
+
+  // Land on the task, which is where most of these actions live.
+  await win.loadURL(`app://agentrq/workspaces/${workspaceId}/board`)
+  await new Promise((r) => setTimeout(r, 2500))
+
+  const taskId = await win.webContents.executeJavaScript(`
+    fetch('/api/v1/workspaces/${workspaceId}/tasks?limit=1')
+      .then((r) => r.json())
+      .then((d) => d.tasks?.[0]?.id ?? '')
+  `)
+  record('the QA task is reachable', Boolean(taskId), taskId || 'none found')
+
+  const landed = await win.webContents.executeJavaScript('location.pathname')
+  record('the board rendered rather than bouncing to login', !landed.endsWith('/login'), 'at ' + landed)
+
+  await win.loadURL(`app://agentrq/workspaces/${workspaceId}/tasks/${taskId}`)
+  await new Promise((r) => setTimeout(r, 2500))
+
+  // Watch what the page reports, installed here because a full page load
+  // replaces the document and every navigation before this one would have
+  // taken the capture with it.
+  await win.webContents.executeJavaScript(`
+    window.__reports = [];
+    const real = window.fetch;
+    window.fetch = (input, init) => {
+      const url = typeof input === 'string' ? input : input?.url ?? '';
+      if (url.includes('/telemetry') && init?.body) window.__reports.push(JSON.parse(init.body));
+      return real(input, init);
+    };
+    true
+  `)
+
+  // Every action first, then one read.
+  //
+  // `recordTelemetry` sends with `keepalive`, and Chromium is entitled to hold
+  // such a request until the page goes away — which it does here, so a report
+  // made on a click may not reach the server until the window next navigates.
+  // Reading after each action therefore measures the browser's send schedule
+  // rather than whether the feature works. Doing the work, then forcing a
+  // navigation, then reading once, measures the thing that matters.
+
+  // 1. A keyboard shortcut. Dispatched as a real keydown, so it travels the
+  //    same path a keypress does — and `t` also switches to the trajectory,
+  //    which is a second metric from one press.
+  await win.webContents.executeJavaScript(`
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 't', bubbles: true }));
+    true
+  `)
+  await pace()
+
+  // The description starts collapsed, and the markdown — with the copy controls
+  // beside it — only exists once it is expanded, which is what a person does
+  // before copying anything.
+  const expanded = await win.webContents.executeJavaScript(`
+    (async () => {
+      const collapsed = document.querySelector('.truncate.cursor-pointer');
+      if (!collapsed) return 'no collapsed description';
+      collapsed.click();
+      await new Promise((r) => setTimeout(r, 400));
+      return document.querySelectorAll('.md-body').length + ' rendered bodies';
+    })()
+  `)
+  record('the description expands to rendered markdown', /[1-9]\d* rendered/.test(expanded), String(expanded))
+
+  // 2. Copying a task body as raw markdown.
+  const copiedMarkdown = await win.webContents.executeJavaScript(`
+    (async () => {
+      const button = document.querySelector('button[title="Copy raw text"]');
+      if (!button) return 'no copy control';
+      button.click();
+      await new Promise((r) => setTimeout(r, 300));
+      return 'clicked';
+    })()
+  `)
+  record('the raw-markdown copy control was reachable', copiedMarkdown === 'clicked', String(copiedMarkdown))
+  await pace()
+
+  // 3. The copy button beside a link in the rendered body.
+  const copiedLink = await win.webContents.executeJavaScript(`
+    (() => {
+      const button = document.querySelector('.md-copy-link');
+      if (!button) return 'no copy-link button';
+      button.click();
+      return 'clicked';
+    })()
+  `)
+  record('the link copy button was reachable', copiedLink === 'clicked', String(copiedLink))
+  await pace()
+
+  // 4. The finder: one search however much is typed, then opening a result.
+  //    One modifier only — `matchShortcut` requires the other to be up, so
+  //    Cmd+Ctrl+K deliberately matches nothing.
+  await win.webContents.executeJavaScript(`
+    window.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'k', ${process.platform === 'darwin' ? 'metaKey' : 'ctrlKey'}: true, bubbles: true,
+    }));
+    true
+  `)
+  await new Promise((r) => setTimeout(r, 800))
+
+  const finder = await win.webContents.executeJavaScript(`
+    (async () => {
+      const input = document.querySelector('[role=dialog][aria-label="Find task"] input');
+      if (!input) return 'no finder';
+      // Six keystrokes, which must be one search.
+      for (const ch of 'Teleme') {
+        input.value += ch;
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        await new Promise((r) => setTimeout(r, 120));
+      }
+      await new Promise((r) => setTimeout(r, 700));
+      const row = document.querySelector('[role=dialog][aria-label="Find task"] ul button');
+      if (!row) return 'no result row';
+      row.click();
+      return 'opened';
+    })()
+  `)
+  record('the finder searched and opened a result', finder === 'opened', String(finder))
+  await pace()
+
+  // Read before navigating anywhere: a full page load replaces the document,
+  // and with it the record of what this one reported. Opening a search result
+  // is a router push, which leaves it intact.
+  const reports = await win.webContents.executeJavaScript('window.__reports ?? []')
+  const reported = (action) => reports.filter((r) => r.action === action)
+  const countOf = (action) => reported(action).length
+
+  record(
+    'pressing a shortcut is reported',
+    countOf('ui_shortcut_use') >= 1,
+    countOf('ui_shortcut_use') + ' reports'
+  )
+  record(
+    'one keypress is one report, not one per listener',
+    countOf('ui_shortcut_use') === 2,
+    'two presses -> ' + countOf('ui_shortcut_use') + ' reports'
+  )
+  record(
+    'switching to the trajectory is reported separately',
+    countOf('ui_trajectory_view') === 1,
+    countOf('ui_trajectory_view') + ' reports'
+  )
+  record(
+    'copying raw markdown is reported',
+    countOf('ui_copy_markdown') >= 1,
+    countOf('ui_copy_markdown') + ' reports'
+  )
+  record(
+    'copying a link is reported',
+    countOf('ui_copy_link') >= 1,
+    countOf('ui_copy_link') + ' reports'
+  )
+  record(
+    'a search is reported once, not once per keystroke',
+    countOf('ui_search') === 1,
+    countOf('ui_search') + ' reports for 6 keystrokes'
+  )
+  record(
+    'opening a search result is reported',
+    countOf('ui_search_open') === 1,
+    countOf('ui_search_open') + ' reports'
+  )
+
+  record(
+    'every report names the workspace it happened in',
+    reports.length > 0 && reports.every((r) => r.workspaceId === workspaceId),
+    reports.length + ' reports, all for ' + workspaceId
+  )
+
+  // 5. The attribution rule: no workspace in context, no report at all.
+  await win.loadURL('app://agentrq/tasks/all')
+  await new Promise((r) => setTimeout(r, 2000))
+  // The document was replaced, so the capture goes back on and starts empty —
+  // which is the point: nothing pressed here should be reported.
+  await win.webContents.executeJavaScript(`
+    window.__reports = [];
+    const real = window.fetch;
+    window.fetch = (input, init) => {
+      const url = typeof input === 'string' ? input : input?.url ?? '';
+      if (url.includes('/telemetry') && init?.body) window.__reports.push(JSON.parse(init.body));
+      return real(input, init);
+    };
+    true
+  `)
+  const helpOpened = await win.webContents.executeJavaScript(`
+    (async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '?', bubbles: true }));
+      await new Promise((r) => setTimeout(r, 600));
+      return Boolean(document.querySelector('[role=dialog][aria-label="Keyboard shortcuts"]'));
+    })()
+  `)
+  record('the shortcut still works off-workspace', helpOpened === true, 'help sheet opened: ' + helpOpened)
+
+  const offWorkspaceReports = await win.webContents.executeJavaScript('(window.__reports ?? []).length')
+  record(
+    'a shortcut with no workspace in context is dropped, not misattributed',
+    offWorkspaceReports === 0,
+    offWorkspaceReports + ' reports made from a page with no workspace'
+  )
+
+  // The two halves, joined: reports made in the page become rows in the table.
+  //
+  // Closing the window is what forces the issue. The reports were sent with
+  // `keepalive`, whose whole purpose is to outlive the document, and this
+  // renderer holds them until there is no document left to outlive.
+  win.destroy()
+  const stored = await waitFor((c) => Object.keys(c).some((a) => Number(a) >= ACTION.uiShortcutUse))
+  const uiRows = Object.entries(stored)
+    .filter(([action]) => Number(action) >= ACTION.uiShortcutUse)
+    .map(([action, count]) => action + '×' + count)
+  record('reports reach the telemetry table', uiRows.length > 0, uiRows.join(', ') || 'no rows')
+
+  const foreign = execFileSync(
+    'sqlite3',
+    [dbPath, `SELECT COUNT(*) FROM telemetries WHERE action >= 22 AND workspace_id NOT IN (SELECT id FROM workspaces);`],
+    { encoding: 'utf8' }
+  ).trim()
+  record('every stored row is attributed to a real workspace', foreign === '0', foreign + ' orphaned rows')
+
+  console.log('\n─── interface telemetry, end to end ───')
+  for (const r of results) console.log(`${r.pass ? '✓' : '✗'} ${r.name} — ${r.detail}`)
+  const failed = results.filter((r) => !r.pass)
+  console.log(failed.length === 0 ? '\n✓ all checks passed' : `\n✗ ${failed.length} check(s) failed`)
+  app.exit(failed.length === 0 ? 0 : 1)
+})

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -385,7 +385,7 @@
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useRegisterSW } from 'virtual:pwa-register/vue'
-import { fetchUser, fetchWorkspaces, API_BASE_URL } from './api'
+import { fetchUser, fetchWorkspaces, API_BASE_URL, TELEMETRY_UI_COPY_LINK, TELEMETRY_UI_SHORTCUT_USE } from './api'
 // The whole module, because the WebMCP catalogue mirrors it function for
 // function — naming each one here would be a second list to keep in step.
 import * as api from './api'
@@ -393,6 +393,7 @@ import { useToasts } from './composables/useToasts'
 import { useEventBus } from './useEventBus'
 import { profileDisplay } from './composables/useProfileDisplay'
 import { connectWebMCP } from './composables/useWebMCP'
+import { recordUiAction } from './composables/useUiTelemetry'
 import { usePlatformStore } from './stores/platformStore'
 import {
   copyLinkTarget,
@@ -462,6 +463,9 @@ async function onMarkdownLinkActivate(event) {
     const copied = await copyLinkTarget(copyTarget, { copyText })
     const notify = copied.tone === 'error' ? notifyError : notifySuccess
     notify(copied.message, copied.title)
+    // Only a copy that worked: a refused clipboard is a failure to count, not
+    // a use of the feature.
+    if (copied.tone !== 'error') recordUiAction(TELEMETRY_UI_COPY_LINK, route)
     return
   }
 
@@ -590,8 +594,20 @@ useShortcuts(
       isHelpOpen.value = true
     },
   },
-  { mac: () => isMacKeyboard.value }
+  { mac: () => isMacKeyboard.value, onUse: recordShortcutUse }
 )
+
+/**
+ * Count a shortcut that actually ran.
+ *
+ * Both registrations report through the same function so the metric does not
+ * depend on each place remembering to; the id is not sent, only that a
+ * shortcut was used, because the telemetry route records an action and nothing
+ * else about it.
+ */
+function recordShortcutUse() {
+  recordUiAction(TELEMETRY_UI_SHORTCUT_USE, route)
+}
 
 // Escape closes an overlay wherever focus happens to be. The palette handles it
 // on its own input too — this is for the help sheet, which has nothing focused.

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -528,6 +528,17 @@ export async function replaceWorkflowFromText(workflowId, text) {
 export const TELEMETRY_LOCAL_AI_TITLE_GENERATE = 'local_ai_title_generate';
 export const TELEMETRY_LOCAL_AI_RECORDING_END = 'local_ai_recording_end';
 
+// Interface usage. Reported for the same reason as the local-AI actions: a
+// keypress, a search and a copy all begin and end in the tab, so nothing
+// server-side would otherwise know they happened. See `useUiTelemetry`, which
+// is how these are sent.
+export const TELEMETRY_UI_SHORTCUT_USE = 'ui_shortcut_use';
+export const TELEMETRY_UI_SEARCH = 'ui_search';
+export const TELEMETRY_UI_SEARCH_OPEN = 'ui_search_open';
+export const TELEMETRY_UI_COPY_LINK = 'ui_copy_link';
+export const TELEMETRY_UI_COPY_MARKDOWN = 'ui_copy_markdown';
+export const TELEMETRY_UI_TRAJECTORY_VIEW = 'ui_trajectory_view';
+
 // Records one local-AI feature use. Never throws and never blocks the caller:
 // a metric is not worth failing a user's click over, so a rejected or
 // unreachable report is dropped rather than surfaced.

--- a/frontend/src/components/CommandPalette.vue
+++ b/frontend/src/components/CommandPalette.vue
@@ -7,9 +7,10 @@
  * and the navigation, and nothing else.
  */
 import { computed, nextTick, ref, watch } from 'vue';
-import { useRouter } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 
-import { fetchGlobalTasks, getTask } from '../api';
+import { fetchGlobalTasks, getTask, TELEMETRY_UI_SEARCH, TELEMETRY_UI_SEARCH_OPEN } from '../api';
+import { createOncePerEpisode, recordUiAction } from '../composables/useUiTelemetry';
 import { looksLikeTaskId, matchTasks, resolveTaskById, taskRoute } from '../composables/useTaskFinder';
 import { searchCachedTasks } from '../composables/useCachedReads';
 import { sharedCache } from '../composables/useCachedTasks';
@@ -23,7 +24,21 @@ const props = defineProps({
 const emit = defineEmits(['close']);
 
 const router = useRouter();
+const route = useRoute();
 const workspaceStore = useWorkspaceStore();
+
+/**
+ * How often the finder is searched, and how often a search leads somewhere.
+ *
+ * One search per opening rather than one per keystroke — the panel searches as
+ * you type, so counting each would report typing "deploy" as six searches.
+ *
+ * Both halves resolve the workspace the same way, at the moment they fire, so
+ * the ratio between them stays meaningful. Neither is recorded when the finder
+ * is used from a page with no workspace in context; see `useUiTelemetry` for
+ * why that is preferred to guessing one.
+ */
+const searchEpisode = createOncePerEpisode();
 
 const query = ref('');
 const tasks = ref([]);
@@ -48,6 +63,9 @@ const searchedLocally = ref(false);
 
 async function runSearch() {
   const asked = query.value;
+  // Counted on what the user typed, not on what came back: a search that finds
+  // nothing is still a search, and is the more interesting half of the funnel.
+  if (asked.trim()) searchEpisode.fire(() => recordUiAction(TELEMETRY_UI_SEARCH, route));
   const local = await searchCachedTasks(sharedCache(), asked, { limit: 8 });
 
   // A slower search for an older query must not overwrite a newer one's answer.
@@ -98,6 +116,7 @@ watch(
     highlighted.value = 0;
     notFound.value = false;
     results.value = [];
+    searchEpisode.reset();
     searchedLocally.value = false;
     await nextTick();
     inputRef.value?.focus();
@@ -138,6 +157,9 @@ function move(delta) {
 }
 
 function open(task) {
+  // Before navigating: the route is what attributes the report, and it is
+  // about to become the task's own page.
+  recordUiAction(TELEMETRY_UI_SEARCH_OPEN, route);
   emit('close');
   router.push(taskRoute(task));
 }
@@ -156,6 +178,8 @@ async function submit() {
       getTask
     );
     if (found) {
+      // The other way out of the finder, and just as much a search that landed.
+      recordUiAction(TELEMETRY_UI_SEARCH_OPEN, route);
       emit('close');
       router.push(taskRoute(found.task, found.workspaceId));
       return;

--- a/frontend/src/composables/useKeyboardShortcuts.js
+++ b/frontend/src/composables/useKeyboardShortcuts.js
@@ -199,6 +199,20 @@ export function formatShortcut(shortcut, { mac = false } = {}) {
  */
 const registrations = [];
 
+/**
+ * Events already answered.
+ *
+ * Every `useShortcuts` call installs its own keydown listener, so on a screen
+ * with two registrations — the shell and the task view — one keypress reaches
+ * `dispatchShortcut` twice and used to run the winning handler twice with it.
+ * That went unnoticed while the handlers were idempotent (opening a panel
+ * twice looks like opening it once), and stopped being invisible the moment a
+ * keypress started being counted: one press, two reports.
+ *
+ * Weak, so an event is forgotten as soon as the browser is done with it.
+ */
+const answered = new WeakSet();
+
 /** Test seam: forget every registration. */
 export function resetShortcuts() {
   registrations.length = 0;
@@ -212,19 +226,29 @@ export function resetShortcuts() {
  * handled. An unclaimed shortcut is left alone so the browser keeps its
  * behaviour on screens that do not implement it.
  *
+ * Counted here rather than in each handler: this is the one point every
+ * shortcut passes through, so a shortcut added later cannot quietly go
+ * unmeasured. Only a shortcut that actually ran is counted — a key nobody is
+ * listening for is not a use of the feature.
+ *
  * @param {KeyboardEvent} event
- * @param {{ mac?: boolean, shortcuts?: typeof SHORTCUTS }} [options]
+ * @param {{ mac?: boolean, shortcuts?: typeof SHORTCUTS, onUse?: (id: string) => void }} [options]
  * @returns {string | null} the id that ran, for tests and callers
  */
-export function dispatchShortcut(event, options = {}) {
+export function dispatchShortcut(event, { onUse, ...options } = {}) {
   const shortcut = matchShortcut(event, options);
   if (!shortcut) return null;
+  // The topmost handler has already had this keypress; a second listener
+  // seeing the same event is the same press, not another one.
+  if (answered.has(event)) return null;
 
   for (let i = registrations.length - 1; i >= 0; i -= 1) {
     const handler = registrations[i][shortcut.id];
     if (!handler) continue;
     event.preventDefault?.();
+    answered.add(event);
     handler(event);
+    onUse?.(shortcut.id);
     return shortcut.id;
   }
   return null;
@@ -235,18 +259,19 @@ export function dispatchShortcut(event, options = {}) {
  *
  * @param {Record<string, (event: KeyboardEvent) => void>} handlers
  *        keyed by shortcut id; ids nobody handles simply do nothing
- * @param {{ mac?: () => boolean, target?: EventTarget,
+ * @param {{ mac?: () => boolean, target?: EventTarget, onUse?: (id: string) => void,
  *           onMounted?: Function, onUnmounted?: Function }} [options]
  */
 export function useShortcuts(handlers, options = {}) {
   const {
     mac = () => false,
     target = globalThis.window,
+    onUse,
     onMounted: mount = onMounted,
     onUnmounted: unmount = onUnmounted,
   } = options;
 
-  const onKeydown = (event) => dispatchShortcut(event, { mac: mac() });
+  const onKeydown = (event) => dispatchShortcut(event, { mac: mac(), onUse });
 
   mount(() => {
     registrations.push(handlers);

--- a/frontend/src/composables/useUiTelemetry.js
+++ b/frontend/src/composables/useUiTelemetry.js
@@ -1,0 +1,99 @@
+/**
+ * Counting how the interface itself gets used.
+ *
+ * The backend emits an event for every piece of work it does, which makes those
+ * counts self-evidently true. Pressing a shortcut, searching, copying a link or
+ * switching to the trajectory begins and ends in the tab — the server sees
+ * nothing at all — so, exactly like the local-AI metrics, the browser has to say
+ * so itself.
+ *
+ * ## Why a workspace has to be resolved first
+ *
+ * `recordTelemetry` takes a workspace, and the backend checks the caller owns
+ * it. That check is the whole security boundary for the ingest route: without
+ * it a caller could attribute its own clicks to somebody else's workspace and
+ * corrupt a metric for a user who never generated it.
+ *
+ * Some of these actions happen where there is no workspace — Cmd+K from the
+ * task list, a shortcut on the workspace list. Those reports are **dropped**.
+ * Attributing them to a guessed workspace would be inventing data, which is
+ * worse than counting less of it, and there is no honest guess available: the
+ * route is the only thing that knows.
+ *
+ * The practical consequence is worth stating where someone reads the numbers:
+ * these are counts of *actions taken with a workspace in context*, not of every
+ * action. Because `ui_search` and `ui_search_open` resolve the workspace the
+ * same way at the same moment, the ratio between them stays meaningful even
+ * though the absolute figures are a floor.
+ */
+import { recordTelemetry } from '../api';
+
+/**
+ * The workspace a route is about, or '' when it is not about one.
+ *
+ * Two shapes, because the route table spells the same thing differently: the
+ * workspace pages carry it as `id`, while a task opened from a filtered list
+ * carries it as `workspaceId`. Missing one would silently drop every report
+ * from half the app.
+ *
+ * @param {{ params?: Record<string, unknown> }} route
+ * @returns {string}
+ */
+export function workspaceIdFromRoute(route) {
+  const params = route?.params ?? {};
+  const candidate = params.workspaceId ?? (isWorkspaceRoute(route) ? params.id : '');
+  return typeof candidate === 'string' ? candidate : '';
+}
+
+/**
+ * `:id` means a workspace only under `/workspaces`. Elsewhere — `/events/:id`,
+ * `/workflows/:id` — it is a different thing entirely, and reporting it as a
+ * workspace would be rejected by the backend at best and misattributed at
+ * worst.
+ */
+function isWorkspaceRoute(route) {
+  return typeof route?.path === 'string' && route.path.startsWith('/workspaces/');
+}
+
+/**
+ * Report one interface action, if it can be attributed.
+ *
+ * Never throws and never returns anything worth checking: a metric is not worth
+ * failing a click over, which is also why `recordTelemetry` itself swallows
+ * transport failures.
+ *
+ * @param {string} action one of the `TELEMETRY_UI_*` names
+ * @param {{ params?: object, path?: string }} route the current route
+ * @param {(action: string, workspaceId: string) => void} [record] test seam
+ */
+export function recordUiAction(action, route, record = recordTelemetry) {
+  const workspaceId = workspaceIdFromRoute(route);
+  // `recordTelemetry` already ignores an empty workspace; checking here as well
+  // keeps that a decision this module makes rather than a behaviour it relies
+  // on another module continuing to have.
+  if (!workspaceId) return;
+  record(action, workspaceId);
+}
+
+/**
+ * A "once per episode" gate.
+ *
+ * The finder searches on every keystroke, so reporting each one would count
+ * typing "deploy" as six searches and make the number meaningless. This records
+ * the first search of a session and nothing more until the session restarts.
+ *
+ * @returns {{ fire: (fn: () => void) => void, reset: () => void }}
+ */
+export function createOncePerEpisode() {
+  let fired = false;
+  return {
+    fire(fn) {
+      if (fired) return;
+      fired = true;
+      fn();
+    },
+    reset() {
+      fired = false;
+    },
+  };
+}

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -74,7 +74,7 @@
                 <span class="hidden sm:inline">Chat</span>
                 <svg class="sm:hidden w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8-1.06 0-2.077-.163-3.02-.463L3 21l1.51-4.532A7.965 7.965 0 013 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/></svg>
               </button>
-              <button @click.stop="activeView = 'trajectory'"
+              <button @click.stop="showTrajectory()"
                       @mouseenter="tooltipStore.show($event, `Tool call trajectory  ${viewShortcut('trajectory-view')}`, 'bottom')"
                       @mouseleave="tooltipStore.hide()"
                       :class="activeView === 'trajectory' ? 'bg-white dark:bg-zinc-700 text-black dark:text-white shadow-sm' : 'text-gray-400 dark:text-zinc-500 hover:text-gray-600 dark:hover:text-zinc-300'"
@@ -747,7 +747,7 @@
 <script setup>
 import { ref, onMounted, computed, onUnmounted, watch, nextTick } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { getWorkspace, fetchTasks, archiveWorkspace, unarchiveWorkspace, updateWorkspace, getWorkspaceToken, getTask, updateTaskStatus, respondToTask, updateTaskAssignee, getAttachmentUrl, sendPermissionVerdict, respondToElicitation, stopTask, updateTaskAllowAllCommands, fetchUser } from '../api';
+import { getWorkspace, fetchTasks, archiveWorkspace, unarchiveWorkspace, updateWorkspace, getWorkspaceToken, getTask, updateTaskStatus, respondToTask, updateTaskAssignee, getAttachmentUrl, sendPermissionVerdict, respondToElicitation, stopTask, updateTaskAllowAllCommands, fetchUser, TELEMETRY_UI_COPY_MARKDOWN, TELEMETRY_UI_SHORTCUT_USE, TELEMETRY_UI_TRAJECTORY_VIEW } from '../api';
 import { useTooltipStore } from '../stores/tooltipStore';
 import { useToasts } from '../composables/useToasts';
 import { useViewport } from '../composables/useViewport';
@@ -767,6 +767,8 @@ import {
   telemetryText,
 } from '../composables/useAgentTelemetry';
 import { belongsInThread } from '../composables/useTrajectory';
+import { recordUiAction } from '../composables/useUiTelemetry';
+import { writeClipboard } from '../composables/useMarkdownLinks';
 import { mergeTaskUpdate } from '../composables/useTaskEvents';
 import TrajectoryPanel from '../components/TrajectoryPanel.vue';
 import {
@@ -848,8 +850,35 @@ function toggleMessageRender(id) {
   rawMessages.value = s;
 }
 const copiedMessages = ref(new Set());
+
+/**
+ * Put text on the clipboard, saying so when it does not work.
+ *
+ * `navigator.clipboard.writeText` rejects outright when the document is not
+ * focused, and these buttons used to await it bare: the rejection went nowhere,
+ * so a failed copy looked exactly like a successful one — no tick, no message,
+ * nothing on the clipboard. `writeClipboard` prefers the desktop shell, which
+ * has no such condition, and the caller now hears about a failure either way.
+ *
+ * @returns {Promise<boolean>} whether the text actually got there
+ */
+async function copyToClipboard(text) {
+  try {
+    await writeClipboard(text || '', {
+      bridge: window.agentrq?.clipboard,
+      clipboard: navigator.clipboard,
+    });
+    // Only a copy that happened is a copy that gets counted.
+    recordUiAction(TELEMETRY_UI_COPY_MARKDOWN, route);
+    return true;
+  } catch {
+    notifyError('Could not copy to the clipboard.');
+    return false;
+  }
+}
+
 async function copyMessageText(id, text) {
-  await navigator.clipboard.writeText(text || '');
+  if (!(await copyToClipboard(text))) return;
   const s = new Set(copiedMessages.value);
   s.add(id);
   copiedMessages.value = s;
@@ -925,8 +954,7 @@ function toggleTaskBodyRender() {
 }
 
 async function copyTaskBodyText() {
-  const text = stripNote(task.value?.body || '');
-  await navigator.clipboard.writeText(text);
+  if (!(await copyToClipboard(stripNote(task.value?.body || '')))) return;
   taskBodyCopied.value = true;
   setTimeout(() => {
     taskBodyCopied.value = false;
@@ -1000,10 +1028,23 @@ const activeView = ref('chat');
 useShortcuts(
   {
     'chat-view': () => { activeView.value = 'chat'; },
-    'trajectory-view': () => { activeView.value = 'trajectory'; },
+    'trajectory-view': () => showTrajectory(),
   },
-  { mac: () => usesCommandKey(platformStore.$state) }
+  { mac: () => usesCommandKey(platformStore.$state), onUse: () => recordUiAction(TELEMETRY_UI_SHORTCUT_USE, route) }
 );
+
+/**
+ * Switch to the trajectory, and count it.
+ *
+ * Both ways in go through here — the toggle and the `T` shortcut — because the
+ * question is how often people read the trajectory, not which control they
+ * reached for. Switching to it while already there is not a second read.
+ */
+function showTrajectory() {
+  if (activeView.value === 'trajectory') return;
+  activeView.value = 'trajectory';
+  recordUiAction(TELEMETRY_UI_TRAJECTORY_VIEW, route);
+}
 
 /** The key hint shown in each toggle's tooltip. */
 const viewShortcut = (id) =>

--- a/frontend/test/keyboardShortcuts.test.js
+++ b/frontend/test/keyboardShortcuts.test.js
@@ -223,6 +223,96 @@ describe('dispatchShortcut', () => {
     expect(unclaimed.preventDefault).not.toHaveBeenCalled()
   })
 
+  it('reports a shortcut that actually ran', () => {
+    const onUse = vi.fn()
+    const { options, mount } = fakeLifecycle()
+    useShortcuts({ 'new-task': vi.fn() }, options)
+    mount()
+
+    dispatchShortcut(press('n'), { onUse })
+
+    expect(onUse).toHaveBeenCalledWith('new-task')
+  })
+
+  it('reports nothing for a key nobody handled', () => {
+    // Pressing a key on a screen that ignores it is not a use of the feature.
+    const onUse = vi.fn()
+    const { options, mount } = fakeLifecycle()
+    useShortcuts({ 'new-task': vi.fn() }, options)
+    mount()
+
+    dispatchShortcut(press('m'), { onUse })
+    dispatchShortcut(press('z'), { onUse })
+
+    expect(onUse).not.toHaveBeenCalled()
+  })
+
+  it('does not treat the reporter as a shortcut table', () => {
+    // `onUse` is pulled out of the options before they reach matchShortcut;
+    // leaving it in would make every match fail.
+    const { options, mount } = fakeLifecycle()
+    useShortcuts({ 'new-task': vi.fn() }, options)
+    mount()
+
+    expect(dispatchShortcut(press('n'), { onUse: vi.fn() })).toBe('new-task')
+  })
+
+  it('needs no reporter at all', () => {
+    const { options, mount } = fakeLifecycle()
+    useShortcuts({ 'new-task': vi.fn() }, options)
+    mount()
+
+    expect(() => dispatchShortcut(press('n'))).not.toThrow()
+  })
+
+  it('passes the reporter through the listener useShortcuts installs', () => {
+    // The production path: the component gives onUse to useShortcuts, not to
+    // dispatchShortcut, so the keydown listener has to carry it.
+    const onUse = vi.fn()
+    const { options, mount } = fakeLifecycle()
+    const { onKeydown } = useShortcuts({ 'new-task': vi.fn() }, { ...options, onUse })
+    mount()
+
+    onKeydown(press('n'))
+
+    expect(onUse).toHaveBeenCalledWith('new-task')
+  })
+
+  it('answers one keypress once, however many listeners see it', () => {
+    // Two registrations means two window listeners, so the same event reaches
+    // dispatch twice. Running the handler twice was invisible while handlers
+    // were idempotent; counting the press made it visible.
+    const shell = vi.fn()
+    const view = vi.fn()
+    const onUse = vi.fn()
+    const a = fakeLifecycle()
+    const b = fakeLifecycle()
+    useShortcuts({ 'chat-view': shell }, a.options)
+    a.mount()
+    useShortcuts({ 'chat-view': view }, b.options)
+    b.mount()
+
+    const event = press('m')
+    expect(dispatchShortcut(event, { onUse })).toBe('chat-view')
+    expect(dispatchShortcut(event, { onUse })).toBeNull()
+
+    expect(view).toHaveBeenCalledOnce()
+    expect(shell).not.toHaveBeenCalled()
+    expect(onUse).toHaveBeenCalledOnce()
+  })
+
+  it('still answers the next keypress', () => {
+    const handler = vi.fn()
+    const { options, mount } = fakeLifecycle()
+    useShortcuts({ 'new-task': handler }, options)
+    mount()
+
+    dispatchShortcut(press('n'))
+    dispatchShortcut(press('n'))
+
+    expect(handler).toHaveBeenCalledTimes(2)
+  })
+
   it('survives an event object with no preventDefault', () => {
     const handler = vi.fn()
     const { options, mount } = fakeLifecycle()

--- a/frontend/test/uiTelemetry.test.js
+++ b/frontend/test/uiTelemetry.test.js
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  createOncePerEpisode,
+  recordUiAction,
+  workspaceIdFromRoute,
+} from '../src/composables/useUiTelemetry';
+
+describe('workspaceIdFromRoute', () => {
+  it('reads the workspace from a workspace page', () => {
+    expect(workspaceIdFromRoute({ path: '/workspaces/ws1/board', params: { id: 'ws1' } })).toBe('ws1');
+  });
+
+  it('reads it from a task opened inside a workspace', () => {
+    expect(workspaceIdFromRoute({ path: '/workspaces/ws1/tasks/t1', params: { id: 'ws1', taskId: 't1' } }))
+      .toBe('ws1');
+  });
+
+  it('reads it from a task opened out of a filtered list', () => {
+    // That route spells the same thing `workspaceId`; missing this shape would
+    // silently drop every report from half the app.
+    expect(
+      workspaceIdFromRoute({ path: '/tasks/ongoing/ws1/t1', params: { filter: 'ongoing', workspaceId: 'ws1', taskId: 't1' } })
+    ).toBe('ws1');
+  });
+
+  it('does not mistake an event id for a workspace', () => {
+    // `:id` means a workspace only under /workspaces.
+    expect(workspaceIdFromRoute({ path: '/events/e1', params: { id: 'e1' } })).toBe('');
+  });
+
+  it('does not mistake a workflow id for a workspace', () => {
+    expect(workspaceIdFromRoute({ path: '/workflows/wf1', params: { id: 'wf1' } })).toBe('');
+  });
+
+  it('reports nothing on a page that is not about a workspace', () => {
+    expect(workspaceIdFromRoute({ path: '/tasks/ongoing', params: { filter: 'ongoing' } })).toBe('');
+    expect(workspaceIdFromRoute({ path: '/', params: {} })).toBe('');
+  });
+
+  it('survives a route it was handed before one existed', () => {
+    expect(workspaceIdFromRoute(undefined)).toBe('');
+    expect(workspaceIdFromRoute({})).toBe('');
+  });
+
+  it('ignores a param that is not a string', () => {
+    // Repeatable params arrive as arrays, which are not a workspace id.
+    expect(workspaceIdFromRoute({ path: '/workspaces/x', params: { id: ['ws1', 'ws2'] } })).toBe('');
+  });
+});
+
+describe('recordUiAction', () => {
+  it('reports the action against the workspace in context', () => {
+    const record = vi.fn();
+
+    recordUiAction('ui_search', { path: '/workspaces/ws1/board', params: { id: 'ws1' } }, record);
+
+    expect(record).toHaveBeenCalledWith('ui_search', 'ws1');
+  });
+
+  it('drops the report rather than guessing a workspace', () => {
+    // Attributing a click to a workspace that did not generate it would
+    // corrupt that workspace's numbers, which is worse than counting less.
+    const record = vi.fn();
+
+    recordUiAction('ui_search', { path: '/tasks/ongoing', params: {} }, record);
+
+    expect(record).not.toHaveBeenCalled();
+  });
+
+  it('drops it on a page whose :id is not a workspace', () => {
+    const record = vi.fn();
+
+    recordUiAction('ui_copy_link', { path: '/events/e1', params: { id: 'e1' } }, record);
+
+    expect(record).not.toHaveBeenCalled();
+  });
+});
+
+describe('createOncePerEpisode', () => {
+  it('runs the first time and not again', () => {
+    // The finder searches on every keystroke; typing "deploy" is one search.
+    const fn = vi.fn();
+    const episode = createOncePerEpisode();
+
+    episode.fire(fn);
+    episode.fire(fn);
+    episode.fire(fn);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs again after a reset, which is what starts a new episode', () => {
+    const fn = vi.fn();
+    const episode = createOncePerEpisode();
+
+    episode.fire(fn);
+    episode.reset();
+    episode.fire(fn);
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('resets cleanly before anything has fired', () => {
+    const fn = vi.fn();
+    const episode = createOncePerEpisode();
+
+    episode.reset();
+    episode.fire(fn);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps episodes independent of each other', () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    const first = createOncePerEpisode();
+    const second = createOncePerEpisode();
+
+    first.fire(a);
+    first.fire(a);
+    second.fire(b);
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -58,6 +58,7 @@ export default defineConfig({
         'src/composables/useAttachmentCache.js',
         'src/composables/useCacheRetention.js',
         'src/composables/useMarkdownLinks.js',
+        'src/composables/useUiTelemetry.js',
         'src/composables/useWebMCP.js',
         'src/utils/markdown.js',
         'src/webmcp/*.js',


### PR DESCRIPTION
## What changed

Six new usage counts for things that happen entirely in the browser and were previously invisible: keyboard shortcuts, searches, searches that led to opening a task, copying a link, copying raw markdown, and switching to the trajectory view. They use the same reporting path and storage as the existing local-AI metrics.

## Why

None of these leave the tab, so nothing server-side knows they happened and there was no way to tell which of them people actually use.

## Test coverage report

- **New lines: 100%.** The new frontend module sits inside the frontend's 100% line/branch/function threshold and was added to the coverage include list so it is genuinely counted; every new backend path has a test.
- **Total coverage impact: none.** Frontend 790 tests passing (up from 768), backend suite green, desktop 443 unchanged.

Each layer is pinned: the allowlist accepts exactly the named actions and rejects near-misses, every action stringifies back to the name it was reported under, each one maps to its own stored id, and the route accepts each name and hands the controller the right action.

## Other reports

Verified end to end against a real backend — a new `npm run verify:ui-telemetry` drives the actual interface and checks what it reports:

```
✓ pressing a shortcut is reported — 2 reports
✓ one keypress is one report, not one per listener — two presses -> 2 reports
✓ switching to the trajectory is reported separately — 1 reports
✓ copying raw markdown is reported — 1 reports
✓ copying a link is reported — 1 reports
✓ a search is reported once, not once per keystroke — 1 reports for 6 keystrokes
✓ opening a search result is reported — 1 reports
✓ every report names the workspace it happened in — 7 reports, all for one workspace
✓ a shortcut with no workspace in context is dropped, not misattributed — 0 reports
✓ reports reach the telemetry table — 22×2, 25×1, 26×1, 27×1
```

**Three changes beyond the literal ask, each because the feature does not work without them:**

1. **The rate limit is raised from 10 to 60 reports per minute.** Ten was sized when the only client-reported actions were two rare local-AI events. Ordinary interface use passes that easily, so the new counts would have been silently short — and worse, would have starved the local-AI metrics that share the bucket, degrading a metric that works today. Sixty a minute is one a second sustained, which still bounds a hostile page to sixty small rows per user per minute.

2. **"Copy raw text" no longer fails silently.** Those buttons awaited the clipboard with no catch, so a refused write produced no tick, no message and nothing on the clipboard — indistinguishable from success. They now use the same shell-backed path the link copy uses and report failure. This is why copy-markdown telemetry recorded nothing on the first test run.

3. **A shortcut on a task page ran its handler twice**, because the shell and the view each install a keydown listener. Harmless while handlers were idempotent, and immediately wrong once a keypress became a number.

**One deliberate limitation:** a report with no workspace in the current route is dropped rather than attributed to a guessed one — inventing attribution would corrupt the per-workspace counts for a user who never generated them. So interface counts are actions taken with a workspace in context, not all actions. Both halves of the search funnel resolve the workspace identically, so the ratio between them stays meaningful even though the absolute figures are a floor.

TaskID: 0iHpNE6lhC5