### PR TITLE
chore: bump patch version to v0.5.9

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.5.8"
+	_appVersion   = "v0.5.9"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.5.8" {
-			t.Errorf("Expected version v0.5.8, got %s", s.Version())
+		if s.Version() != "v0.5.9" {
+			t.Errorf("Expected version v0.5.9, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.5.8",
+  "version": "0.5.9",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
## What changed

Bumps the project version from 0.5.8 to 0.5.9 across all six declaration sites, so the release build's version-sync gate passes.

## Why

Cuts a release containing the two changes that have landed since v0.5.8. Merging alone publishes nothing — the release is built by tagging `main` with `v0.5.9` afterwards.

## Changes in this version

**feat**
- Tell people the finder exists (#455). The workspace header now shows the key combination that opens the task finder — spelled for whichever keyboard is in front of you, in both the browser and the desktop app — and steps aside on narrow screens.
- Count how the interface itself is used (#454). Six usage counts for things that happen entirely in the browser and were previously invisible: keyboard shortcuts, searches, searches that led to opening a task, copying a link, copying raw markdown, and switching to the trajectory view.

**fix**
- The "copy raw text" buttons no longer fail silently when the clipboard refuses, and a keyboard shortcut pressed on a task page no longer runs its handler twice (both in #454).

## Test coverage report

- **New lines: none** — this changes only version literals.
- **Total coverage impact: none.** The backend config test asserting the version string was updated alongside the constant; `go test ./internal/service/config/...` passes.

## Other reports

Version sync verified both ways, including the form CI runs on a tag build:

```
$ node desktop/scripts/check-versions.mjs
✓ desktop, frontend and backend are all at 0.5.9

$ GITHUB_REF=refs/tags/v0.5.9 node desktop/scripts/check-versions.mjs
✓ desktop, frontend and backend are all at 0.5.9
✓ tag v0.5.9 matches version 0.5.9
```

Lockfile version fields were edited by hand rather than regenerated, so no dependency resolution shifted underneath the release; `npm ci` still succeeds in both `desktop/` and `frontend/`.

TaskID: 0iHux9pcqZN