### PR TITLE
feat(mcp): add deleteMemory tool for workspace agents

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -605,6 +605,17 @@ func New(cfg Config) (*App, error) {
 				})
 				return err
 			},
+			func(ctx context.Context, name string) (bool, error) {
+				uid := monoflake.IDFromBase62(workspaceOwner).Int64()
+				err := repo.DeleteMemory(ctx, uid, workspaceID, name)
+				if errors.Is(err, base.ErrNotFound) {
+					return false, nil
+				}
+				if err != nil {
+					return false, err
+				}
+				return true, nil
+			},
 			func(ctx context.Context, tc model.ToolCall) (model.ToolCall, error) {
 				created, err := repo.CreateToolCall(ctx, tc)
 				if err == nil {

--- a/backend/internal/controller/mcp/memory.go
+++ b/backend/internal/controller/mcp/memory.go
@@ -54,6 +54,13 @@ type LoadMemoryFunc func(ctx context.Context, name string) (content string, foun
 // was stored under that name.
 type SaveMemoryFunc func(ctx context.Context, name string, content string) error
 
+// DeleteMemoryFunc removes one of the workspace's memories.
+//
+// `deleted` mirrors LoadMemoryFunc's `found`: deleting a memory that was never
+// written (or already deleted) is not a failure, so the tool can say plainly
+// that there was nothing to remove instead of erroring on a harmless retry.
+type DeleteMemoryFunc func(ctx context.Context, name string) (deleted bool, err error)
+
 // LoadMemoryParams is the input to the loadMemory tool.
 type LoadMemoryParams struct {
 	Name string `json:"name,omitempty" jsonschema:"Which memory to read. Defaults to MEMORY.md, the index that says what else this workspace remembers."`
@@ -63,6 +70,11 @@ type LoadMemoryParams struct {
 type SaveMemoryParams struct {
 	Name    string `json:"name,omitempty" jsonschema:"Which memory to write. Defaults to MEMORY.md, the index that says what else this workspace remembers."`
 	Content string `json:"content" jsonschema:"The full new content. This replaces the memory entirely — there is no append, so include everything worth keeping."`
+}
+
+// DeleteMemoryParams is the input to the deleteMemory tool.
+type DeleteMemoryParams struct {
+	Name string `json:"name,omitempty" jsonschema:"Which memory to delete. Defaults to MEMORY.md, the index that says what else this workspace remembers."`
 }
 
 // memoryNamePattern is the shape a stored name takes: a lowercase slug with a
@@ -176,5 +188,35 @@ func (ps *WorkspaceServer) handleSaveMemory(ctx context.Context, req *mcp.CallTo
 		Content: []mcp.Content{&mcp.TextContent{
 			Text: fmt.Sprintf("Saved %q (%d bytes).", name, len(params.Content)),
 		}},
+	}, nil, nil
+}
+
+func (ps *WorkspaceServer) handleDeleteMemory(ctx context.Context, req *mcp.CallToolRequest, params DeleteMemoryParams) (*mcp.CallToolResult, any, error) {
+	ps.emitTelemetry(ctx, ActionMCPToolCall, "deleteMemory", clientIdentityFromRequest(req))
+
+	name, err := resolveMemoryName(params.Name)
+	if err != nil {
+		return toolError("%v", err), nil, nil
+	}
+	if ps.deleteMemory == nil {
+		return toolError("memory is not available on this server"), nil, nil
+	}
+
+	deleted, err := ps.deleteMemory(ctx, name)
+	if err != nil {
+		return toolError("failed to delete memory %q: %v", name, err), nil, nil
+	}
+	if !deleted {
+		// Not an error: deleting something that was never written, or was
+		// already removed, ends in the same state the caller wanted.
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{
+				Text: fmt.Sprintf("No memory was stored under %q; nothing to delete.", name),
+			}},
+		}, nil, nil
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Deleted %q.", name)}},
 	}, nil, nil
 }

--- a/backend/internal/controller/mcp/memory_test.go
+++ b/backend/internal/controller/mcp/memory_test.go
@@ -15,11 +15,13 @@ import (
 // A server with the memory tools wired to an in-memory store, so a save and the
 // load that follows it exercise the same path a real agent takes.
 type memoryStore struct {
-	saved    map[string]string
-	loadErr  error
-	saveErr  error
-	loadName string
-	saveName string
+	saved      map[string]string
+	loadErr    error
+	saveErr    error
+	deleteErr  error
+	loadName   string
+	saveName   string
+	deleteName string
 }
 
 func newMemoryServer(t *testing.T, store *memoryStore) *WorkspaceServer {
@@ -50,6 +52,17 @@ func newMemoryServer(t *testing.T, store *memoryStore) *WorkspaceServer {
 			}
 			store.saved[name] = content
 			return nil
+		},
+		deleteMemory: func(ctx context.Context, name string) (bool, error) {
+			store.deleteName = name
+			if store.deleteErr != nil {
+				return false, store.deleteErr
+			}
+			if _, ok := store.saved[name]; !ok {
+				return false, nil
+			}
+			delete(store.saved, name)
+			return true, nil
 		},
 	}
 }
@@ -333,6 +346,89 @@ func TestMemoryNamesThatAreAccepted(t *testing.T) {
 	}
 }
 
+func TestDeleteMemoryRemovesWhatWasSaved(t *testing.T) {
+	store := &memoryStore{saved: map[string]string{"notes.md": "keep this"}}
+	ps := newMemoryServer(t, store)
+	ctx := context.Background()
+
+	res, _, err := ps.handleDeleteMemory(ctx, &mcp.CallToolRequest{}, DeleteMemoryParams{Name: "notes.md"})
+	if err != nil {
+		t.Fatalf("deleteMemory: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("deleteMemory reported an error: %s", resultText(t, res))
+	}
+	if _, ok := store.saved["notes.md"]; ok {
+		t.Error("the memory should have been removed")
+	}
+
+	loaded, _, err := ps.handleLoadMemory(ctx, &mcp.CallToolRequest{}, LoadMemoryParams{Name: "notes.md"})
+	if err != nil {
+		t.Fatalf("loadMemory: %v", err)
+	}
+	if loaded.IsError {
+		t.Fatalf("a load after delete should miss, not error: %s", resultText(t, loaded))
+	}
+}
+
+// Deleting a name nobody wrote under ends in the state the caller wanted, so
+// it must not read as a failure.
+func TestDeleteMemoryMissIsNotAnError(t *testing.T) {
+	ps := newMemoryServer(t, &memoryStore{})
+
+	res, _, err := ps.handleDeleteMemory(context.Background(), &mcp.CallToolRequest{}, DeleteMemoryParams{Name: "never-written.md"})
+
+	if err != nil {
+		t.Fatalf("deleteMemory: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("a miss must not be an error: %s", resultText(t, res))
+	}
+	text := resultText(t, res)
+	if !strings.Contains(text, "never-written.md") {
+		t.Errorf("a miss should name the memory; got %q", text)
+	}
+}
+
+func TestDeleteMemoryDefaultsToTheIndex(t *testing.T) {
+	store := &memoryStore{saved: map[string]string{DefaultMemoryName: "x"}}
+	ps := newMemoryServer(t, store)
+
+	if _, _, err := ps.handleDeleteMemory(context.Background(), &mcp.CallToolRequest{}, DeleteMemoryParams{}); err != nil {
+		t.Fatalf("deleteMemory: %v", err)
+	}
+	if store.deleteName != DefaultMemoryName {
+		t.Errorf("deleted %q, want %q", store.deleteName, DefaultMemoryName)
+	}
+}
+
+// The same folding as save/load, so a differently-spelled delete still finds
+// the memory a save stored.
+func TestDeleteMemoryFoldsTheNameToo(t *testing.T) {
+	store := &memoryStore{saved: map[string]string{"release-notes.md": "what shipped"}}
+	ps := newMemoryServer(t, store)
+
+	if _, _, err := ps.handleDeleteMemory(context.Background(), &mcp.CallToolRequest{}, DeleteMemoryParams{Name: "Release-Notes.MD"}); err != nil {
+		t.Fatalf("deleteMemory: %v", err)
+	}
+	if store.deleteName != "release-notes.md" {
+		t.Errorf("deleted %q, want the folded name", store.deleteName)
+	}
+}
+
+func TestDeleteMemoryRefusesAnUnusableName(t *testing.T) {
+	ps := newMemoryServer(t, &memoryStore{})
+
+	res, _, err := ps.handleDeleteMemory(context.Background(), &mcp.CallToolRequest{}, DeleteMemoryParams{Name: "release notes.md"})
+
+	if err != nil {
+		t.Fatalf("deleteMemory: %v", err)
+	}
+	if !res.IsError {
+		t.Error("an unusable name must be refused")
+	}
+}
+
 func TestMemoryToolsReportStorageFailures(t *testing.T) {
 	ctx := context.Background()
 
@@ -365,6 +461,21 @@ func TestMemoryToolsReportStorageFailures(t *testing.T) {
 			t.Errorf("got %q", resultText(t, res))
 		}
 	})
+
+	t.Run("delete", func(t *testing.T) {
+		ps := newMemoryServer(t, &memoryStore{deleteErr: errors.New("disk on fire")})
+
+		res, _, err := ps.handleDeleteMemory(ctx, &mcp.CallToolRequest{}, DeleteMemoryParams{})
+
+		if err != nil {
+			t.Fatalf("deleteMemory: %v", err)
+		}
+		// Distinct from a miss: "nothing to remove" and "could not delete" call
+		// for different responses from the agent.
+		if !res.IsError || !strings.Contains(resultText(t, res), "disk on fire") {
+			t.Errorf("got %q", resultText(t, res))
+		}
+	})
 }
 
 // A server built without the memory funcs must say so rather than panic — the
@@ -392,5 +503,13 @@ func TestMemoryToolsWithoutStorage(t *testing.T) {
 	}
 	if !save.IsError {
 		t.Error("saveMemory should report that memory is unavailable")
+	}
+
+	del, _, err := ps.handleDeleteMemory(ctx, &mcp.CallToolRequest{}, DeleteMemoryParams{})
+	if err != nil {
+		t.Fatalf("deleteMemory: %v", err)
+	}
+	if !del.IsError {
+		t.Error("deleteMemory should report that memory is unavailable")
 	}
 }

--- a/backend/internal/controller/mcp/protocol_version_test.go
+++ b/backend/internal/controller/mcp/protocol_version_test.go
@@ -30,7 +30,7 @@ func newProtocolTestServer(t *testing.T) *httptest.Server {
 	ps := NewWorkspaceServer(
 		1, "user", "http://localhost",
 		nil, nil, nil, listTasks, nil, nil, nil, nil, nil,
-		nil, nil, // loadMemory, saveMemory
+		nil, nil, nil, // loadMemory, saveMemory, deleteMemory
 		nil, nil,
 		eventbus.New(), nil, nil, "icon", "name", "desc", nil, nil, nil, pub,
 	)

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -100,6 +100,7 @@ type WorkspaceServer struct {
 	publishEvent          PublishEventFunc
 	loadMemory            LoadMemoryFunc
 	saveMemory            SaveMemoryFunc
+	deleteMemory          DeleteMemoryFunc
 	recordToolCall        RecordToolCallFunc
 	updateToolCallStatus  UpdateToolCallStatusFunc
 	bus                   *eventbus.Bus
@@ -323,6 +324,7 @@ func NewWorkspaceServer(
 	publishEvent PublishEventFunc,
 	loadMemory LoadMemoryFunc,
 	saveMemory SaveMemoryFunc,
+	deleteMemory DeleteMemoryFunc,
 	recordToolCall RecordToolCallFunc,
 	updateToolCallStatus UpdateToolCallStatusFunc,
 	bus *eventbus.Bus,
@@ -352,6 +354,7 @@ func NewWorkspaceServer(
 		publishEvent:           publishEvent,
 		loadMemory:             loadMemory,
 		saveMemory:             saveMemory,
+		deleteMemory:           deleteMemory,
 		recordToolCall:         recordToolCall,
 		updateToolCallStatus:   updateToolCallStatus,
 		bus:                    bus,
@@ -483,6 +486,13 @@ func NewWorkspaceServer(
 			"One memory holds at most 16 KiB; a larger one is refused rather than truncated, so split it and index the parts. " +
 			"The memory belongs to the workspace, not to you — other agents working here read the same notes.",
 	}, ps.handleSaveMemory)
+
+	mcp.AddTool(mcpSrv, &mcp.Tool{
+		Name: "deleteMemory",
+		Description: "Delete one of the workspace's memories. " +
+			"With no name it deletes " + DefaultMemoryName + " itself — think before doing that, since it is the index the other memories link from. " +
+			"Deleting a name nobody wrote under (or one already deleted) is not an error; it just says there was nothing to remove.",
+	}, ps.handleDeleteMemory)
 
 	mcp.AddTool(mcpSrv, &mcp.Tool{
 		Name:        "elicit",

--- a/backend/internal/repository/base/memory_test.go
+++ b/backend/internal/repository/base/memory_test.go
@@ -220,3 +220,69 @@ func TestUpsertMemory_ReportsAWriteThatFailed(t *testing.T) {
 		t.Error("expected an error when the write cannot land")
 	}
 }
+
+func TestDeleteMemory_RemovesTheRow(t *testing.T) {
+	db := memoryDB(t)
+	repo := New(&mockDB{db: db})
+	ctx := context.Background()
+
+	if _, err := repo.UpsertMemory(ctx, memory(1, memUserID, memWorkspaceID, "MEMORY.md", "x")); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := repo.DeleteMemory(ctx, memUserID, memWorkspaceID, "MEMORY.md"); err != nil {
+		t.Fatalf("DeleteMemory: %v", err)
+	}
+
+	if _, err := repo.GetMemory(ctx, memUserID, memWorkspaceID, "MEMORY.md"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("got %v, want ErrNotFound after delete", err)
+	}
+}
+
+func TestDeleteMemory_MissingIsNotFound(t *testing.T) {
+	repo := New(&mockDB{db: memoryDB(t)})
+
+	err := repo.DeleteMemory(context.Background(), memUserID, memWorkspaceID, "never-written.md")
+
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("got %v, want ErrNotFound", err)
+	}
+}
+
+// The delete is scoped by all three columns, the same as every other memory
+// lookup — deleting under one owner/workspace must never remove another's row
+// that merely shares a name.
+func TestDeleteMemory_ScopedToOwnerAndWorkspace(t *testing.T) {
+	repo := New(&mockDB{db: memoryDB(t)})
+	ctx := context.Background()
+
+	if _, err := repo.UpsertMemory(ctx, memory(1, memUserID, memWorkspaceID, "MEMORY.md", "mine")); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+	if _, err := repo.UpsertMemory(ctx, memory(2, memUserID, memOtherWSID, "MEMORY.md", "other workspace")); err != nil {
+		t.Fatalf("seed other workspace: %v", err)
+	}
+	if _, err := repo.UpsertMemory(ctx, memory(3, memOtherUserID, memWorkspaceID, "MEMORY.md", "other owner")); err != nil {
+		t.Fatalf("seed other owner: %v", err)
+	}
+
+	if err := repo.DeleteMemory(ctx, memUserID, memWorkspaceID, "MEMORY.md"); err != nil {
+		t.Fatalf("DeleteMemory: %v", err)
+	}
+
+	for _, tc := range []struct {
+		userID, workspaceID int64
+		want                string
+	}{
+		{memUserID, memOtherWSID, "other workspace"},
+		{memOtherUserID, memWorkspaceID, "other owner"},
+	} {
+		got, err := repo.GetMemory(ctx, tc.userID, tc.workspaceID, "MEMORY.md")
+		if err != nil {
+			t.Fatalf("GetMemory(%d, %d): %v", tc.userID, tc.workspaceID, err)
+		}
+		if got.Content != tc.want {
+			t.Errorf("GetMemory(%d, %d): got %q, want %q", tc.userID, tc.workspaceID, got.Content, tc.want)
+		}
+	}
+}

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -43,6 +43,7 @@ type Repository interface {
 	GetMemory(ctx context.Context, userID, workspaceID int64, name string) (model.Memory, error)
 	UpsertMemory(ctx context.Context, m model.Memory) (model.Memory, error)
 	ListMemoriesByWorkspace(ctx context.Context, userID, workspaceID int64) ([]model.Memory, error)
+	DeleteMemory(ctx context.Context, userID, workspaceID int64, name string) error
 
 	// ToolCall
 	CreateToolCall(ctx context.Context, tc model.ToolCall) (model.ToolCall, error)
@@ -939,6 +940,22 @@ func (r *repository) ListMemoriesByWorkspace(ctx context.Context, userID, worksp
 		Order("name asc").
 		Find(&memories).Error
 	return memories, err
+}
+
+// DeleteMemory removes one named memory. Deleting a name nobody wrote under
+// is reported as ErrNotFound rather than silently succeeding, so a caller can
+// tell "removed" apart from "was never there" the same way GetMemory does.
+func (r *repository) DeleteMemory(ctx context.Context, userID, workspaceID int64, name string) error {
+	res := r.conn(ctx).
+		Where("user_id = ? AND workspace_id = ? AND name = ?", userID, workspaceID, name).
+		Delete(&model.Memory{})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
 }
 
 func (r *repository) CreateEvent(ctx context.Context, e model.Event) (model.Event, error) {


### PR DESCRIPTION
## What changed
Agents connected to a workspace over MCP can now delete a named memory (or the index itself) with a new `deleteMemory` tool, alongside the existing `loadMemory`/`saveMemory` tools. Deleting a memory nobody wrote under (or one already removed) is reported as "nothing to delete" rather than an error, matching how a missing `loadMemory` read is already handled.

## Why changed
The memory feature only supported writing and reading; there was no way for an agent to remove a note that was no longer useful. This is agent-driven only (an MCP tool), not a frontend/REST feature.

## Test coverage report
- New MCP handler code (`handleDeleteMemory`): 100% covered (name resolution, wiring-missing case, not-found case, success case, and storage-failure case all have dedicated tests).
- New repository method (`DeleteMemory`): 83.3% covered via real-sqlite tests (row removed, missing-row reports `ErrNotFound`, scoped to owner+workspace so it can't remove another workspace's row). The one uncovered branch is the raw DB-error path, which is untested the same way for the sibling `DeleteEvent`/`DeleteTask` methods this one was modeled on.
- Full backend suite passes (`go test ./internal/...`); package coverage for the touched packages: `internal/controller/mcp` 69.6%, `internal/repository/base` 39.5%.

## TaskID: 0iKVrTwZnhh