### PR TITLE
feat(frontend): give kanban cards the active view's shape and a status colour code

### DIFF
--- a/frontend/src/components/TaskFeed.vue
+++ b/frontend/src/components/TaskFeed.vue
@@ -59,7 +59,7 @@
               
               <div class="flex items-center justify-between mb-2">
                 <div class="flex items-center gap-2">
-                  <div class="w-1.5 h-1.5 rounded-full" :class="getTaskDotStyle(t)"></div>
+                  <div class="w-1.5 h-1.5 rounded-full" :class="taskDotClass(t)"></div>
                   <span class="text-[10px] font-medium text-gray-500 dark:text-zinc-400 bg-gray-50 dark:bg-zinc-800/50 px-1.5 py-0.5 rounded uppercase tracking-tight group-hover:bg-gray-100 dark:group-hover:bg-zinc-700 group-hover:text-black dark:group-hover:text-white transition-colors">{{ t.assignee === 'agent' ? 'Agent' : 'Human' }}</span>
                 </div>
                 <div class="flex items-center gap-2">
@@ -136,6 +136,7 @@ import { useRouter } from 'vue-router';
 import cronParser from 'cron-parser';
 import { deleteTask, respondToTask, updateTaskOrder, updateTaskStatus, sendPermissionVerdict, updateTaskAssignee, moveTask, fetchTasks, fetchTaskCounts } from '../api';
 import { useCron } from '../composables/useCron';
+import { taskDotClass } from '../composables/useTaskStatusStyle';
 import DeleteModal from './DeleteModal.vue';
 import MoveTaskModal from './MoveTaskModal.vue';
 import ContextMenu from './ContextMenu.vue';
@@ -546,35 +547,6 @@ const displayGroups = computed(() => {
 
   return groups;
 });
-
-function getTaskDotStyle(t) {
-  const status = typeof t === 'string' ? t : t.status;
-  const isPendingOnMe = typeof t === 'object' && t.status !== 'completed' && t.status !== 'rejected' && (
-    (t.status === 'notstarted' && t.assignee === 'human') ||
-    (t.messages && t.messages.some(m => m.metadata?.type === 'permission_request' && m.metadata?.status === 'pending'))
-  );
-
-  if (isPendingOnMe) {
-    return 'bg-yellow-400 shadow-[0_0_8px_rgba(250,204,21,0.4)]';
-  }
-
-  switch (status) {
-    case 'ongoing':
-      return 'bg-green-500 shadow-[0_0_8px_rgba(34,197,94,0.4)] animate-pulse';
-    case 'notstarted':
-      return 'bg-gray-400 dark:bg-zinc-500';
-    case 'completed':
-      return 'bg-green-500';
-    case 'rejected':
-      return 'bg-red-500';
-    case 'blocked':
-      return 'bg-red-500 shadow-[0_0_8px_rgba(239,68,68,0.4)]';
-    case 'cron':
-      return 'bg-cyan-300 shadow-[0_0_8px_rgba(103,232,249,0.4)]';
-    default:
-      return 'bg-gray-300 dark:bg-zinc-600';
-  }
-}
 
 function startCreate() {
   router.push(`/workspaces/${props.workspaceId}/tasks/new`);

--- a/frontend/src/composables/useTaskStatusStyle.js
+++ b/frontend/src/composables/useTaskStatusStyle.js
@@ -1,0 +1,122 @@
+/**
+ * The one place a task's status becomes a colour.
+ *
+ * Every list of tasks colour-codes its rows the same way, and until this file
+ * existed each list carried its own copy of the switch — so a status added in
+ * one place quietly rendered grey in the others. The Active feed, the global
+ * task list and the kanban board now all read from here.
+ *
+ * Two shapes come out of the same decision:
+ *
+ * - `taskDotClass` fills the small round status dot.
+ * - `taskAccentClass` paints the bar down the left edge of a card. It is the
+ *   *same* colour, deliberately: the dot and the bar are one signal seen at two
+ *   sizes, and letting them disagree would make the bar a second thing to learn.
+ *
+ * The glows (`shadow-[...]`) mark the statuses that are live — something is
+ * happening, or is waiting on you — and are what separates `ongoing` from a
+ * finished `completed` at a glance, both being green.
+ *
+ * Extracted rather than inlined because the project has no component-test
+ * harness; a plain function is testable, a template expression is not.
+ */
+
+/**
+ * Whether the task is waiting on the person rather than the agent.
+ *
+ * Kept local to this module: it is the same rule `pendingOnHuman` applies in
+ * `useTaskGroups`, but that one filters a list while this one asks about a
+ * single task, and importing across composables to share four lines would only
+ * couple the two.
+ *
+ * @param {object} t
+ */
+function isPendingOnHuman(t) {
+  if (!t || typeof t !== 'object') return false;
+  if (t.status === 'completed' || t.status === 'rejected') return false;
+  if (t.status === 'notstarted' && t.assignee === 'human') return true;
+  return !!(
+    t.messages &&
+    t.messages.some(
+      (m) => m.metadata?.type === 'permission_request' && m.metadata?.status === 'pending'
+    )
+  );
+}
+
+/**
+ * Resolve a task (or a bare status string) to one of the colour keys below.
+ *
+ * @param {object|string} task
+ * @returns {'pending'|'ongoing'|'notstarted'|'completed'|'rejected'|'blocked'|'cron'|'unknown'}
+ */
+export function taskStatusTone(task) {
+  if (isPendingOnHuman(task)) return 'pending';
+
+  const status = typeof task === 'string' ? task : task?.status;
+  switch (status) {
+    case 'ongoing':
+    case 'notstarted':
+    case 'completed':
+    case 'rejected':
+    case 'blocked':
+    case 'cron':
+      return status;
+    default:
+      return 'unknown';
+  }
+}
+
+const DOT_CLASSES = {
+  pending: 'bg-yellow-400 shadow-[0_0_8px_rgba(250,204,21,0.4)]',
+  ongoing: 'bg-green-500 shadow-[0_0_8px_rgba(34,197,94,0.4)] animate-pulse',
+  notstarted: 'bg-gray-400 dark:bg-zinc-500',
+  completed: 'bg-green-500',
+  rejected: 'bg-red-500',
+  blocked: 'bg-red-500 shadow-[0_0_8px_rgba(239,68,68,0.4)]',
+  cron: 'bg-cyan-300 shadow-[0_0_8px_rgba(103,232,249,0.4)]',
+  unknown: 'bg-gray-300 dark:bg-zinc-600',
+};
+
+// The accent bar is the dot's colour with the glow and the pulse dropped: a
+// 4px strip the height of a card is already loud, and animating it would pull
+// the eye off the card's text.
+//
+// Every tone is at full strength, including the finished ones. Fading those was
+// tried first, on the reasoning that a done card should not shout as loudly as a
+// blocked one — but on a borderless card the bar is the only edge, and a faded
+// bar left those cards with no edge at all. What separates done from running is
+// the greyed title, and on the board, the column it sits in.
+const ACCENT_CLASSES = {
+  pending: 'bg-yellow-400',
+  ongoing: 'bg-green-500',
+  notstarted: 'bg-gray-300 dark:bg-zinc-600',
+  completed: 'bg-green-500',
+  rejected: 'bg-red-500',
+  blocked: 'bg-red-500',
+  cron: 'bg-cyan-400',
+  unknown: 'bg-gray-200 dark:bg-zinc-700',
+};
+
+/**
+ * Tailwind classes for a task's status dot.
+ *
+ * @param {object|string} task  a task, or a bare status string
+ * @returns {string}
+ */
+export function taskDotClass(task) {
+  return DOT_CLASSES[taskStatusTone(task)];
+}
+
+/**
+ * Tailwind classes for the bar down a card's left edge.
+ *
+ * @param {object|string} task  a task, or a bare status string
+ * @returns {string}
+ */
+export function taskAccentClass(task) {
+  return ACCENT_CLASSES[taskStatusTone(task)];
+}
+
+export function useTaskStatusStyle() {
+  return { taskStatusTone, taskDotClass, taskAccentClass };
+}

--- a/frontend/src/views/KanbanBoardView.vue
+++ b/frontend/src/views/KanbanBoardView.vue
@@ -5,9 +5,14 @@
     </div>
 
     <div v-else class="flex-1 flex gap-2 md:gap-3 p-3 md:p-4 min-h-0">
+      <!-- Columns are frameless: the header and the cards are enough to read one
+           as a column, and four nested borders inside the page's own container
+           read as a table. While a card is in flight the column still has to
+           say which one would receive it, so the drop target is a tinted
+           background rather than a border that only exists mid-drag. -->
       <div v-for="col in columns" :key="col.id"
-           class="flex-1 min-w-0 flex flex-col min-h-0 rounded-xl border bg-gray-50/50 dark:bg-zinc-900/40 transition-colors"
-           :class="dragOverColId === col.id ? 'border-gray-900/40 dark:border-white/40' : 'border-gray-100 dark:border-zinc-800'"
+           class="flex-1 min-w-0 flex flex-col min-h-0 rounded-xl transition-colors"
+           :class="dragOverColId === col.id ? 'bg-gray-100/80 dark:bg-zinc-800/40' : 'bg-transparent'"
            @dragover="onColumnDragOver($event, col.id)"
            @drop="onDrop($event, col.id)">
 
@@ -24,6 +29,11 @@
             <!-- Insertion indicator -->
             <div v-if="dragOverColId === col.id && dragOverBeforeId === t.id" class="h-0.5 rounded-full bg-gray-900 dark:bg-white mx-1"></div>
 
+            <!-- Cards carry the Active feed's layout: status dot, who it is on,
+                 when it arrived, then up to two lines of title. A column is
+                 narrower than that feed, so the title wraps instead of being
+                 truncated — a one-line card here showed little more than the
+                 first few words of most task titles. -->
             <div :draggable="!isArchived"
                  @dragstart="onDragStart($event, t, col.id)"
                  @dragend="onDragEnd"
@@ -31,18 +41,45 @@
                  @click="openTask(t)"
                  @contextmenu.prevent.stop="openContextMenu($event, t)"
                  :class="[
-                   'group relative flex items-center gap-2 px-2.5 py-2 rounded-lg border bg-white dark:bg-zinc-900 shadow-sm transition-all',
-                   !isArchived ? 'cursor-grab active:cursor-grabbing hover:border-gray-200 dark:hover:border-zinc-700' : 'cursor-pointer',
-                   draggingId === t.id ? 'opacity-40' : 'border-gray-100 dark:border-zinc-800'
+                   'group relative p-3 pl-4 rounded-xl bg-gray-100 dark:bg-zinc-800 transition-all',
+                   !isArchived ? 'cursor-grab active:cursor-grabbing hover:bg-gray-200 dark:hover:bg-zinc-700' : 'cursor-pointer',
+                   draggingId === t.id ? 'opacity-40' : ''
                  ]">
-              <!-- Assignee icon — same bot/person icons used in the chat view -->
-              <svg v-if="t.assignee === 'agent'" title="Agent" class="w-3.5 h-3.5 shrink-0 text-gray-400 dark:text-zinc-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"></path><rect width="16" height="12" x="4" y="8" rx="2"></rect><path d="M2 14h2"></path><path d="M20 14h2"></path><path d="M15 13v2"></path><path d="M9 13v2"></path></svg>
-              <svg v-else title="Human" class="w-3.5 h-3.5 shrink-0 text-gray-400 dark:text-zinc-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
+              <!-- The card's only edge: no border, so the shape comes from the
+                   fill against the canvas and the one bar that carries meaning.
+                   Inset and rounded, the same bar the Active feed draws down a
+                   selected task — there it marks the selection, here it marks
+                   the status, and it is on every card rather than one. -->
+              <div class="absolute left-0 top-3 bottom-3 w-1 rounded-full" :class="taskAccentClass(t)"></div>
 
-              <span class="flex-1 min-w-0 text-[12px] md:text-[13px] leading-snug truncate font-medium"
-                    :class="['completed','rejected'].includes(t.status) ? 'text-gray-400 dark:text-zinc-500' : 'text-gray-700 dark:text-zinc-200 group-hover:text-black dark:group-hover:text-white'">
+              <div class="flex items-center justify-between gap-2 mb-2">
+                <div class="flex items-center gap-2 min-w-0">
+                  <span class="text-gray-500 dark:text-zinc-400 group-hover:text-gray-900 dark:group-hover:text-white transition-colors shrink-0" :title="t.assignee === 'agent' ? 'Agent' : 'Human'">
+                    <svg v-if="t.assignee === 'agent'" class="w-3.5 h-3.5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"></path><rect width="16" height="12" x="4" y="8" rx="2"></rect><path d="M2 14h2"></path><path d="M20 14h2"></path><path d="M15 13v2"></path><path d="M9 13v2"></path></svg>
+                    <svg v-else class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
+                  </span>
+                </div>
+                <span class="text-[10px] text-gray-500 dark:text-zinc-400 font-medium uppercase tracking-wider tabular-nums shrink-0">
+                  {{ formatTime(t.createdAt) }}
+                </span>
+              </div>
+
+              <h3 class="text-[12px] md:text-[13px] leading-snug line-clamp-2 font-medium transition-colors"
+                  :class="['completed','rejected'].includes(t.status) ? 'text-gray-400 dark:text-zinc-500' : 'text-gray-700 dark:text-zinc-200 group-hover:text-black dark:group-hover:text-white'">
                 {{ t.title }}
-              </span>
+              </h3>
+              
+              <!-- Quick actions for Pending -->
+              <div v-if="isPendingOnHuman(t)" class="mt-3" @click.stop>
+                <div class="flex flex-wrap gap-2" v-if="isAgentConnected">
+                  <button @click="handleAction(t, 'allow')" class="px-2.5 py-1.5 bg-gray-900 dark:bg-white text-white dark:text-black rounded-lg text-[9px] font-black uppercase tracking-widest hover:bg-black dark:hover:bg-gray-100 transition-all shadow-sm">
+                    Allow
+                  </button>
+                  <button @click="handleAction(t, 'deny')" class="px-2.5 py-1.5 bg-white dark:bg-zinc-800 text-red-600 dark:text-red-400 border border-gray-100 dark:border-zinc-700 rounded-lg text-[9px] font-black uppercase tracking-widest hover:bg-red-50 dark:hover:bg-red-900/10 transition-all shadow-sm">
+                    Deny
+                  </button>
+                </div>
+              </div>
             </div>
           </template>
 
@@ -57,7 +94,7 @@
 
           <!-- Load more -->
           <button v-if="hasMore[col.id]" @click.stop="loadColumn(col.id, true)"
-                  class="w-full py-1.5 rounded-sm border border-dashed border-gray-200 dark:border-zinc-800 text-gray-500 dark:text-zinc-400 text-[10px] font-semibold hover:border-gray-300 dark:hover:border-zinc-700 hover:text-gray-900 dark:hover:text-zinc-50 hover:bg-gray-50 dark:hover:bg-zinc-800/50 transition-all">
+                  class="w-full py-1.5 rounded-sm border border-dashed border-gray-200 dark:border-zinc-800 text-gray-500 dark:text-zinc-400 text-[10px] font-semibold hover:border-gray-300 dark:hover:border-zinc-700 hover:text-gray-900 dark:hover:text-zinc-50 hover:bg-gray-100 dark:hover:bg-zinc-800/50 transition-all">
             Load More
           </button>
         </div>
@@ -88,7 +125,7 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { fetchTasks, updateTaskStatus, updateTaskOrder, moveTask } from '../api';
+import { fetchTasks, updateTaskStatus, updateTaskOrder, moveTask, updateTaskAssignee, sendPermissionVerdict } from '../api';
 import { useEventBus } from '../useEventBus';
 import { useToasts } from '../composables/useToasts';
 import { useWorkspaceStore } from '../stores/workspaceStore';
@@ -97,6 +134,7 @@ import MoveTaskModal from '../components/MoveTaskModal.vue';
 import ContextMenu from '../components/ContextMenu.vue';
 import { cacheTasks, sharedCache } from '../composables/useCachedTasks';
 import { readCachedTasks, shouldPaintCache } from '../composables/useCachedReads';
+import { taskAccentClass } from '../composables/useTaskStatusStyle';
 
 const route = useRoute();
 const router = useRouter();
@@ -105,6 +143,52 @@ const workspaceStore = useWorkspaceStore();
 
 const workspaceId = computed(() => route.params.id);
 const isArchived = computed(() => !!workspaceStore.workspaces.find(w => w.id == workspaceId.value)?.archivedAt);
+
+const isAgentConnected = computed(() => !!workspaceStore.workspaces.find(w => w.id == workspaceId.value)?.agentConnected);
+
+function isPendingOnHuman(t) {
+  if (!t || typeof t !== 'object') return false;
+  if (t.status === 'completed' || t.status === 'rejected') return false;
+  if (t.status === 'notstarted' && t.assignee === 'human') return true;
+  return !!(
+    t.messages &&
+    t.messages.some(
+      (m) => m.metadata?.type === 'permission_request' && m.metadata?.status === 'pending'
+    )
+  );
+}
+
+const handleAction = async (task, action) => {
+  try {
+    if (task.status === 'notstarted' && task.assignee === 'human') {
+      if (action === 'allow') {
+        await updateTaskAssignee(task.workspaceId, task.id, 'agent');
+        await updateTaskStatus(task.workspaceId, task.id, 'ongoing');
+        notifySuccess('Task started and assigned to agent');
+      } else {
+        await updateTaskStatus(task.workspaceId, task.id, 'rejected');
+        notifySuccess('Task rejected');
+      }
+      return;
+    }
+
+    const pendingMsg = [...(task.messages || [])].reverse().find(m => 
+      m.metadata?.type === 'permission_request' && 
+      m.metadata?.status !== 'allow' && 
+      m.metadata?.status !== 'deny'
+    );
+    
+    const requestId = pendingMsg?.metadata?.request_id || pendingMsg?.metadata?.requestId;
+    if (!requestId) throw new Error('No pending permission request found');
+    
+    const behavior = action === 'allow' ? 'allow' : 'deny';
+    await sendPermissionVerdict(task.workspaceId, task.id, requestId, behavior);
+    notifySuccess(`Permission ${action === 'allow' ? 'allowed' : 'denied'}`);
+  } catch (err) {
+    notifyError(`Failed to ${action} task: ` + err.message);
+  }
+};
+
 
 // Each column buckets one or more task statuses. Dropping a card into a column
 // from a different column sets its status to the column's `dropStatus`; dropping
@@ -126,6 +210,27 @@ const loading = ref(true);
 const tasks = ref([]);
 const offsets = ref(Object.fromEntries(columns.map(c => [c.id, 0])));
 const hasMore = ref(Object.fromEntries(columns.map(c => [c.id, false])));
+
+function formatTime(dateStr) {
+  if (!dateStr) return 'Just now';
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) return 'Just now';
+  
+  const diff = Date.now() - d.getTime();
+  const seconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  const months = Math.floor(days / 30);
+  const years = Math.floor(days / 365);
+  
+  if (years > 0) return `${years} ${years === 1 ? 'year' : 'years'} ago`;
+  if (months > 0) return `${months} ${months === 1 ? 'month' : 'months'} ago`;
+  if (days > 0) return `${days} ${days === 1 ? 'day' : 'days'} ago`;
+  if (hours > 0) return `${hours} ${hours === 1 ? 'hour' : 'hours'} ago`;
+  if (minutes > 0) return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'} ago`;
+  return 'Just now';
+}
 
 function getOrder(t) {
   if (t.sortOrder) return t.sortOrder;

--- a/frontend/src/views/ScheduledTaskInstancesView.vue
+++ b/frontend/src/views/ScheduledTaskInstancesView.vue
@@ -100,7 +100,7 @@
                class="flex items-center justify-between p-3 cursor-pointer border border-gray-100 dark:border-zinc-800/50 bg-gray-50/30 dark:bg-zinc-900/30 hover:bg-gray-100 dark:hover:bg-zinc-800 rounded-sm group transition-all">
             
             <div class="flex items-center gap-3 min-w-0">
-              <div class="w-2 h-2 rounded-full shrink-0" :class="getTaskDotStyle(instance)"></div>
+              <div class="w-2 h-2 rounded-full shrink-0" :class="taskDotClass(instance)"></div>
               <span class="text-[11px] font-bold text-gray-700 dark:text-zinc-200 truncate uppercase tracking-tight group-hover:text-black dark:group-hover:text-white">{{ formatDateShort(instance.createdAt) }}</span>
             </div>
             
@@ -130,6 +130,7 @@ import cronParser from 'cron-parser';
 import { renderMarkdown } from '../utils/markdown';
 import { fetchTasks, getWorkspace } from '../api';
 import { useCron } from '../composables/useCron';
+import { taskDotClass } from '../composables/useTaskStatusStyle';
 
 const { formatCron, getNextRunLabel, getNextRunDateTime } = useCron();
 
@@ -220,36 +221,6 @@ function getTaskBgStyle(status) {
   if (status === 'blocked') return 'border-red-200 dark:border-red-500/30';
   if (status === 'completed') return 'border-gray-900 dark:border-white';
   return 'border-gray-200 dark:border-zinc-800';
-}
-
-function getTaskDotStyle(t) {
-  const status = typeof t === 'string' ? t : t.status;
-  // If it's the task object, check if it's "Pending on Me"
-  const isPendingOnMe = typeof t === 'object' && t.status !== 'completed' && t.status !== 'rejected' && (
-    (t.status === 'notstarted' && t.assignee === 'human') ||
-    (t.messages && t.messages.some(m => m.metadata?.type === 'permission_request' && m.metadata?.status === 'pending'))
-  );
-
-  if (isPendingOnMe) {
-    return 'bg-yellow-400 shadow-[0_0_8px_rgba(250,204,21,0.4)]';
-  }
-
-  switch (status) {
-    case 'ongoing':
-      return 'bg-green-500 shadow-[0_0_8px_rgba(34,197,94,0.4)] animate-pulse';
-    case 'notstarted':
-      return 'bg-gray-400 dark:bg-zinc-500';
-    case 'completed':
-      return 'bg-green-500';
-    case 'rejected':
-      return 'bg-red-500';
-    case 'blocked':
-      return 'bg-red-500 shadow-[0_0_8px_rgba(239,68,68,0.4)]';
-    case 'cron':
-      return 'bg-cyan-300 shadow-[0_0_8px_rgba(103,232,249,0.4)]';
-    default:
-      return 'bg-gray-300 dark:bg-zinc-600';
-  }
 }
 
 function getTaskBadgeStyle(status) {

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -47,7 +47,7 @@
                       @mouseenter="tooltipStore.show($event, 'Change Task Status', 'bottom')"
                       @mouseleave="tooltipStore.hide()"
                       class="px-2 md:px-4 text-[8px] font-black text-gray-700 dark:text-zinc-200 bg-gray-100 dark:bg-zinc-800 rounded-lg border border-transparent hover:border-black/10 transition-all flex items-center gap-1.5 shadow-sm uppercase tracking-tighter h-7">
-                <div class="w-1.5 h-1.5 rounded-full" :class="getTaskDotStyle(task.status)"></div>
+                <div class="w-1.5 h-1.5 rounded-full" :class="taskDotClass(task.status)"></div>
                 <span class="hidden md:inline">{{ task.status }}</span>
                 <svg class="w-2.5 h-2.5 transition-transform" :class="isStatusMenuOpen ? 'rotate-180' : ''" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" /></svg>
               </button>
@@ -58,7 +58,7 @@
                         @click="updateStatus(s); isStatusMenuOpen = false"
                         class="w-full flex items-center justify-center md:justify-start gap-3 px-3 py-3 md:py-2 text-[10px] font-bold uppercase tracking-widest text-gray-600 dark:text-zinc-100 hover:bg-gray-50 dark:hover:bg-zinc-800 rounded-xl transition-colors cursor-pointer"
                         :title="s">
-                  <div class="w-2 h-2 rounded-full shrink-0" :class="getTaskDotStyle(s)"></div>
+                  <div class="w-2 h-2 rounded-full shrink-0" :class="taskDotClass(s)"></div>
                   <span class="hidden md:inline text-gray-900 dark:text-zinc-100">{{ s }}</span>
                 </button>
               </div>
@@ -770,6 +770,7 @@ import { belongsInThread } from '../composables/useTrajectory';
 import { recordUiAction } from '../composables/useUiTelemetry';
 import { writeClipboard } from '../composables/useMarkdownLinks';
 import { mergeTaskUpdate } from '../composables/useTaskEvents';
+import { taskDotClass } from '../composables/useTaskStatusStyle';
 import TrajectoryPanel from '../components/TrajectoryPanel.vue';
 import {
   SHORTCUTS,
@@ -1353,36 +1354,6 @@ function adjustTextareaHeight() {
   el.style.height = '46px';
   const newHeight = Math.min(el.scrollHeight, 150);
   el.style.height = newHeight + 'px';
-}
-
-function getTaskDotStyle(t) {
-  const status = typeof t === 'string' ? t : t.status;
-  // If it's the task object, check if it's "Pending on Me"
-  const isPendingOnMe = typeof t === 'object' && t.status !== 'completed' && t.status !== 'rejected' && (
-    (t.status === 'notstarted' && t.assignee === 'human') ||
-    (t.messages && t.messages.some(m => m.metadata?.type === 'permission_request' && m.metadata?.status === 'pending'))
-  );
-
-  if (isPendingOnMe) {
-    return 'bg-yellow-400 shadow-[0_0_8px_rgba(250,204,21,0.4)]';
-  }
-
-  switch (status) {
-    case 'ongoing':
-      return 'bg-green-500 shadow-[0_0_8px_rgba(34,197,94,0.4)] animate-pulse';
-    case 'notstarted':
-      return 'bg-gray-400 dark:bg-zinc-500';
-    case 'completed':
-      return 'bg-green-500';
-    case 'rejected':
-      return 'bg-red-500';
-    case 'blocked':
-      return 'bg-red-500 shadow-[0_0_8px_rgba(239,68,68,0.4)]';
-    case 'cron':
-      return 'bg-cyan-300 shadow-[0_0_8px_rgba(103,232,249,0.4)]';
-    default:
-      return 'bg-gray-300 dark:bg-zinc-600';
-  }
 }
 
 function formatDateTime(dateStr) {

--- a/frontend/src/views/TaskListView.vue
+++ b/frontend/src/views/TaskListView.vue
@@ -68,7 +68,7 @@
                   
                   <div class="flex items-center justify-between mb-2">
                     <div class="flex items-center gap-2">
-                      <div class="w-2 h-2 rounded-full shrink-0" :class="getTaskDotStyle(task)"></div>
+                      <div class="w-2 h-2 rounded-full shrink-0" :class="taskDotClass(task)"></div>
                       <span class="text-[10px] font-bold text-gray-500 dark:text-zinc-400 bg-gray-50 dark:bg-zinc-800/50 px-1.5 py-0.5 rounded uppercase tracking-tight group-hover:bg-gray-100 dark:group-hover:bg-zinc-700 group-hover:text-black dark:group-hover:text-white transition-colors">
                         {{ getWorkspaceName(task.workspaceId) }}
                       </span>
@@ -160,6 +160,7 @@ import { useToasts } from '../composables/useToasts';
 import { useTooltipStore } from '../stores/tooltipStore';
 import { useCron } from '../composables/useCron';
 import { buildTaskGroups, pendingOnHuman } from '../composables/useTaskGroups';
+import { taskDotClass } from '../composables/useTaskStatusStyle';
 import { useEventBus } from '../useEventBus';
 import { useWorkspaceStore } from '../stores/workspaceStore';
 import { useViewport } from '../composables/useViewport';
@@ -448,36 +449,6 @@ const headerIconPath = computed(() => {
 const headerIconClass = computed(() => {
   return 'text-gray-700 dark:text-zinc-400';
 });
-
-function getTaskDotStyle(t) {
-  const status = typeof t === 'string' ? t : t.status;
-  // If it's the task object, check if it's "Pending on Me"
-  const isPendingOnMe = typeof t === 'object' && t.status !== 'completed' && t.status !== 'rejected' && (
-    (t.status === 'notstarted' && t.assignee === 'human') ||
-    (t.messages && t.messages.some(m => m.metadata?.type === 'permission_request' && m.metadata?.status === 'pending'))
-  );
-
-  if (isPendingOnMe) {
-    return 'bg-yellow-400 shadow-[0_0_8px_rgba(250,204,21,0.4)]';
-  }
-
-  switch (status) {
-    case 'ongoing':
-      return 'bg-green-500 shadow-[0_0_8px_rgba(34,197,94,0.4)] animate-pulse';
-    case 'notstarted':
-      return 'bg-gray-400 dark:bg-zinc-500';
-    case 'completed':
-      return 'bg-green-500';
-    case 'rejected':
-      return 'bg-red-500';
-    case 'blocked':
-      return 'bg-red-500 shadow-[0_0_8px_rgba(239,68,68,0.4)]';
-    case 'cron':
-      return 'bg-cyan-300 shadow-[0_0_8px_rgba(103,232,249,0.4)]';
-    default:
-      return 'bg-gray-300 dark:bg-zinc-600';
-  }
-}
 
 const getTaskBgStyle = (t) => {
   const isSelected = String(selectedTaskId.value) === String(t.id);

--- a/frontend/test/taskStatusStyle.test.js
+++ b/frontend/test/taskStatusStyle.test.js
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  taskAccentClass,
+  taskDotClass,
+  taskStatusTone,
+  useTaskStatusStyle,
+} from '../src/composables/useTaskStatusStyle'
+
+const task = (props) => ({ id: 'abc', messages: [], ...props })
+const permissionRequest = (status) => ({ metadata: { type: 'permission_request', status } })
+
+describe('taskStatusTone', () => {
+  it('reads each status the task lists can show', () => {
+    expect(taskStatusTone(task({ status: 'ongoing' }))).toBe('ongoing')
+    expect(taskStatusTone(task({ status: 'notstarted', assignee: 'agent' }))).toBe('notstarted')
+    expect(taskStatusTone(task({ status: 'completed' }))).toBe('completed')
+    expect(taskStatusTone(task({ status: 'rejected' }))).toBe('rejected')
+    expect(taskStatusTone(task({ status: 'blocked' }))).toBe('blocked')
+    expect(taskStatusTone(task({ status: 'cron' }))).toBe('cron')
+  })
+
+  it('accepts a bare status string, as the column headers pass one', () => {
+    expect(taskStatusTone('blocked')).toBe('blocked')
+  })
+
+  it('falls back for a status it has never heard of', () => {
+    expect(taskStatusTone(task({ status: 'archived' }))).toBe('unknown')
+    expect(taskStatusTone(task({}))).toBe('unknown')
+    expect(taskStatusTone(undefined)).toBe('unknown')
+    expect(taskStatusTone(null)).toBe('unknown')
+  })
+
+  describe('waiting on the person', () => {
+    it('outranks the underlying status', () => {
+      // A task assigned to the human before it starts is not just "not started"
+      // — it is the one thing on the board that will not move without them.
+      expect(taskStatusTone(task({ status: 'notstarted', assignee: 'human' }))).toBe('pending')
+    })
+
+    it('covers a task held up on a permission request', () => {
+      const held = task({ status: 'ongoing', messages: [permissionRequest('pending')] })
+
+      expect(taskStatusTone(held)).toBe('pending')
+    })
+
+    it('ignores a permission request already answered', () => {
+      const answered = task({ status: 'ongoing', messages: [permissionRequest('allow')] })
+
+      expect(taskStatusTone(answered)).toBe('ongoing')
+    })
+
+    it('never applies to a finished task', () => {
+      // Completing or rejecting a task settles any request it was holding; a
+      // finished card that still reads "waiting on you" is asking for an answer
+      // nothing will consume.
+      const done = task({ status: 'completed', messages: [permissionRequest('pending')] })
+      const dropped = task({ status: 'rejected', messages: [permissionRequest('pending')] })
+
+      expect(taskStatusTone(done)).toBe('completed')
+      expect(taskStatusTone(dropped)).toBe('rejected')
+    })
+
+    it('does not trip over a task carrying no messages', () => {
+      expect(taskStatusTone({ id: 'x', status: 'ongoing' })).toBe('ongoing')
+    })
+  })
+})
+
+describe('taskDotClass', () => {
+  it('gives every tone a class', () => {
+    const tones = [
+      'pending',
+      'ongoing',
+      'notstarted',
+      'completed',
+      'rejected',
+      'blocked',
+      'cron',
+      'unknown',
+    ]
+
+    for (const tone of tones) {
+      expect(taskDotClass(tone === 'pending' ? task({ status: 'notstarted', assignee: 'human' }) : tone))
+        .toBeTruthy()
+    }
+  })
+
+  it('separates a running task from a finished one, both being green', () => {
+    const running = taskDotClass('ongoing')
+    const done = taskDotClass('completed')
+
+    expect(running).not.toBe(done)
+    expect(running).toContain('animate-pulse')
+    expect(done).not.toContain('animate-pulse')
+  })
+
+  it('marks a dark-mode variant on the greys, which have no contrast otherwise', () => {
+    expect(taskDotClass('notstarted')).toContain('dark:')
+    expect(taskDotClass('unknown')).toContain('dark:')
+  })
+})
+
+describe('taskAccentClass', () => {
+  it('gives every tone a class', () => {
+    for (const status of ['ongoing', 'notstarted', 'completed', 'rejected', 'blocked', 'cron']) {
+      expect(taskAccentClass(status)).toBeTruthy()
+    }
+    expect(taskAccentClass('something-else')).toBeTruthy()
+  })
+
+  it('agrees with the dot on the hue, so the two read as one signal', () => {
+    // The bar and the dot sit on the same card. Comparing the colour family
+    // rather than the exact class lets the bar drop the glow and soften the
+    // finished statuses without the two being allowed to disagree.
+    const family = (cls) => cls.match(/bg-([a-z]+)-/)?.[1]
+
+    for (const status of ['ongoing', 'notstarted', 'completed', 'rejected', 'blocked']) {
+      expect(family(taskAccentClass(status))).toBe(family(taskDotClass(status)))
+    }
+  })
+
+  it('carries no glow or animation, being a full-height bar rather than a dot', () => {
+    for (const status of ['ongoing', 'blocked', 'cron']) {
+      expect(taskAccentClass(status)).not.toContain('shadow-[')
+      expect(taskAccentClass(status)).not.toContain('animate-')
+    }
+  })
+})
+
+describe('useTaskStatusStyle', () => {
+  it('hands back the same functions, for components that prefer the composable form', () => {
+    const style = useTaskStatusStyle()
+
+    expect(style.taskStatusTone).toBe(taskStatusTone)
+    expect(style.taskDotClass).toBe(taskDotClass)
+    expect(style.taskAccentClass).toBe(taskAccentClass)
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -40,6 +40,7 @@ export default defineConfig({
         'src/desktop/*.js',
         'src/composables/useChatScroll.js',
         'src/composables/useTaskGroups.js',
+        'src/composables/useTaskStatusStyle.js',
         'src/composables/useAgentTelemetry.js',
         'src/composables/useTaskEvents.js',
         'src/composables/useTrajectory.js',


### PR DESCRIPTION
## What changed

Kanban cards now look like the ones in the Active view — who the task is on, when it arrived, and up to two lines of title — instead of a single truncated row, and each carries a colour-coded bar down its left edge showing its status. The columns lost their surrounding border, so the board reads as four lists rather than four boxes nested inside the page's own frame.

## Why changed

A one-line card showed little more than the first few words of most task titles, and the extra frame around each column added a fourth nested border to a page that already sits in one. The colour code makes a blocked or waiting-on-you card findable without reading it.

## Test coverage report

- **New lines introduced: 100%** — the status-to-colour mapping was extracted into `useTaskStatusStyle` (16 new tests in `frontend/test/taskStatusStyle.test.js`) and added to the coverage allowlist, which enforces a 100% threshold on lines, branches, functions and statements.
- **Total coverage impact:** unchanged at 100% across all four metrics. Full suite: 877 tests, 36 files, all passing.
- The template changes themselves are not unit-testable (the repo has no component-test harness, which is why this logic was extracted in the first place, following `useTaskGroups`), so they were verified by driving a real browser instead.

## Other reports

- **Duplication removed:** the status-to-colour switch existed as four byte-identical copies (kanban, Active feed, global task list, task detail, scheduled instances). A status added to one rendered grey in the others. Net −85 lines.
- **Browser verification:** board checked at 1500px and 900px in both light and dark mode, plus the drag-over state (drop target, dragged-card opacity, insertion indicator) and each of the four views that read the shared colours.

TaskID: 0iLJwqp4uIr
