### PR TITLE
fix(setup): pre-approve every workspace MCP tool in the Claude config

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,18 +246,23 @@ Create a `.mcp.json` file in your local project directory (the leading dot is re
 
 ### Step 2 — `.claude/settings.local.json`
 
-Add a `.claude/settings.local.json` file in the same project directory to pre-approve the AgentRQ tools and avoid permission prompts on every action:
+Add a `.claude/settings.local.json` file in the same project directory to pre-approve the AgentRQ tools and avoid permission prompts on every action. The list below covers every tool the workspace exposes — drop any line you would rather be asked about:
 
 ```json
 {
   "permissions": {
     "allow": [
-      "mcp__agentrq-WORKSPACE_ID__updateTaskStatus",
-      "mcp__agentrq-WORKSPACE_ID__getWorkspace",
-      "mcp__agentrq-WORKSPACE_ID__reply",
       "mcp__agentrq-WORKSPACE_ID__createTask",
+      "mcp__agentrq-WORKSPACE_ID__updateTaskStatus",
+      "mcp__agentrq-WORKSPACE_ID__reply",
       "mcp__agentrq-WORKSPACE_ID__downloadAttachment",
-      "mcp__agentrq-WORKSPACE_ID__getTask"
+      "mcp__agentrq-WORKSPACE_ID__getWorkspace",
+      "mcp__agentrq-WORKSPACE_ID__getTask",
+      "mcp__agentrq-WORKSPACE_ID__publishEvent",
+      "mcp__agentrq-WORKSPACE_ID__loadMemory",
+      "mcp__agentrq-WORKSPACE_ID__saveMemory",
+      "mcp__agentrq-WORKSPACE_ID__deleteMemory",
+      "mcp__agentrq-WORKSPACE_ID__elicit"
     ]
   },
   "enableAllProjectMcpServers": true,
@@ -283,6 +288,11 @@ When connected, the AI agent has access to:
 - `getWorkspace`: Fetch the workspace name, mission description, and task statistics.
 - `getTask`: Fetch a task — with no `taskId` it dequeues the next "not started" task assigned to the agent; with a `taskId` it returns that task. Pass `includeConversation: true` to also include the chat history (cursor-based pagination).
 - `downloadAttachment`: Retrieve an attachment by its ID.
+- `publishEvent`: Fire a named event so subscriber workspaces spawn their trigger tasks.
+- `loadMemory`: Read the workspace's notes — with no name it reads `memory.md`, the index of everything remembered here.
+- `saveMemory`: Write a note that outlives the task, so the next agent starts with it.
+- `deleteMemory`: Remove one of the workspace's notes.
+- `elicit`: Ask the human a question and block until they answer, either as a form or as a link to confirm.
 - **Real-time Notifications**: Agents receive notifications via the `notifications/claude/channel` protocol whenever a human interacts with their tasks.
 
 ## 🌉 ACP Gateway (Bridge for ACP Agents)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -255,7 +255,7 @@ AgentRQ 可以接入多种 Agent CLI 或 MCP 客户端。每个 Workspace 的 MC
 }
 ```
 
-也可以创建 `.claude/settings.local.json` 预批准 AgentRQ 工具，减少每次调用时的确认提示。详细配置见英文 [README.md](README.md) 的 `Claude Code & AI Integration` 部分。
+也可以创建 `.claude/settings.local.json` 预批准 AgentRQ 工具，减少每次调用时的确认提示；建议把下列全部工具都列进去。详细配置见英文 [README.md](README.md) 的 `Claude Code & AI Integration` 部分。
 
 连接后，Agent 常用的 Workspace MCP 工具包括：
 
@@ -265,6 +265,11 @@ AgentRQ 可以接入多种 Agent CLI 或 MCP 客户端。每个 Workspace 的 MC
 - `getWorkspace`：读取工作区名称、任务说明和统计信息。
 - `getTask`：获取任务——不传 `taskId` 时返回分配给 Agent 的下一个未开始任务，传入 `taskId` 时返回该任务；设置 `includeConversation: true` 可一并返回对话历史（游标分页）。
 - `downloadAttachment`：按 ID 下载附件。
+- `publishEvent`：触发命名事件，让订阅的 Workspace 自动创建对应的触发任务。
+- `loadMemory`：读取 Workspace 记忆——不传 name 时读取 `memory.md`，即所有记忆的索引。
+- `saveMemory`：写入跨任务保留的记忆，让下一个 Agent 直接继承。
+- `deleteMemory`：删除某一条 Workspace 记忆。
+- `elicit`：向人类提问并等待回答，支持表单模式和链接确认模式。
 
 ### Codex Gateway
 

--- a/frontend/src/composables/useWorkspaceSettings.js
+++ b/frontend/src/composables/useWorkspaceSettings.js
@@ -62,3 +62,52 @@ export function shouldShowSettingsActionBar(tab, workspaceOrArchived = null) {
   }
   return true;
 }
+
+/**
+ * Every tool the workspace MCP server exposes to a connected agent, in the
+ * order the server registers them.
+ *
+ * This list mirrors the `mcp.AddTool` block in
+ * `backend/internal/controller/mcp/server.go`, and `test/workspaceSettings.test.js`
+ * reads that Go source to enforce the match. Keeping it whole is the point: a
+ * name missing here is a tool the agent has to stop and ask permission for on
+ * every single call, which is exactly the prompt fatigue the generated config
+ * exists to remove.
+ *
+ * Note that `deleteMemory` is pre-approved along with the rest. Workspace
+ * memory is versioned by nothing, so this does hand the agent an irreversible
+ * tool — but the alternative is a config that stalls mid-task, and an operator
+ * who wants the prompt can drop the line from the snippet they paste.
+ */
+export const WORKSPACE_MCP_TOOLS = Object.freeze([
+  'createTask',
+  'updateTaskStatus',
+  'reply',
+  'downloadAttachment',
+  'getWorkspace',
+  'getTask',
+  'publishEvent',
+  'loadMemory',
+  'saveMemory',
+  'deleteMemory',
+  'elicit',
+]);
+
+/**
+ * Builds the `.claude/settings.local.json` contents shown on the setup tab.
+ *
+ * The server name has to match the key used in `.mcp.json`, since that is what
+ * Claude Code prefixes onto each tool to form the permission entry.
+ *
+ * @param {string} serverName The MCP server key, e.g. `agentrq-0ZzhYQG2qtl`.
+ * @returns {{permissions: {allow: string[]}, enableAllProjectMcpServers: boolean, enabledMcpjsonServers: string[]}}
+ */
+export function buildClaudePermissionsConfig(serverName) {
+  return {
+    permissions: {
+      allow: WORKSPACE_MCP_TOOLS.map((tool) => `mcp__${serverName}__${tool}`),
+    },
+    enableAllProjectMcpServers: true,
+    enabledMcpjsonServers: [serverName],
+  };
+}

--- a/frontend/src/views/WorkspaceSettingsView.vue
+++ b/frontend/src/views/WorkspaceSettingsView.vue
@@ -835,7 +835,7 @@ import {
   getRetentionDays,
   setRetentionDays,
 } from '../composables/useCacheRetention';
-import { shouldShowSettingsActionBar } from '../composables/useWorkspaceSettings';
+import { shouldShowSettingsActionBar, buildClaudePermissionsConfig } from '../composables/useWorkspaceSettings';
 import { WHISPER_LANGUAGES } from '../utils/whisperLanguages';
 
 const { toKebabCase, liveKebabCase } = useFormat();
@@ -1159,21 +1159,9 @@ const mcpConfig = computed(() => ({
 
 const configJson = computed(() => JSON.stringify(mcpConfig.value, null, 2));
 
-const permissionsConfig = computed(() => ({
-  permissions: {
-    allow: [
-      `mcp__${serverName.value}__updateTaskStatus`,
-      `mcp__${serverName.value}__getWorkspace`,
-      `mcp__${serverName.value}__reply`,
-      `mcp__${serverName.value}__createTask`,
-      `mcp__${serverName.value}__downloadAttachment`,
-      `mcp__${serverName.value}__getTask`,
-      `mcp__${serverName.value}__publishEvent`,
-    ]
-  },
-  enableAllProjectMcpServers: true,
-  enabledMcpjsonServers: [serverName.value]
-}));
+// The allow list is built from the composable's tool list rather than spelled
+// out here, so it stays in step with what the MCP server actually registers.
+const permissionsConfig = computed(() => buildClaudePermissionsConfig(serverName.value));
 
 const permissionsConfigJson = computed(() => JSON.stringify(permissionsConfig.value, null, 2));
 

--- a/frontend/test/workspaceSettings.test.js
+++ b/frontend/test/workspaceSettings.test.js
@@ -1,11 +1,49 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
 import { describe, it, expect } from 'vitest';
 
 import {
   EDITABLE_SETTINGS_TABS,
   READ_ONLY_SETTINGS_TABS,
+  WORKSPACE_MCP_TOOLS,
+  buildClaudePermissionsConfig,
   isReadOnlySettingsTab,
   shouldShowSettingsActionBar,
 } from '../src/composables/useWorkspaceSettings';
+
+const SERVER_GO = 'backend/internal/controller/mcp/server.go';
+
+/**
+ * Locates the Go MCP server's source by walking up from the working directory.
+ *
+ * The path is not derived from `import.meta.url`: these tests run under jsdom,
+ * where that is an http URL rather than a file one.
+ */
+function serverSourcePath() {
+  for (let dir = process.cwd(); ; dir = dirname(dir)) {
+    const candidate = resolve(dir, SERVER_GO);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    if (dirname(dir) === dir) {
+      throw new Error(`could not find ${SERVER_GO} above ${process.cwd()}`);
+    }
+  }
+}
+
+/**
+ * The tool names the Go MCP server registers, read straight out of its source.
+ *
+ * Every `Name:` in that file belongs to an `mcp.AddTool` call, but the call is
+ * matched explicitly so that a `Name` field added elsewhere later cannot quietly
+ * inflate this list.
+ */
+function toolsRegisteredByServer() {
+  const source = readFileSync(serverSourcePath(), 'utf-8');
+  return [...source.matchAll(/mcp\.AddTool\(mcpSrv, &mcp\.Tool\{\s*Name:\s*"([^"]+)"/g)]
+    .map((match) => match[1]);
+}
 
 describe('useWorkspaceSettings', () => {
   describe('tab classification constants', () => {
@@ -81,6 +119,76 @@ describe('useWorkspaceSettings', () => {
 
       // Boolean flag overload
       expect(shouldShowSettingsActionBar('general', true)).toBe(false);
+    });
+  });
+
+  describe('WORKSPACE_MCP_TOOLS', () => {
+    it('lists every tool the MCP server registers, in the same order', () => {
+      expect(WORKSPACE_MCP_TOOLS).toEqual(toolsRegisteredByServer());
+    });
+
+    it('names the tools an agent needs to work a task end to end', () => {
+      expect(WORKSPACE_MCP_TOOLS).toEqual([
+        'createTask',
+        'updateTaskStatus',
+        'reply',
+        'downloadAttachment',
+        'getWorkspace',
+        'getTask',
+        'publishEvent',
+        'loadMemory',
+        'saveMemory',
+        'deleteMemory',
+        'elicit',
+      ]);
+    });
+
+    it('is frozen, so a caller cannot mutate the shared list', () => {
+      expect(Object.isFrozen(WORKSPACE_MCP_TOOLS)).toBe(true);
+    });
+  });
+
+  describe('buildClaudePermissionsConfig', () => {
+    it('prefixes every tool with the MCP server name', () => {
+      const { permissions } = buildClaudePermissionsConfig('agentrq-ws1');
+
+      expect(permissions.allow).toEqual([
+        'mcp__agentrq-ws1__createTask',
+        'mcp__agentrq-ws1__updateTaskStatus',
+        'mcp__agentrq-ws1__reply',
+        'mcp__agentrq-ws1__downloadAttachment',
+        'mcp__agentrq-ws1__getWorkspace',
+        'mcp__agentrq-ws1__getTask',
+        'mcp__agentrq-ws1__publishEvent',
+        'mcp__agentrq-ws1__loadMemory',
+        'mcp__agentrq-ws1__saveMemory',
+        'mcp__agentrq-ws1__deleteMemory',
+        'mcp__agentrq-ws1__elicit',
+      ]);
+    });
+
+    it('pre-approves every registered tool, leaving no prompt behind', () => {
+      const { permissions } = buildClaudePermissionsConfig('agentrq-ws1');
+
+      expect(permissions.allow).toHaveLength(toolsRegisteredByServer().length);
+    });
+
+    it('enables the project MCP servers and names this one', () => {
+      const config = buildClaudePermissionsConfig('agentrq-ws1');
+
+      expect(config.enableAllProjectMcpServers).toBe(true);
+      expect(config.enabledMcpjsonServers).toEqual(['agentrq-ws1']);
+    });
+
+    it('serialises to the snippet shape the setup tab displays', () => {
+      const config = buildClaudePermissionsConfig('agentrq-ws1');
+
+      expect(Object.keys(config)).toEqual([
+        'permissions',
+        'enableAllProjectMcpServers',
+        'enabledMcpjsonServers',
+      ]);
+      expect(JSON.parse(JSON.stringify(config))).toEqual(config);
     });
   });
 });


### PR DESCRIPTION
## What changed

The pre-approval snippet that AgentRQ hands you for Claude Code now lists every tool a workspace actually offers — the memory and question-asking tools were missing, so a correctly set-up agent still hit a permission prompt the first time it tried to read the workspace's memory. The setup screen and both READMEs now agree with the server.

## Why changed

The snippet exists to remove permission prompts, and an incomplete one quietly fails at that. The list had also drifted twice already, so it is now defined in one place and checked against the server's own source.

## Test coverage report

- New lines introduced: **100%** (`WORKSPACE_MCP_TOOLS` and `buildClaudePermissionsConfig` are both in `useWorkspaceSettings`, which the coverage config already gates at 100%).
- Total coverage impact: **none — still 100%** on statements, branches, functions and lines. Suite is 883 passing across 36 files, up 8 tests.

## Other reports

- The parity test reads the `mcp.AddTool` block out of `backend/internal/controller/mcp/server.go`, so adding a tool to the server without listing it for the config now fails the suite. Verified by dropping a tool locally: 4 tests fail, including the parity assertion.
- No backend change, and no change to what any tool does — this only affects which tools are pre-approved.
- The repo's own `.claude/settings.local.json` is not in this PR: `.gitignore` excludes the whole `.claude/` directory. It was updated locally, which also cleared two names the server no longer registers (`getTaskMessages`, `getNextTask`, both folded into `getTask`).
- Worth a maintainer's call: `deleteMemory` is pre-approved along with the rest, and it is irreversible. Say so and I will leave it off the generated list so it keeps prompting.

TaskID: 0iMkgASRoTB
