### PR TITLE
feat(frontend): open written trajectory entries on their content

### DIFF
--- a/frontend/src/components/TrajectoryPanel.vue
+++ b/frontend/src/components/TrajectoryPanel.vue
@@ -193,7 +193,9 @@ watch(items, (list) => {
   }
 }, { immediate: true });
 
-const activeTab = ref('summary');
+// The newest entry is selected before this runs, and it deserves the same tab
+// a clicked one gets — the watcher below fires only on a *change* of selection.
+const activeTab = ref(defaultDetailTab(selectedItem.value));
 const detailTabs = computed(() => {
   if (!selectedItem.value) return [];
   return selectedItem.value.lane === 'tool'

--- a/frontend/src/composables/useTrajectory.js
+++ b/frontend/src/composables/useTrajectory.js
@@ -261,14 +261,18 @@ export function buildTrajectory(messages, toolCalls) {
  * The tab an entry opens on.
  *
  * A tool's summary is the interesting part — what ran, and whether it was
- * allowed. Reasoning and plans are the opposite: the summary knows only when
- * they were written, and what the reader came for is the text itself.
+ * allowed, neither of which the payload says. Everything else in a trajectory
+ * is something that was written — a request, an answer, a piece of reasoning,
+ * a plan — and its summary knows only who wrote it and when. Opening those on
+ * the summary costs a second click to reach the words the reader came for, so
+ * they open on the content instead.
  *
  * @param {object|null} item
  * @returns {'summary'|'content'}
  */
 export function defaultDetailTab(item) {
-  return item?.lane === 'thought' ? 'content' : 'summary';
+  if (!item) return 'summary';
+  return item.lane === 'tool' ? 'summary' : 'content';
 }
 
 /**

--- a/frontend/test/trajectory.test.js
+++ b/frontend/test/trajectory.test.js
@@ -376,15 +376,25 @@ describe('filterTrajectory', () => {
 })
 
 describe('defaultDetailTab', () => {
-  // What a reader came to a thought for is the text; the summary of one knows
-  // only when it was written.
+  // What a reader came to any written entry for is the text; its summary knows
+  // only who wrote it and when.
   it('opens reasoning and plans on their content', () => {
     expect(defaultDetailTab({ lane: 'thought' })).toBe('content')
   })
 
-  it('opens everything else on its summary', () => {
+  it('opens what a person and an agent wrote on its content', () => {
+    expect(defaultDetailTab({ lane: 'input' })).toBe('content')
+    expect(defaultDetailTab({ lane: 'agent' })).toBe('content')
+  })
+
+  // The one entry whose summary is the point: the payload says what was asked
+  // for, but not what ran or whether it was allowed.
+  it('opens a tool call on its summary', () => {
     expect(defaultDetailTab({ lane: 'tool' })).toBe('summary')
-    expect(defaultDetailTab({ lane: 'agent' })).toBe('summary')
+  })
+
+  it('falls back to the summary with nothing selected', () => {
     expect(defaultDetailTab(null)).toBe('summary')
+    expect(defaultDetailTab(undefined)).toBe('summary')
   })
 })


### PR DESCRIPTION
## What changed

Clicking an entry in the trajectory view now opens straight onto its content for anything that was *written* — what a person asked for, what the agent answered, and its reasoning or plans. Tool calls still open on their summary, where what ran and whether it was allowed is the interesting part.

Also fixed a related inconsistency: the panel selects the newest entry on load, but the tab only followed a *change* of selection, so that first entry always showed a summary whatever its kind.

## Why changed

Reading a message meant a second click to reach the words themselves, and the summary of a message says only who wrote it and when — nothing the reader came for.

## Test coverage report

- **New lines: 100% covered.** Four new assertions cover the input lane, the agent lane, the tool lane and the no-selection fallback.
- **Total coverage impact: none — still 100%** statements / branches / functions / lines across the suite (the project enforces a 100% global threshold).
- `vitest run` — 861 tests in 35 files, all passing.

## Other reports

- `vite build` — clean, including the PWA precache step.
- The rule lives in a single exported function (`defaultDetailTab`), so the list view and the initial selection cannot drift apart.

TaskID: 0iLBvbviPLt

🤖 Generated with [Claude Code](https://claude.com/claude-code)