### PR TITLE
chore: bump patch version to v0.5.11

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.5.10"
+	_appVersion   = "v0.5.11"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.5.10" {
-			t.Errorf("Expected version v0.5.10, got %s", s.Version())
+		if s.Version() != "v0.5.11" {
+			t.Errorf("Expected version v0.5.11, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.5.10",
+      "version": "0.5.11",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.5.10",
+      "version": "0.5.11",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.5.10",
+  "version": "0.5.11",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
## What changed
Bumps the project patch version from 0.5.10 to 0.5.11 across backend, frontend, and desktop packages.

## Why changed
Prepares the release containing recent fixes for workspace settings action bar visibility and desktop self-notifications, along with memory management tools.

## Changes in this version
**feat**
- Add deleteMemory tool for workspace agents (#464)
- Add listMemories and getMemory tools to supervisor MCP server (#465)

**fix**
- Hide action bar on read-only workspace settings pages (#467)
- Mute notifications for replies the desktop app just sent itself (#466)

## Test coverage report
- New lines introduced: 100%
- Total coverage impact: 0% net coverage impact; all backend, frontend, and desktop test suites pass with 100% test coverage maintained.

## Other reports
Version synchronization verified with release script:
```
$ node desktop/scripts/check-versions.mjs
✓ desktop, frontend and backend are all at 0.5.11

$ GITHUB_REF=refs/tags/v0.5.11 node desktop/scripts/check-versions.mjs
✓ desktop, frontend and backend are all at 0.5.11
✓ tag v0.5.11 matches version 0.5.11
```

TaskID: 0iKdcOEW9fF