### PR TITLE
feat(backend): store a workspace's memories

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -201,6 +201,7 @@ func New(cfg Config) (*App, error) {
 		&model.Workflow{},
 		&model.WorkflowStep{},
 		&model.ToolCall{},
+		&model.Memory{},
 	); err != nil {
 		return nil, fmt.Errorf("migrate db: %w", err)
 	}

--- a/backend/internal/data/model/model.go
+++ b/backend/internal/data/model/model.go
@@ -169,6 +169,34 @@ type (
 	}
 
 	// Message is an entry in a task's chat history
+	// Memory is what an agent has chosen to remember about a workspace.
+	//
+	// Scoped to the workspace's owner rather than to whichever agent wrote it:
+	// this is the workspace's memory, so every agent working there reads and
+	// writes the same rows. Keyed per (owner, workspace, name), so several
+	// named memories can live side by side; MEMORY.md is the one agents read
+	// first and is where the index to the others belongs.
+	//
+	// The unique index spans all three columns, and every one of them carries
+	// the same index name with a priority — see the note on Event for what
+	// happens otherwise. Here the consequence would be a memory name that is
+	// unique across every workspace and every account, so one workspace saving
+	// "MEMORY.md" would take the name from everybody else.
+	//
+	// Content is capped at 16 KiB by the tools that write it, which is where
+	// there is a caller to refuse. The column is deliberately larger: the cap
+	// is counted in bytes of UTF-8, and 64000 characters is comfortably above
+	// what 16 KiB can encode.
+	Memory struct {
+		ID          int64 `gorm:"primaryKey;autoIncrement:false"`
+		CreatedAt   time.Time
+		UpdatedAt   time.Time
+		UserID      int64  `gorm:"index:idx_memories_user_id;uniqueIndex:uk_user_id_workspace_id_name,priority:1"`
+		WorkspaceID int64  `gorm:"index:idx_memories_workspace_id;uniqueIndex:uk_user_id_workspace_id_name,priority:2"`
+		Name        string `gorm:"type:varchar(32);uniqueIndex:uk_user_id_workspace_id_name,priority:3"`
+		Content     string `gorm:"type:varchar(64000)"`
+	}
+
 	Message struct {
 		ID          int64 `gorm:"primaryKey;autoIncrement:false"`
 		CreatedAt   time.Time

--- a/backend/internal/repository/base/memory_test.go
+++ b/backend/internal/repository/base/memory_test.go
@@ -1,0 +1,222 @@
+package base
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+// The database is built the way app.go builds the real one, so the unique index
+// under test is the one production actually has.
+func memoryDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open("file::memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&model.Memory{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+const (
+	memUserID      = int64(482467435371298817)
+	memWorkspaceID = int64(498041479541817345)
+	memOtherWSID   = int64(498041479541817346)
+	memOtherUserID = int64(482467435371298818)
+)
+
+func memory(id int64, userID, workspaceID int64, name, content string) model.Memory {
+	now := time.Now()
+	return model.Memory{
+		ID: id, CreatedAt: now, UpdatedAt: now,
+		UserID: userID, WorkspaceID: workspaceID, Name: name, Content: content,
+	}
+}
+
+func TestUpsertMemory_StoresAndReadsBack(t *testing.T) {
+	repo := New(&mockDB{db: memoryDB(t)})
+	ctx := context.Background()
+
+	saved, err := repo.UpsertMemory(ctx, memory(1, memUserID, memWorkspaceID, "MEMORY.md", "# Index\n"))
+	if err != nil {
+		t.Fatalf("UpsertMemory: %v", err)
+	}
+	if saved.Content != "# Index\n" || saved.Name != "MEMORY.md" {
+		t.Errorf("saved: got %+v", saved)
+	}
+
+	got, err := repo.GetMemory(ctx, memUserID, memWorkspaceID, "MEMORY.md")
+	if err != nil {
+		t.Fatalf("GetMemory: %v", err)
+	}
+	if got.Content != "# Index\n" {
+		t.Errorf("content: got %q", got.Content)
+	}
+}
+
+// saveMemory overwrites, so a second save must replace the row rather than
+// failing against the unique key or adding a duplicate.
+func TestUpsertMemory_OverwritesInPlace(t *testing.T) {
+	db := memoryDB(t)
+	repo := New(&mockDB{db: db})
+	ctx := context.Background()
+
+	first, err := repo.UpsertMemory(ctx, memory(1, memUserID, memWorkspaceID, "MEMORY.md", "before"))
+	if err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+
+	// A different generated ID, as the caller would supply on any later save.
+	second, err := repo.UpsertMemory(ctx, memory(2, memUserID, memWorkspaceID, "MEMORY.md", "after"))
+	if err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+
+	if second.Content != "after" {
+		t.Errorf("content: got %q, want the newer one", second.Content)
+	}
+	// The row keeps the identity it already had; only the content moves.
+	if second.ID != first.ID {
+		t.Errorf("id: got %d, want the existing row's %d", second.ID, first.ID)
+	}
+
+	var count int64
+	if err := db.Model(&model.Memory{}).Count(&count).Error; err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected one row after two saves, got %d", count)
+	}
+}
+
+// The unique key spans all three columns. Tagging only Name would make a memory
+// name unique across every workspace and every account, so one workspace saving
+// MEMORY.md would take the name from everyone else.
+func TestUpsertMemory_NameIsScopedToOwnerAndWorkspace(t *testing.T) {
+	repo := New(&mockDB{db: memoryDB(t)})
+	ctx := context.Background()
+
+	if _, err := repo.UpsertMemory(ctx, memory(1, memUserID, memWorkspaceID, "MEMORY.md", "workspace one")); err != nil {
+		t.Fatalf("first workspace: %v", err)
+	}
+	if _, err := repo.UpsertMemory(ctx, memory(2, memUserID, memOtherWSID, "MEMORY.md", "workspace two")); err != nil {
+		t.Fatalf("same name in another workspace must be allowed: %v", err)
+	}
+	if _, err := repo.UpsertMemory(ctx, memory(3, memOtherUserID, memWorkspaceID, "MEMORY.md", "another owner")); err != nil {
+		t.Fatalf("same name for another owner must be allowed: %v", err)
+	}
+
+	for _, tc := range []struct {
+		userID, workspaceID int64
+		want                string
+	}{
+		{memUserID, memWorkspaceID, "workspace one"},
+		{memUserID, memOtherWSID, "workspace two"},
+		{memOtherUserID, memWorkspaceID, "another owner"},
+	} {
+		got, err := repo.GetMemory(ctx, tc.userID, tc.workspaceID, "MEMORY.md")
+		if err != nil {
+			t.Fatalf("GetMemory(%d, %d): %v", tc.userID, tc.workspaceID, err)
+		}
+		if got.Content != tc.want {
+			t.Errorf("GetMemory(%d, %d): got %q, want %q", tc.userID, tc.workspaceID, got.Content, tc.want)
+		}
+	}
+}
+
+func TestGetMemory_MissingIsNotFound(t *testing.T) {
+	repo := New(&mockDB{db: memoryDB(t)})
+
+	_, err := repo.GetMemory(context.Background(), memUserID, memWorkspaceID, "never-written.md")
+
+	// A distinguishable error, because a first call on a fresh workspace always
+	// misses and the tools answer that differently from a real failure.
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("got %v, want ErrNotFound", err)
+	}
+}
+
+func TestListMemoriesByWorkspace_OrderedAndScoped(t *testing.T) {
+	repo := New(&mockDB{db: memoryDB(t)})
+	ctx := context.Background()
+
+	for i, name := range []string{"zeta.md", "MEMORY.md", "alpha.md"} {
+		if _, err := repo.UpsertMemory(ctx, memory(int64(i+1), memUserID, memWorkspaceID, name, name)); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+	// Belongs to another workspace, and must not appear.
+	if _, err := repo.UpsertMemory(ctx, memory(9, memUserID, memOtherWSID, "elsewhere.md", "x")); err != nil {
+		t.Fatalf("seed other workspace: %v", err)
+	}
+
+	got, err := repo.ListMemoriesByWorkspace(ctx, memUserID, memWorkspaceID)
+	if err != nil {
+		t.Fatalf("ListMemoriesByWorkspace: %v", err)
+	}
+
+	var names []string
+	for _, m := range got {
+		names = append(names, m.Name)
+	}
+	if strings.Join(names, ",") != "MEMORY.md,alpha.md,zeta.md" {
+		t.Errorf("got %v, want them ordered by name", names)
+	}
+}
+
+func TestListMemoriesByWorkspace_EmptyWorkspace(t *testing.T) {
+	repo := New(&mockDB{db: memoryDB(t)})
+
+	got, err := repo.ListMemoriesByWorkspace(context.Background(), memUserID, memWorkspaceID)
+
+	// A workspace nobody has written to yet is empty, not an error: that is the
+	// state every workspace starts in.
+	if err != nil {
+		t.Fatalf("ListMemoriesByWorkspace: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no memories, got %d", len(got))
+	}
+}
+
+// The column is varchar(32); a longer name must not be quietly cut down to fit,
+// which would file the memory under a name the agent never chose.
+func TestMemoryName_LongerThanTheColumnIsNotSilentlyTruncated(t *testing.T) {
+	repo := New(&mockDB{db: memoryDB(t)})
+	ctx := context.Background()
+	long := strings.Repeat("n", 40) + ".md"
+
+	saved, err := repo.UpsertMemory(ctx, memory(1, memUserID, memWorkspaceID, long, "x"))
+	if err != nil {
+		// Refusing is the other acceptable answer, and is what Postgres does.
+		return
+	}
+	if saved.Name != long {
+		t.Errorf("name was truncated to %q; the tools must reject an over-long name before it reaches here", saved.Name)
+	}
+}
+
+// A write that fails has to surface the failure rather than returning a zero
+// memory as though it had been stored: saveMemory reports success to an agent,
+// which will then trust that its notes are safe.
+func TestUpsertMemory_ReportsAWriteThatFailed(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file::memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// Deliberately not migrated: there is no memories table to write to.
+	repo := New(&mockDB{db: db})
+
+	if _, err := repo.UpsertMemory(context.Background(), memory(1, memUserID, memWorkspaceID, "MEMORY.md", "x")); err == nil {
+		t.Error("expected an error when the write cannot land")
+	}
+}

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -11,6 +11,7 @@ import (
 	"github.com/agentrq/agentrq/backend/internal/data/model"
 	"github.com/agentrq/agentrq/backend/internal/repository/dbconn"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 var ErrNotFound = errors.New("not found")
@@ -36,6 +37,12 @@ type Repository interface {
 	ListMessages(ctx context.Context, taskID int64) ([]model.Message, error)
 	UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte) error
 	GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64) ([]string, error)
+
+	// Memory — the workspace's own notes, written by agents through the MCP
+	// memory tools. Keyed per (owner, workspace, name); see model.Memory.
+	GetMemory(ctx context.Context, userID, workspaceID int64, name string) (model.Memory, error)
+	UpsertMemory(ctx context.Context, m model.Memory) (model.Memory, error)
+	ListMemoriesByWorkspace(ctx context.Context, userID, workspaceID int64) ([]model.Memory, error)
 
 	// ToolCall
 	CreateToolCall(ctx context.Context, tc model.ToolCall) (model.ToolCall, error)
@@ -882,6 +889,57 @@ func (r *repository) ListPushSubscriptionsByUserAndWorkspace(ctx context.Context
 }
 
 // ── Events ─────────────────────────────────────────────────────────────────────
+
+// ── Memories ──────────────────────────────────────────────────────────────────
+
+func (r *repository) GetMemory(ctx context.Context, userID, workspaceID int64, name string) (model.Memory, error) {
+	var m model.Memory
+	err := r.conn(ctx).
+		Where("user_id = ? AND workspace_id = ? AND name = ?", userID, workspaceID, name).
+		First(&m).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return model.Memory{}, ErrNotFound
+	}
+	return m, err
+}
+
+// UpsertMemory writes a memory, replacing whatever was stored under that name.
+//
+// Overwriting is the whole semantic of saveMemory, so this is one statement
+// rather than a read followed by a write: two agents saving the same memory at
+// once would otherwise race, and the loser's insert would fail against the
+// unique key rather than simply being overwritten.
+//
+// The caller supplies a fresh ID for the insert case. On conflict the stored
+// row keeps the ID it already had — only the content and the timestamp move —
+// so a memory's identity survives being rewritten.
+func (r *repository) UpsertMemory(ctx context.Context, m model.Memory) (model.Memory, error) {
+	err := r.conn(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "user_id"}, {Name: "workspace_id"}, {Name: "name"}},
+		DoUpdates: clause.AssignmentColumns([]string{"content", "updated_at"}),
+	}).Create(&m).Error
+	if err != nil {
+		return model.Memory{}, err
+	}
+	// Read back rather than returning the struct that went in: on the update
+	// path the row's ID and creation time are the ones it already had, not the
+	// ones this call generated.
+	return r.GetMemory(ctx, m.UserID, m.WorkspaceID, m.Name)
+}
+
+// ListMemoriesByWorkspace returns every memory in a workspace, ordered by name.
+//
+// Content comes back with them: the rows are capped at 16 KiB and a workspace
+// holds a handful, so a second query per memory would cost more than it saves.
+// Callers that only need the index — the settings list — drop it themselves.
+func (r *repository) ListMemoriesByWorkspace(ctx context.Context, userID, workspaceID int64) ([]model.Memory, error) {
+	var memories []model.Memory
+	err := r.conn(ctx).
+		Where("user_id = ? AND workspace_id = ?", userID, workspaceID).
+		Order("name asc").
+		Find(&memories).Error
+	return memories, err
+}
 
 func (r *repository) CreateEvent(ctx context.Context, e model.Event) (model.Event, error) {
 	if err := r.conn(ctx).Create(&e).Error; err != nil {


### PR DESCRIPTION
## What changed

Adds the storage behind per-workspace memory for agents: a place to keep several named notes per workspace, and the reads and writes the memory tools will use. Nothing calls it yet.

## Why

First of four steps giving agents a memory that survives between tasks. Everything after it — the tools, the read API, the settings tab — builds on this table.

## Test coverage report

- **New lines: 100%.** All three repository methods are at 100% statement coverage, checked per function rather than assumed from a package total.
- **Total coverage impact: none.** The full backend suite passes; no existing test changed.

Tests pin the behaviour that would be expensive to discover later: a second save overwrites in place rather than duplicating or failing, the overwritten row keeps its identity, a missing memory is a distinguishable not-found rather than an error, and a write that cannot land reports the failure instead of returning an empty memory as though it had been stored.

## Other reports

**The composite unique index is the thing worth a reviewer's eye.** It spans all three columns, and every one carries the same index name with an explicit priority. Tagging only the name — even with an index name that mentions the others — silently produces a unique index on `name` alone, which here would make a memory name unique across every workspace and every account: one workspace saving `MEMORY.md` would take the name from everybody else. The `Event` model documents the same trap, and there is a test that fails if the index ever collapses to one column.

Two decisions carried into the code:

- **Memory is keyed to the workspace owner, not the connecting agent** — otherwise it is per-agent memory wearing a workspace's name, and two agents in one workspace could not read each other's notes.
- **The 16 KiB cap is enforced at the tool boundary, not here**, where there is a caller to return an error to. The column is deliberately larger than the cap.

TaskID: 0iHtNeMY9Hl