### PR TITLE
feat(frontend): tell people the finder exists

### DIFF
--- a/frontend/src/composables/useKeyboardShortcuts.js
+++ b/frontend/src/composables/useKeyboardShortcuts.js
@@ -52,6 +52,11 @@ export const SHORTCUTS = [
     // The finder is how you leave a screen you are typing on, so unlike the
     // bare letters it stays live while a text box has focus.
     hint: 'Titles from your recent tasks; a full ID reaches any task you own',
+    // Shown in the workspace header, where it is the one shortcut worth
+    // advertising: a keystroke nobody discovers is a keystroke nobody uses.
+    // Deliberately shorter and more verb-like than `label`, which titles a row
+    // in the help sheet — here it has to read as an instruction at a glance.
+    hintLabel: 'Search tasks',
     scope: 'global',
   },
   {
@@ -185,6 +190,23 @@ export function formatShortcut(shortcut, { mac = false } = {}) {
   const key = shortcut.key.toUpperCase();
   if (!shortcut.mod) return key;
   return mac ? `⌘${key}` : `Ctrl+${key}`;
+}
+
+/**
+ * A shortcut worth showing in the interface's own chrome, or null.
+ *
+ * Only shortcuts that declare a `hintLabel` are advertised — a hint is a claim
+ * on space beside the controls, and most of the table does not earn one. The
+ * help sheet is where the rest live.
+ *
+ * @param {string} id
+ * @param {{ mac?: boolean, shortcuts?: typeof SHORTCUTS }} [options]
+ * @returns {{ keys: string, label: string } | null}
+ */
+export function shortcutHint(id, { mac = false, shortcuts = SHORTCUTS } = {}) {
+  const shortcut = shortcuts.find((s) => s.id === id);
+  if (!shortcut?.hintLabel) return null;
+  return { keys: formatShortcut(shortcut, { mac }), label: shortcut.hintLabel };
 }
 
 /**

--- a/frontend/src/views/WorkspaceDetailView.vue
+++ b/frontend/src/views/WorkspaceDetailView.vue
@@ -42,6 +42,18 @@
         <!-- Stats & Actions Row -->
         <div class="flex items-center gap-4 shrink-0 justify-between sm:justify-end">
           <div class="flex items-center gap-2">
+            <!-- How to reach the finder.
+                 Beside the controls because that is where someone looks when
+                 they want to get somewhere, and a keystroke nobody discovers is
+                 a keystroke nobody uses. Hidden below `lg`: the row is already
+                 tight at that width, and a hint is the first thing that should
+                 give up its space. Not a button — it says which key to press,
+                 and pressing it is the thing being taught. -->
+            <span v-if="findTaskHint" class="hidden lg:flex items-center gap-1.5 mr-1 text-gray-400 dark:text-zinc-500 select-none">
+              <kbd class="font-sans text-[9px] font-black uppercase tracking-widest border border-gray-200 dark:border-zinc-700 rounded px-1.5 py-0.5 bg-white dark:bg-zinc-900">{{ findTaskHint.keys }}</kbd>
+              <span class="text-[10px] font-medium">{{ findTaskHint.label }}</span>
+            </span>
+
             <!-- Filters Toggle & Menu Wrapper -->
             <div class="relative flex items-center">
               <button @click="showMobileFilters = !showMobileFilters" 
@@ -176,6 +188,8 @@ import { useTooltipStore } from '../stores/tooltipStore';
 import { useViewport } from '../composables/useViewport';
 import { useWorkspaceStore } from '../stores/workspaceStore';
 import { useFormat } from '../composables/useFormat';
+import { shortcutHint, usesCommandKey } from '../composables/useKeyboardShortcuts';
+import { usePlatformStore } from '../stores/platformStore';
 import TaskFeed from '../components/TaskFeed.vue';
 import LoadingState from '../components/LoadingState.vue';
 
@@ -185,6 +199,14 @@ const route = useRoute();
 const router = useRouter();
 const { notifySuccess, notifyError } = useToasts();
 const { isMobile } = useViewport();
+
+const platformStore = usePlatformStore();
+// Which modifier this keyboard has is a per-machine fact, so the hint is
+// computed rather than written: ⌘K on a Mac, Ctrl+K everywhere else, in both
+// the browser and the desktop app.
+const findTaskHint = computed(() =>
+  shortcutHint('find-task', { mac: usesCommandKey(platformStore.$state) })
+);
 const workspaceId = computed(() => route.params.id);
 const selectedTaskId = computed(() => route.params.taskId);
 

--- a/frontend/test/keyboardShortcuts.test.js
+++ b/frontend/test/keyboardShortcuts.test.js
@@ -4,6 +4,7 @@ import { createApp, h } from 'vue'
 import {
   SHORTCUTS,
   dispatchShortcut,
+  shortcutHint,
   formatShortcut,
   isTypingTarget,
   matchShortcut,
@@ -189,6 +190,46 @@ describe('formatShortcut', () => {
     expect(formatShortcut({ key: '?' })).toBe('?')
   })
 
+})
+
+describe('shortcutHint', () => {
+  it('spells the finder for a Mac keyboard', () => {
+    expect(shortcutHint('find-task', { mac: true })).toEqual({ keys: '⌘K', label: 'Search tasks' })
+  })
+
+  it('spells it for every other keyboard', () => {
+    expect(shortcutHint('find-task', { mac: false })).toEqual({ keys: 'Ctrl+K', label: 'Search tasks' })
+  })
+
+  it('defaults to the non-Mac spelling rather than guessing', () => {
+    expect(shortcutHint('find-task').keys).toBe('Ctrl+K')
+  })
+
+  it('offers nothing for a shortcut that does not ask to be advertised', () => {
+    // A hint takes space beside the controls; most of the table has not earned
+    // one and lives in the help sheet instead.
+    expect(shortcutHint('new-task')).toBeNull()
+    expect(shortcutHint('trajectory-view')).toBeNull()
+  })
+
+  it('offers nothing for a shortcut that does not exist', () => {
+    expect(shortcutHint('no-such-shortcut')).toBeNull()
+  })
+
+  it('reads the table it is given, so a caller can test its own', () => {
+    const table = [{ id: 'x', key: 'j', mod: true, label: 'X', hintLabel: 'Do the thing' }]
+
+    expect(shortcutHint('x', { mac: true, shortcuts: table }))
+      .toEqual({ keys: '⌘J', label: 'Do the thing' })
+  })
+
+  it('advertises exactly one shortcut today', () => {
+    // Guards the claim the header makes: adding a hintLabel puts a hint on
+    // screen, so it should be a decision rather than a side effect.
+    const advertised = SHORTCUTS.filter((s) => s.hintLabel).map((s) => s.id)
+
+    expect(advertised).toEqual(['find-task'])
+  })
 })
 
 describe('dispatchShortcut', () => {


### PR DESCRIPTION
## What changed

The workspace header now shows a small hint — the key combination and "Search tasks" — beside its controls, so people can discover that Cmd/Ctrl+K opens the task finder. It appears in both the browser and the desktop app, spelled for whichever keyboard is in front of you, and steps aside on narrow screens.

## Why

The finder was reachable only by knowing about it, and nothing on screen said so.

## Test coverage report

- **New lines: 100%.** The new helper sits inside the frontend's 100% line/branch/function threshold.
- **Total coverage impact: none — the suite stays at 100%.** 797 tests passing, up from 790.

## Other reports

Checked in a real window against a running backend, rather than only in tests.

The hint reads `⌘K  Search tasks` on a Mac and `Ctrl+K  Search tasks` elsewhere, sitting to the left of the filter controls in muted text:

| viewport | shown |
|---|---|
| 1440px | yes |
| 1200px | yes |
| 1023px | no |
| 900px | no |
| 700px | no |

Two small decisions worth a reviewer's attention:

- **It is text, not a button.** What it teaches is the keystroke, so pressing the hint instead would defeat it — and a click is not shortcut usage, so counting it would inflate the metric added in #454.
- **Advertising is opt-in per shortcut**, via a `hintLabel` on the shortcut definition, and a test pins that exactly one shortcut declares it today. A hint is a claim on space beside the controls; the rest of the table stays in the help sheet.

TaskID: 0iHux9pcqZN