### PR TITLE
chore: bump patch version to v0.5.15

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.5.14"
+	_appVersion   = "v0.5.15"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.5.14" {
-			t.Errorf("Expected version v0.5.14, got %s", s.Version())
+		if s.Version() != "v0.5.15" {
+			t.Errorf("Expected version v0.5.15, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.5.14",
+      "version": "0.5.15",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.5.14",
+  "version": "0.5.15",
   "description": "AgentRQ desktop app — AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.5.14",
+      "version": "0.5.15",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.5.14",
+  "version": "0.5.15",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
## What changed

Bumped the patch version from 0.5.14 to 0.5.15 across the desktop app, the frontend and the backend, so all three report the same version and the release can be cut.

## Why changed

One change has landed since 0.5.14 and needs a version to ship under. The release pipeline refuses to package a tree whose versions disagree, so all six declarations move together.

## Test coverage report

- New lines introduced: **none** — this only changes version strings, so there are no new lines to cover.
- Total coverage impact: **none.** Frontend stays at 100% (883 tests, 36 files) and desktop at 461 tests, 17 files, both passing. `go test ./internal/service/config/...` passes with the updated assertion.

## Other reports

- Version sync verified both ways: `node desktop/scripts/check-versions.mjs` reports desktop, frontend and backend all at 0.5.15, and the tag form CI runs (`GITHUB_REF=refs/tags/v0.5.15`) additionally confirms the tag matches.
- Lockfile versions were edited by hand rather than regenerated, so no dependency resolution shifted underneath the release. `npm ci --dry-run` resolves cleanly in both `desktop/` and `frontend/`. It was run as a dry run deliberately: a real `npm ci` would delete `node_modules` out from under a running dev server.
- Version strings used as test fixtures and as worked examples in comments were left alone — they are illustrations, not declarations.

## Included in this version

**fix**
- Pre-approve every workspace MCP tool in the generated Claude config (#480).

TaskID: 0iN8jQKXCu9
