### PR TITLE
fix(desktop): mute notifications for replies the desktop app just sent itself

### DIFF
--- a/desktop/src/main/index.js
+++ b/desktop/src/main/index.js
@@ -33,7 +33,14 @@ import {
 } from './server-config.js'
 import { AUTH_COOKIE, matchOAuthLogin, oauthStartUrl, runOAuthFlow } from './auth.js'
 import { QUICK_CREATE_ACCELERATOR, buildMenuTemplate } from './menu.js'
-import { badgeFor, createNotificationGate, createUnreadCounter, mapEventToNotification } from './notifications.js'
+import {
+  badgeFor,
+  createNotificationGate,
+  createSelfActionGate,
+  createUnreadCounter,
+  mapEventToNotification,
+  taskIdFromSelfActionRequest,
+} from './notifications.js'
 import { createEventStreamClient } from './sse.js'
 import { LinkTarget, classifyLink, linkWindowBounds } from './links.js'
 import { FileOpenAction, fileOpenAction, localPathFromFileUrl } from './files.js'
@@ -106,6 +113,13 @@ let unread = null
 // handler and once by the CRUD-event consumer — so identical notifications
 // have to be collapsed before they reach the user.
 const notificationGate = createNotificationGate()
+
+// The SSE stream carries the task, not the message, so it cannot say whether
+// a reply/respond event was the human's own action or the agent's. This is
+// marked from the protocol handler's onRequestProxied hook the moment the
+// renderer's own reply/respond call goes out, and checked in handleStreamEvent
+// before a notification is shown.
+const selfActionGate = createSelfActionGate()
 
 const recentWorkspaces = createRecentWorkspaces()
 let windowStateStore
@@ -181,6 +195,10 @@ function sessionFor(partition) {
         // The web build caches attachments in a service worker. This build has
         // none, so the bytes are kept on disk and served from here instead.
         attachments: attachmentStoreFor(partition),
+        onRequestProxied: (method, pathname) => {
+          const taskId = taskIdFromSelfActionRequest(method, pathname)
+          if (taskId) selfActionGate.markSelf(taskId)
+        },
       })
     )
     handledSessions.add(ses)
@@ -412,6 +430,9 @@ function handleStreamEvent(event) {
     workspaceName: (id) => workspaceNames.get(id) ?? '',
   })
   if (!notification) return
+  // This desktop instance sent the reply/respond that produced this event
+  // itself — being told about your own message is noise, not news.
+  if (selfActionGate.isRecentSelfAction(event.payload.id)) return
 
   // An unknown workspace means the list is stale — refresh for next time
   // rather than blocking this notification on a round trip.

--- a/desktop/src/main/index.js
+++ b/desktop/src/main/index.js
@@ -195,10 +195,7 @@ function sessionFor(partition) {
         // The web build caches attachments in a service worker. This build has
         // none, so the bytes are kept on disk and served from here instead.
         attachments: attachmentStoreFor(partition),
-        onRequestProxied: (method, pathname) => {
-          const taskId = taskIdFromSelfActionRequest(method, pathname)
-          if (taskId) selfActionGate.markSelf(taskId)
-        },
+        onRequestProxied: (method, pathname) => selfActionGate.markSelf(taskIdFromSelfActionRequest(method, pathname)),
       })
     )
     handledSessions.add(ses)
@@ -432,7 +429,7 @@ function handleStreamEvent(event) {
   if (!notification) return
   // This desktop instance sent the reply/respond that produced this event
   // itself — being told about your own message is noise, not news.
-  if (selfActionGate.isRecentSelfAction(event.payload.id)) return
+  if (selfActionGate.isRecentSelfAction(event.payload.id, event.type)) return
 
   // An unknown workspace means the list is stale — refresh for next time
   // rather than blocking this notification on a round trip.

--- a/desktop/src/main/notifications.js
+++ b/desktop/src/main/notifications.js
@@ -11,6 +11,13 @@
  * `frontend/src/composables/usePushNotifications.js` is untouched and still
  * serves the browser; the desktop renderer simply never calls it.
  *
+ * One rule the push controller does not need: the SSE payload is a task, not
+ * a message, so there is no sender field to check before deciding whether a
+ * reply/respond notification is about the human's own action. `protocol.js`
+ * sees every outgoing request the renderer makes, so it reports reply/respond
+ * calls here instead — `taskIdFromSelfActionRequest` and `createSelfActionGate`
+ * are how that becomes "mute the next notification for this task".
+ *
  * Pure functions, so the mapping and mute rules are testable without Electron.
  */
 
@@ -90,6 +97,57 @@ export function mapEventToNotification(event, { mutedWorkspaces = [], workspaceN
         route: `${workspaceRoute}/tasks/${task.id}`,
         tag: `reply-${task.id}`,
       }
+  }
+}
+
+/**
+ * The task ID a reply/respond request names, or null when the request is
+ * neither.
+ *
+ * These are the two ways this desktop instance's own action reaches the
+ * server — a human typing a reply, or clicking allow/deny — and both land
+ * back on this same SSE stream, indistinguishable from an agent's, because
+ * the payload carries the task rather than the message (see module doc).
+ * Recognising the outgoing request here, at the point the renderer's own API
+ * call is proxied, is what lets the desktop tell "I just did this" apart from
+ * "the agent did this" without the backend having to say so.
+ */
+export function taskIdFromSelfActionRequest(method, pathname) {
+  if (method.toUpperCase() !== 'POST') return null
+  const match = /^\/api\/v1\/workspaces\/[^/]+\/tasks\/([^/]+)\/(?:reply|respond)$/.exec(pathname)
+  return match ? match[1] : null
+}
+
+/** How long a task stays muted after this desktop sends a reply/respond for it. */
+export const SELF_ACTION_WINDOW_MS = 10000
+
+/**
+ * Tracks tasks this desktop instance just acted on itself, so the
+ * notification that same action produces on the SSE stream a moment later
+ * can be suppressed.
+ *
+ * A time window rather than a one-shot latch consumed by the next event: a
+ * genuine, later agent reply on the same task must still notify, and an
+ * unrelated event of a different type arriving first (say, `task.updated`)
+ * must not use up the mute before the actual echo of this action arrives.
+ */
+export function createSelfActionGate({ windowMs = SELF_ACTION_WINDOW_MS, now = () => Date.now() } = {}) {
+  const markedAt = new Map()
+
+  return {
+    markSelf(taskId) {
+      if (taskId) markedAt.set(taskId, now())
+    },
+    /** @returns {boolean} true when this task was actioned by this desktop instance moments ago. */
+    isRecentSelfAction(taskId) {
+      const at = markedAt.get(taskId)
+      if (at === undefined) return false
+      if (now() - at >= windowMs) {
+        markedAt.delete(taskId)
+        return false
+      }
+      return true
+    },
   }
 }
 

--- a/desktop/src/main/notifications.js
+++ b/desktop/src/main/notifications.js
@@ -122,31 +122,59 @@ export function taskIdFromSelfActionRequest(method, pathname) {
 export const SELF_ACTION_WINDOW_MS = 10000
 
 /**
+ * Event types that can be the SSE echo of a reply/respond this desktop
+ * instance just sent — a message create republishes as `reply.received`, and
+ * the task row touched by that same write republishes as `task.updated`.
+ *
+ * Deliberately not "every notifiable type": `task.created` and
+ * `status.updated` are never the result of sending a reply, so muting them
+ * just because a reply on the same task happened moments ago would drop a
+ * genuine, unrelated notification instead of the self-sent echo this gate
+ * exists to catch.
+ */
+const SELF_ECHO_TYPES = new Set(['reply.received', 'task.updated'])
+
+/**
+ * Removes entries whose timestamp is at least `windowMs` old.
+ *
+ * Shared by the two windowed-key trackers below, which differ in what they
+ * key on and when they check but not in how a window expires.
+ */
+function pruneStale(map, windowMs, at) {
+  for (const [key, timestamp] of map) {
+    if (at - timestamp >= windowMs) map.delete(key)
+  }
+}
+
+/**
  * Tracks tasks this desktop instance just acted on itself, so the
  * notification that same action produces on the SSE stream a moment later
  * can be suppressed.
  *
  * A time window rather than a one-shot latch consumed by the next event: a
  * genuine, later agent reply on the same task must still notify, and an
- * unrelated event of a different type arriving first (say, `task.updated`)
- * must not use up the mute before the actual echo of this action arrives.
+ * unrelated event of a different type arriving first (say, `task.created`)
+ * must not use up the mute before the actual echo of this action arrives —
+ * see `SELF_ECHO_TYPES`.
+ *
+ * Pruned on every call, not just a matching one: `markSelf` fires on every
+ * reply/respond regardless of what (if anything) the stream echoes back for
+ * it, so a check keyed only to the same task id could otherwise never run for
+ * a stale entry and the map would grow for the life of the process.
  */
 export function createSelfActionGate({ windowMs = SELF_ACTION_WINDOW_MS, now = () => Date.now() } = {}) {
   const markedAt = new Map()
 
   return {
     markSelf(taskId) {
-      if (taskId) markedAt.set(taskId, now())
+      const at = now()
+      pruneStale(markedAt, windowMs, at)
+      if (taskId) markedAt.set(taskId, at)
     },
-    /** @returns {boolean} true when this task was actioned by this desktop instance moments ago. */
-    isRecentSelfAction(taskId) {
-      const at = markedAt.get(taskId)
-      if (at === undefined) return false
-      if (now() - at >= windowMs) {
-        markedAt.delete(taskId)
-        return false
-      }
-      return true
+    /** @returns {boolean} true when this event is likely this desktop's own reply/respond echoing back. */
+    isRecentSelfAction(taskId, eventType) {
+      pruneStale(markedAt, windowMs, now())
+      return SELF_ECHO_TYPES.has(eventType) && markedAt.has(taskId)
     },
   }
 }
@@ -177,10 +205,7 @@ export function createNotificationGate({ windowMs = DEDUPE_WINDOW_MS, now = () =
     /** @returns {boolean} true when this notification should be shown. */
     allow(tag) {
       const at = now()
-
-      for (const [key, timestamp] of seen) {
-        if (at - timestamp >= windowMs) seen.delete(key)
-      }
+      pruneStale(seen, windowMs, at)
 
       if (seen.has(tag)) return false
       seen.set(tag, at)

--- a/desktop/src/main/protocol.js
+++ b/desktop/src/main/protocol.js
@@ -232,6 +232,14 @@ export function mimeTypeFor(pathname) {
  *                                             the Vite dev server instead of disk,
  *                                             so HMR works without breaking the
  *                                             same-origin illusion.
+ * @param {(method: string, pathname: string) => void} [deps.onRequestProxied]
+ *                                             Called with every request forwarded
+ *                                             to the server, before the fetch is
+ *                                             made. This is the only place the main
+ *                                             process sees the renderer's own
+ *                                             outgoing calls — notifications.js
+ *                                             uses it to recognise a reply/respond
+ *                                             this desktop instance just sent.
  */
 export function createAppProtocolHandler({
   serverUrl,
@@ -240,11 +248,14 @@ export function createAppProtocolHandler({
   readFile,
   devServerUrl = '',
   attachments = null,
+  onRequestProxied = () => {},
 }) {
   const dev = Boolean(devServerUrl)
   const csp = buildCSP({ dev, devServerUrl })
 
   async function proxyToServer(request, url) {
+    onRequestProxied(request.method, url.pathname)
+
     const base = serverUrl()
     if (!base) {
       // Before the first run's connection screen is answered there is nowhere

--- a/desktop/test/notifications.test.js
+++ b/desktop/test/notifications.test.js
@@ -169,26 +169,42 @@ describe('taskIdFromSelfActionRequest', () => {
 
 describe('createSelfActionGate', () => {
   it('reports no recent self-action for a task never marked', () => {
-    expect(createSelfActionGate().isRecentSelfAction('t1')).toBe(false)
+    expect(createSelfActionGate().isRecentSelfAction('t1', 'reply.received')).toBe(false)
   })
 
   it('reports a recent self-action right after it is marked', () => {
     const gate = createSelfActionGate()
     gate.markSelf('t1')
-    expect(gate.isRecentSelfAction('t1')).toBe(true)
+    expect(gate.isRecentSelfAction('t1', 'reply.received')).toBe(true)
+  })
+
+  it('recognises task.updated as the other type a reply/respond can echo as', () => {
+    const gate = createSelfActionGate()
+    gate.markSelf('t1')
+    expect(gate.isRecentSelfAction('t1', 'task.updated')).toBe(true)
+  })
+
+  it('does not mute a type a reply/respond could never produce', () => {
+    // task.created and status.updated are never the result of sending a
+    // reply, so a real one of either must still notify even for a task this
+    // desktop instance just replied to.
+    const gate = createSelfActionGate()
+    gate.markSelf('t1')
+    expect(gate.isRecentSelfAction('t1', 'task.created')).toBe(false)
+    expect(gate.isRecentSelfAction('t1', 'status.updated')).toBe(false)
   })
 
   it('does not mark a task when given no id', () => {
     const gate = createSelfActionGate()
     gate.markSelf(null)
     gate.markSelf(undefined)
-    expect(gate.isRecentSelfAction(null)).toBe(false)
+    expect(gate.isRecentSelfAction(null, 'reply.received')).toBe(false)
   })
 
   it('does not confuse one task for another', () => {
     const gate = createSelfActionGate()
     gate.markSelf('t1')
-    expect(gate.isRecentSelfAction('t2')).toBe(false)
+    expect(gate.isRecentSelfAction('t2', 'reply.received')).toBe(false)
   })
 
   it('expires the mute once the window passes', () => {
@@ -197,9 +213,9 @@ describe('createSelfActionGate', () => {
 
     gate.markSelf('t1')
     clock = 999
-    expect(gate.isRecentSelfAction('t1')).toBe(true)
+    expect(gate.isRecentSelfAction('t1', 'reply.received')).toBe(true)
     clock = 1000
-    expect(gate.isRecentSelfAction('t1')).toBe(false)
+    expect(gate.isRecentSelfAction('t1', 'reply.received')).toBe(false)
   })
 
   it('lets a genuine later reply on the same task notify again', () => {
@@ -210,7 +226,24 @@ describe('createSelfActionGate', () => {
 
     gate.markSelf('t1')
     clock = 2000
-    expect(gate.isRecentSelfAction('t1')).toBe(false)
+    expect(gate.isRecentSelfAction('t1', 'reply.received')).toBe(false)
+  })
+
+  it('forgets a stale mark even when only markSelf is ever called for it again', () => {
+    // markSelf fires on every reply/respond regardless of what the stream
+    // echoes back, so isRecentSelfAction may never run for a given task (a
+    // muted workspace, say). Pruning has to happen from markSelf too, or the
+    // map would grow for the life of the process.
+    let clock = 0
+    const gate = createSelfActionGate({ windowMs: 1000, now: () => clock })
+
+    gate.markSelf('stale-task')
+    clock = 5000
+    gate.markSelf('other-task')
+
+    clock = 5001
+    expect(gate.isRecentSelfAction('stale-task', 'reply.received')).toBe(false)
+    expect(gate.isRecentSelfAction('other-task', 'reply.received')).toBe(true)
   })
 
   it('has a sane default window', () => {

--- a/desktop/test/notifications.test.js
+++ b/desktop/test/notifications.test.js
@@ -3,11 +3,14 @@ import { describe, it, expect, vi } from 'vitest'
 import {
   DEDUPE_WINDOW_MS,
   NOTIFIABLE_TYPES,
+  SELF_ACTION_WINDOW_MS,
   createNotificationGate,
+  createSelfActionGate,
   badgeFor,
   createUnreadCounter,
   mapEventToNotification,
   shouldNotify,
+  taskIdFromSelfActionRequest,
   truncate,
 } from '../src/main/notifications.js'
 
@@ -132,6 +135,86 @@ describe('mapEventToNotification', () => {
   it('copes with a status that is missing', () => {
     expect(mapEventToNotification(event('status.updated', { status: undefined }), names).title)
       .toBe('Task : Ship the desktop app')
+  })
+})
+
+describe('taskIdFromSelfActionRequest', () => {
+  it('reads the task id out of a reply request', () => {
+    expect(taskIdFromSelfActionRequest('POST', '/api/v1/workspaces/ws1/tasks/t1/reply')).toBe('t1')
+  })
+
+  it('reads the task id out of a respond request', () => {
+    expect(taskIdFromSelfActionRequest('POST', '/api/v1/workspaces/ws1/tasks/t1/respond')).toBe('t1')
+  })
+
+  it('is case-insensitive on the method, matching how Electron reports it', () => {
+    expect(taskIdFromSelfActionRequest('post', '/api/v1/workspaces/ws1/tasks/t1/reply')).toBe('t1')
+  })
+
+  it('ignores a GET on the same path', () => {
+    // Fetching a task's detail is not sending anything.
+    expect(taskIdFromSelfActionRequest('GET', '/api/v1/workspaces/ws1/tasks/t1/reply')).toBeNull()
+  })
+
+  it('ignores requests that are not a reply or respond', () => {
+    expect(taskIdFromSelfActionRequest('POST', '/api/v1/workspaces/ws1/tasks/t1/status')).toBeNull()
+    expect(taskIdFromSelfActionRequest('POST', '/api/v1/workspaces/ws1/tasks')).toBeNull()
+    expect(taskIdFromSelfActionRequest('PATCH', '/api/v1/workspaces/ws1/tasks/t1/reply')).toBeNull()
+  })
+
+  it('does not match a reply nested under something else', () => {
+    expect(taskIdFromSelfActionRequest('POST', '/api/v1/workspaces/ws1/tasks/t1/reply/extra')).toBeNull()
+  })
+})
+
+describe('createSelfActionGate', () => {
+  it('reports no recent self-action for a task never marked', () => {
+    expect(createSelfActionGate().isRecentSelfAction('t1')).toBe(false)
+  })
+
+  it('reports a recent self-action right after it is marked', () => {
+    const gate = createSelfActionGate()
+    gate.markSelf('t1')
+    expect(gate.isRecentSelfAction('t1')).toBe(true)
+  })
+
+  it('does not mark a task when given no id', () => {
+    const gate = createSelfActionGate()
+    gate.markSelf(null)
+    gate.markSelf(undefined)
+    expect(gate.isRecentSelfAction(null)).toBe(false)
+  })
+
+  it('does not confuse one task for another', () => {
+    const gate = createSelfActionGate()
+    gate.markSelf('t1')
+    expect(gate.isRecentSelfAction('t2')).toBe(false)
+  })
+
+  it('expires the mute once the window passes', () => {
+    let clock = 0
+    const gate = createSelfActionGate({ windowMs: 1000, now: () => clock })
+
+    gate.markSelf('t1')
+    clock = 999
+    expect(gate.isRecentSelfAction('t1')).toBe(true)
+    clock = 1000
+    expect(gate.isRecentSelfAction('t1')).toBe(false)
+  })
+
+  it('lets a genuine later reply on the same task notify again', () => {
+    // The mute must not persist forever just because the task was replied to
+    // once; a real agent reply after the window is news again.
+    let clock = 0
+    const gate = createSelfActionGate({ windowMs: 1000, now: () => clock })
+
+    gate.markSelf('t1')
+    clock = 2000
+    expect(gate.isRecentSelfAction('t1')).toBe(false)
+  })
+
+  it('has a sane default window', () => {
+    expect(SELF_ACTION_WINDOW_MS).toBe(10000)
   })
 })
 

--- a/desktop/test/protocol.test.js
+++ b/desktop/test/protocol.test.js
@@ -31,6 +31,7 @@ function makeHandler(overrides = {}) {
       readFile: overrides.readFile ?? (async () => new TextEncoder().encode('<html></html>')),
       ...(overrides.devServerUrl !== undefined ? { devServerUrl: overrides.devServerUrl } : {}),
       ...(overrides.attachments !== undefined ? { attachments: overrides.attachments } : {}),
+      ...(overrides.onRequestProxied !== undefined ? { onRequestProxied: overrides.onRequestProxied } : {}),
     }),
   }
 }
@@ -341,6 +342,31 @@ describe('createAppProtocolHandler — proxying', () => {
 
     const res = await handler(makeRequest('app://agentrq/api/v1/auth/user'))
     expect((await res.json()).detail).toBe('socket hang up')
+  })
+
+  it('reports every forwarded request to onRequestProxied before fetching', async () => {
+    // This hook is the only place the main process sees the renderer's own
+    // outgoing calls; notifications.js relies on it firing before the fetch,
+    // not after, so a reply can be marked as self-sent before its SSE echo
+    // has any chance to arrive.
+    const seen = []
+    const netFetch = vi.fn(async () => {
+      expect(seen).toEqual([['POST', '/api/v1/workspaces/ws1/tasks/t1/reply']])
+      return new Response('ok', { status: 200 })
+    })
+    const { handler } = makeHandler({
+      netFetch,
+      onRequestProxied: (method, pathname) => seen.push([method, pathname]),
+    })
+
+    await handler(makeRequest('app://agentrq/api/v1/workspaces/ws1/tasks/t1/reply', { method: 'POST' }))
+
+    expect(seen).toEqual([['POST', '/api/v1/workspaces/ws1/tasks/t1/reply']])
+  })
+
+  it('defaults to a no-op hook so callers that do not care are unaffected', async () => {
+    const { handler } = makeHandler()
+    await expect(handler(makeRequest('app://agentrq/api/v1/tasks'))).resolves.toBeDefined()
   })
 })
 


### PR DESCRIPTION
## What changed
The desktop app's native notifications no longer fire for a reply or allow/deny response the human just sent themselves — only for messages that actually came from somewhere else (the agent).

## Why changed
The event stream the desktop app watches carries the task, not the message, so it had no way to check who actually sent a given reply — every reply produced a notification, including the one the human just typed. The desktop's own request proxy already sees every outgoing call the renderer makes, so it now uses that to recognize "I just sent this" and mutes the resulting notification for a few seconds, without needing the backend or the web app to change at all.

## Test coverage report
- New code (`taskIdFromSelfActionRequest`, `createSelfActionGate` in notifications.js, the `onRequestProxied` hook in protocol.js, and the wiring in index.js) is covered by new unit tests. Full desktop coverage run shows 100% statements/branches/functions/lines across every file in `src/main`, notifications.js and protocol.js included.
- Full desktop test suite passes: 458/458 tests across 17 files.
- `index.js` itself (the Electron entry point wiring these pieces together) has no dedicated tests, consistent with the rest of that file — all the actual logic being changed lives in the two tested modules.

## TaskID: 0iKcuryTfft