### PR TITLE
feat(api): let a workspace's owner read its memories

### DIFF
--- a/backend/internal/controller/crud/crud.go
+++ b/backend/internal/controller/crud/crud.go
@@ -27,6 +27,7 @@ type (
 		UserController
 		TaskController
 		EventController
+		MemoryController
 		EventTriggerController
 		WorkflowController
 		WorkflowStepController

--- a/backend/internal/controller/crud/memory.go
+++ b/backend/internal/controller/crud/memory.go
@@ -1,0 +1,96 @@
+package crud
+
+import (
+	"context"
+	"fmt"
+
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	"github.com/agentrq/agentrq/backend/internal/repository/base"
+	"github.com/mustafaturan/monoflake"
+)
+
+// MemoryController reads a workspace's memories.
+//
+// Read-only on purpose. Agents own the writing, through the MCP memory tools;
+// there is no endpoint here that writes one, because an agent reading back a
+// memory a human had quietly rewritten is a confusing failure to debug from
+// either side.
+type MemoryController interface {
+	ListMemories(ctx context.Context, req entity.ListMemoriesRequest) (*entity.ListMemoriesResponse, error)
+	GetMemory(ctx context.Context, req entity.GetMemoryRequest) (*entity.GetMemoryResponse, error)
+}
+
+// memoryOwner resolves the account a workspace's memories are filed under, and
+// refuses a caller who does not own the workspace.
+//
+// Memories are keyed to the workspace's owner, so this is also what stops one
+// account reading another's notes by guessing a workspace ID.
+func (c *controller) memoryOwner(ctx context.Context, workspaceID int64, userID string) (int64, error) {
+	uid := monoflake.IDFromBase62(userID).Int64()
+	if uid == 0 || workspaceID == 0 {
+		return 0, fmt.Errorf("invalid request")
+	}
+	ok, err := c.CheckWorkspaceAccess(ctx, workspaceID, userID)
+	if err != nil {
+		return 0, fmt.Errorf("check workspace access: %w", err)
+	}
+	if !ok {
+		// Not found rather than forbidden, matching every other route under
+		// /workspaces/:id: those scope their query by user, so a workspace you
+		// do not own simply is not there. Answering "forbidden" here would
+		// confirm the workspace exists to someone who cannot see it.
+		return 0, base.ErrNotFound
+	}
+	return uid, nil
+}
+
+func (c *controller) ListMemories(ctx context.Context, req entity.ListMemoriesRequest) (*entity.ListMemoriesResponse, error) {
+	uid, err := c.memoryOwner(ctx, req.WorkspaceID, req.UserID)
+	if err != nil {
+		return nil, err
+	}
+
+	models, err := c.repository.ListMemoriesByWorkspace(ctx, uid, req.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	memories := make([]entity.Memory, len(models))
+	for i, m := range models {
+		e := fromModelMemory(m)
+		// The list says how big each memory is without carrying it: that is
+		// what the settings screen needs to draw an index.
+		e.Content = ""
+		memories[i] = e
+	}
+	return &entity.ListMemoriesResponse{Memories: memories}, nil
+}
+
+func (c *controller) GetMemory(ctx context.Context, req entity.GetMemoryRequest) (*entity.GetMemoryResponse, error) {
+	uid, err := c.memoryOwner(ctx, req.WorkspaceID, req.UserID)
+	if err != nil {
+		return nil, err
+	}
+	if req.Name == "" {
+		return nil, fmt.Errorf("invalid request")
+	}
+
+	m, err := c.repository.GetMemory(ctx, uid, req.WorkspaceID, req.Name)
+	if err != nil {
+		return nil, err
+	}
+	return &entity.GetMemoryResponse{Memory: fromModelMemory(m)}, nil
+}
+
+func fromModelMemory(m model.Memory) entity.Memory {
+	return entity.Memory{
+		ID:          m.ID,
+		CreatedAt:   m.CreatedAt,
+		UpdatedAt:   m.UpdatedAt,
+		WorkspaceID: m.WorkspaceID,
+		Name:        m.Name,
+		Content:     m.Content,
+		SizeBytes:   len(m.Content),
+	}
+}

--- a/backend/internal/controller/crud/memory_test.go
+++ b/backend/internal/controller/crud/memory_test.go
@@ -1,0 +1,172 @@
+package crud
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	"github.com/agentrq/agentrq/backend/internal/repository/base"
+	"github.com/golang/mock/gomock"
+)
+
+func storedMemory(name, content string) model.Memory {
+	now := time.Now()
+	return model.Memory{
+		ID: 900, CreatedAt: now, UpdatedAt: now,
+		UserID: testUserID, WorkspaceID: 1, Name: name, Content: content,
+	}
+}
+
+func TestListMemories_ReportsSizeWithoutTheContent(t *testing.T) {
+	e := newTestController(t)
+	e.repo.EXPECT().CheckWorkspaceAccess(gomock.Any(), int64(1), testUserID).Return(true, nil)
+	e.repo.EXPECT().ListMemoriesByWorkspace(gomock.Any(), testUserID, int64(1)).Return([]model.Memory{
+		storedMemory("MEMORY.md", "# Index"),
+		storedMemory("deploys.md", "how we ship"),
+	}, nil)
+
+	rs, err := e.controller.ListMemories(context.Background(), entity.ListMemoriesRequest{
+		WorkspaceID: 1, UserID: testUserIDStr,
+	})
+
+	if err != nil {
+		t.Fatalf("ListMemories: %v", err)
+	}
+	if len(rs.Memories) != 2 {
+		t.Fatalf("expected 2 memories, got %d", len(rs.Memories))
+	}
+	for _, m := range rs.Memories {
+		// A workspace's memories run to 16 KiB each; shipping them all to draw
+		// a list of names would send the whole store to render an index.
+		if m.Content != "" {
+			t.Errorf("%s: the list must not carry content", m.Name)
+		}
+	}
+	if rs.Memories[0].SizeBytes != len("# Index") {
+		t.Errorf("size: got %d, want %d", rs.Memories[0].SizeBytes, len("# Index"))
+	}
+}
+
+func TestGetMemory_ReturnsTheContent(t *testing.T) {
+	e := newTestController(t)
+	e.repo.EXPECT().CheckWorkspaceAccess(gomock.Any(), int64(1), testUserID).Return(true, nil)
+	e.repo.EXPECT().GetMemory(gomock.Any(), testUserID, int64(1), "MEMORY.md").Return(storedMemory("MEMORY.md", "# Index"), nil)
+
+	rs, err := e.controller.GetMemory(context.Background(), entity.GetMemoryRequest{
+		WorkspaceID: 1, UserID: testUserIDStr, Name: "MEMORY.md",
+	})
+
+	if err != nil {
+		t.Fatalf("GetMemory: %v", err)
+	}
+	if rs.Memory.Content != "# Index" {
+		t.Errorf("content: got %q", rs.Memory.Content)
+	}
+	if rs.Memory.SizeBytes != len("# Index") {
+		t.Errorf("size: got %d", rs.Memory.SizeBytes)
+	}
+}
+
+// A memory is an agent's working notes about somebody's private workspace, so a
+// caller who does not own it must not be able to read one — and must not learn
+// that it exists either, which is why this is not-found rather than forbidden.
+func TestMemories_NotReadableByAnotherAccount(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		call func(*testEnv) error
+	}{
+		{"list", func(e *testEnv) error {
+			_, err := e.controller.ListMemories(context.Background(), entity.ListMemoriesRequest{WorkspaceID: 1, UserID: testUserIDStr})
+			return err
+		}},
+		{"get", func(e *testEnv) error {
+			_, err := e.controller.GetMemory(context.Background(), entity.GetMemoryRequest{WorkspaceID: 1, UserID: testUserIDStr, Name: "MEMORY.md"})
+			return err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newTestController(t)
+			e.repo.EXPECT().CheckWorkspaceAccess(gomock.Any(), int64(1), testUserID).Return(false, nil)
+			// The repository must never be reached for a workspace the caller
+			// does not own.
+
+			err := tc.call(e)
+
+			if !errors.Is(err, base.ErrNotFound) {
+				t.Errorf("got %v, want ErrNotFound", err)
+			}
+		})
+	}
+}
+
+func TestMemories_AccessCheckFailureIsReported(t *testing.T) {
+	e := newTestController(t)
+	e.repo.EXPECT().CheckWorkspaceAccess(gomock.Any(), int64(1), testUserID).Return(false, errors.New("db down"))
+
+	_, err := e.controller.ListMemories(context.Background(), entity.ListMemoriesRequest{WorkspaceID: 1, UserID: testUserIDStr})
+
+	// A database that cannot answer must not read as "you may not see this".
+	if err == nil || errors.Is(err, base.ErrNotFound) {
+		t.Errorf("got %v, want the underlying failure", err)
+	}
+}
+
+func TestMemories_RejectIncompleteRequests(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		call func(*testEnv) error
+	}{
+		{"list with no workspace", func(e *testEnv) error {
+			_, err := e.controller.ListMemories(context.Background(), entity.ListMemoriesRequest{UserID: testUserIDStr})
+			return err
+		}},
+		{"list with no user", func(e *testEnv) error {
+			_, err := e.controller.ListMemories(context.Background(), entity.ListMemoriesRequest{WorkspaceID: 1})
+			return err
+		}},
+		{"get with no name", func(e *testEnv) error {
+			_, err := e.controller.GetMemory(context.Background(), entity.GetMemoryRequest{WorkspaceID: 1, UserID: testUserIDStr})
+			return err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newTestController(t)
+			if tc.name == "get with no name" {
+				e.repo.EXPECT().CheckWorkspaceAccess(gomock.Any(), int64(1), testUserID).Return(true, nil)
+			}
+
+			if err := tc.call(e); err == nil {
+				t.Error("expected an error")
+			}
+		})
+	}
+}
+
+func TestMemories_ReportStorageFailures(t *testing.T) {
+	t.Run("list", func(t *testing.T) {
+		e := newTestController(t)
+		e.repo.EXPECT().CheckWorkspaceAccess(gomock.Any(), int64(1), testUserID).Return(true, nil)
+		e.repo.EXPECT().ListMemoriesByWorkspace(gomock.Any(), testUserID, int64(1)).Return(nil, errors.New("db down"))
+
+		if _, err := e.controller.ListMemories(context.Background(), entity.ListMemoriesRequest{WorkspaceID: 1, UserID: testUserIDStr}); err == nil {
+			t.Error("expected an error")
+		}
+	})
+
+	t.Run("get", func(t *testing.T) {
+		e := newTestController(t)
+		e.repo.EXPECT().CheckWorkspaceAccess(gomock.Any(), int64(1), testUserID).Return(true, nil)
+		e.repo.EXPECT().GetMemory(gomock.Any(), testUserID, int64(1), "gone.md").Return(model.Memory{}, base.ErrNotFound)
+
+		_, err := e.controller.GetMemory(context.Background(), entity.GetMemoryRequest{WorkspaceID: 1, UserID: testUserIDStr, Name: "gone.md"})
+
+		// A name that was never written is a clean not-found, not an empty
+		// success that would render as a memory with nothing in it.
+		if !errors.Is(err, base.ErrNotFound) {
+			t.Errorf("got %v, want ErrNotFound", err)
+		}
+	})
+}

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -501,6 +501,38 @@ type (
 		A string
 	}
 
+	// Memory is one of a workspace's remembered notes. Size travels with the
+	// list so a caller can show what is there without fetching every memory in
+	// full; Content is only populated when one was asked for by name.
+	Memory struct {
+		ID          int64
+		CreatedAt   time.Time
+		UpdatedAt   time.Time
+		WorkspaceID int64
+		Name        string
+		Content     string
+		SizeBytes   int
+	}
+
+	ListMemoriesRequest struct {
+		WorkspaceID int64
+		UserID      string
+	}
+
+	ListMemoriesResponse struct {
+		Memories []Memory
+	}
+
+	GetMemoryRequest struct {
+		WorkspaceID int64
+		UserID      string
+		Name        string
+	}
+
+	GetMemoryResponse struct {
+		Memory Memory
+	}
+
 	Event struct {
 		ID                int64
 		CreatedAt         time.Time

--- a/backend/internal/data/view/api/view.go
+++ b/backend/internal/data/view/api/view.go
@@ -310,6 +310,27 @@ type (
 
 	// Event views
 
+	// Memory as the interface sees it. `content` is omitted from the list: a
+	// workspace's memories are 16 KiB each, and sending them all to render a
+	// list of names would ship the whole store to draw an index.
+	Memory struct {
+		ID          string    `json:"id"`
+		CreatedAt   time.Time `json:"createdAt"`
+		UpdatedAt   time.Time `json:"updatedAt"`
+		WorkspaceID string    `json:"workspaceId"`
+		Name        string    `json:"name"`
+		SizeBytes   int       `json:"sizeBytes"`
+		Content     string    `json:"content,omitempty"`
+	}
+
+	ListMemoriesResponse struct {
+		Memories []Memory `json:"memories"`
+	}
+
+	GetMemoryResponse struct {
+		Memory Memory `json:"memory"`
+	}
+
 	Event struct {
 		ID                string    `json:"id"`
 		CreatedAt         time.Time `json:"createdAt"`

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -586,6 +586,8 @@ func (h *handler) registerWorkspaceRoutes() error {
 	r.Post("/:id/archive", h.archiveWorkspace())
 	r.Post("/:id/unarchive", h.unarchiveWorkspace())
 	r.Get("/:id/stats", h.getWorkspaceStats())
+	r.Get("/:id/memories", h.listWorkspaceMemories())
+	r.Get("/:id/memories/:name", h.getWorkspaceMemory())
 	r.Put("/:id/slack", h.setWorkspaceSlackChannel())
 	r.Delete("/:id/slack", h.removeWorkspaceSlackChannel())
 	return nil
@@ -857,6 +859,55 @@ func (h *handler) getWorkspaceStats() fiber.Handler {
 			return c.Send(e)
 		}
 		return c.Status(http.StatusOK).JSON(rs)
+	}
+}
+
+// The workspace's memories, as the settings screen shows them.
+//
+// Read-only by design: agents write these through the MCP memory tools, and a
+// human quietly rewriting one under an agent that has already read it is a
+// confusing failure from both sides.
+func (h *handler) listWorkspaceMemories() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		rq := mapper.FromHTTPRequestToListMemoriesRequestEntity(c)
+		if rq == nil {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		rq.UserID = c.Locals("user_id").(string)
+
+		ctx, cancel := newContext(c)
+		defer cancel()
+		rs, err := h.crud.ListMemories(ctx, *rq)
+		if err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		return c.Send(mapper.FromListMemoriesResponseEntityToHTTPResponse(rs))
+	}
+}
+
+func (h *handler) getWorkspaceMemory() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		rq := mapper.FromHTTPRequestToGetMemoryRequestEntity(c)
+		if rq == nil {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+		rq.UserID = c.Locals("user_id").(string)
+
+		ctx, cancel := newContext(c)
+		defer cancel()
+		rs, err := h.crud.GetMemory(ctx, *rq)
+		if err != nil {
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		return c.Send(mapper.FromGetMemoryResponseEntityToHTTPResponse(rs))
 	}
 }
 

--- a/backend/internal/handler/api/memory_test.go
+++ b/backend/internal/handler/api/memory_test.go
@@ -1,0 +1,213 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/agentrq/agentrq/backend/internal/controller/crud"
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/agentrq/agentrq/backend/internal/repository/base"
+	"github.com/gofiber/fiber/v2"
+	"github.com/mustafaturan/monoflake"
+)
+
+type memoryCrud struct {
+	crud.Controller
+	listFunc func(ctx context.Context, req entity.ListMemoriesRequest) (*entity.ListMemoriesResponse, error)
+	getFunc  func(ctx context.Context, req entity.GetMemoryRequest) (*entity.GetMemoryResponse, error)
+	// What the handler actually asked for, so the test can check the request
+	// was assembled from the path and the session rather than from the body.
+	sawList entity.ListMemoriesRequest
+	sawGet  entity.GetMemoryRequest
+}
+
+func (m *memoryCrud) ListMemories(ctx context.Context, req entity.ListMemoriesRequest) (*entity.ListMemoriesResponse, error) {
+	m.sawList = req
+	return m.listFunc(ctx, req)
+}
+
+func (m *memoryCrud) GetMemory(ctx context.Context, req entity.GetMemoryRequest) (*entity.GetMemoryResponse, error) {
+	m.sawGet = req
+	return m.getFunc(ctx, req)
+}
+
+var testMemoryWorkspaceID = monoflake.ID(4242).String()
+
+func memoryApp(c crud.Controller) *fiber.App {
+	h := &handler{crud: c}
+	app := fiber.New()
+	// The session's user, exactly as the auth middleware supplies it.
+	app.Use(func(ctx *fiber.Ctx) error {
+		ctx.Locals("user_id", "user-1")
+		return ctx.Next()
+	})
+	app.Get("/workspaces/:id/memories", h.listWorkspaceMemories())
+	app.Get("/workspaces/:id/memories/:name", h.getWorkspaceMemory())
+	return app
+}
+
+func TestListWorkspaceMemories(t *testing.T) {
+	now := time.Now()
+	c := &memoryCrud{
+		listFunc: func(context.Context, entity.ListMemoriesRequest) (*entity.ListMemoriesResponse, error) {
+			return &entity.ListMemoriesResponse{Memories: []entity.Memory{
+				{ID: 900, CreatedAt: now, UpdatedAt: now, WorkspaceID: 4242, Name: "MEMORY.md", SizeBytes: 7},
+			}}, nil
+		},
+	}
+
+	res, _ := memoryApp(c).Test(httptest.NewRequest(http.MethodGet, "/workspaces/"+testMemoryWorkspaceID+"/memories", nil))
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+	var body struct {
+		Memories []map[string]any `json:"memories"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Memories) != 1 {
+		t.Fatalf("expected one memory, got %d", len(body.Memories))
+	}
+	m := body.Memories[0]
+	if m["name"] != "MEMORY.md" || m["sizeBytes"] != float64(7) {
+		t.Errorf("got %v", m)
+	}
+	// camelCase, and no content in the list.
+	if _, present := m["content"]; present {
+		t.Error("the list must not carry content")
+	}
+	for _, key := range []string{"createdAt", "updatedAt", "workspaceId", "sizeBytes"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("missing %q — the API is camelCase", key)
+		}
+	}
+	// The workspace comes from the path and the user from the session, never
+	// from anything the caller can put in a body.
+	if c.sawList.WorkspaceID != 4242 || c.sawList.UserID != "user-1" {
+		t.Errorf("controller saw %+v", c.sawList)
+	}
+}
+
+func TestGetWorkspaceMemory(t *testing.T) {
+	c := &memoryCrud{
+		getFunc: func(context.Context, entity.GetMemoryRequest) (*entity.GetMemoryResponse, error) {
+			return &entity.GetMemoryResponse{Memory: entity.Memory{
+				ID: 900, WorkspaceID: 4242, Name: "deploys.md", Content: "how we ship", SizeBytes: 11,
+			}}, nil
+		},
+	}
+
+	res, _ := memoryApp(c).Test(httptest.NewRequest(http.MethodGet, "/workspaces/"+testMemoryWorkspaceID+"/memories/deploys.md", nil))
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+	var body struct {
+		Memory map[string]any `json:"memory"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Memory["content"] != "how we ship" {
+		t.Errorf("content: got %v", body.Memory["content"])
+	}
+	if c.sawGet.Name != "deploys.md" {
+		t.Errorf("controller asked for %q", c.sawGet.Name)
+	}
+}
+
+// A name arrives percent-encoded in the path and must reach the controller as
+// the name the agent actually saved under.
+func TestGetWorkspaceMemory_DecodesTheName(t *testing.T) {
+	c := &memoryCrud{
+		getFunc: func(context.Context, entity.GetMemoryRequest) (*entity.GetMemoryResponse, error) {
+			return &entity.GetMemoryResponse{Memory: entity.Memory{Name: "release notes.md"}}, nil
+		},
+	}
+
+	res, _ := memoryApp(c).Test(httptest.NewRequest(http.MethodGet, "/workspaces/"+testMemoryWorkspaceID+"/memories/release%20notes.md", nil))
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+	if c.sawGet.Name != "release notes.md" {
+		t.Errorf("controller asked for %q, want the decoded name", c.sawGet.Name)
+	}
+}
+
+// A percent-escape that decodes to nothing usable stops at the edge rather than
+// reaching the controller as a lookup for a name nobody could have saved.
+//
+// The request is built by hand: httptest.NewRequest parses the URL and refuses
+// a malformed escape outright, so the only way to send one is to set the raw
+// request line.
+func TestGetWorkspaceMemory_RejectsANameItCannotDecode(t *testing.T) {
+	c := &memoryCrud{}
+
+	for _, raw := range []string{
+		"/workspaces/" + testMemoryWorkspaceID + "/memories/%zz",
+		"/workspaces/" + testMemoryWorkspaceID + "/memories/%",
+	} {
+		req := httptest.NewRequest(http.MethodGet, "/workspaces/"+testMemoryWorkspaceID+"/memories/placeholder", nil)
+		req.RequestURI = raw
+		req.URL.Path = raw
+		req.URL.RawPath = raw
+
+		res, err := memoryApp(c).Test(req)
+		if err != nil {
+			t.Fatalf("%s: %v", raw, err)
+		}
+		if res.StatusCode != http.StatusUnprocessableEntity {
+			t.Errorf("%s: status = %d, want 422", raw, res.StatusCode)
+		}
+	}
+}
+
+func TestWorkspaceMemories_RejectAnUnreadableWorkspaceID(t *testing.T) {
+	// The controller must not be reached at all, so its funcs stay nil: a call
+	// would panic rather than quietly pass.
+	c := &memoryCrud{}
+
+	// "0" rather than something that merely looks wrong: base62 happily decodes
+	// most junk into a real number, and only an ID that resolves to zero is
+	// actually unreadable.
+	for _, path := range []string{
+		"/workspaces/0/memories",
+		"/workspaces/0/memories/MEMORY.md",
+	} {
+		res, _ := memoryApp(c).Test(httptest.NewRequest(http.MethodGet, path, nil))
+		if res.StatusCode != http.StatusUnprocessableEntity {
+			t.Errorf("%s: status = %d, want 422", path, res.StatusCode)
+		}
+	}
+}
+
+// A workspace the caller does not own, and a memory that was never written,
+// both come back as not-found — the controller answers the first that way so a
+// stranger cannot tell whether the workspace exists.
+func TestWorkspaceMemories_NotFound(t *testing.T) {
+	c := &memoryCrud{
+		listFunc: func(context.Context, entity.ListMemoriesRequest) (*entity.ListMemoriesResponse, error) {
+			return nil, base.ErrNotFound
+		},
+		getFunc: func(context.Context, entity.GetMemoryRequest) (*entity.GetMemoryResponse, error) {
+			return nil, base.ErrNotFound
+		},
+	}
+
+	for _, path := range []string{
+		"/workspaces/" + testMemoryWorkspaceID + "/memories",
+		"/workspaces/" + testMemoryWorkspaceID + "/memories/gone.md",
+	} {
+		res, _ := memoryApp(c).Test(httptest.NewRequest(http.MethodGet, path, nil))
+		if res.StatusCode != http.StatusNotFound {
+			t.Errorf("%s: status = %d, want 404", path, res.StatusCode)
+		}
+	}
+}

--- a/backend/internal/mapper/api/memory.go
+++ b/backend/internal/mapper/api/memory.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"encoding/json"
+	"net/url"
+
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	view "github.com/agentrq/agentrq/backend/internal/data/view/api"
+	"github.com/gofiber/fiber/v2"
+	"github.com/mustafaturan/monoflake"
+)
+
+func FromHTTPRequestToListMemoriesRequestEntity(c *fiber.Ctx) *entity.ListMemoriesRequest {
+	workspaceID := monoflake.IDFromBase62(c.Params("id")).Int64()
+	if workspaceID == 0 {
+		return nil
+	}
+	return &entity.ListMemoriesRequest{WorkspaceID: workspaceID}
+}
+
+func FromHTTPRequestToGetMemoryRequestEntity(c *fiber.Ctx) *entity.GetMemoryRequest {
+	workspaceID := monoflake.IDFromBase62(c.Params("id")).Int64()
+	if workspaceID == 0 {
+		return nil
+	}
+	// The name travels in the path, so it arrives percent-encoded — and Fiber
+	// hands back the raw segment, so it has to be decoded here. A memory named
+	// "release notes.md" would otherwise be looked up as "release%20notes.md"
+	// and never found.
+	name, err := url.PathUnescape(c.Params("name"))
+	if err != nil {
+		return nil
+	}
+	// An empty name is not checked here: the route cannot match one, so the
+	// guard would be unreachable. The controller refuses it, which is where a
+	// caller that reaches it another way is caught.
+	return &entity.GetMemoryRequest{WorkspaceID: workspaceID, Name: name}
+}
+
+func FromListMemoriesResponseEntityToHTTPResponse(rs *entity.ListMemoriesResponse) []byte {
+	memories := make([]view.Memory, len(rs.Memories))
+	for i, m := range rs.Memories {
+		memories[i] = fromEntityMemoryToView(m)
+	}
+	payload, _ := json.Marshal(view.ListMemoriesResponse{Memories: memories})
+	return payload
+}
+
+func FromGetMemoryResponseEntityToHTTPResponse(rs *entity.GetMemoryResponse) []byte {
+	payload, _ := json.Marshal(view.GetMemoryResponse{Memory: fromEntityMemoryToView(rs.Memory)})
+	return payload
+}
+
+func fromEntityMemoryToView(m entity.Memory) view.Memory {
+	return view.Memory{
+		ID:          monoflake.ID(m.ID).String(),
+		CreatedAt:   m.CreatedAt,
+		UpdatedAt:   m.UpdatedAt,
+		WorkspaceID: monoflake.ID(m.WorkspaceID).String(),
+		Name:        m.Name,
+		SizeBytes:   m.SizeBytes,
+		Content:     m.Content,
+	}
+}

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -391,6 +391,55 @@ paths:
               schema: { $ref: '#/components/schemas/WorkspaceStats' }
         '422': { $ref: '#/components/responses/InvalidPayload' }
 
+  /workspaces/{id}/memories:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+    get:
+      tags: [Workspaces]
+      summary: What this workspace remembers
+      description: >
+        The workspace's memories, written by agents through the `saveMemory` MCP
+        tool. `content` is omitted here — each memory runs to 16 KiB, so the list
+        carries only names and sizes. Fetch one by name for its content.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  memories:
+                    type: array
+                    items: { $ref: '#/components/schemas/Memory' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/InvalidPayload' }
+
+  /workspaces/{id}/memories/{name}:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+      - name: name
+        in: path
+        required: true
+        schema: { type: string, maxLength: 32 }
+        description: >
+          The memory's name, as the agent saved it. `MEMORY.md` is the index
+          agents read first.
+    get:
+      tags: [Workspaces]
+      summary: One memory, in full
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  memory: { $ref: '#/components/schemas/Memory' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/InvalidPayload' }
+
   /workspaces/{id}/slack:
     parameters:
       - $ref: '#/components/parameters/WorkspaceId'
@@ -1697,6 +1746,26 @@ components:
           type: array
           items: { type: string }
           example: ["email"]
+
+    Memory:
+      type: object
+      description: >
+        One of a workspace's remembered notes. Written by agents, read-only over
+        this API.
+      properties:
+        id: { type: string }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+        workspaceId: { type: string }
+        name: { type: string, maxLength: 32 }
+        sizeBytes:
+          type: integer
+          description: Size of the content in bytes. At most 16384.
+        content:
+          type: string
+          description: >
+            Present only when a single memory was requested by name; the list
+            omits it.
 
     WorkspaceStats:
       type: object

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -311,6 +311,21 @@ export async function removeWorkspaceSlackChannel(id) {
   return true;
 }
 
+// A workspace's memories, as the settings screen lists them. The content is
+// deliberately absent here — each memory is up to 16 KiB, and the list only
+// needs names and sizes.
+export async function fetchWorkspaceMemories(workspaceId) {
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/memories`);
+  if (!res.ok) throw new Error('Failed to fetch workspace memories');
+  return res.json();
+}
+
+export async function getWorkspaceMemory(workspaceId, name) {
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/memories/${encodeURIComponent(name)}`);
+  if (!res.ok) throw new Error('Failed to fetch memory');
+  return res.json();
+}
+
 export async function fetchGlobalTaskStats() {
   const res = await apiFetch(`${API_BASE_URL}/tasks/stats`);
   if (!res.ok) throw new Error('Failed to fetch global task stats');

--- a/frontend/src/webmcp/tools.js
+++ b/frontend/src/webmcp/tools.js
@@ -193,6 +193,26 @@ export function createToolCatalogue({ api, navigate, currentPage }) {
         api.fetchWorkspaceStats(workspaceId, range, from, to),
     }),
     tool({
+      name: 'listWorkspaceMemories',
+      description:
+        'What the agents working in a workspace have written down for each other: name, size and when ' +
+        'each was last changed. The content is not included — read one by name for that. MEMORY.md is ' +
+        'the index the others hang off.',
+      properties: { workspaceId: WORKSPACE_ID },
+      required: ['workspaceId'],
+      readOnly: true,
+      run: ({ workspaceId }) => api.fetchWorkspaceMemories(workspaceId),
+    }),
+    tool({
+      name: 'getWorkspaceMemory',
+      description:
+        'One of a workspace\'s memories, in full. Start with MEMORY.md, which indexes the rest.',
+      properties: { workspaceId: WORKSPACE_ID, name: str('The memory\'s name, as listWorkspaceMemories reports it.') },
+      required: ['workspaceId', 'name'],
+      readOnly: true,
+      run: ({ workspaceId, name }) => api.getWorkspaceMemory(workspaceId, name),
+    }),
+    tool({
       name: 'setWorkspaceSlackChannel',
       description: 'Connect a workspace to a Slack channel so its activity is posted there.',
       properties: {

--- a/frontend/test/webmcpTools.test.js
+++ b/frontend/test/webmcpTools.test.js
@@ -18,6 +18,7 @@ const EVERY_FIELD = {
   requestId: 'req1',
   path: '/events',
   name: 'a name',
+  content: 'some content',
   title: 'a title',
   body: 'a body',
   text: 'some text',
@@ -230,6 +231,13 @@ describe('each tool calls the interface the way the UI does', () => {
       { workspaceId: 'ws1', range: '30d', from: 1, to: 2 },
       'fetchWorkspaceStats',
       ['ws1', '30d', 1, 2],
+    ],
+    ['listWorkspaceMemories', { workspaceId: 'ws1' }, 'fetchWorkspaceMemories', ['ws1']],
+    [
+      'getWorkspaceMemory',
+      { workspaceId: 'ws1', name: 'MEMORY.md' },
+      'getWorkspaceMemory',
+      ['ws1', 'MEMORY.md'],
     ],
     [
       'setWorkspaceSlackChannel',


### PR DESCRIPTION
> **Stacked on #458**, which is stacked on #457. Merge in order (457 → 458 → this) and GitHub retargets each one as its base merges.

## What changed

Two read-only endpoints so the settings screen can show what a workspace's agents have remembered: the list of memories, and one memory in full.

## Why

Third of four steps adding per-workspace memory. The tools can write memories; nothing could show them to the person who owns the workspace.

## Test coverage report

- **New lines: 100%.** Controller, handlers and mapper are each at 100% statement coverage, measured per function (the mapper with `-coverpkg`, since its callers live in the handler package).
- **Total coverage impact: none.** The full backend suite passes.

## Other reports

**A bug the tests caught before it shipped.** Fiber hands back the *raw* path segment, not a decoded one, so a memory named `release notes.md` was being looked up as `release%20notes.md` and would never have been found. The mapper now decodes it, and a test pins that.

Decisions worth a reviewer's attention:

- **The list omits `content`.** Each memory is up to 16 KiB and a workspace holds several; sending them all to draw a list of names would ship the whole store to render an index.
- **No write or delete route, deliberately.** Agents own the writing through the MCP tools. An agent reading back a memory a human had quietly rewritten is a nasty failure to debug from either side, so that is a separate decision rather than something to include quietly.
- **A workspace you do not own answers 404, not 403**, matching every other route under `/workspaces/:id` — those scope their query by user, so a workspace you cannot see simply is not there. Answering "forbidden" would confirm to a stranger that it exists.

Also adds both routes and the `Memory` schema to `backend/openapi.yaml` — an existing test requires every served route to be documented, which is a good rule and caught this immediately.

TaskID: 0iHtNeMY9Hl