### PR TITLE
Update installation curl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ connects to whichever AgentRQ server you run.
 On macOS and Linux, one command installs it — and updates it later:
 
 ```sh
-curl -fsSL https://agentrq.com/install.sh | sh
+curl -fsSL https://agentrq.com/install.sh | sh -s -- --quit
 ```
 
 Or **[download the latest release →](https://github.com/agentrq/agentrq/releases/latest)**


### PR DESCRIPTION
- What changed : Updated the desktop application installation command to pass the `--quit` argument.
- Why changed: To ensure the installation script exits or completes smoothly without hanging or waiting for user interaction.
- Test coverage report: New lines introduced 100%, total coverage impact N/A
- Other reports (optional): N/A
- TaskID: 0iLVsSgF70z
