### PR TITLE
chore: Bump patch version to 0.5.13

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.5.12"
+	_appVersion   = "v0.5.13"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.5.12" {
-			t.Errorf("Expected version v0.5.12, got %s", s.Version())
+		if s.Version() != "v0.5.13" {
+			t.Errorf("Expected version v0.5.13, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.5.12",
+      "version": "0.5.13",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,8 +1,8 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.5.12",
-  "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
+  "version": "0.5.13",
+  "description": "AgentRQ desktop app — AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.5.12",
+      "version": "0.5.13",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.5.12",
+  "version": "0.5.13",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
**What changed:**
Bumped the application patch version to 0.5.13 for both the frontend and desktop.

**Changes since previous version (0.5.12):**
- fix(ui): use reply.received for task message notifications (#474)
- feat: add mobile search icon on task listing views (#475)
- feat(kanban): kanban view UX improvements (#473)

**Why changed:**
To release a new patch version of the application.

**Test coverage report:**
New lines introduced: 100%
Total coverage impact: None

**Other reports (optional):**
N/A

**TaskID:** 0iLUfvcZuVt
