### PR TITLE
chore: bump patch version to v0.5.12

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.5.11"
+	_appVersion   = "v0.5.12"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.5.11" {
-			t.Errorf("Expected version v0.5.11, got %s", s.Version())
+		if s.Version() != "v0.5.12" {
+			t.Errorf("Expected version v0.5.12, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.5.11",
+      "version": "0.5.12",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.5.11",
+      "version": "0.5.12",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.5.11",
+  "version": "0.5.12",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
Bumps the patch version from `0.5.11` to `0.5.12` across all six version sources (desktop/frontend `package.json` + `package-lock.json`, backend `_appVersion`, and its test assertion).

## Changes since v0.5.11

**feat**
- frontend: open written trajectory entries on their content (#472)
- frontend: apply matte theme, slender line charts, and fix heatmap layout (#470)

**chore**
- add remote-agy and update remote-claude targets in Makefile (#469)

## Verification

Rebased onto `main` at `0e5f797` (after #472 merged) and re-checked:

```
$ node desktop/scripts/check-versions.mjs
✓ desktop, frontend and backend are all at 0.5.12

$ GITHUB_REF=refs/tags/v0.5.12 node desktop/scripts/check-versions.mjs
✓ desktop, frontend and backend are all at 0.5.12
✓ tag v0.5.12 matches version 0.5.12
```

- `go test ./internal/service/config/` — ok
- `npm ci --dry-run` resolves cleanly in both `desktop/` and `frontend/` (lockfile version fields edited by hand, no dependency-tree churn)

Merging alone publishes nothing; the release is cut by tagging `main` with `v0.5.12` and pushing the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)