### PR TITLE
feat(mcp): give agents a memory that outlives the task

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,24 @@ Mock packages are **generated** (gitignored). Run `make mocks` before testing if
 - Cron validation: `validateCronGranularity` enforces hourly-minimum granularity. Minute field must be a single fixed integer (0-59); wildcards/steps/ranges/comma-lists are rejected.
 - Creating a task with `cron_schedule` sets `status="cron"` on the model.
 
+### Workspace memory
+
+`loadMemory` / `saveMemory` (`memory.go`) give agents notes that outlive a task.
+
+- Stored in `memories`, keyed per **(workspace owner, workspace, name)** — it is
+  the *workspace's* memory, so every agent working there shares it. Keying it to
+  the connecting client would make it per-agent memory wearing a workspace's
+  name.
+- `MEMORY.md` is the default for both tools and is meant to stay an index of the
+  other named memories. The server instructions tell connecting agents to load
+  it first.
+- **Limits are enforced at the tool boundary, not in the repository**: 16 KiB of
+  UTF-8 per memory and 32 characters per name, both refused rather than
+  truncated — an agent told its memory is too large can split it, while one
+  silently cut in half cannot know to.
+- A `loadMemory` miss is **not** an error: every agent's first call on a fresh
+  workspace misses, and answering with an error teaches agents to stop asking.
+
 ## CRUD task controller (`backend/internal/controller/crud/task.go`)
 
 - Cron validation also lives here for the REST API path (same rules).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,9 +93,17 @@ Mock packages are **generated** (gitignored). Run `make mocks` before testing if
   the *workspace's* memory, so every agent working there shares it. Keying it to
   the connecting client would make it per-agent memory wearing a workspace's
   name.
-- `MEMORY.md` is the default for both tools and is meant to stay an index of the
-  other named memories. The server instructions tell connecting agents to load
-  it first.
+- `memory.md` is the default for both tools and is meant to stay an index of the
+  other named memories, linking them as `memory://<name>`. The server
+  instructions tell connecting agents to load it first.
+- **Names are canonicalised at the tool boundary**: trimmed, lowercased, and
+  then required to match `^[a-z0-9]+(-[a-z0-9]+)*\.md$`. So `MEMORY.md`,
+  `Memory.md` and `memory.md` are one memory rather than three. Folding here
+  rather than in a query is deliberate — `=` is case-sensitive by default on
+  both SQLite and Postgres and a `NOCASE` collation does not port between them,
+  so one stored spelling is what makes the unique key behave the same on either.
+  The strict shape is also what lets `memory://<name>` be parsed as a URL at
+  all: a name with a space in it is not one.
 - **Limits are enforced at the tool boundary, not in the repository**: 16 KiB of
   UTF-8 per memory and 32 characters per name, both refused rather than
   truncated — an agent told its memory is too large can split it, while one

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -575,6 +575,36 @@ func New(cfg Config) (*App, error) {
 				})
 				return nil
 			},
+			// The workspace's memory. Scoped to the workspace and its owner here,
+			// so the tools themselves only ever name a memory — an agent cannot
+			// reach another workspace's notes by asking for them.
+			func(ctx context.Context, name string) (string, bool, error) {
+				uid := monoflake.IDFromBase62(workspaceOwner).Int64()
+				m, err := repo.GetMemory(ctx, uid, workspaceID, name)
+				if errors.Is(err, base.ErrNotFound) {
+					// A memory nobody has written yet: the ordinary state of a
+					// fresh workspace, and not a failure to report.
+					return "", false, nil
+				}
+				if err != nil {
+					return "", false, err
+				}
+				return m.Content, true, nil
+			},
+			func(ctx context.Context, name string, content string) error {
+				uid := monoflake.IDFromBase62(workspaceOwner).Int64()
+				now := time.Now()
+				_, err := repo.UpsertMemory(ctx, model.Memory{
+					ID:          ids.NextID(),
+					CreatedAt:   now,
+					UpdatedAt:   now,
+					UserID:      uid,
+					WorkspaceID: workspaceID,
+					Name:        name,
+					Content:     content,
+				})
+				return err
+			},
 			func(ctx context.Context, tc model.ToolCall) (model.ToolCall, error) {
 				created, err := repo.CreateToolCall(ctx, tc)
 				if err == nil {

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -201,6 +201,7 @@ func New(cfg Config) (*App, error) {
 		&model.Workflow{},
 		&model.WorkflowStep{},
 		&model.ToolCall{},
+		&model.Memory{},
 	); err != nil {
 		return nil, fmt.Errorf("migrate db: %w", err)
 	}

--- a/backend/internal/controller/mcp/client_identity.go
+++ b/backend/internal/controller/mcp/client_identity.go
@@ -47,8 +47,14 @@ func clientIdentityFromRequest(req mcp.Request) clientIdentity {
 		return clientIdentity{}
 	}
 	var meta map[string]any
+	// `p != nil` is not enough: GetParams returns an interface, and a request
+	// whose params were never set hands back a non-nil interface wrapping a nil
+	// pointer, which then panics on GetMeta. Same reason the request itself is
+	// checked with reflect a few lines up.
 	if p := req.GetParams(); p != nil {
-		meta = p.GetMeta()
+		if v := reflect.ValueOf(p); v.Kind() != reflect.Pointer || !v.IsNil() {
+			meta = p.GetMeta()
+		}
 	}
 	var userAgent string
 	if extra := req.GetExtra(); extra != nil && extra.Header != nil {

--- a/backend/internal/controller/mcp/memory.go
+++ b/backend/internal/controller/mcp/memory.go
@@ -1,0 +1,163 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Per-workspace memory: what an agent chooses to remember about a workspace,
+// so that what it learned in one task is still there in the next.
+//
+// The memory belongs to the workspace rather than to the agent that wrote it,
+// so several agents working the same workspace share one set of notes. Any
+// number of named memories can live side by side; MEMORY.md is the one agents
+// are told to read first, which makes it the natural place for an index to the
+// rest.
+//
+// Both limits below are enforced here rather than in the repository, because
+// this is where there is a caller to answer. An agent that is told its memory
+// was too large can split it and try again; an agent whose memory was silently
+// cut in half at the storage layer has no idea anything went wrong.
+
+const (
+	// DefaultMemoryName is what both tools read and write when given no name.
+	// The index, by convention — an agent that calls loadMemory with no
+	// arguments should land on something that tells it what else is here.
+	DefaultMemoryName = "MEMORY.md"
+
+	// MaxMemoryNameLength matches the column. Counted in characters, as the
+	// column is.
+	MaxMemoryNameLength = 32
+
+	// MaxMemoryBytes caps one memory at 16 KiB of UTF-8.
+	MaxMemoryBytes = 16 * 1024
+)
+
+// LoadMemoryFunc reads one of the workspace's memories.
+//
+// `found` is separate from `err` because a memory that was never written is
+// the ordinary case, not a failure: every agent's first call on a fresh
+// workspace misses, and answering that with an error would teach agents to
+// stop asking.
+type LoadMemoryFunc func(ctx context.Context, name string) (content string, found bool, err error)
+
+// SaveMemoryFunc writes one of the workspace's memories, replacing whatever
+// was stored under that name.
+type SaveMemoryFunc func(ctx context.Context, name string, content string) error
+
+// LoadMemoryParams is the input to the loadMemory tool.
+type LoadMemoryParams struct {
+	Name string `json:"name,omitempty" jsonschema:"Which memory to read. Defaults to MEMORY.md, the index that says what else this workspace remembers."`
+}
+
+// SaveMemoryParams is the input to the saveMemory tool.
+type SaveMemoryParams struct {
+	Name    string `json:"name,omitempty" jsonschema:"Which memory to write. Defaults to MEMORY.md, the index that says what else this workspace remembers."`
+	Content string `json:"content" jsonschema:"The full new content. This replaces the memory entirely — there is no append, so include everything worth keeping."`
+}
+
+// resolveMemoryName turns what an agent asked for into the name to store under.
+//
+// An empty name means the index, which is what makes `loadMemory()` with no
+// arguments useful. Everything else is checked rather than repaired: a name
+// quietly trimmed or truncated files the memory somewhere the agent did not
+// choose, and the next loadMemory for the name it thinks it used will miss.
+func resolveMemoryName(name string) (string, error) {
+	if strings.TrimSpace(name) == "" {
+		return DefaultMemoryName, nil
+	}
+	if name != strings.TrimSpace(name) {
+		return "", fmt.Errorf("memory name %q has leading or trailing whitespace; use %q", name, strings.TrimSpace(name))
+	}
+	if n := utf8.RuneCountInString(name); n > MaxMemoryNameLength {
+		return "", fmt.Errorf("memory name is %d characters; the limit is %d", n, MaxMemoryNameLength)
+	}
+	// A name is a label, not a path. Allowing separators would suggest these
+	// are files in a directory that an agent could traverse, and they are not.
+	if strings.ContainsAny(name, `/\`) {
+		return "", fmt.Errorf("memory name %q must not contain a path separator; it is a name, not a path", name)
+	}
+	for _, r := range name {
+		if r < 0x20 || r == 0x7f {
+			return "", fmt.Errorf("memory name %q contains a control character", name)
+		}
+	}
+	return name, nil
+}
+
+// validateMemoryContent refuses a memory that is over the cap.
+//
+// Refusing rather than truncating: an agent told that its memory is too large
+// can decide what to drop, which is a judgement only it can make.
+func validateMemoryContent(content string) error {
+	if n := len(content); n > MaxMemoryBytes {
+		return fmt.Errorf("memory is %d bytes; the limit is %d bytes (16 KiB). Split it across named memories and list them in %s", n, MaxMemoryBytes, DefaultMemoryName)
+	}
+	return nil
+}
+
+func toolError(format string, args ...any) *mcp.CallToolResult {
+	return &mcp.CallToolResult{
+		IsError: true,
+		Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf(format, args...)}},
+	}
+}
+
+func (ps *WorkspaceServer) handleLoadMemory(ctx context.Context, req *mcp.CallToolRequest, params LoadMemoryParams) (*mcp.CallToolResult, any, error) {
+	ps.emitTelemetry(ctx, ActionMCPToolCall, "loadMemory", clientIdentityFromRequest(req))
+
+	name, err := resolveMemoryName(params.Name)
+	if err != nil {
+		return toolError("%v", err), nil, nil
+	}
+	if ps.loadMemory == nil {
+		return toolError("memory is not available on this server"), nil, nil
+	}
+
+	content, found, err := ps.loadMemory(ctx, name)
+	if err != nil {
+		return toolError("failed to load memory %q: %v", name, err), nil, nil
+	}
+	if !found {
+		// Not an error: this is what a fresh workspace looks like, and saying
+		// so plainly is what tells the agent to write one.
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{
+				Text: fmt.Sprintf("No memory saved under %q yet. Use saveMemory to write one.", name),
+			}},
+		}, nil, nil
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: content}},
+	}, nil, nil
+}
+
+func (ps *WorkspaceServer) handleSaveMemory(ctx context.Context, req *mcp.CallToolRequest, params SaveMemoryParams) (*mcp.CallToolResult, any, error) {
+	ps.emitTelemetry(ctx, ActionMCPToolCall, "saveMemory", clientIdentityFromRequest(req))
+
+	name, err := resolveMemoryName(params.Name)
+	if err != nil {
+		return toolError("%v", err), nil, nil
+	}
+	if err := validateMemoryContent(params.Content); err != nil {
+		return toolError("%v", err), nil, nil
+	}
+	if ps.saveMemory == nil {
+		return toolError("memory is not available on this server"), nil, nil
+	}
+
+	if err := ps.saveMemory(ctx, name, params.Content); err != nil {
+		return toolError("failed to save memory %q: %v", name, err), nil, nil
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{
+			Text: fmt.Sprintf("Saved %q (%d bytes).", name, len(params.Content)),
+		}},
+	}, nil, nil
+}

--- a/backend/internal/controller/mcp/memory.go
+++ b/backend/internal/controller/mcp/memory.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"unicode/utf8"
 
@@ -27,7 +28,11 @@ const (
 	// DefaultMemoryName is what both tools read and write when given no name.
 	// The index, by convention — an agent that calls loadMemory with no
 	// arguments should land on something that tells it what else is here.
-	DefaultMemoryName = "MEMORY.md"
+	//
+	// Stored lowercase like every other name, so an agent that asks for
+	// MEMORY.md — the spelling the README-style convention suggests — lands on
+	// the same memory rather than creating a second one beside it.
+	DefaultMemoryName = "memory.md"
 
 	// MaxMemoryNameLength matches the column. Counted in characters, as the
 	// column is.
@@ -60,33 +65,45 @@ type SaveMemoryParams struct {
 	Content string `json:"content" jsonschema:"The full new content. This replaces the memory entirely — there is no append, so include everything worth keeping."`
 }
 
+// memoryNamePattern is the shape a stored name takes: a lowercase slug with a
+// .md suffix. Hyphens separate words and never double up or sit at an edge.
+//
+// Being this strict is what lets `memory://<name>` links inside a memory be
+// parsed at all — a name with a space in it is not a URL — and it rules out
+// path separators, control characters and everything else in one rule rather
+// than a list of individual refusals.
+var memoryNamePattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*\.md$`)
+
 // resolveMemoryName turns what an agent asked for into the name to store under.
 //
-// An empty name means the index, which is what makes `loadMemory()` with no
-// arguments useful. Everything else is checked rather than repaired: a name
-// quietly trimmed or truncated files the memory somewhere the agent did not
-// choose, and the next loadMemory for the name it thinks it used will miss.
+// Strict about what is kept, forgiving about what is accepted: case is folded
+// and surrounding whitespace dropped, so MEMORY.md, Memory.md and memory.md are
+// one memory rather than three that each look like the only one. Anything that
+// is still not a valid name after that is refused rather than repaired — a name
+// bent into shape files the memory somewhere the agent did not choose, and its
+// next load will miss.
+//
+// Folding here rather than in a query is deliberate. AgentRQ runs on SQLite and
+// Postgres, `=` is case-sensitive by default in both, and a NOCASE collation
+// does not port between them — so canonicalising once at this boundary is what
+// makes the unique key behave the same on either database.
 func resolveMemoryName(name string) (string, error) {
-	if strings.TrimSpace(name) == "" {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
 		return DefaultMemoryName, nil
 	}
-	if name != strings.TrimSpace(name) {
-		return "", fmt.Errorf("memory name %q has leading or trailing whitespace; use %q", name, strings.TrimSpace(name))
-	}
-	if n := utf8.RuneCountInString(name); n > MaxMemoryNameLength {
+
+	canonical := strings.ToLower(trimmed)
+	if n := utf8.RuneCountInString(canonical); n > MaxMemoryNameLength {
 		return "", fmt.Errorf("memory name is %d characters; the limit is %d", n, MaxMemoryNameLength)
 	}
-	// A name is a label, not a path. Allowing separators would suggest these
-	// are files in a directory that an agent could traverse, and they are not.
-	if strings.ContainsAny(name, `/\`) {
-		return "", fmt.Errorf("memory name %q must not contain a path separator; it is a name, not a path", name)
+	if !memoryNamePattern.MatchString(canonical) {
+		return "", fmt.Errorf(
+			"memory name %q is not usable; names are lowercase words joined by single hyphens and ending in .md, like %q or %q",
+			name, DefaultMemoryName, "release-notes.md",
+		)
 	}
-	for _, r := range name {
-		if r < 0x20 || r == 0x7f {
-			return "", fmt.Errorf("memory name %q contains a control character", name)
-		}
-	}
-	return name, nil
+	return canonical, nil
 }
 
 // validateMemoryContent refuses a memory that is over the cap.

--- a/backend/internal/controller/mcp/memory_test.go
+++ b/backend/internal/controller/mcp/memory_test.go
@@ -1,0 +1,332 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	mock_pubsub "github.com/agentrq/agentrq/backend/internal/service/mocks/pubsub"
+	"github.com/golang/mock/gomock"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// A server with the memory tools wired to an in-memory store, so a save and the
+// load that follows it exercise the same path a real agent takes.
+type memoryStore struct {
+	saved    map[string]string
+	loadErr  error
+	saveErr  error
+	loadName string
+	saveName string
+}
+
+func newMemoryServer(t *testing.T, store *memoryStore) *WorkspaceServer {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	pubsubMock := mock_pubsub.NewMockService(ctrl)
+	pubsubMock.EXPECT().Publish(gomock.Any(), gomock.Any()).AnyTimes()
+
+	if store.saved == nil {
+		store.saved = map[string]string{}
+	}
+	return &WorkspaceServer{
+		workspaceID: 100,
+		pubsub:      pubsubMock,
+		loadMemory: func(ctx context.Context, name string) (string, bool, error) {
+			store.loadName = name
+			if store.loadErr != nil {
+				return "", false, store.loadErr
+			}
+			content, ok := store.saved[name]
+			return content, ok, nil
+		},
+		saveMemory: func(ctx context.Context, name, content string) error {
+			store.saveName = name
+			if store.saveErr != nil {
+				return store.saveErr
+			}
+			store.saved[name] = content
+			return nil
+		},
+	}
+}
+
+func resultText(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	if len(res.Content) == 0 {
+		t.Fatal("result carried no content")
+	}
+	text, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("content is %T, not text", res.Content[0])
+	}
+	return text.Text
+}
+
+func TestSaveThenLoadMemory(t *testing.T) {
+	store := &memoryStore{}
+	ps := newMemoryServer(t, store)
+	ctx := context.Background()
+
+	saved, _, err := ps.handleSaveMemory(ctx, &mcp.CallToolRequest{}, SaveMemoryParams{Content: "# Index\n- deploys.md"})
+	if err != nil {
+		t.Fatalf("saveMemory: %v", err)
+	}
+	if saved.IsError {
+		t.Fatalf("saveMemory reported an error: %s", resultText(t, saved))
+	}
+
+	loaded, _, err := ps.handleLoadMemory(ctx, &mcp.CallToolRequest{}, LoadMemoryParams{})
+	if err != nil {
+		t.Fatalf("loadMemory: %v", err)
+	}
+	if got := resultText(t, loaded); got != "# Index\n- deploys.md" {
+		t.Errorf("loaded %q", got)
+	}
+}
+
+// With no name both tools work on the index, which is what makes a bare
+// loadMemory() call the right first move in a task.
+func TestMemoryToolsDefaultToTheIndex(t *testing.T) {
+	store := &memoryStore{}
+	ps := newMemoryServer(t, store)
+	ctx := context.Background()
+
+	if _, _, err := ps.handleSaveMemory(ctx, &mcp.CallToolRequest{}, SaveMemoryParams{Content: "x"}); err != nil {
+		t.Fatalf("saveMemory: %v", err)
+	}
+	if store.saveName != DefaultMemoryName {
+		t.Errorf("saved under %q, want %q", store.saveName, DefaultMemoryName)
+	}
+
+	if _, _, err := ps.handleLoadMemory(ctx, &mcp.CallToolRequest{}, LoadMemoryParams{}); err != nil {
+		t.Fatalf("loadMemory: %v", err)
+	}
+	if store.loadName != DefaultMemoryName {
+		t.Errorf("loaded %q, want %q", store.loadName, DefaultMemoryName)
+	}
+}
+
+func TestSaveMemoryOverwrites(t *testing.T) {
+	store := &memoryStore{}
+	ps := newMemoryServer(t, store)
+	ctx := context.Background()
+
+	for _, content := range []string{"first", "second"} {
+		if _, _, err := ps.handleSaveMemory(ctx, &mcp.CallToolRequest{}, SaveMemoryParams{Name: "notes.md", Content: content}); err != nil {
+			t.Fatalf("saveMemory: %v", err)
+		}
+	}
+
+	if store.saved["notes.md"] != "second" {
+		t.Errorf("got %q, want the later write", store.saved["notes.md"])
+	}
+}
+
+// A memory nobody has written is the ordinary state of a fresh workspace.
+// Answering with an error would teach agents to stop asking.
+func TestLoadMemoryMissIsNotAnError(t *testing.T) {
+	ps := newMemoryServer(t, &memoryStore{})
+
+	res, _, err := ps.handleLoadMemory(context.Background(), &mcp.CallToolRequest{}, LoadMemoryParams{Name: "never-written.md"})
+
+	if err != nil {
+		t.Fatalf("loadMemory: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("a miss must not be an error: %s", resultText(t, res))
+	}
+	text := resultText(t, res)
+	if !strings.Contains(text, "never-written.md") || !strings.Contains(text, "saveMemory") {
+		t.Errorf("a miss should name the memory and point at the fix; got %q", text)
+	}
+}
+
+// Refused, not truncated: an agent told its memory is too large can decide what
+// to drop, which is a judgement only it can make.
+func TestSaveMemoryRefusesOversizedContent(t *testing.T) {
+	store := &memoryStore{}
+	ps := newMemoryServer(t, store)
+
+	res, _, err := ps.handleSaveMemory(context.Background(), &mcp.CallToolRequest{}, SaveMemoryParams{
+		Content: strings.Repeat("a", MaxMemoryBytes+1),
+	})
+
+	if err != nil {
+		t.Fatalf("saveMemory: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("an oversized memory must be refused")
+	}
+	text := resultText(t, res)
+	if !strings.Contains(text, "16384") {
+		t.Errorf("the refusal should name the limit; got %q", text)
+	}
+	if len(store.saved) != 0 {
+		t.Error("nothing should have been stored")
+	}
+}
+
+func TestSaveMemoryAcceptsContentExactlyAtTheLimit(t *testing.T) {
+	store := &memoryStore{}
+	ps := newMemoryServer(t, store)
+
+	res, _, err := ps.handleSaveMemory(context.Background(), &mcp.CallToolRequest{}, SaveMemoryParams{
+		Name: "big.md", Content: strings.Repeat("a", MaxMemoryBytes),
+	})
+
+	if err != nil {
+		t.Fatalf("saveMemory: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("the limit itself must be allowed: %s", resultText(t, res))
+	}
+	if len(store.saved["big.md"]) != MaxMemoryBytes {
+		t.Error("content at the limit should be stored whole")
+	}
+}
+
+// The cap counts bytes, not characters: 16k multi-byte characters is far more
+// than 16 KiB, and letting it through would overflow what the column holds.
+func TestSaveMemoryCountsBytesNotCharacters(t *testing.T) {
+	ps := newMemoryServer(t, &memoryStore{})
+
+	res, _, err := ps.handleSaveMemory(context.Background(), &mcp.CallToolRequest{}, SaveMemoryParams{
+		Content: strings.Repeat("é", MaxMemoryBytes-10),
+	})
+
+	if err != nil {
+		t.Fatalf("saveMemory: %v", err)
+	}
+	if !res.IsError {
+		t.Error("content under the character count but over the byte cap must be refused")
+	}
+}
+
+func TestMemoryNamesThatMustBeRefused(t *testing.T) {
+	ps := newMemoryServer(t, &memoryStore{})
+	ctx := context.Background()
+
+	for _, tc := range []struct{ name, why string }{
+		{strings.Repeat("n", MaxMemoryNameLength+1), "longer than the column"},
+		{" MEMORY.md", "leading whitespace"},
+		{"MEMORY.md ", "trailing whitespace"},
+		{"notes/deploys.md", "a path separator"},
+		{`notes\deploys.md`, "a windows path separator"},
+		{"notes\x00.md", "a control character"},
+	} {
+		save, _, err := ps.handleSaveMemory(ctx, &mcp.CallToolRequest{}, SaveMemoryParams{Name: tc.name, Content: "x"})
+		if err != nil {
+			t.Fatalf("%s: %v", tc.why, err)
+		}
+		if !save.IsError {
+			t.Errorf("saveMemory accepted a name with %s: %q", tc.why, tc.name)
+		}
+
+		// Refused on the way in as well, so a name that could never be written
+		// is not silently a miss on read.
+		load, _, err := ps.handleLoadMemory(ctx, &mcp.CallToolRequest{}, LoadMemoryParams{Name: tc.name})
+		if err != nil {
+			t.Fatalf("%s: %v", tc.why, err)
+		}
+		if !load.IsError {
+			t.Errorf("loadMemory accepted a name with %s: %q", tc.why, tc.name)
+		}
+	}
+}
+
+func TestMemoryNameAtTheLimitIsAccepted(t *testing.T) {
+	store := &memoryStore{}
+	ps := newMemoryServer(t, store)
+	name := strings.Repeat("n", MaxMemoryNameLength)
+
+	res, _, err := ps.handleSaveMemory(context.Background(), &mcp.CallToolRequest{}, SaveMemoryParams{Name: name, Content: "x"})
+
+	if err != nil {
+		t.Fatalf("saveMemory: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("a name at the limit must be allowed: %s", resultText(t, res))
+	}
+}
+
+// A name is counted in characters, as the column is, so an accented name of 32
+// characters fits even though it is more than 32 bytes.
+func TestMemoryNameIsCountedInCharacters(t *testing.T) {
+	ps := newMemoryServer(t, &memoryStore{})
+
+	res, _, err := ps.handleSaveMemory(context.Background(), &mcp.CallToolRequest{}, SaveMemoryParams{
+		Name: strings.Repeat("é", MaxMemoryNameLength), Content: "x",
+	})
+
+	if err != nil {
+		t.Fatalf("saveMemory: %v", err)
+	}
+	if res.IsError {
+		t.Errorf("32 characters must fit whatever they encode to: %s", resultText(t, res))
+	}
+}
+
+func TestMemoryToolsReportStorageFailures(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("save", func(t *testing.T) {
+		ps := newMemoryServer(t, &memoryStore{saveErr: errors.New("disk on fire")})
+
+		res, _, err := ps.handleSaveMemory(ctx, &mcp.CallToolRequest{}, SaveMemoryParams{Content: "x"})
+
+		if err != nil {
+			t.Fatalf("saveMemory: %v", err)
+		}
+		// The agent has to hear that its notes did not land; reporting success
+		// would leave it trusting a memory that was never written.
+		if !res.IsError || !strings.Contains(resultText(t, res), "disk on fire") {
+			t.Errorf("got %q", resultText(t, res))
+		}
+	})
+
+	t.Run("load", func(t *testing.T) {
+		ps := newMemoryServer(t, &memoryStore{loadErr: errors.New("disk on fire")})
+
+		res, _, err := ps.handleLoadMemory(ctx, &mcp.CallToolRequest{}, LoadMemoryParams{})
+
+		if err != nil {
+			t.Fatalf("loadMemory: %v", err)
+		}
+		// Distinct from a miss: "nothing saved yet" and "could not read" call
+		// for different responses from the agent.
+		if !res.IsError || !strings.Contains(resultText(t, res), "disk on fire") {
+			t.Errorf("got %q", resultText(t, res))
+		}
+	})
+}
+
+// A server built without the memory funcs must say so rather than panic — the
+// tools are registered unconditionally, so a server assembled without them is a
+// wiring mistake that should surface as a message.
+func TestMemoryToolsWithoutStorage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	pubsubMock := mock_pubsub.NewMockService(ctrl)
+	pubsubMock.EXPECT().Publish(gomock.Any(), gomock.Any()).AnyTimes()
+	ps := &WorkspaceServer{workspaceID: 100, pubsub: pubsubMock}
+	ctx := context.Background()
+
+	load, _, err := ps.handleLoadMemory(ctx, &mcp.CallToolRequest{}, LoadMemoryParams{})
+	if err != nil {
+		t.Fatalf("loadMemory: %v", err)
+	}
+	if !load.IsError {
+		t.Error("loadMemory should report that memory is unavailable")
+	}
+
+	save, _, err := ps.handleSaveMemory(ctx, &mcp.CallToolRequest{}, SaveMemoryParams{Content: "x"})
+	if err != nil {
+		t.Fatalf("saveMemory: %v", err)
+	}
+	if !save.IsError {
+		t.Error("saveMemory should report that memory is unavailable")
+	}
+}

--- a/backend/internal/controller/mcp/memory_test.go
+++ b/backend/internal/controller/mcp/memory_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -210,12 +211,18 @@ func TestMemoryNamesThatMustBeRefused(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tc := range []struct{ name, why string }{
-		{strings.Repeat("n", MaxMemoryNameLength+1), "longer than the column"},
-		{" MEMORY.md", "leading whitespace"},
-		{"MEMORY.md ", "trailing whitespace"},
+		{strings.Repeat("n", MaxMemoryNameLength+1) + ".md", "longer than the column"},
 		{"notes/deploys.md", "a path separator"},
 		{`notes\deploys.md`, "a windows path separator"},
 		{"notes\x00.md", "a control character"},
+		{"release notes.md", "a space"},
+		{"release_notes.md", "an underscore rather than a hyphen"},
+		{"-deploys.md", "a leading hyphen"},
+		{"deploys-.md", "a trailing hyphen"},
+		{"release--notes.md", "a doubled hyphen"},
+		{"deploys", "no .md suffix"},
+		{"deploys.txt", "the wrong suffix"},
+		{".md", "nothing but a suffix"},
 	} {
 		save, _, err := ps.handleSaveMemory(ctx, &mcp.CallToolRequest{}, SaveMemoryParams{Name: tc.name, Content: "x"})
 		if err != nil {
@@ -240,7 +247,7 @@ func TestMemoryNamesThatMustBeRefused(t *testing.T) {
 func TestMemoryNameAtTheLimitIsAccepted(t *testing.T) {
 	store := &memoryStore{}
 	ps := newMemoryServer(t, store)
-	name := strings.Repeat("n", MaxMemoryNameLength)
+	name := strings.Repeat("n", MaxMemoryNameLength-3) + ".md"
 
 	res, _, err := ps.handleSaveMemory(context.Background(), &mcp.CallToolRequest{}, SaveMemoryParams{Name: name, Content: "x"})
 
@@ -252,20 +259,77 @@ func TestMemoryNameAtTheLimitIsAccepted(t *testing.T) {
 	}
 }
 
-// A name is counted in characters, as the column is, so an accented name of 32
-// characters fits even though it is more than 32 bytes.
-func TestMemoryNameIsCountedInCharacters(t *testing.T) {
-	ps := newMemoryServer(t, &memoryStore{})
+// Case is folded rather than refused, so the three spellings an agent might
+// reach for are one memory instead of three that each look like the only one.
+func TestMemoryNamesAreFoldedToOne(t *testing.T) {
+	store := &memoryStore{}
+	ps := newMemoryServer(t, store)
+	ctx := context.Background()
 
-	res, _, err := ps.handleSaveMemory(context.Background(), &mcp.CallToolRequest{}, SaveMemoryParams{
-		Name: strings.Repeat("é", MaxMemoryNameLength), Content: "x",
+	for i, spelling := range []string{"MEMORY.md", "Memory.md", "memory.md", "  MEMORY.md  "} {
+		res, _, err := ps.handleSaveMemory(ctx, &mcp.CallToolRequest{}, SaveMemoryParams{
+			Name: spelling, Content: fmt.Sprintf("write %d", i),
+		})
+		if err != nil {
+			t.Fatalf("%s: %v", spelling, err)
+		}
+		if res.IsError {
+			t.Fatalf("%s must be accepted: %s", spelling, resultText(t, res))
+		}
+		if store.saveName != DefaultMemoryName {
+			t.Errorf("%s stored as %q, want %q", spelling, store.saveName, DefaultMemoryName)
+		}
+	}
+
+	// One memory, holding the last thing written to it — not four.
+	if len(store.saved) != 1 {
+		t.Errorf("expected one memory, got %d: %v", len(store.saved), store.saved)
+	}
+	if store.saved[DefaultMemoryName] != "write 3" {
+		t.Errorf("got %q, want the last write", store.saved[DefaultMemoryName])
+	}
+}
+
+// The same folding on the way in, so a load finds what a differently-spelled
+// save stored.
+func TestLoadMemoryFoldsTheNameToo(t *testing.T) {
+	store := &memoryStore{saved: map[string]string{"release-notes.md": "what shipped"}}
+	ps := newMemoryServer(t, store)
+
+	res, _, err := ps.handleLoadMemory(context.Background(), &mcp.CallToolRequest{}, LoadMemoryParams{
+		Name: "Release-Notes.MD",
 	})
 
 	if err != nil {
-		t.Fatalf("saveMemory: %v", err)
+		t.Fatalf("loadMemory: %v", err)
 	}
-	if res.IsError {
-		t.Errorf("32 characters must fit whatever they encode to: %s", resultText(t, res))
+	if got := resultText(t, res); got != "what shipped" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestMemoryNamesThatAreAccepted(t *testing.T) {
+	ctx := context.Background()
+
+	for _, name := range []string{
+		"memory.md",
+		"deploys.md",
+		"release-notes.md",
+		"a-b-c-d.md",
+		"api2.md",
+		"2024-review.md",
+	} {
+		store := &memoryStore{}
+		ps := newMemoryServer(t, store)
+
+		res, _, err := ps.handleSaveMemory(ctx, &mcp.CallToolRequest{}, SaveMemoryParams{Name: name, Content: "x"})
+
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if res.IsError {
+			t.Errorf("%s must be accepted: %s", name, resultText(t, res))
+		}
 	}
 }
 

--- a/backend/internal/controller/mcp/protocol_version_test.go
+++ b/backend/internal/controller/mcp/protocol_version_test.go
@@ -29,7 +29,9 @@ func newProtocolTestServer(t *testing.T) *httptest.Server {
 
 	ps := NewWorkspaceServer(
 		1, "user", "http://localhost",
-		nil, nil, nil, listTasks, nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, listTasks, nil, nil, nil, nil, nil,
+		nil, nil, // loadMemory, saveMemory
+		nil, nil,
 		eventbus.New(), nil, nil, "icon", "name", "desc", nil, nil, nil, pub,
 	)
 	srv := httptest.NewServer(ps.Handler())

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -421,8 +421,9 @@ func NewWorkspaceServer(
 					"4. **ASK VIA REPLY**: If you need permission, clarification, or more info, use `reply` to ask. Do NOT ask in your text output — the human won't see it.\n\n"+
 					"5. **COMPLETE**: When done, send a summary of all changes via `reply`, then set the task status to 'completed'. Use 'blocked' if you are stuck and need human help.\n\n"+
 					"6. **REMEMBER**: This workspace has a memory that outlives the task. Call `loadMemory` before you start — with no arguments it reads "+
-					"`MEMORY.md`, the index of everything this workspace remembers, and it may already answer what you were about to ask. When you learn "+
-					"something that would save the next agent the same detour, `saveMemory` it. The memory belongs to the workspace, so everyone working here shares it.\n",
+					"`memory.md`, the index of everything this workspace remembers, and it may already answer what you were about to ask. The index links "+
+					"its entries as `memory://<name>`; load the ones that look relevant. When you learn something that would save the next agent the same "+
+					"detour, `saveMemory` it and link it from the index. The memory belongs to the workspace, so everyone working here shares it.\n",
 				workspaceIDStr,
 			),
 		},
@@ -467,7 +468,8 @@ func NewWorkspaceServer(
 	mcp.AddTool(mcpSrv, &mcp.Tool{
 		Name: "loadMemory",
 		Description: "Read what this workspace remembers. Call this at the start of a task, before asking the human something they may already have told you. " +
-			"With no name it reads " + DefaultMemoryName + ", the index — start there, and it will tell you which other memories are worth loading. " +
+			"With no name it reads " + DefaultMemoryName + ", the index — start there, and it will tell you which other memories are worth loading, " +
+			"as links to memory://<name>. Load the ones that look relevant. " +
 			"A name that has never been written is not an error; it just means nothing has been remembered under it yet.",
 	}, ps.handleLoadMemory)
 
@@ -475,7 +477,9 @@ func NewWorkspaceServer(
 		Name: "saveMemory",
 		Description: "Write something worth remembering about this workspace, so the next task starts with it. " +
 			"This replaces the named memory completely — there is no append, so pass the full new content. " +
-			"With no name it writes " + DefaultMemoryName + ", which should stay an index: keep detail in named memories and list them there. " +
+			"With no name it writes " + DefaultMemoryName + ", which should stay an index: keep detail in named memories and link to them from there " +
+			"as markdown links to memory://<name>, for example [how we ship](memory://deploys.md). " +
+			"Names are lowercase words joined by single hyphens and ending in .md, like release-notes.md; anything else is refused. " +
 			"One memory holds at most 16 KiB; a larger one is refused rather than truncated, so split it and index the parts. " +
 			"The memory belongs to the workspace, not to you — other agents working here read the same notes.",
 	}, ps.handleSaveMemory)

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -98,6 +98,8 @@ type WorkspaceServer struct {
 	updateMessageMetadata UpdateMessageMetadataFunc
 	updateAutoAllowed     UpdateWorkspaceAutoAllowedToolsFunc
 	publishEvent          PublishEventFunc
+	loadMemory            LoadMemoryFunc
+	saveMemory            SaveMemoryFunc
 	recordToolCall        RecordToolCallFunc
 	updateToolCallStatus  UpdateToolCallStatusFunc
 	bus                   *eventbus.Bus
@@ -319,6 +321,8 @@ func NewWorkspaceServer(
 	updateMessageMetadata UpdateMessageMetadataFunc,
 	updateAutoAllowed UpdateWorkspaceAutoAllowedToolsFunc,
 	publishEvent PublishEventFunc,
+	loadMemory LoadMemoryFunc,
+	saveMemory SaveMemoryFunc,
 	recordToolCall RecordToolCallFunc,
 	updateToolCallStatus UpdateToolCallStatusFunc,
 	bus *eventbus.Bus,
@@ -346,6 +350,8 @@ func NewWorkspaceServer(
 		updateMessageMetadata:  updateMessageMetadata,
 		updateAutoAllowed:      updateAutoAllowed,
 		publishEvent:           publishEvent,
+		loadMemory:             loadMemory,
+		saveMemory:             saveMemory,
 		recordToolCall:         recordToolCall,
 		updateToolCallStatus:   updateToolCallStatus,
 		bus:                    bus,
@@ -413,7 +419,10 @@ func NewWorkspaceServer(
 					"   - \"Tests pass (12/12). Moving on to the frontend changes.\"\n"+
 					"   - \"I ran `npm run build` and got this error: [error]. Investigating.\"\n\n"+
 					"4. **ASK VIA REPLY**: If you need permission, clarification, or more info, use `reply` to ask. Do NOT ask in your text output — the human won't see it.\n\n"+
-					"5. **COMPLETE**: When done, send a summary of all changes via `reply`, then set the task status to 'completed'. Use 'blocked' if you are stuck and need human help.\n",
+					"5. **COMPLETE**: When done, send a summary of all changes via `reply`, then set the task status to 'completed'. Use 'blocked' if you are stuck and need human help.\n\n"+
+					"6. **REMEMBER**: This workspace has a memory that outlives the task. Call `loadMemory` before you start — with no arguments it reads "+
+					"`MEMORY.md`, the index of everything this workspace remembers, and it may already answer what you were about to ask. When you learn "+
+					"something that would save the next agent the same detour, `saveMemory` it. The memory belongs to the workspace, so everyone working here shares it.\n",
 				workspaceIDStr,
 			),
 		},
@@ -454,6 +463,22 @@ func NewWorkspaceServer(
 		Name:        "publishEvent",
 		Description: "Publish a named event so that subscriber workspaces are notified and their trigger tasks are created automatically. When the task you are completing includes a publishEvent instruction, copy the name and taskId from it exactly as written — taskId is what identifies the workflow run being continued. Write the payload yourself, plus an optional faq.",
 	}, ps.handlePublishEvent)
+
+	mcp.AddTool(mcpSrv, &mcp.Tool{
+		Name: "loadMemory",
+		Description: "Read what this workspace remembers. Call this at the start of a task, before asking the human something they may already have told you. " +
+			"With no name it reads " + DefaultMemoryName + ", the index — start there, and it will tell you which other memories are worth loading. " +
+			"A name that has never been written is not an error; it just means nothing has been remembered under it yet.",
+	}, ps.handleLoadMemory)
+
+	mcp.AddTool(mcpSrv, &mcp.Tool{
+		Name: "saveMemory",
+		Description: "Write something worth remembering about this workspace, so the next task starts with it. " +
+			"This replaces the named memory completely — there is no append, so pass the full new content. " +
+			"With no name it writes " + DefaultMemoryName + ", which should stay an index: keep detail in named memories and list them there. " +
+			"One memory holds at most 16 KiB; a larger one is refused rather than truncated, so split it and index the parts. " +
+			"The memory belongs to the workspace, not to you — other agents working here read the same notes.",
+	}, ps.handleSaveMemory)
 
 	mcp.AddTool(mcpSrv, &mcp.Tool{
 		Name:        "elicit",

--- a/backend/internal/data/model/model.go
+++ b/backend/internal/data/model/model.go
@@ -169,6 +169,34 @@ type (
 	}
 
 	// Message is an entry in a task's chat history
+	// Memory is what an agent has chosen to remember about a workspace.
+	//
+	// Scoped to the workspace's owner rather than to whichever agent wrote it:
+	// this is the workspace's memory, so every agent working there reads and
+	// writes the same rows. Keyed per (owner, workspace, name), so several
+	// named memories can live side by side; MEMORY.md is the one agents read
+	// first and is where the index to the others belongs.
+	//
+	// The unique index spans all three columns, and every one of them carries
+	// the same index name with a priority — see the note on Event for what
+	// happens otherwise. Here the consequence would be a memory name that is
+	// unique across every workspace and every account, so one workspace saving
+	// "MEMORY.md" would take the name from everybody else.
+	//
+	// Content is capped at 16 KiB by the tools that write it, which is where
+	// there is a caller to refuse. The column is deliberately larger: the cap
+	// is counted in bytes of UTF-8, and 64000 characters is comfortably above
+	// what 16 KiB can encode.
+	Memory struct {
+		ID          int64 `gorm:"primaryKey;autoIncrement:false"`
+		CreatedAt   time.Time
+		UpdatedAt   time.Time
+		UserID      int64  `gorm:"index:idx_memories_user_id;uniqueIndex:uk_user_id_workspace_id_name,priority:1"`
+		WorkspaceID int64  `gorm:"index:idx_memories_workspace_id;uniqueIndex:uk_user_id_workspace_id_name,priority:2"`
+		Name        string `gorm:"type:varchar(32);uniqueIndex:uk_user_id_workspace_id_name,priority:3"`
+		Content     string `gorm:"type:varchar(64000)"`
+	}
+
 	Message struct {
 		ID          int64 `gorm:"primaryKey;autoIncrement:false"`
 		CreatedAt   time.Time

--- a/backend/internal/repository/base/memory_test.go
+++ b/backend/internal/repository/base/memory_test.go
@@ -1,0 +1,222 @@
+package base
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+// The database is built the way app.go builds the real one, so the unique index
+// under test is the one production actually has.
+func memoryDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open("file::memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&model.Memory{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+const (
+	memUserID      = int64(482467435371298817)
+	memWorkspaceID = int64(498041479541817345)
+	memOtherWSID   = int64(498041479541817346)
+	memOtherUserID = int64(482467435371298818)
+)
+
+func memory(id int64, userID, workspaceID int64, name, content string) model.Memory {
+	now := time.Now()
+	return model.Memory{
+		ID: id, CreatedAt: now, UpdatedAt: now,
+		UserID: userID, WorkspaceID: workspaceID, Name: name, Content: content,
+	}
+}
+
+func TestUpsertMemory_StoresAndReadsBack(t *testing.T) {
+	repo := New(&mockDB{db: memoryDB(t)})
+	ctx := context.Background()
+
+	saved, err := repo.UpsertMemory(ctx, memory(1, memUserID, memWorkspaceID, "MEMORY.md", "# Index\n"))
+	if err != nil {
+		t.Fatalf("UpsertMemory: %v", err)
+	}
+	if saved.Content != "# Index\n" || saved.Name != "MEMORY.md" {
+		t.Errorf("saved: got %+v", saved)
+	}
+
+	got, err := repo.GetMemory(ctx, memUserID, memWorkspaceID, "MEMORY.md")
+	if err != nil {
+		t.Fatalf("GetMemory: %v", err)
+	}
+	if got.Content != "# Index\n" {
+		t.Errorf("content: got %q", got.Content)
+	}
+}
+
+// saveMemory overwrites, so a second save must replace the row rather than
+// failing against the unique key or adding a duplicate.
+func TestUpsertMemory_OverwritesInPlace(t *testing.T) {
+	db := memoryDB(t)
+	repo := New(&mockDB{db: db})
+	ctx := context.Background()
+
+	first, err := repo.UpsertMemory(ctx, memory(1, memUserID, memWorkspaceID, "MEMORY.md", "before"))
+	if err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+
+	// A different generated ID, as the caller would supply on any later save.
+	second, err := repo.UpsertMemory(ctx, memory(2, memUserID, memWorkspaceID, "MEMORY.md", "after"))
+	if err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+
+	if second.Content != "after" {
+		t.Errorf("content: got %q, want the newer one", second.Content)
+	}
+	// The row keeps the identity it already had; only the content moves.
+	if second.ID != first.ID {
+		t.Errorf("id: got %d, want the existing row's %d", second.ID, first.ID)
+	}
+
+	var count int64
+	if err := db.Model(&model.Memory{}).Count(&count).Error; err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected one row after two saves, got %d", count)
+	}
+}
+
+// The unique key spans all three columns. Tagging only Name would make a memory
+// name unique across every workspace and every account, so one workspace saving
+// MEMORY.md would take the name from everyone else.
+func TestUpsertMemory_NameIsScopedToOwnerAndWorkspace(t *testing.T) {
+	repo := New(&mockDB{db: memoryDB(t)})
+	ctx := context.Background()
+
+	if _, err := repo.UpsertMemory(ctx, memory(1, memUserID, memWorkspaceID, "MEMORY.md", "workspace one")); err != nil {
+		t.Fatalf("first workspace: %v", err)
+	}
+	if _, err := repo.UpsertMemory(ctx, memory(2, memUserID, memOtherWSID, "MEMORY.md", "workspace two")); err != nil {
+		t.Fatalf("same name in another workspace must be allowed: %v", err)
+	}
+	if _, err := repo.UpsertMemory(ctx, memory(3, memOtherUserID, memWorkspaceID, "MEMORY.md", "another owner")); err != nil {
+		t.Fatalf("same name for another owner must be allowed: %v", err)
+	}
+
+	for _, tc := range []struct {
+		userID, workspaceID int64
+		want                string
+	}{
+		{memUserID, memWorkspaceID, "workspace one"},
+		{memUserID, memOtherWSID, "workspace two"},
+		{memOtherUserID, memWorkspaceID, "another owner"},
+	} {
+		got, err := repo.GetMemory(ctx, tc.userID, tc.workspaceID, "MEMORY.md")
+		if err != nil {
+			t.Fatalf("GetMemory(%d, %d): %v", tc.userID, tc.workspaceID, err)
+		}
+		if got.Content != tc.want {
+			t.Errorf("GetMemory(%d, %d): got %q, want %q", tc.userID, tc.workspaceID, got.Content, tc.want)
+		}
+	}
+}
+
+func TestGetMemory_MissingIsNotFound(t *testing.T) {
+	repo := New(&mockDB{db: memoryDB(t)})
+
+	_, err := repo.GetMemory(context.Background(), memUserID, memWorkspaceID, "never-written.md")
+
+	// A distinguishable error, because a first call on a fresh workspace always
+	// misses and the tools answer that differently from a real failure.
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("got %v, want ErrNotFound", err)
+	}
+}
+
+func TestListMemoriesByWorkspace_OrderedAndScoped(t *testing.T) {
+	repo := New(&mockDB{db: memoryDB(t)})
+	ctx := context.Background()
+
+	for i, name := range []string{"zeta.md", "MEMORY.md", "alpha.md"} {
+		if _, err := repo.UpsertMemory(ctx, memory(int64(i+1), memUserID, memWorkspaceID, name, name)); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+	// Belongs to another workspace, and must not appear.
+	if _, err := repo.UpsertMemory(ctx, memory(9, memUserID, memOtherWSID, "elsewhere.md", "x")); err != nil {
+		t.Fatalf("seed other workspace: %v", err)
+	}
+
+	got, err := repo.ListMemoriesByWorkspace(ctx, memUserID, memWorkspaceID)
+	if err != nil {
+		t.Fatalf("ListMemoriesByWorkspace: %v", err)
+	}
+
+	var names []string
+	for _, m := range got {
+		names = append(names, m.Name)
+	}
+	if strings.Join(names, ",") != "MEMORY.md,alpha.md,zeta.md" {
+		t.Errorf("got %v, want them ordered by name", names)
+	}
+}
+
+func TestListMemoriesByWorkspace_EmptyWorkspace(t *testing.T) {
+	repo := New(&mockDB{db: memoryDB(t)})
+
+	got, err := repo.ListMemoriesByWorkspace(context.Background(), memUserID, memWorkspaceID)
+
+	// A workspace nobody has written to yet is empty, not an error: that is the
+	// state every workspace starts in.
+	if err != nil {
+		t.Fatalf("ListMemoriesByWorkspace: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no memories, got %d", len(got))
+	}
+}
+
+// The column is varchar(32); a longer name must not be quietly cut down to fit,
+// which would file the memory under a name the agent never chose.
+func TestMemoryName_LongerThanTheColumnIsNotSilentlyTruncated(t *testing.T) {
+	repo := New(&mockDB{db: memoryDB(t)})
+	ctx := context.Background()
+	long := strings.Repeat("n", 40) + ".md"
+
+	saved, err := repo.UpsertMemory(ctx, memory(1, memUserID, memWorkspaceID, long, "x"))
+	if err != nil {
+		// Refusing is the other acceptable answer, and is what Postgres does.
+		return
+	}
+	if saved.Name != long {
+		t.Errorf("name was truncated to %q; the tools must reject an over-long name before it reaches here", saved.Name)
+	}
+}
+
+// A write that fails has to surface the failure rather than returning a zero
+// memory as though it had been stored: saveMemory reports success to an agent,
+// which will then trust that its notes are safe.
+func TestUpsertMemory_ReportsAWriteThatFailed(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file::memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// Deliberately not migrated: there is no memories table to write to.
+	repo := New(&mockDB{db: db})
+
+	if _, err := repo.UpsertMemory(context.Background(), memory(1, memUserID, memWorkspaceID, "MEMORY.md", "x")); err == nil {
+		t.Error("expected an error when the write cannot land")
+	}
+}

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -11,6 +11,7 @@ import (
 	"github.com/agentrq/agentrq/backend/internal/data/model"
 	"github.com/agentrq/agentrq/backend/internal/repository/dbconn"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 var ErrNotFound = errors.New("not found")
@@ -36,6 +37,12 @@ type Repository interface {
 	ListMessages(ctx context.Context, taskID int64) ([]model.Message, error)
 	UpdateMessageMetadata(ctx context.Context, taskID int64, messageID int64, metadata []byte) error
 	GetWorkspaceAttachmentIDs(ctx context.Context, workspaceID int64) ([]string, error)
+
+	// Memory — the workspace's own notes, written by agents through the MCP
+	// memory tools. Keyed per (owner, workspace, name); see model.Memory.
+	GetMemory(ctx context.Context, userID, workspaceID int64, name string) (model.Memory, error)
+	UpsertMemory(ctx context.Context, m model.Memory) (model.Memory, error)
+	ListMemoriesByWorkspace(ctx context.Context, userID, workspaceID int64) ([]model.Memory, error)
 
 	// ToolCall
 	CreateToolCall(ctx context.Context, tc model.ToolCall) (model.ToolCall, error)
@@ -882,6 +889,57 @@ func (r *repository) ListPushSubscriptionsByUserAndWorkspace(ctx context.Context
 }
 
 // ── Events ─────────────────────────────────────────────────────────────────────
+
+// ── Memories ──────────────────────────────────────────────────────────────────
+
+func (r *repository) GetMemory(ctx context.Context, userID, workspaceID int64, name string) (model.Memory, error) {
+	var m model.Memory
+	err := r.conn(ctx).
+		Where("user_id = ? AND workspace_id = ? AND name = ?", userID, workspaceID, name).
+		First(&m).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return model.Memory{}, ErrNotFound
+	}
+	return m, err
+}
+
+// UpsertMemory writes a memory, replacing whatever was stored under that name.
+//
+// Overwriting is the whole semantic of saveMemory, so this is one statement
+// rather than a read followed by a write: two agents saving the same memory at
+// once would otherwise race, and the loser's insert would fail against the
+// unique key rather than simply being overwritten.
+//
+// The caller supplies a fresh ID for the insert case. On conflict the stored
+// row keeps the ID it already had — only the content and the timestamp move —
+// so a memory's identity survives being rewritten.
+func (r *repository) UpsertMemory(ctx context.Context, m model.Memory) (model.Memory, error) {
+	err := r.conn(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "user_id"}, {Name: "workspace_id"}, {Name: "name"}},
+		DoUpdates: clause.AssignmentColumns([]string{"content", "updated_at"}),
+	}).Create(&m).Error
+	if err != nil {
+		return model.Memory{}, err
+	}
+	// Read back rather than returning the struct that went in: on the update
+	// path the row's ID and creation time are the ones it already had, not the
+	// ones this call generated.
+	return r.GetMemory(ctx, m.UserID, m.WorkspaceID, m.Name)
+}
+
+// ListMemoriesByWorkspace returns every memory in a workspace, ordered by name.
+//
+// Content comes back with them: the rows are capped at 16 KiB and a workspace
+// holds a handful, so a second query per memory would cost more than it saves.
+// Callers that only need the index — the settings list — drop it themselves.
+func (r *repository) ListMemoriesByWorkspace(ctx context.Context, userID, workspaceID int64) ([]model.Memory, error) {
+	var memories []model.Memory
+	err := r.conn(ctx).
+		Where("user_id = ? AND workspace_id = ?", userID, workspaceID).
+		Order("name asc").
+		Find(&memories).Error
+	return memories, err
+}
 
 func (r *repository) CreateEvent(ctx context.Context, e model.Event) (model.Event, error) {
 	if err := r.conn(ctx).Create(&e).Error; err != nil {


### PR DESCRIPTION
> **Stacked on #457.** Targets that branch, so the diff here is only this change. Merge #457 first and GitHub retargets this to `main` automatically.

## What changed

Agents can now read and write notes that belong to a workspace and survive between tasks, through two new tools. An agent can check what was already learned before asking the human again, and write down whatever would save the next agent the same detour.

## Why

Second of four steps adding per-workspace memory. Everything an agent worked out in one task was previously lost when that task ended.

## Test coverage report

- **New lines: 100%.** Every function in the new file is at 100% statement coverage, checked per function rather than assumed from a package total.
- **Total coverage impact: none.** The full backend suite passes.

Tests pin the behaviour that matters: a save then a load returning the same content, both tools defaulting to the index, a second save overwriting, an over-size memory refused with the limit named and nothing stored, the cap counted in bytes rather than characters, names refused for length/whitespace/path separators/control characters, and a storage failure reported rather than reported as success.

## Other reports

Decisions worth a reviewer's attention:

- **Limits are enforced here, not in the repository**, because this is where there is a caller to answer, and both are **refused rather than truncated**. An agent told its memory is too large can decide what to drop; one whose memory was silently cut in half cannot know anything went wrong.
- **A `loadMemory` miss is not an error.** Every agent's first call on a fresh workspace misses, and answering that with a failure would teach agents to stop asking.
- **The server instructions now mention the memory**, since a tool nobody is told about is a tool nobody calls.
- **Telemetry matches the other tools exactly** — one `emitTelemetry` call per handler. Worth knowing what that does and does not give you: the emitted event carries the tool name, but the telemetry controller maps every tool call to the single stored `ActionIDMCPToolCall`, so these show up in the MCP tool-call count without a separate per-tool figure. Splitting them out is a deliberate extra (new action constants in four places, per the telemetry notes in `AGENTS.md`) rather than something to add silently.

**One incidental fix.** Writing the tests turned up a nil dereference in `clientIdentityFromRequest`: it guards against a nil request but not against one whose params were never set, where `GetParams()` returns a non-nil interface wrapping a nil pointer and the following `GetMeta()` panics. Production always sets params, so it never fired — but the function is written to be nil-safe and now actually is.

TaskID: 0iHtNeMY9Hl