### PR TITLE
feat(analytics): account-wide performance dashboard on the overview page

### DIFF
--- a/backend/internal/controller/crud/crud.go
+++ b/backend/internal/controller/crud/crud.go
@@ -84,6 +84,7 @@ type WorkspaceController interface {
 	UpdateWorkspace(ctx context.Context, req entity.UpdateWorkspaceRequest) (*entity.UpdateWorkspaceResponse, error)
 	UpdateWorkspaceAutoAllowedTools(ctx context.Context, req entity.UpdateWorkspaceAutoAllowedToolsRequest) error
 	GetDetailedWorkspaceStats(ctx context.Context, req entity.GetWorkspaceStatsRequest) (*entity.GetDetailedWorkspaceStatsResponse, error)
+	GetDetailedUserStats(ctx context.Context, req entity.GetUserStatsRequest) (*entity.GetDetailedUserStatsResponse, error)
 	SystemGetWorkspace(ctx context.Context, id int64) (entity.Workspace, error)
 }
 

--- a/backend/internal/controller/crud/stats_test.go
+++ b/backend/internal/controller/crud/stats_test.go
@@ -1,0 +1,256 @@
+package crud
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/golang/mock/gomock"
+	"github.com/mustafaturan/monoflake"
+)
+
+// statsWindow is shared by the per-workspace and account-wide endpoints, so the
+// calendar cases are pinned here at a fixed date. Wednesday 2026-09-09 12:00
+// local is deliberately mid-week and mid-month: a Monday or a 1st would let an
+// off-by-one in either direction pass unnoticed.
+func TestStatsWindow(t *testing.T) {
+	now := time.Date(2026, 9, 9, 12, 0, 0, 0, time.Local)
+	if now.Weekday() != time.Wednesday {
+		t.Fatalf("fixture is meant to be a Wednesday, got %s", now.Weekday())
+	}
+
+	midnight := func(y int, m time.Month, d int) time.Time {
+		return time.Date(y, m, d, 0, 0, 0, 0, time.Local)
+	}
+
+	tests := []struct {
+		name      string
+		rng       string
+		from, to  int64
+		wantStart int64
+		wantEnd   int64
+	}{
+		{
+			name:      "1d looks back exactly a day",
+			rng:       "1d",
+			wantStart: now.AddDate(0, 0, -1).Unix(),
+			wantEnd:   now.Unix(),
+		},
+		{
+			name:      "7d looks back exactly a week",
+			rng:       "7d",
+			wantStart: now.AddDate(0, 0, -7).Unix(),
+			wantEnd:   now.Unix(),
+		},
+		{
+			name:      "30d looks back exactly 30 days",
+			rng:       "30d",
+			wantStart: now.AddDate(0, 0, -30).Unix(),
+			wantEnd:   now.Unix(),
+		},
+		{
+			// Monday the 7th through the end of Sunday the 13th, not the
+			// trailing seven days from Wednesday.
+			name:      "week is the whole calendar week from Monday",
+			rng:       "week",
+			wantStart: midnight(2026, 9, 7).Unix(),
+			wantEnd:   midnight(2026, 9, 14).Unix() - 1,
+		},
+		{
+			name:      "month is the whole calendar month",
+			rng:       "month",
+			wantStart: midnight(2026, 9, 1).Unix(),
+			wantEnd:   midnight(2026, 10, 1).Unix() - 1,
+		},
+		{
+			name:      "custom uses the timestamps given",
+			rng:       "custom",
+			from:      1000,
+			to:        2000,
+			wantStart: 1000,
+			wantEnd:   2000,
+		},
+		{
+			// An open-ended custom range runs up to now rather than to zero,
+			// which would otherwise produce an empty window.
+			name:      "custom without an end runs to now",
+			rng:       "custom",
+			from:      1000,
+			wantStart: 1000,
+			wantEnd:   now.Unix(),
+		},
+		{
+			name:      "an unknown range falls back to 7d",
+			rng:       "not-a-range",
+			wantStart: now.AddDate(0, 0, -7).Unix(),
+			wantEnd:   now.Unix(),
+		},
+		{
+			name:      "an empty range falls back to 7d",
+			rng:       "",
+			wantStart: now.AddDate(0, 0, -7).Unix(),
+			wantEnd:   now.Unix(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, end := statsWindow(tt.rng, tt.from, tt.to, now)
+			if start != tt.wantStart {
+				t.Errorf("start: want %d, got %d", tt.wantStart, start)
+			}
+			if end != tt.wantEnd {
+				t.Errorf("end: want %d, got %d", tt.wantEnd, end)
+			}
+		})
+	}
+}
+
+// The Monday case is the one that varies by which day the fixture lands on, so
+// it is walked across a whole week rather than trusted at one date.
+func TestStatsWindow_WeekStartsMondayWhicheverDayItIs(t *testing.T) {
+	// 2026-09-07 is a Monday; step through to the following Sunday.
+	monday := time.Date(2026, 9, 7, 9, 30, 0, 0, time.Local)
+	wantStart := time.Date(2026, 9, 7, 0, 0, 0, 0, time.Local).Unix()
+	wantEnd := time.Date(2026, 9, 14, 0, 0, 0, 0, time.Local).Unix() - 1
+
+	for i := 0; i < 7; i++ {
+		day := monday.AddDate(0, 0, i)
+		start, end := statsWindow("week", 0, 0, day)
+		if start != wantStart || end != wantEnd {
+			t.Errorf("%s: want [%d,%d], got [%d,%d]", day.Weekday(), wantStart, wantEnd, start, end)
+		}
+	}
+}
+
+func TestGetDetailedUserStats(t *testing.T) {
+	e := newTestController(t)
+
+	const wsID = int64(4242)
+	e.repo.EXPECT().
+		GetDetailedUserStats(gomock.Any(), testUserID, gomock.Any(), gomock.Any()).
+		Return(entity.GetDetailedUserStatsRows{
+			Summary: entity.WorkspaceStatsSummary{TasksCompleted: 9, Messages: 4},
+			Workspaces: []entity.WorkspaceStatsBreakdownRow{
+				{WorkspaceID: wsID, Name: "busy", TasksCompleted: 9, Messages: 4},
+			},
+		}, nil)
+
+	res, err := e.controller.GetDetailedUserStats(context.Background(), entity.GetUserStatsRequest{
+		UserID: testUserIDStr,
+		Range:  "7d",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Summary.TasksCompleted != 9 || res.Summary.Messages != 4 {
+		t.Errorf("summary should pass through unchanged, got %+v", res.Summary)
+	}
+	if len(res.Workspaces) != 1 {
+		t.Fatalf("expected 1 workspace in the breakdown, got %d", len(res.Workspaces))
+	}
+	// The raw ID must be re-encoded: the API speaks base62 everywhere else, and
+	// a numeric ID here would not resolve against any route.
+	if want := monoflake.ID(wsID).String(); res.Workspaces[0].WorkspaceID != want {
+		t.Errorf("expected base62 workspace ID %q, got %q", want, res.Workspaces[0].WorkspaceID)
+	}
+	if res.Workspaces[0].Name != "busy" {
+		t.Errorf("expected the name to pass through, got %q", res.Workspaces[0].Name)
+	}
+}
+
+// The window the controller hands the repository has to match the range asked
+// for; a 7d request that quietly queried all of time would look like working
+// code and wrong numbers.
+func TestGetDetailedUserStats_PassesTheRequestedWindow(t *testing.T) {
+	e := newTestController(t)
+
+	var gotStart, gotEnd int64
+	e.repo.EXPECT().
+		GetDetailedUserStats(gomock.Any(), testUserID, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ int64, start, end int64) (entity.GetDetailedUserStatsRows, error) {
+			gotStart, gotEnd = start, end
+			return entity.GetDetailedUserStatsRows{}, nil
+		})
+
+	before := time.Now()
+	if _, err := e.controller.GetDetailedUserStats(context.Background(), entity.GetUserStatsRequest{
+		UserID: testUserIDStr,
+		Range:  "custom",
+		From:   1000,
+		To:     2000,
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotStart != 1000 || gotEnd != 2000 {
+		t.Errorf("expected the custom window [1000,2000], got [%d,%d]", gotStart, gotEnd)
+	}
+
+	// And a relative range resolves against the clock rather than being passed
+	// through as zero.
+	e.repo.EXPECT().
+		GetDetailedUserStats(gomock.Any(), testUserID, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ int64, start, end int64) (entity.GetDetailedUserStatsRows, error) {
+			gotStart, gotEnd = start, end
+			return entity.GetDetailedUserStatsRows{}, nil
+		})
+	if _, err := e.controller.GetDetailedUserStats(context.Background(), entity.GetUserStatsRequest{
+		UserID: testUserIDStr,
+		Range:  "7d",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotEnd < before.Unix() {
+		t.Errorf("expected the window to end at or after now (%d), got %d", before.Unix(), gotEnd)
+	}
+	if want := gotEnd - 7*24*3600; gotStart > want+5 || gotStart < want-5 {
+		t.Errorf("expected a ~7 day window ending now, got [%d,%d]", gotStart, gotEnd)
+	}
+}
+
+func TestGetDetailedUserStats_RepositoryError(t *testing.T) {
+	e := newTestController(t)
+
+	boom := errors.New("boom")
+	e.repo.EXPECT().
+		GetDetailedUserStats(gomock.Any(), testUserID, gomock.Any(), gomock.Any()).
+		Return(entity.GetDetailedUserStatsRows{}, boom)
+
+	res, err := e.controller.GetDetailedUserStats(context.Background(), entity.GetUserStatsRequest{
+		UserID: testUserIDStr,
+		Range:  "7d",
+	})
+	if !errors.Is(err, boom) {
+		t.Errorf("expected the repository error to surface, got %v", err)
+	}
+	if res != nil {
+		t.Errorf("expected no response alongside an error, got %+v", res)
+	}
+}
+
+// An empty breakdown must serialise as [] rather than null: the frontend
+// iterates it without a guard, and null would be a runtime error rather than an
+// empty panel.
+func TestGetDetailedUserStats_EmptyBreakdownIsNotNil(t *testing.T) {
+	e := newTestController(t)
+
+	e.repo.EXPECT().
+		GetDetailedUserStats(gomock.Any(), testUserID, gomock.Any(), gomock.Any()).
+		Return(entity.GetDetailedUserStatsRows{}, nil)
+
+	res, err := e.controller.GetDetailedUserStats(context.Background(), entity.GetUserStatsRequest{
+		UserID: testUserIDStr,
+		Range:  "7d",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Workspaces == nil {
+		t.Error("expected an empty slice, got nil")
+	}
+	if len(res.Workspaces) != 0 {
+		t.Errorf("expected an empty breakdown, got %+v", res.Workspaces)
+	}
+}

--- a/backend/internal/controller/crud/workspace.go
+++ b/backend/internal/controller/crud/workspace.go
@@ -299,12 +299,19 @@ func (c *controller) UpdateWorkspaceAutoAllowedTools(ctx context.Context, req en
 	return err
 }
 
-func (c *controller) GetDetailedWorkspaceStats(ctx context.Context, req entity.GetWorkspaceStatsRequest) (*entity.GetDetailedWorkspaceStatsResponse, error) {
-	now := time.Now()
-	var startTime, endTime int64
+// statsWindow resolves a range selector into the [start, end] unix window the
+// statistics queries run over.
+//
+// Shared by the per-workspace and account-wide endpoints deliberately: the two
+// dashboards offer the same range buttons, and "this week" meaning one thing on
+// one screen and something else on the other is the kind of discrepancy nobody
+// reports as a bug, they just stop trusting the numbers.
+//
+// now is a parameter so the calendar cases can be tested at a fixed date.
+func statsWindow(rng string, from, to int64, now time.Time) (startTime, endTime int64) {
 	endTime = now.Unix()
 
-	switch req.Range {
+	switch rng {
 	case "1d":
 		startTime = now.AddDate(0, 0, -1).Unix()
 	case "7d":
@@ -326,14 +333,19 @@ func (c *controller) GetDetailedWorkspaceStats(ctx context.Context, req entity.G
 		startTime = start.Unix()
 		endTime = start.AddDate(0, 1, 0).Unix() - 1
 	case "custom":
-		startTime = req.From
-		if req.To > 0 {
-			endTime = req.To
+		startTime = from
+		if to > 0 {
+			endTime = to
 		}
 	default:
 		// Default to 7d
 		startTime = now.AddDate(0, 0, -7).Unix()
 	}
+	return startTime, endTime
+}
+
+func (c *controller) GetDetailedWorkspaceStats(ctx context.Context, req entity.GetWorkspaceStatsRequest) (*entity.GetDetailedWorkspaceStatsResponse, error) {
+	startTime, endTime := statsWindow(req.Range, req.From, req.To, time.Now())
 
 	uid := monoflake.IDFromBase62(req.UserID).Int64()
 	// Verify user ownership to prevent IDOR
@@ -347,6 +359,43 @@ func (c *controller) GetDetailedWorkspaceStats(ctx context.Context, req entity.G
 	}
 
 	return &res, nil
+}
+
+// GetDetailedUserStats is the account-wide counterpart: the same statistics
+// summed across every workspace the caller owns.
+//
+// There is no ownership check because there is nothing to check against — the
+// scope is the caller's own ID, taken from the session by the handler, so the
+// query cannot be pointed at anyone else's data.
+func (c *controller) GetDetailedUserStats(ctx context.Context, req entity.GetUserStatsRequest) (*entity.GetDetailedUserStatsResponse, error) {
+	startTime, endTime := statsWindow(req.Range, req.From, req.To, time.Now())
+
+	// No zero-check on uid: the handler rejects an unusable session before it
+	// gets here, and a zero would in any case scope the query to a user that
+	// owns nothing rather than widening it.
+	uid := monoflake.IDFromBase62(req.UserID).Int64()
+
+	res, err := c.repository.GetDetailedUserStats(ctx, uid, startTime, endTime)
+	if err != nil {
+		return nil, err
+	}
+
+	// The repository deals in raw IDs; base62 is the API's currency.
+	out := entity.GetDetailedUserStatsResponse{
+		Summary:    res.Summary,
+		Timeseries: res.Timeseries,
+		Heatmap:    res.Heatmap,
+		Workspaces: make([]entity.WorkspaceStatsBreakdown, 0, len(res.Workspaces)),
+	}
+	for _, row := range res.Workspaces {
+		out.Workspaces = append(out.Workspaces, entity.WorkspaceStatsBreakdown{
+			WorkspaceID:    monoflake.ID(row.WorkspaceID).String(),
+			Name:           row.Name,
+			TasksCompleted: row.TasksCompleted,
+			Messages:       row.Messages,
+		})
+	}
+	return &out, nil
 }
 
 func (c *controller) SystemGetWorkspace(ctx context.Context, id int64) (entity.Workspace, error) {

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -426,6 +426,64 @@ type (
 		Messages       []HeatmapStat `json:"messages"`
 	}
 
+	// GetUserStatsRequest asks for the same statistics as
+	// GetWorkspaceStatsRequest, but summed over every workspace the user owns.
+	// There is no ID to pass: the scope *is* the caller, taken from the
+	// session, which is what makes the endpoint safe without an ownership
+	// check of its own.
+	GetUserStatsRequest struct {
+		UserID string `json:"userId"`
+		Range  string `json:"range"` // 1d, 7d, week, 30d, month, custom
+		From   int64  `json:"from"`  // unix timestamp for custom range
+		To     int64  `json:"to"`    // unix timestamp for custom range
+	}
+
+	// GetDetailedUserStatsResponse embeds the per-workspace response shape
+	// verbatim so the account dashboard can render the very same components,
+	// and adds the breakdown that only makes sense once several workspaces are
+	// in view.
+	GetDetailedUserStatsResponse struct {
+		Summary    WorkspaceStatsSummary     `json:"summary"`
+		Timeseries WorkspaceStatsTimeseries  `json:"timeseries"`
+		Heatmap    WorkspaceStatsHeatmap     `json:"heatmap"`
+		Workspaces []WorkspaceStatsBreakdown `json:"workspaces"`
+	}
+
+	// GetDetailedUserStatsRows is what the repository returns: the same
+	// aggregates, but with the breakdown still keyed by raw int64 ID. The
+	// repository deals in int64 throughout and does not know about base62, so
+	// the controller is what turns this into GetDetailedUserStatsResponse.
+	GetDetailedUserStatsRows struct {
+		Summary    WorkspaceStatsSummary
+		Timeseries WorkspaceStatsTimeseries
+		Heatmap    WorkspaceStatsHeatmap
+		Workspaces []WorkspaceStatsBreakdownRow
+	}
+
+	// WorkspaceStatsBreakdownRow is the repository's shape for a breakdown
+	// entry, keyed by the raw ID.
+	WorkspaceStatsBreakdownRow struct {
+		WorkspaceID    int64
+		Name           string
+		TasksCompleted int64
+		Messages       int64
+	}
+
+	// WorkspaceStatsBreakdown is one workspace's contribution to the account
+	// totals over the same window.
+	//
+	// Name is resolved from the workspaces table rather than stored on the
+	// telemetry row, so a renamed workspace reads correctly in history. A
+	// workspace the user has since deleted keeps its rows and surfaces with an
+	// empty name; the frontend labels that case rather than dropping the count,
+	// which would make the breakdown fail to add up to the total.
+	WorkspaceStatsBreakdown struct {
+		WorkspaceID    string `json:"workspaceId"`
+		Name           string `json:"name"`
+		TasksCompleted int64  `json:"tasksCompleted"`
+		Messages       int64  `json:"messages"`
+	}
+
 	User struct {
 		ID        int64
 		CreatedAt time.Time

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -576,6 +576,11 @@ func (h *handler) sanitizeRedirectURL(raw string) string {
 // ── Workspaces ──────────────────────────────────────────────────────────────────
 
 func (h *handler) registerWorkspaceRoutes() error {
+	// Account-wide statistics are not under /workspaces: they are not scoped to
+	// one, and hanging them off the collection would read as "stats about the
+	// list of workspaces".
+	h.router.Get("/stats", h.getUserStats())
+
 	r := h.router.Group("/workspaces")
 	r.Post("", h.createWorkspace())
 	r.Get("", h.listWorkspaces())
@@ -854,6 +859,42 @@ func (h *handler) getWorkspaceStats() fiber.Handler {
 		if err != nil {
 			zlog.Error().Err(err).Msg("Failed to get workspace stats")
 			c.Set(_headerContentType, _mimeJSON)
+			e, status := mapper.FromErrorToHTTPResponse(err)
+			c.Status(status)
+			return c.Send(e)
+		}
+		return c.Status(http.StatusOK).JSON(rs)
+	}
+}
+
+// Account-wide statistics: the same shape as the per-workspace endpoint, summed
+// over every workspace the caller owns, plus a per-workspace breakdown.
+//
+// The scope comes from the session rather than the path, so there is no ID to
+// authorize — a caller can only ever ask for their own totals.
+func (h *handler) getUserStats() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(_headerContentType, _mimeJSON)
+		userID, ok := c.Locals("user_id").(string)
+		if !ok || userID == "" {
+			c.Status(http.StatusUnprocessableEntity)
+			return c.Send(_invalidPayload)
+		}
+
+		rng := c.Query("range", "7d")
+		from, _ := strconv.ParseInt(c.Query("from"), 10, 64)
+		to, _ := strconv.ParseInt(c.Query("to"), 10, 64)
+
+		ctx, cancel := newContext(c)
+		defer cancel()
+		rs, err := h.crud.GetDetailedUserStats(ctx, entity.GetUserStatsRequest{
+			UserID: userID,
+			Range:  rng,
+			From:   from,
+			To:     to,
+		})
+		if err != nil {
+			zlog.Error().Err(err).Msg("Failed to get user stats")
 			e, status := mapper.FromErrorToHTTPResponse(err)
 			c.Status(status)
 			return c.Send(e)

--- a/backend/internal/repository/base/repository.go
+++ b/backend/internal/repository/base/repository.go
@@ -58,6 +58,7 @@ type Repository interface {
 	SystemListTasksByStatus(ctx context.Context, status string) ([]model.Task, error)
 	SystemCheckTaskExists(ctx context.Context, workspaceID, parentID int64, status string) (bool, error)
 	GetDetailedWorkspaceStats(ctx context.Context, workspaceID int64, startTime, endTime int64) (entity.GetDetailedWorkspaceStatsResponse, error)
+	GetDetailedUserStats(ctx context.Context, userID int64, startTime, endTime int64) (entity.GetDetailedUserStatsRows, error)
 	GetWorkspaceTaskCounts(ctx context.Context, workspaceID int64) (int64, int64, error)
 	GetWorkspaceTaskCountsByCategory(ctx context.Context, workspaceID int64, userID int64) (map[string]int64, error)
 	GetTelemetryActionCounts(ctx context.Context) (map[uint8]int64, error)
@@ -559,6 +560,73 @@ func (r *repository) SystemCheckTaskExists(ctx context.Context, workspaceID, par
 }
 
 func (r *repository) GetDetailedWorkspaceStats(ctx context.Context, workspaceID int64, startTime, endTime int64) (entity.GetDetailedWorkspaceStatsResponse, error) {
+	return r.detailedStats(ctx, "workspace_id = ?", workspaceID, startTime, endTime)
+}
+
+// GetDetailedUserStats is the same five aggregations summed over every
+// workspace the user owns, plus the per-workspace breakdown.
+//
+// It scopes on telemetries.user_id, which every writer sets and which carries
+// its own index, rather than joining through the workspace list. The one
+// difference that follows from scoping this way is that rows belonging to no
+// workspace (user creation, action 18) are in scope — none of them are actions
+// the summary buckets, so the account totals still add up to exactly the sum of
+// the per-workspace views.
+func (r *repository) GetDetailedUserStats(ctx context.Context, userID int64, startTime, endTime int64) (entity.GetDetailedUserStatsRows, error) {
+	var res entity.GetDetailedUserStatsRows
+
+	base, err := r.detailedStats(ctx, "user_id = ?", userID, startTime, endTime)
+	if err != nil {
+		return res, err
+	}
+	res.Summary = base.Summary
+	res.Timeseries = base.Timeseries
+	res.Heatmap = base.Heatmap
+
+	// Conditional sums keep this to one pass over the window instead of one
+	// query per metric. The LEFT JOIN is what supplies the name; a workspace
+	// that has since been deleted still has telemetry rows, and those come back
+	// with an empty name rather than being dropped — dropping them would make
+	// the breakdown quietly fail to add up to the summary above.
+	//
+	// workspace_id = 0 is excluded because it is not a workspace: those are the
+	// account-level rows described above, and they have no row to join to.
+	res.Workspaces = make([]entity.WorkspaceStatsBreakdownRow, 0)
+	err = r.conn(ctx).Model(&model.Telemetry{}).
+		Select(
+			"telemetries.workspace_id as workspace_id,"+
+				" COALESCE(workspaces.name, '') as name,"+
+				" SUM(CASE WHEN telemetries.action = ? THEN 1 ELSE 0 END) as tasks_completed,"+
+				" SUM(CASE WHEN telemetries.action = ? THEN 1 ELSE 0 END) as messages",
+			model.ActionIDTaskComplete, model.ActionIDMessageCreate).
+		Joins("LEFT JOIN workspaces ON workspaces.id = telemetries.workspace_id").
+		Where("telemetries.user_id = ?", userID).
+		Where("telemetries.occurred_at >= ? AND telemetries.occurred_at <= ?", startTime, endTime).
+		Where("telemetries.workspace_id <> 0").
+		// Postgres requires every non-aggregated column in the GROUP BY, so the
+		// name is grouped alongside the ID rather than merely selected.
+		Group("telemetries.workspace_id, workspaces.name").
+		// A workspace with neither a completion nor a message in the window has
+		// nothing to say on this panel — it would still be listed, because
+		// other action types (a rename, a permission prompt) put a row in
+		// range. The expressions are repeated rather than referenced by alias:
+		// Postgres allows a select alias in ORDER BY but not in HAVING.
+		Having(
+			"SUM(CASE WHEN telemetries.action = ? THEN 1 ELSE 0 END) > 0"+
+				" OR SUM(CASE WHEN telemetries.action = ? THEN 1 ELSE 0 END) > 0",
+			model.ActionIDTaskComplete, model.ActionIDMessageCreate).
+		Order("tasks_completed DESC, messages DESC, telemetries.workspace_id ASC").
+		Scan(&res.Workspaces).Error
+
+	return res, err
+}
+
+// detailedStats runs the five aggregations behind both statistics endpoints.
+//
+// scopeClause is a parameterised predicate ("workspace_id = ?" or
+// "user_id = ?") rather than a column name pasted into a string, so widening
+// the scope cannot become a way to inject SQL.
+func (r *repository) detailedStats(ctx context.Context, scopeClause string, scopeValue int64, startTime, endTime int64) (entity.GetDetailedWorkspaceStatsResponse, error) {
 	var res entity.GetDetailedWorkspaceStatsResponse
 
 	// Dialect specific date formatting
@@ -581,7 +649,8 @@ func (r *repository) GetDetailedWorkspaceStats(ctx context.Context, workspaceID 
 	var summaryResults []countResult
 	err := r.conn(ctx).Model(&model.Telemetry{}).
 		Select("action, count(*) as count").
-		Where("workspace_id = ? AND occurred_at >= ? AND occurred_at <= ?", workspaceID, startTime, endTime).
+		Where(scopeClause, scopeValue).
+		Where("occurred_at >= ? AND occurred_at <= ?", startTime, endTime).
 		Group("action").
 		Scan(&summaryResults).Error
 	if err != nil {
@@ -608,7 +677,8 @@ func (r *repository) GetDetailedWorkspaceStats(ctx context.Context, workspaceID 
 	// 2. Get Timeseries for Tasks Completed
 	err = r.conn(ctx).Model(&model.Telemetry{}).
 		Select(dateExpr+" as date, count(*) as count").
-		Where("workspace_id = ? AND occurred_at >= ? AND occurred_at <= ? AND action = ?", workspaceID, startTime, endTime, model.ActionIDTaskComplete).
+		Where(scopeClause, scopeValue).
+		Where("occurred_at >= ? AND occurred_at <= ? AND action = ?", startTime, endTime, model.ActionIDTaskComplete).
 		Group("date").
 		Order("date ASC").
 		Scan(&res.Timeseries.TasksCompleted).Error
@@ -619,7 +689,8 @@ func (r *repository) GetDetailedWorkspaceStats(ctx context.Context, workspaceID 
 	// 3. Get Timeseries for Messages
 	err = r.conn(ctx).Model(&model.Telemetry{}).
 		Select(dateExpr+" as date, count(*) as count").
-		Where("workspace_id = ? AND occurred_at >= ? AND occurred_at <= ? AND action = ?", workspaceID, startTime, endTime, model.ActionIDMessageCreate).
+		Where(scopeClause, scopeValue).
+		Where("occurred_at >= ? AND occurred_at <= ? AND action = ?", startTime, endTime, model.ActionIDMessageCreate).
 		Group("date").
 		Order("date ASC").
 		Scan(&res.Timeseries.Messages).Error
@@ -640,7 +711,8 @@ func (r *repository) GetDetailedWorkspaceStats(ctx context.Context, workspaceID 
 
 	err = r.conn(ctx).Model(&model.Telemetry{}).
 		Select(bucketExpr+" as bucket, count(*) as count").
-		Where("workspace_id = ? AND occurred_at >= ? AND occurred_at <= ? AND action = ?", workspaceID, startTime, endTime, model.ActionIDTaskComplete).
+		Where(scopeClause, scopeValue).
+		Where("occurred_at >= ? AND occurred_at <= ? AND action = ?", startTime, endTime, model.ActionIDTaskComplete).
 		Group("bucket").
 		Order("bucket ASC").
 		Scan(&res.Heatmap.TasksCompleted).Error
@@ -650,7 +722,8 @@ func (r *repository) GetDetailedWorkspaceStats(ctx context.Context, workspaceID 
 
 	err = r.conn(ctx).Model(&model.Telemetry{}).
 		Select(bucketExpr+" as bucket, count(*) as count").
-		Where("workspace_id = ? AND occurred_at >= ? AND occurred_at <= ? AND action = ?", workspaceID, startTime, endTime, model.ActionIDMessageCreate).
+		Where(scopeClause, scopeValue).
+		Where("occurred_at >= ? AND occurred_at <= ? AND action = ?", startTime, endTime, model.ActionIDMessageCreate).
 		Group("bucket").
 		Order("bucket ASC").
 		Scan(&res.Heatmap.Messages).Error

--- a/backend/internal/repository/base/repository_test.go
+++ b/backend/internal/repository/base/repository_test.go
@@ -711,3 +711,162 @@ func TestRepository_ListToolCalls(t *testing.T) {
 		t.Errorf("expected no tool calls, got %d", len(empty))
 	}
 }
+
+// TestRepository_GetDetailedUserStats covers the account-wide aggregation: what
+// it sums, whose rows it refuses to sum, and how the per-workspace breakdown is
+// shaped.
+func TestRepository_GetDetailedUserStats(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+
+	_ = db.AutoMigrate(&model.Telemetry{}, &model.Workspace{})
+	repo := New(&mockDB{db: db})
+
+	ctx := context.Background()
+	now := time.Now()
+	const (
+		userID    = int64(7)
+		otherUser = int64(8)
+		wsBusy    = int64(101)
+		wsQuiet   = int64(102)
+		wsNoisy   = int64(103)
+		wsGone    = int64(104)
+	)
+
+	db.Create(&model.Workspace{ID: wsBusy, UserID: userID, Name: "busy"})
+	db.Create(&model.Workspace{ID: wsQuiet, UserID: userID, Name: "quiet"})
+	db.Create(&model.Workspace{ID: wsNoisy, UserID: userID, Name: "noisy"})
+	// wsGone deliberately has no workspaces row: a workspace deleted after its
+	// telemetry was recorded.
+
+	at := func(hoursAgo int) int64 { return now.Add(-time.Duration(hoursAgo) * time.Hour).Unix() }
+	add := func(user, ws int64, action uint8, hoursAgo int) {
+		db.Create(&model.Telemetry{UserID: user, WorkspaceID: ws, OccurredAt: at(hoursAgo), Action: action})
+	}
+
+	// The busy workspace: three completions and one message.
+	add(userID, wsBusy, model.ActionIDTaskComplete, 3)
+	add(userID, wsBusy, model.ActionIDTaskComplete, 2)
+	add(userID, wsBusy, model.ActionIDTaskComplete, 1)
+	add(userID, wsBusy, model.ActionIDMessageCreate, 1)
+	// The quiet workspace: one message only.
+	add(userID, wsQuiet, model.ActionIDMessageCreate, 2)
+	// The noisy workspace: activity, but none of it a completion or a message,
+	// so it must not reach the breakdown.
+	add(userID, wsNoisy, model.ActionIDWorkspaceUpdate, 2)
+	add(userID, wsNoisy, model.ActionIDMCPPermissionAuto, 2)
+	// A deleted workspace still holding one completion.
+	add(userID, wsGone, model.ActionIDTaskComplete, 2)
+	// Account-level row belonging to no workspace at all.
+	add(userID, 0, model.ActionIDUserCreate, 2)
+	// Another user's activity, which must not be counted anywhere.
+	add(otherUser, wsBusy, model.ActionIDTaskComplete, 2)
+	add(otherUser, wsBusy, model.ActionIDMessageCreate, 2)
+	// In range for nobody: older than the window.
+	add(userID, wsBusy, model.ActionIDTaskComplete, 100)
+
+	start, end := at(6), at(0)
+	res, err := repo.GetDetailedUserStats(ctx, userID, start, end)
+	if err != nil {
+		t.Fatalf("GetDetailedUserStats failed: %v", err)
+	}
+
+	// Summary sums the user's rows across every workspace, and only theirs.
+	if res.Summary.TasksCompleted != 4 {
+		t.Errorf("expected 4 completions across workspaces, got %d", res.Summary.TasksCompleted)
+	}
+	if res.Summary.Messages != 2 {
+		t.Errorf("expected 2 messages across workspaces, got %d", res.Summary.Messages)
+	}
+	if res.Summary.AutoApprovals != 1 {
+		t.Errorf("expected 1 auto approval, got %d", res.Summary.AutoApprovals)
+	}
+
+	// The window is honoured: the 100-hours-ago completion is excluded above,
+	// and widening the window brings it in.
+	wide, err := repo.GetDetailedUserStats(ctx, userID, at(200), end)
+	if err != nil {
+		t.Fatalf("GetDetailedUserStats (wide) failed: %v", err)
+	}
+	if wide.Summary.TasksCompleted != 5 {
+		t.Errorf("expected 5 completions over the wider window, got %d", wide.Summary.TasksCompleted)
+	}
+
+	// Breakdown: busiest first, all-zero workspaces dropped, the workspace-less
+	// row excluded, and the deleted workspace present but unnamed.
+	if len(res.Workspaces) != 3 {
+		t.Fatalf("expected 3 workspaces in the breakdown, got %d: %+v", len(res.Workspaces), res.Workspaces)
+	}
+	if got := res.Workspaces[0]; got.WorkspaceID != wsBusy || got.Name != "busy" || got.TasksCompleted != 3 || got.Messages != 1 {
+		t.Errorf("expected busy workspace first with 3 tasks and 1 message, got %+v", got)
+	}
+	if got := res.Workspaces[1]; got.WorkspaceID != wsGone || got.Name != "" || got.TasksCompleted != 1 {
+		t.Errorf("expected the deleted workspace second with an empty name and 1 task, got %+v", got)
+	}
+	if got := res.Workspaces[2]; got.WorkspaceID != wsQuiet || got.Name != "quiet" || got.TasksCompleted != 0 || got.Messages != 1 {
+		t.Errorf("expected quiet workspace last with 0 tasks and 1 message, got %+v", got)
+	}
+	for _, w := range res.Workspaces {
+		if w.WorkspaceID == wsNoisy {
+			t.Errorf("a workspace with no completions and no messages must not be listed: %+v", w)
+		}
+		if w.WorkspaceID == 0 {
+			t.Errorf("account-level rows have no workspace and must not be listed: %+v", w)
+		}
+	}
+
+	// The breakdown adds up to the summary for the metrics it reports, which is
+	// the property that makes the two panels believable side by side.
+	var tasks, messages int64
+	for _, w := range res.Workspaces {
+		tasks += w.TasksCompleted
+		messages += w.Messages
+	}
+	if tasks != res.Summary.TasksCompleted {
+		t.Errorf("breakdown tasks %d do not add up to summary %d", tasks, res.Summary.TasksCompleted)
+	}
+	if messages != res.Summary.Messages {
+		t.Errorf("breakdown messages %d do not add up to summary %d", messages, res.Summary.Messages)
+	}
+
+	// Timeseries and heatmap come from the shared aggregation, so a spot check
+	// that they are scoped to the user is enough.
+	var series int64
+	for _, d := range res.Timeseries.TasksCompleted {
+		series += d.Count
+	}
+	if series != 4 {
+		t.Errorf("expected the timeseries to total 4 completions, got %d", series)
+	}
+	if res.Heatmap.Granularity != "hour" {
+		t.Errorf("expected hour granularity for a 6-hour window, got %q", res.Heatmap.Granularity)
+	}
+
+	// A user with nothing recorded gets empty results, not an error, and an
+	// empty breakdown rather than a nil one so it serialises as [].
+	empty, err := repo.GetDetailedUserStats(ctx, int64(999), start, end)
+	if err != nil {
+		t.Fatalf("GetDetailedUserStats for an unknown user failed: %v", err)
+	}
+	if empty.Summary.TasksCompleted != 0 || empty.Workspaces == nil || len(empty.Workspaces) != 0 {
+		t.Errorf("expected zeroed stats and an empty (non-nil) breakdown, got %+v", empty)
+	}
+}
+
+// A failure in the shared aggregation must surface rather than being reported
+// as an account with no activity, which is what an ignored error would look
+// like on the dashboard.
+func TestRepository_GetDetailedUserStats_AggregationError(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to connect database: %v", err)
+	}
+	// Deliberately not migrated: there is no telemetries table to query.
+	repo := New(&mockDB{db: db})
+
+	if _, err := repo.GetDetailedUserStats(context.Background(), 1, 0, 1); err == nil {
+		t.Error("expected an error when the telemetry table is missing, got nil")
+	}
+}

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -359,6 +359,40 @@ paths:
                 properties:
                   status: { type: string, example: unarchived }
 
+  /stats:
+    get:
+      tags: [Workspaces]
+      summary: Activity statistics across every workspace the caller owns
+      description: >
+        The same aggregates as `/workspaces/{id}/stats`, summed over the whole
+        account, plus a per-workspace breakdown of what drove them. The scope is
+        the authenticated caller, so there is no id to pass.
+      parameters:
+        - name: range
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: ['1d', '7d', 'week', '30d', 'month', 'custom']
+            default: '7d'
+        - name: from
+          in: query
+          required: false
+          schema: { type: integer, format: int64 }
+          description: Unix timestamp. Used only when `range=custom`.
+        - name: to
+          in: query
+          required: false
+          schema: { type: integer, format: int64 }
+          description: Unix timestamp. Used only when `range=custom`.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/UserStats' }
+        '422': { $ref: '#/components/responses/InvalidPayload' }
+
   /workspaces/{id}/stats:
     parameters:
       - $ref: '#/components/parameters/WorkspaceId'
@@ -1800,6 +1834,28 @@ components:
             messages:
               type: array
               items: { $ref: '#/components/schemas/HeatmapStat' }
+
+    UserStats:
+      allOf:
+        - $ref: '#/components/schemas/WorkspaceStats'
+        - type: object
+          properties:
+            workspaces:
+              type: array
+              description: >
+                Per-workspace contribution to the totals above, busiest first.
+                Workspaces with no completions and no messages in the window are
+                omitted. A workspace deleted since the events were recorded
+                still appears, with an empty name.
+              items: { $ref: '#/components/schemas/WorkspaceStatsBreakdown' }
+
+    WorkspaceStatsBreakdown:
+      type: object
+      properties:
+        workspaceId: { type: string }
+        name: { type: string }
+        tasksCompleted: { type: integer, format: int64 }
+        messages: { type: integer, format: int64 }
 
     DailyStat:
       type: object

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -293,6 +293,20 @@ export async function fetchWorkspaceStats(id, range = '7d', from = 0, to = 0) {
   return res.json();
 }
 
+// The same statistics as fetchWorkspaceStats, summed across every workspace the
+// signed-in user owns, plus a per-workspace breakdown. There is no id to pass:
+// the scope is the session.
+export async function fetchUserStats(range = '7d', from = 0, to = 0) {
+  const params = new URLSearchParams();
+  params.append('range', range);
+  if (from) params.append('from', from);
+  if (to) params.append('to', to);
+
+  const res = await apiFetch(`${API_BASE_URL}/stats?${params.toString()}`);
+  if (!res.ok) throw new Error('Failed to fetch account stats');
+  return res.json();
+}
+
 export async function setWorkspaceSlackChannel(id, channelId, channelName) {
   const res = await apiFetch(`${API_BASE_URL}/workspaces/${id}/slack`, {
     method: 'PUT',

--- a/frontend/src/components/AccountStats.vue
+++ b/frontend/src/components/AccountStats.vue
@@ -1,0 +1,143 @@
+<template>
+  <StatsPanels
+    :stats="stats"
+    :loading="loading"
+    :active-range="activeRange"
+    :range-options="rangeOptions"
+    :custom-from="customFrom"
+    :custom-to="customTo"
+    :chart-fixed-length="chartFixedLength"
+    :chart-end-date="chartEndDate"
+    :heatmap-granularity="heatmapGranularity"
+    :palette="palette"
+    @update:active-range="setRange"
+    @update:custom-from="onCustomFrom"
+    @update:custom-to="onCustomTo"
+    @apply="apply"
+  >
+    <!-- The panel that only makes sense once several workspaces are in view:
+         which of them actually produced the totals above. -->
+    <template #after-summary>
+      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-zinc-700/80 rounded-sm p-6 shadow-sm transition-all">
+        <div class="flex items-center justify-between mb-6">
+          <div class="flex items-center gap-2">
+            <span class="w-2 h-2 rounded-full bg-zinc-800 dark:bg-[#aec477]"></span>
+            <h3 class="text-[11px] font-black uppercase tracking-widest text-gray-900 dark:text-zinc-50">By Workspace</h3>
+          </div>
+          <div class="text-gray-400 dark:text-zinc-500 text-[9px] font-black uppercase tracking-widest">Busiest First</div>
+        </div>
+
+        <div v-if="loading && !breakdown.length" class="py-8 text-center text-[10px] font-black text-gray-300 dark:text-zinc-400 animate-pulse">
+          Computing...
+        </div>
+
+        <div v-else-if="!breakdown.length" class="py-8 text-center border border-dashed border-gray-200 dark:border-zinc-800 rounded-sm">
+          <p class="text-[10px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-500">No activity in this range</p>
+        </div>
+
+        <div v-else class="flex flex-col">
+          <!-- Column headings -->
+          <div class="flex items-center gap-4 px-2 pb-2 border-b border-gray-100 dark:border-zinc-800">
+            <span class="flex-1 text-[9px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-500">Workspace</span>
+            <span class="w-20 text-right text-[9px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-500">Completed</span>
+            <span class="w-20 text-right text-[9px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-500">Messages</span>
+            <span class="hidden sm:block w-28 text-[9px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-500">Share</span>
+          </div>
+
+          <button
+            v-for="row in breakdown"
+            :key="row.workspaceId"
+            type="button"
+            @click="openWorkspace(row)"
+            :disabled="!row.name"
+            class="group flex items-center gap-4 px-2 py-3 border-b border-gray-100 dark:border-zinc-800/60 text-left transition-colors enabled:hover:bg-gray-50 dark:enabled:hover:bg-zinc-800/40 disabled:cursor-default"
+          >
+            <span class="flex-1 min-w-0 flex items-center gap-2">
+              <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="row.name ? 'bg-zinc-800 dark:bg-[#aec477]' : 'bg-gray-300 dark:bg-zinc-700'"></span>
+              <span v-if="row.name" class="text-[11px] font-black text-gray-800 dark:text-zinc-200 truncate group-hover:text-black dark:group-hover:text-white transition-colors">{{ row.name }}</span>
+              <!-- Telemetry outlives the workspace it was recorded in. The row
+                   is kept rather than dropped so the breakdown still adds up to
+                   the totals above, but there is nothing to navigate to. -->
+              <span v-else class="text-[11px] font-black text-gray-400 dark:text-zinc-500 italic truncate">Deleted workspace</span>
+            </span>
+            <span class="w-20 text-right text-[11px] font-black text-gray-900 dark:text-zinc-50 tabular-nums">{{ row.tasksCompleted.toLocaleString() }}</span>
+            <span class="w-20 text-right text-[11px] font-black text-gray-900 dark:text-zinc-50 tabular-nums">{{ row.messages.toLocaleString() }}</span>
+            <span class="hidden sm:block w-28">
+              <span class="block h-1.5 rounded-sm bg-gray-100 dark:bg-zinc-800 overflow-hidden">
+                <span class="block h-full rounded-sm bg-zinc-800 dark:bg-[#aec477]" :style="{ width: shareOf(row) }"></span>
+              </span>
+            </span>
+          </button>
+        </div>
+      </div>
+    </template>
+  </StatsPanels>
+</template>
+
+<script setup>
+/**
+ * Account-wide analytics: the same panels as one workspace's dashboard, summed
+ * across every workspace the signed-in user owns, plus a breakdown of which
+ * workspaces drove the totals.
+ *
+ * Everything shared with `WorkspaceStats.vue` comes from `StatsPanels` and
+ * `useStatsRange`; all this adds is the endpoint and the breakdown panel.
+ */
+import { computed } from 'vue';
+import { useRouter } from 'vue-router';
+import { fetchUserStats } from '../api';
+import StatsPanels from './StatsPanels.vue';
+import { useStatsRange, statsPalette } from '../composables/useStatsRange';
+import { useThemeStore } from '../stores/themeStore';
+
+const router = useRouter();
+const themeStore = useThemeStore();
+const palette = computed(() => statsPalette(themeStore.isDark));
+
+const {
+  stats,
+  loading,
+  activeRange,
+  customFrom,
+  customTo,
+  load,
+  setRange,
+  apply,
+  rangeOptions,
+  chartFixedLength,
+  chartEndDate,
+  heatmapGranularity,
+} = useStatsRange({ fetchStats: fetchUserStats });
+
+const breakdown = computed(() => stats.value?.workspaces ?? []);
+
+// The share bar is relative to the busiest workspace rather than to the total:
+// with a dozen workspaces every bar would otherwise be a sliver, and the
+// question the panel answers is which ones are carrying the work.
+const busiest = computed(() =>
+  breakdown.value.reduce((max, row) => Math.max(max, row.tasksCompleted + row.messages), 0)
+);
+
+function shareOf(row) {
+  if (!busiest.value) return '0%';
+  return `${Math.round(((row.tasksCompleted + row.messages) / busiest.value) * 100)}%`;
+}
+
+function openWorkspace(row) {
+  if (!row.name) return;
+  router.push(`/workspaces/${row.workspaceId}/analytics`);
+}
+
+function onCustomFrom(value) {
+  customFrom.value = value;
+  apply();
+}
+function onCustomTo(value) {
+  customTo.value = value;
+  apply();
+}
+
+defineExpose({ load });
+
+load();
+</script>

--- a/frontend/src/components/StatsPanels.vue
+++ b/frontend/src/components/StatsPanels.vue
@@ -1,0 +1,224 @@
+<template>
+  <div class="flex flex-col gap-8">
+    <!-- Filters -->
+    <div class="flex flex-wrap items-center gap-1.5 bg-gray-100 dark:bg-zinc-900/90 p-1 border border-gray-200 dark:border-zinc-800 rounded-sm max-w-max shadow-sm">
+      <button
+        v-for="opt in rangeOptions"
+        :key="opt.id"
+        @click="$emit('update:activeRange', opt.id)"
+        class="px-3 py-1.5 text-[10px] font-black uppercase tracking-widest rounded-sm transition-all"
+        :class="activeRange === opt.id
+          ? 'bg-white dark:bg-zinc-800 text-black dark:text-zinc-50 shadow-sm border border-gray-200 dark:border-zinc-700'
+          : 'text-gray-500 hover:text-gray-900 dark:text-zinc-400 dark:hover:text-zinc-50'"
+      >
+        {{ opt.label }}
+      </button>
+
+      <!-- Custom Date Inputs (only if custom is selected) -->
+      <div v-if="activeRange === 'custom'" class="flex items-center gap-2 px-2 border-l border-gray-200 dark:border-zinc-800 ml-1">
+        <input type="date" :value="customFrom" @input="$emit('update:customFrom', $event.target.value)" class="text-[10px] bg-transparent border-none focus:ring-0 text-gray-900 dark:text-zinc-50 font-black p-0 w-24" />
+        <span class="text-[10px] font-black text-gray-500 dark:text-zinc-500">–</span>
+        <input type="date" :value="customTo" @input="$emit('update:customTo', $event.target.value)" class="text-[10px] bg-transparent border-none focus:ring-0 text-gray-900 dark:text-zinc-50 font-black p-0 w-24" />
+        <button @click="$emit('apply')" class="p-1 text-gray-500 hover:text-black dark:hover:text-white transition-all">
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path d="M5 13l4 4L19 7" /></svg>
+        </button>
+      </div>
+    </div>
+
+    <!-- Summary Cards -->
+    <div v-if="stats && stats.summary" class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
+      <!-- Tasks Completed -->
+      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-[#aec477]/40 rounded-sm p-5 flex flex-col gap-1.5 shadow-sm hover:shadow-md transition-all duration-200 group">
+        <div class="flex items-center gap-1.5">
+          <span class="w-1.5 h-1.5 rounded-full bg-zinc-800 dark:bg-[#aec477]"></span>
+          <span class="text-[10px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-400 dark:group-hover:text-[#aec477] transition-colors">Completed</span>
+        </div>
+        <span class="text-3xl font-black text-gray-900 dark:text-zinc-50 tabular-nums leading-none">{{ stats.summary.tasksCompleted.toLocaleString() }}</span>
+      </div>
+
+      <!-- Tasks Scheduled -->
+      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-zinc-700/80 rounded-sm p-5 flex flex-col gap-1.5 shadow-sm hover:shadow-md transition-all duration-200 group">
+        <div class="flex items-center gap-1.5">
+          <span class="w-1.5 h-1.5 rounded-full bg-gray-400 dark:bg-zinc-500"></span>
+          <span class="text-[10px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-400">Scheduled</span>
+        </div>
+        <span class="text-3xl font-black text-gray-900 dark:text-zinc-50 tabular-nums leading-none">{{ stats.summary.tasksScheduled.toLocaleString() }}</span>
+      </div>
+
+      <!-- Messages -->
+      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-[#a8a3d9]/40 rounded-sm p-5 flex flex-col gap-1.5 shadow-sm hover:shadow-md transition-all duration-200 group">
+        <div class="flex items-center gap-1.5">
+          <span class="w-1.5 h-1.5 rounded-full bg-zinc-800 dark:bg-[#a8a3d9]"></span>
+          <span class="text-[10px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-400 dark:group-hover:text-[#a8a3d9] transition-colors">Messages</span>
+        </div>
+        <span class="text-3xl font-black text-gray-900 dark:text-zinc-50 tabular-nums leading-none">{{ stats.summary.messages.toLocaleString() }}</span>
+      </div>
+
+      <!-- Manual Approvals -->
+      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-zinc-700/80 rounded-sm p-5 flex flex-col gap-1.5 shadow-sm hover:shadow-md transition-all duration-200 group">
+        <div class="flex items-center gap-1.5">
+          <span class="w-1.5 h-1.5 rounded-full bg-gray-400 dark:bg-zinc-500"></span>
+          <span class="text-[10px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-400">Manual</span>
+        </div>
+        <span class="text-3xl font-black text-gray-900 dark:text-zinc-50 tabular-nums leading-none">{{ stats.summary.manualApprovals.toLocaleString() }}</span>
+      </div>
+
+      <!-- Auto Approvals -->
+      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-zinc-700/80 rounded-sm p-5 flex flex-col gap-1.5 shadow-sm hover:shadow-md transition-all duration-200 group">
+        <div class="flex items-center gap-1.5">
+          <span class="w-1.5 h-1.5 rounded-full bg-gray-400 dark:bg-zinc-500"></span>
+          <span class="text-[10px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-400">Auto</span>
+        </div>
+        <span class="text-3xl font-black text-gray-900 dark:text-zinc-50 tabular-nums leading-none">{{ stats.summary.autoApprovals.toLocaleString() }}</span>
+      </div>
+
+      <!-- Denies -->
+      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-zinc-700/80 rounded-sm p-5 flex flex-col gap-1.5 shadow-sm hover:shadow-md transition-all duration-200 group">
+        <div class="flex items-center gap-1.5">
+          <span class="w-1.5 h-1.5 rounded-full bg-gray-400 dark:bg-zinc-500"></span>
+          <span class="text-[10px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-400">Denies</span>
+        </div>
+        <span class="text-3xl font-black text-gray-900 dark:text-zinc-50 tabular-nums leading-none">{{ stats.summary.denies.toLocaleString() }}</span>
+      </div>
+    </div>
+
+    <!-- Anything the host wants between the cards and the charts. The account
+         dashboard puts its per-workspace breakdown here. -->
+    <slot name="after-summary" />
+
+    <!-- Heatmaps Section -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <!-- Task Heatmap -->
+      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-zinc-700/80 rounded-sm p-6 shadow-sm transition-all">
+        <div class="flex items-center justify-between mb-6">
+          <div class="flex items-center gap-2">
+            <span class="w-2 h-2 rounded-full bg-zinc-800 dark:bg-[#aec477]"></span>
+            <h3 class="text-[11px] font-black uppercase tracking-widest text-gray-900 dark:text-zinc-50">Task Activity Heatmap</h3>
+          </div>
+          <div class="text-gray-400 dark:text-zinc-500 text-[9px] font-black uppercase tracking-widest">{{ heatmapGranularity === 'hour' ? 'By Hour' : 'By Day' }}</div>
+        </div>
+        <div class="h-56 w-full relative">
+          <div v-if="loading" class="absolute inset-0 flex items-center justify-center z-10">
+            <div class="text-[10px] font-black text-gray-300 dark:text-zinc-400 animate-pulse">Computing...</div>
+          </div>
+          <HeatmapChart
+            v-if="stats && stats.heatmap"
+            :data="stats.heatmap.tasksCompleted || []"
+            :granularity="heatmapGranularity"
+            :range-start="stats.heatmap.rangeStart"
+            :range-end="stats.heatmap.rangeEnd"
+            :weekday-column-labels="activeRange === 'week'"
+            metric-label="Tasks"
+            :color="palette.taskHeatmap"
+          />
+        </div>
+      </div>
+
+      <!-- Message Heatmap -->
+      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-zinc-700/80 rounded-sm p-6 shadow-sm transition-all">
+        <div class="flex items-center justify-between mb-6">
+          <div class="flex items-center gap-2">
+            <span class="w-2 h-2 rounded-full bg-zinc-800 dark:bg-[#a8a3d9]"></span>
+            <h3 class="text-[11px] font-black uppercase tracking-widest text-gray-900 dark:text-zinc-50">Message Activity Heatmap</h3>
+          </div>
+          <div class="text-gray-400 dark:text-zinc-500 text-[9px] font-black uppercase tracking-widest">{{ heatmapGranularity === 'hour' ? 'By Hour' : 'By Day' }}</div>
+        </div>
+        <div class="h-56 w-full relative">
+          <div v-if="loading" class="absolute inset-0 flex items-center justify-center z-10">
+            <div class="text-[10px] font-black text-gray-300 dark:text-zinc-400 animate-pulse">Computing...</div>
+          </div>
+          <HeatmapChart
+            v-if="stats && stats.heatmap"
+            :data="stats.heatmap.messages || []"
+            :granularity="heatmapGranularity"
+            :range-start="stats.heatmap.rangeStart"
+            :range-end="stats.heatmap.rangeEnd"
+            :weekday-column-labels="activeRange === 'week'"
+            metric-label="Messages"
+            :color="palette.messageHeatmap"
+          />
+        </div>
+      </div>
+    </div>
+
+    <!-- Charts Section -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <!-- Task Chart -->
+      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-zinc-700/80 rounded-sm p-6 shadow-sm transition-all">
+        <div class="flex items-center justify-between mb-6">
+          <div class="flex items-center gap-2">
+            <span class="w-2 h-2 rounded-full bg-zinc-800 dark:bg-[#aec477]"></span>
+            <h3 class="text-[11px] font-black uppercase tracking-widest text-gray-900 dark:text-zinc-50">Task Completion Velocity</h3>
+          </div>
+          <div class="text-gray-400 dark:text-zinc-500 text-[9px] font-black uppercase tracking-widest">Daily Trend</div>
+        </div>
+        <div class="h-56 w-full relative">
+          <div v-if="loading" class="absolute inset-0 flex items-center justify-center z-10">
+            <div class="text-[10px] font-black text-gray-300 dark:text-zinc-400 animate-pulse">Computing...</div>
+          </div>
+          <ChartSVG
+            v-if="stats && stats.timeseries"
+            :data="stats.timeseries.tasksCompleted || []"
+            :color="palette.taskChart"
+            :fixed-length="chartFixedLength"
+            :last-date="chartEndDate"
+          />
+        </div>
+      </div>
+
+      <!-- Message Chart -->
+      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-zinc-700/80 rounded-sm p-6 shadow-sm transition-all">
+        <div class="flex items-center justify-between mb-6">
+          <div class="flex items-center gap-2">
+            <span class="w-2 h-2 rounded-full bg-zinc-800 dark:bg-[#a8a3d9]"></span>
+            <h3 class="text-[11px] font-black uppercase tracking-widest text-gray-900 dark:text-zinc-50">Communication Volume</h3>
+          </div>
+          <div class="text-gray-400 dark:text-zinc-500 text-[9px] font-black uppercase tracking-widest">Total Messages</div>
+        </div>
+        <div class="h-56 w-full relative">
+          <div v-if="loading" class="absolute inset-0 flex items-center justify-center z-10">
+            <div class="text-[10px] font-black text-gray-300 dark:text-zinc-400 animate-pulse">Computing...</div>
+          </div>
+          <ChartSVG
+            v-if="stats && stats.timeseries"
+            :data="stats.timeseries.messages || []"
+            :color="palette.messageChart"
+            :fixed-length="chartFixedLength"
+            :last-date="chartEndDate"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * The analytics panels, given data — the range control, the six summary cards,
+ * the two heatmaps and the two line charts.
+ *
+ * Purely presentational: it holds no range state and fetches nothing, so the
+ * per-workspace and account-wide dashboards can render the identical set of
+ * panels from their own endpoint. `useStatsRange` is the other half.
+ */
+import ChartSVG from './ChartSVG.vue';
+import HeatmapChart from './HeatmapChart.vue';
+
+defineProps({
+  /** The stats response, or null while loading / after a failure. */
+  stats: { type: Object, default: null },
+  loading: { type: Boolean, default: false },
+  activeRange: { type: String, required: true },
+  rangeOptions: { type: Array, required: true },
+  customFrom: { type: String, default: '' },
+  customTo: { type: String, default: '' },
+  /** Day-columns the line charts reserve; 0 means "as many as the data has". */
+  chartFixedLength: { type: Number, default: 0 },
+  chartEndDate: { type: String, required: true },
+  heatmapGranularity: { type: String, default: 'day' },
+  /** From `statsPalette(isDark)`; the SVGs take colours as props. */
+  palette: { type: Object, required: true },
+});
+
+defineEmits(['update:activeRange', 'update:customFrom', 'update:customTo', 'apply']);
+</script>

--- a/frontend/src/components/WorkspaceStats.vue
+++ b/frontend/src/components/WorkspaceStats.vue
@@ -1,296 +1,74 @@
 <template>
-  <div class="flex flex-col gap-8">
-    <!-- Filters -->
-    <div class="flex flex-wrap items-center gap-1.5 bg-gray-100 dark:bg-zinc-900/90 p-1 border border-gray-200 dark:border-zinc-800 rounded-sm max-w-max shadow-sm">
-      <button 
-        v-for="opt in rangeOptions" 
-        :key="opt.id"
-        @click="setRange(opt.id)"
-        class="px-3 py-1.5 text-[10px] font-black uppercase tracking-widest rounded-sm transition-all"
-        :class="activeRange === opt.id 
-          ? 'bg-white dark:bg-zinc-800 text-black dark:text-zinc-50 shadow-sm border border-gray-200 dark:border-zinc-700' 
-          : 'text-gray-500 hover:text-gray-900 dark:text-zinc-400 dark:hover:text-zinc-50'"
-      >
-        {{ opt.label }}
-      </button>
-      
-      <!-- Custom Date Inputs (only if custom is selected) -->
-      <div v-if="activeRange === 'custom'" class="flex items-center gap-2 px-2 border-l border-gray-200 dark:border-zinc-800 ml-1">
-        <input type="date" v-model="customFrom" class="text-[10px] bg-transparent border-none focus:ring-0 text-gray-900 dark:text-zinc-50 font-black p-0 w-24" />
-        <span class="text-[10px] font-black text-gray-500 dark:text-zinc-500">–</span>
-        <input type="date" v-model="customTo" class="text-[10px] bg-transparent border-none focus:ring-0 text-gray-900 dark:text-zinc-50 font-black p-0 w-24" />
-        <button @click="load" class="p-1 text-gray-500 hover:text-black dark:hover:text-white transition-all">
-          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path d="M5 13l4 4L19 7" /></svg>
-        </button>
-      </div>
-    </div>
-
-    <!-- Summary Cards -->
-    <div v-if="stats && stats.summary" class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
-      <!-- Tasks Completed -->
-      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-[#aec477]/40 rounded-sm p-5 flex flex-col gap-1.5 shadow-sm hover:shadow-md transition-all duration-200 group">
-        <div class="flex items-center gap-1.5">
-          <span class="w-1.5 h-1.5 rounded-full bg-zinc-800 dark:bg-[#aec477]"></span>
-          <span class="text-[10px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-400 dark:group-hover:text-[#aec477] transition-colors">Completed</span>
-        </div>
-        <span class="text-3xl font-black text-gray-900 dark:text-zinc-50 tabular-nums leading-none">{{ stats.summary.tasksCompleted.toLocaleString() }}</span>
-      </div>
-
-      <!-- Tasks Scheduled -->
-      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-zinc-700/80 rounded-sm p-5 flex flex-col gap-1.5 shadow-sm hover:shadow-md transition-all duration-200 group">
-        <div class="flex items-center gap-1.5">
-          <span class="w-1.5 h-1.5 rounded-full bg-gray-400 dark:bg-zinc-500"></span>
-          <span class="text-[10px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-400">Scheduled</span>
-        </div>
-        <span class="text-3xl font-black text-gray-900 dark:text-zinc-50 tabular-nums leading-none">{{ stats.summary.tasksScheduled.toLocaleString() }}</span>
-      </div>
-
-      <!-- Messages -->
-      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-[#a8a3d9]/40 rounded-sm p-5 flex flex-col gap-1.5 shadow-sm hover:shadow-md transition-all duration-200 group">
-        <div class="flex items-center gap-1.5">
-          <span class="w-1.5 h-1.5 rounded-full bg-zinc-800 dark:bg-[#a8a3d9]"></span>
-          <span class="text-[10px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-400 dark:group-hover:text-[#a8a3d9] transition-colors">Messages</span>
-        </div>
-        <span class="text-3xl font-black text-gray-900 dark:text-zinc-50 tabular-nums leading-none">{{ stats.summary.messages.toLocaleString() }}</span>
-      </div>
-
-      <!-- Manual Approvals -->
-      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-zinc-700/80 rounded-sm p-5 flex flex-col gap-1.5 shadow-sm hover:shadow-md transition-all duration-200 group">
-        <div class="flex items-center gap-1.5">
-          <span class="w-1.5 h-1.5 rounded-full bg-gray-400 dark:bg-zinc-500"></span>
-          <span class="text-[10px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-400">Manual</span>
-        </div>
-        <span class="text-3xl font-black text-gray-900 dark:text-zinc-50 tabular-nums leading-none">{{ stats.summary.manualApprovals.toLocaleString() }}</span>
-      </div>
-
-      <!-- Auto Approvals -->
-      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-zinc-700/80 rounded-sm p-5 flex flex-col gap-1.5 shadow-sm hover:shadow-md transition-all duration-200 group">
-        <div class="flex items-center gap-1.5">
-          <span class="w-1.5 h-1.5 rounded-full bg-gray-400 dark:bg-zinc-500"></span>
-          <span class="text-[10px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-400">Auto</span>
-        </div>
-        <span class="text-3xl font-black text-gray-900 dark:text-zinc-50 tabular-nums leading-none">{{ stats.summary.autoApprovals.toLocaleString() }}</span>
-      </div>
-
-      <!-- Denies -->
-      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-zinc-700/80 rounded-sm p-5 flex flex-col gap-1.5 shadow-sm hover:shadow-md transition-all duration-200 group">
-        <div class="flex items-center gap-1.5">
-          <span class="w-1.5 h-1.5 rounded-full bg-gray-400 dark:bg-zinc-500"></span>
-          <span class="text-[10px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-400">Denies</span>
-        </div>
-        <span class="text-3xl font-black text-gray-900 dark:text-zinc-50 tabular-nums leading-none">{{ stats.summary.denies.toLocaleString() }}</span>
-      </div>
-    </div>
-
-    <!-- Heatmaps Section -->
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-      <!-- Task Heatmap -->
-      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-zinc-700/80 rounded-sm p-6 shadow-sm transition-all">
-        <div class="flex items-center justify-between mb-6">
-          <div class="flex items-center gap-2">
-            <span class="w-2 h-2 rounded-full bg-zinc-800 dark:bg-[#aec477]"></span>
-            <h3 class="text-[11px] font-black uppercase tracking-widest text-gray-900 dark:text-zinc-50">Task Activity Heatmap</h3>
-          </div>
-          <div class="text-gray-400 dark:text-zinc-500 text-[9px] font-black uppercase tracking-widest">{{ heatmapGranularity === 'hour' ? 'By Hour' : 'By Day' }}</div>
-        </div>
-        <div class="h-56 w-full relative">
-          <div v-if="loading" class="absolute inset-0 flex items-center justify-center z-10">
-            <div class="text-[10px] font-black text-gray-300 dark:text-zinc-400 animate-pulse">Computing...</div>
-          </div>
-          <HeatmapChart
-            v-if="stats && stats.heatmap"
-            :data="stats.heatmap.tasksCompleted || []"
-            :granularity="heatmapGranularity"
-            :range-start="stats.heatmap.rangeStart"
-            :range-end="stats.heatmap.rangeEnd"
-            :weekday-column-labels="activeRange === 'week'"
-            metric-label="Tasks"
-            :color="taskHeatmapColor"
-          />
-        </div>
-      </div>
-
-      <!-- Message Heatmap -->
-      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-zinc-700/80 rounded-sm p-6 shadow-sm transition-all">
-        <div class="flex items-center justify-between mb-6">
-          <div class="flex items-center gap-2">
-            <span class="w-2 h-2 rounded-full bg-zinc-800 dark:bg-[#a8a3d9]"></span>
-            <h3 class="text-[11px] font-black uppercase tracking-widest text-gray-900 dark:text-zinc-50">Message Activity Heatmap</h3>
-          </div>
-          <div class="text-gray-400 dark:text-zinc-500 text-[9px] font-black uppercase tracking-widest">{{ heatmapGranularity === 'hour' ? 'By Hour' : 'By Day' }}</div>
-        </div>
-        <div class="h-56 w-full relative">
-          <div v-if="loading" class="absolute inset-0 flex items-center justify-center z-10">
-            <div class="text-[10px] font-black text-gray-300 dark:text-zinc-400 animate-pulse">Computing...</div>
-          </div>
-          <HeatmapChart
-            v-if="stats && stats.heatmap"
-            :data="stats.heatmap.messages || []"
-            :granularity="heatmapGranularity"
-            :range-start="stats.heatmap.rangeStart"
-            :range-end="stats.heatmap.rangeEnd"
-            :weekday-column-labels="activeRange === 'week'"
-            metric-label="Messages"
-            :color="messageHeatmapColor"
-          />
-        </div>
-      </div>
-    </div>
-
-    <!-- Charts Section -->
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-      <!-- Task Chart -->
-      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-zinc-700/80 rounded-sm p-6 shadow-sm transition-all">
-        <div class="flex items-center justify-between mb-6">
-          <div class="flex items-center gap-2">
-            <span class="w-2 h-2 rounded-full bg-zinc-800 dark:bg-[#aec477]"></span>
-            <h3 class="text-[11px] font-black uppercase tracking-widest text-gray-900 dark:text-zinc-50">Task Completion Velocity</h3>
-          </div>
-          <div class="text-gray-400 dark:text-zinc-500 text-[9px] font-black uppercase tracking-widest">Daily Trend</div>
-        </div>
-        <div class="h-56 w-full relative">
-          <div v-if="loading" class="absolute inset-0 flex items-center justify-center z-10">
-            <div class="text-[10px] font-black text-gray-300 dark:text-zinc-400 animate-pulse">Computing...</div>
-          </div>
-          <ChartSVG
-            v-if="stats && stats.timeseries"
-            :data="stats.timeseries.tasksCompleted || []"
-            :color="taskChartColor"
-            :fixed-length="chartFixedLength"
-            :last-date="chartEndDate"
-          />
-        </div>
-      </div>
-
-      <!-- Message Chart -->
-      <div class="bg-white dark:bg-zinc-900/90 border border-gray-200 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-zinc-700/80 rounded-sm p-6 shadow-sm transition-all">
-        <div class="flex items-center justify-between mb-6">
-          <div class="flex items-center gap-2">
-            <span class="w-2 h-2 rounded-full bg-zinc-800 dark:bg-[#a8a3d9]"></span>
-            <h3 class="text-[11px] font-black uppercase tracking-widest text-gray-900 dark:text-zinc-50">Communication Volume</h3>
-          </div>
-          <div class="text-gray-400 dark:text-zinc-500 text-[9px] font-black uppercase tracking-widest">Total Messages</div>
-        </div>
-        <div class="h-56 w-full relative">
-          <div v-if="loading" class="absolute inset-0 flex items-center justify-center z-10">
-            <div class="text-[10px] font-black text-gray-300 dark:text-zinc-400 animate-pulse">Computing...</div>
-          </div>
-          <ChartSVG
-            v-if="stats && stats.timeseries"
-            :data="stats.timeseries.messages || []"
-            :color="messageChartColor"
-            :fixed-length="chartFixedLength"
-            :last-date="chartEndDate"
-          />
-        </div>
-      </div>
-    </div>
-  </div>
+  <StatsPanels
+    :stats="stats"
+    :loading="loading"
+    :active-range="activeRange"
+    :range-options="rangeOptions"
+    :custom-from="customFrom"
+    :custom-to="customTo"
+    :chart-fixed-length="chartFixedLength"
+    :chart-end-date="chartEndDate"
+    :heatmap-granularity="heatmapGranularity"
+    :palette="palette"
+    @update:active-range="setRange"
+    @update:custom-from="onCustomFrom"
+    @update:custom-to="onCustomTo"
+    @apply="apply"
+  />
 </template>
 
 <script setup>
-import { ref, onMounted, computed, watch } from 'vue';
+/**
+ * One workspace's analytics. The account-wide counterpart is `AccountStats.vue`
+ * — both are thin: the panels come from `StatsPanels`, the range behaviour from
+ * `useStatsRange`, and all either adds is which endpoint to call.
+ */
+import { computed, onMounted, watch } from 'vue';
 import { fetchWorkspaceStats } from '../api';
-import ChartSVG from './ChartSVG.vue';
-import HeatmapChart from './HeatmapChart.vue';
+import StatsPanels from './StatsPanels.vue';
+import { useStatsRange, statsPalette } from '../composables/useStatsRange';
 import { useThemeStore } from '../stores/themeStore';
 
 const props = defineProps({
-  workspaceId: { type: [String, Number], required: true }
+  workspaceId: { type: [String, Number], required: true },
 });
 
 const themeStore = useThemeStore();
-const stats = ref(null);
-const loading = ref(true);
-const activeRange = ref('7d');
-const customFrom = ref('');
-const customTo = ref('');
+const palette = computed(() => statsPalette(themeStore.isDark));
 
-const isDark = computed(() => {
-  if (themeStore.theme === 'dark') return true;
-  if (themeStore.theme === 'light') return false;
-  if (typeof document !== 'undefined' && document.documentElement.classList.contains('dark')) {
-    return true;
-  }
-  if (typeof window !== 'undefined' && window.matchMedia?.('(prefers-color-scheme: dark)')?.matches) {
-    return true;
-  }
-  return false;
+const {
+  stats,
+  loading,
+  activeRange,
+  customFrom,
+  customTo,
+  load,
+  setRange,
+  apply,
+  rangeOptions,
+  chartFixedLength,
+  chartEndDate,
+  heatmapGranularity,
+} = useStatsRange({
+  fetchStats: (range, from, to) => fetchWorkspaceStats(props.workspaceId, range, from, to),
 });
 
-// Original light mode color #27272a; dark mode uses matte tones sampled from reference ss (#aec477, #a8a3d9) with zero glow
-const taskChartColor = computed(() => isDark.value ? '#aec477' : '#27272a');
-const messageChartColor = computed(() => isDark.value ? '#a8a3d9' : '#27272a');
-const taskHeatmapColor = computed(() => isDark.value ? 'yellow' : 'gray');
-const messageHeatmapColor = computed(() => isDark.value ? 'violet' : 'gray');
-
-const rangeOptions = [
-  { id: '1d', label: '1d' },
-  { id: '7d', label: '7d' },
-  { id: 'week', label: 'Wk' },
-  { id: '30d', label: '30d' },
-  { id: 'month', label: 'Mo' },
-  { id: 'custom', label: 'Cust' }
-];
-
-async function load() {
-  loading.value = true;
-  try {
-    let fromTs = 0;
-    let toTs = 0;
-    
-    if (activeRange.value === 'custom') {
-      if (customFrom.value) fromTs = Math.floor(new Date(customFrom.value).getTime() / 1000);
-      if (customTo.value) toTs = Math.floor(new Date(customTo.value).getTime() / 1000);
-    }
-    
-    const res = await fetchWorkspaceStats(props.workspaceId, activeRange.value, fromTs, toTs);
-    stats.value = res;
-  } catch (err) {
-    console.error('Failed to load stats:', err);
-    stats.value = null;
-  } finally {
-    loading.value = false;
-  }
+// Setting either end of a custom range loads as soon as both are present, so
+// the common case needs no extra click; the tick button re-runs a range that is
+// already complete.
+function onCustomFrom(value) {
+  customFrom.value = value;
+  apply();
+}
+function onCustomTo(value) {
+  customTo.value = value;
+  apply();
 }
 
-const chartEndDate = computed(() => {
-  if (activeRange.value === 'custom' && customTo.value) {
-    return customTo.value;
-  }
-  const now = new Date();
-  const y = now.getFullYear();
-  const m = String(now.getMonth() + 1).padStart(2, '0');
-  const d = String(now.getDate()).padStart(2, '0');
-  return `${y}-${m}-${d}`;
-});
-
-const heatmapGranularity = computed(() => stats.value?.heatmap?.granularity || 'day');
-
-const chartFixedLength = computed(() => {
-  if (activeRange.value === '7d' || activeRange.value === 'week') return 7;
-  if (activeRange.value === '30d' || activeRange.value === 'month') return 30;
-  if (activeRange.value === 'custom' && customFrom.value && customTo.value) {
-    const f = new Date(customFrom.value);
-    const t = new Date(customTo.value);
-    const diff = Math.ceil((t - f) / (1000 * 60 * 60 * 24));
-    return diff >= 0 ? diff + 1 : 0;
-  }
-  return 0;
-});
-
-watch([customFrom, customTo], () => {
-  if (activeRange.value === 'custom' && customFrom.value && customTo.value) {
-    load();
-  }
-});
-
-function setRange(range) {
-  activeRange.value = range;
-  if (range !== 'custom') {
-    load();
-  }
-}
+// The analytics tab is reached by changing a route parameter, so switching
+// workspace does not remount this — without the watch, the previous
+// workspace's numbers would stay on screen under the new workspace's name.
+watch(() => props.workspaceId, load);
 
 onMounted(load);
 </script>

--- a/frontend/src/composables/useStatsRange.js
+++ b/frontend/src/composables/useStatsRange.js
@@ -1,0 +1,182 @@
+import { computed, ref } from 'vue';
+
+/**
+ * The time-range control shared by the analytics dashboards.
+ *
+ * There are two of these screens — one workspace, and the whole account — and
+ * they differ only in which endpoint they call. Everything else about them (the
+ * range buttons, what "this week" means, how many columns the charts reserve,
+ * which colours the SVGs are handed) has to stay identical, or the same numbers
+ * appear to disagree depending on which screen you are looking at. So it lives
+ * here once and both screens read it, rather than being copied and drifting.
+ *
+ * The window arithmetic mirrors `statsWindow` in the Go controller. The backend
+ * is authoritative — it is what actually filters the rows — but the chart needs
+ * to know how many buckets to reserve before the response arrives, so the shape
+ * of the window is computed on both sides.
+ */
+
+/** The range buttons, in the order they are shown. */
+export const STATS_RANGE_OPTIONS = Object.freeze([
+  { id: '1d', label: '1d' },
+  { id: '7d', label: '7d' },
+  { id: 'week', label: 'Wk' },
+  { id: '30d', label: '30d' },
+  { id: 'month', label: 'Mo' },
+  { id: 'custom', label: 'Cust' },
+]);
+
+/** The range a dashboard opens on. */
+export const DEFAULT_STATS_RANGE = '7d';
+
+/**
+ * How many day-columns the line chart should reserve.
+ *
+ * A fixed length is what stops a quiet week from being drawn as a full-width
+ * chart of three points: the axis stays the length of the range asked for, and
+ * missing days read as missing.
+ *
+ * 0 means "as many as the data has" — the honest answer for the calendar ranges,
+ * whose length depends on today's date, and for an incomplete custom range.
+ *
+ * @param {string} range
+ * @param {string} customFrom ISO date, `YYYY-MM-DD`
+ * @param {string} customTo ISO date, `YYYY-MM-DD`
+ * @returns {number}
+ */
+export function chartFixedLengthFor(range, customFrom = '', customTo = '') {
+  if (range === '7d' || range === 'week') return 7;
+  if (range === '30d' || range === 'month') return 30;
+  if (range === 'custom' && customFrom && customTo) {
+    const from = new Date(customFrom);
+    const to = new Date(customTo);
+    const days = Math.ceil((to - from) / (1000 * 60 * 60 * 24));
+    // An inverted range is not a negative number of columns; it is no range.
+    return days >= 0 ? days + 1 : 0;
+  }
+  return 0;
+}
+
+/**
+ * The date the chart's last column stands for, as `YYYY-MM-DD`.
+ *
+ * Built from the local date parts rather than `toISOString`, which would shift
+ * the label by a day for anyone east or west of UTC at the wrong hour.
+ *
+ * @param {string} range
+ * @param {string} customTo ISO date
+ * @param {Date} [now]
+ * @returns {string}
+ */
+export function chartEndDateFor(range, customTo = '', now = new Date()) {
+  if (range === 'custom' && customTo) return customTo;
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * The `from`/`to` the request should carry, as Unix seconds.
+ *
+ * Only a custom range sends them; every other range is a name the backend
+ * resolves itself, and sending a window alongside it would invite the two to
+ * disagree. 0 means "not sent".
+ *
+ * @param {string} range
+ * @param {string} customFrom ISO date
+ * @param {string} customTo ISO date
+ * @returns {{from: number, to: number}}
+ */
+export function customWindowFor(range, customFrom = '', customTo = '') {
+  if (range !== 'custom') return { from: 0, to: 0 };
+  return {
+    from: customFrom ? Math.floor(new Date(customFrom).getTime() / 1000) : 0,
+    to: customTo ? Math.floor(new Date(customTo).getTime() / 1000) : 0,
+  };
+}
+
+/**
+ * The colours handed to the chart and heatmap components.
+ *
+ * These are props rather than CSS because both components draw SVG and pick
+ * their own scales, so the value has to exist in JavaScript. The light theme
+ * deliberately uses one neutral for both series — the distinction is carried by
+ * the panel headings there — while dark mode separates them with the matte
+ * green and violet the rest of the analytics screen uses.
+ *
+ * @param {boolean} isDark
+ */
+export function statsPalette(isDark) {
+  return {
+    taskChart: isDark ? '#aec477' : '#27272a',
+    messageChart: isDark ? '#a8a3d9' : '#27272a',
+    taskHeatmap: isDark ? 'yellow' : 'gray',
+    messageHeatmap: isDark ? 'violet' : 'gray',
+  };
+}
+
+/**
+ * Range state plus the fetch it drives.
+ *
+ * `fetchStats` is injected rather than imported so the two dashboards can point
+ * at their own endpoint, and so this is testable without a server.
+ *
+ * A custom range does not load on every keystroke: it waits until both ends are
+ * set, and `apply` is what the tick button calls to re-run an already-complete
+ * range.
+ *
+ * @param {object} deps
+ * @param {(range: string, from: number, to: number) => Promise<object>} deps.fetchStats
+ * @param {(err: Error) => void} [deps.onError] defaults to console.error
+ */
+export function useStatsRange({ fetchStats, onError }) {
+  const stats = ref(null);
+  const loading = ref(true);
+  const activeRange = ref(DEFAULT_STATS_RANGE);
+  const customFrom = ref('');
+  const customTo = ref('');
+
+  async function load() {
+    loading.value = true;
+    try {
+      const { from, to } = customWindowFor(activeRange.value, customFrom.value, customTo.value);
+      stats.value = await fetchStats(activeRange.value, from, to);
+    } catch (err) {
+      // The panels render nothing rather than the previous range's numbers,
+      // which would otherwise sit there looking like the answer.
+      stats.value = null;
+      (onError ?? ((e) => console.error('Failed to load stats:', e)))(err);
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  /** Switch range. A custom range waits for both dates before it loads. */
+  function setRange(range) {
+    activeRange.value = range;
+    if (range !== 'custom') load();
+  }
+
+  /** Re-run the current custom range, once both ends are set. */
+  function apply() {
+    if (activeRange.value === 'custom' && customFrom.value && customTo.value) load();
+  }
+
+  return {
+    stats,
+    loading,
+    activeRange,
+    customFrom,
+    customTo,
+    load,
+    setRange,
+    apply,
+    rangeOptions: STATS_RANGE_OPTIONS,
+    chartFixedLength: computed(() =>
+      chartFixedLengthFor(activeRange.value, customFrom.value, customTo.value)
+    ),
+    chartEndDate: computed(() => chartEndDateFor(activeRange.value, customTo.value)),
+    heatmapGranularity: computed(() => stats.value?.heatmap?.granularity || 'day'),
+  };
+}

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -9,10 +9,32 @@
           </div>
         </div>
       </div>
+
+      <!-- Tabs -->
+      <div class="flex items-center gap-1.5 bg-gray-100 dark:bg-zinc-900/90 p-1 border border-gray-200 dark:border-zinc-800 rounded-sm max-w-max shadow-sm shrink-0">
+        <button
+          v-for="tab in TABS"
+          :key="tab.id"
+          type="button"
+          @click="activeTab = tab.id"
+          class="px-3 py-1.5 text-[10px] font-black uppercase tracking-widest rounded-sm transition-all"
+          :class="activeTab === tab.id
+            ? 'bg-white dark:bg-zinc-800 text-black dark:text-zinc-50 shadow-sm border border-gray-200 dark:border-zinc-700'
+            : 'text-gray-500 hover:text-gray-900 dark:text-zinc-400 dark:hover:text-zinc-50'"
+        >
+          {{ tab.label }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Performance: the same analytics as a single workspace, summed across
+         every workspace the user owns. -->
+    <div v-if="activeTab === 'performance'" class="flex-1 overflow-y-auto px-4 pb-10 custom-scrollbar">
+      <AccountStats />
     </div>
 
     <!-- Create workspace form -->
-    <Transition name="fade-down">
+    <Transition v-if="activeTab === 'workspaces'" name="fade-down">
       <div v-if="showCreate" class="fixed inset-0 z-[110] flex items-center justify-center p-4 md:relative md:inset-auto md:p-0 md:bg-transparent md:z-10 md:block">
         <div class="fixed inset-0 bg-black/60 backdrop-blur-sm md:hidden" @click="showCreate = false"></div>
         
@@ -68,12 +90,12 @@
       </div>
     </Transition>
 
-    <div v-if="error" class="bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/30 text-red-700 dark:text-red-400 px-5 py-3 rounded-sm text-[10px] font-black shadow-sm">
+    <div v-if="error && activeTab === 'workspaces'" class="bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/30 text-red-700 dark:text-red-400 px-5 py-3 rounded-sm text-[10px] font-black shadow-sm">
       {{ error }}
     </div>
 
     <!-- Workspace list -->
-    <div class="flex-1 overflow-y-auto px-4 pb-10 custom-scrollbar">
+    <div v-if="activeTab === 'workspaces'" class="flex-1 overflow-y-auto px-4 pb-10 custom-scrollbar">
       <div v-if="loadingWorkspaces" class="py-8">
         <LoadingState label="Loading Workspaces..." />
       </div>
@@ -204,7 +226,7 @@
     </div>
 
     <!-- Bottom Stats -->
-    <div v-if="!loadingWorkspaces && workspaces.length > 0" class="px-4 pb-4 flex flex-wrap items-center gap-6 border-t border-gray-100 dark:border-zinc-800 pt-3">
+    <div v-if="activeTab === 'workspaces' && !loadingWorkspaces && workspaces.length > 0" class="px-4 pb-4 flex flex-wrap items-center gap-6 border-t border-gray-100 dark:border-zinc-800 pt-3">
       <div class="flex items-center gap-1.5 cursor-help" 
            @mouseenter="tooltipStore.show($event, 'Online Agents', 'top')"
            @mouseleave="tooltipStore.hide()">
@@ -253,6 +275,21 @@ import {
   workingDirectoryPlaceholder as directoryPlaceholderFor,
 } from '../composables/useDirectoryPicker';
 import LoadingState from '../components/LoadingState.vue';
+import AccountStats from '../components/AccountStats.vue';
+
+/**
+ * The overview screen's tabs. "Workspaces" is the list this page has always
+ * been; "Performance" is the account-wide analytics.
+ *
+ * The tab is local state rather than a route: it is a view of the same
+ * overview page, and giving it a URL would mean a second route table entry for
+ * something the desktop build would have to mirror.
+ */
+const TABS = Object.freeze([
+  { id: 'workspaces', label: 'Workspaces' },
+  { id: 'performance', label: 'Performance' },
+]);
+const activeTab = ref('workspaces');
 
 const { toKebabCase, liveKebabCase } = useFormat();
 const tooltipStore = useTooltipStore();

--- a/frontend/src/webmcp/tools.js
+++ b/frontend/src/webmcp/tools.js
@@ -193,6 +193,19 @@ export function createToolCatalogue({ api, navigate, currentPage }) {
         api.fetchWorkspaceStats(workspaceId, range, from, to),
     }),
     tool({
+      name: 'getAccountStats',
+      description:
+        'Activity statistics across every workspace the user owns, over a time range, with a ' +
+        'per-workspace breakdown of what drove the totals.',
+      properties: {
+        range: str('Range such as "7d" or "30d". Defaults to "7d".'),
+        from: int('Optional start as a Unix timestamp.'),
+        to: int('Optional end as a Unix timestamp.'),
+      },
+      readOnly: true,
+      run: ({ range = '7d', from = 0, to = 0 }) => api.fetchUserStats(range, from, to),
+    }),
+    tool({
       name: 'listWorkspaceMemories',
       description:
         'What the agents working in a workspace have written down for each other: name, size and when ' +

--- a/frontend/test/statsRange.test.js
+++ b/frontend/test/statsRange.test.js
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi } from 'vitest';
+import { nextTick } from 'vue';
+
+import {
+  DEFAULT_STATS_RANGE,
+  STATS_RANGE_OPTIONS,
+  chartEndDateFor,
+  chartFixedLengthFor,
+  customWindowFor,
+  statsPalette,
+  useStatsRange,
+} from '../src/composables/useStatsRange';
+
+describe('STATS_RANGE_OPTIONS', () => {
+  it('offers the six ranges both dashboards share, in order', () => {
+    expect(STATS_RANGE_OPTIONS.map((o) => o.id)).toEqual([
+      '1d',
+      '7d',
+      'week',
+      '30d',
+      'month',
+      'custom',
+    ]);
+  });
+
+  it('opens on the last 7 days', () => {
+    expect(DEFAULT_STATS_RANGE).toBe('7d');
+    expect(STATS_RANGE_OPTIONS.map((o) => o.id)).toContain(DEFAULT_STATS_RANGE);
+  });
+
+  it('is frozen, so one dashboard cannot mutate the other\'s options', () => {
+    expect(Object.isFrozen(STATS_RANGE_OPTIONS)).toBe(true);
+  });
+});
+
+describe('chartFixedLengthFor', () => {
+  it('reserves a week of columns for the seven-day ranges', () => {
+    expect(chartFixedLengthFor('7d')).toBe(7);
+    expect(chartFixedLengthFor('week')).toBe(7);
+  });
+
+  it('reserves thirty columns for the month-length ranges', () => {
+    expect(chartFixedLengthFor('30d')).toBe(30);
+    expect(chartFixedLengthFor('month')).toBe(30);
+  });
+
+  it('counts a custom range inclusively', () => {
+    // The 1st through the 7th is seven days, not six.
+    expect(chartFixedLengthFor('custom', '2026-09-01', '2026-09-07')).toBe(7);
+    expect(chartFixedLengthFor('custom', '2026-09-01', '2026-09-01')).toBe(1);
+  });
+
+  it('treats an inverted custom range as no range rather than negative columns', () => {
+    expect(chartFixedLengthFor('custom', '2026-09-07', '2026-09-01')).toBe(0);
+  });
+
+  it('reserves nothing until a custom range has both ends', () => {
+    expect(chartFixedLengthFor('custom', '2026-09-01', '')).toBe(0);
+    expect(chartFixedLengthFor('custom', '', '2026-09-07')).toBe(0);
+    expect(chartFixedLengthFor('custom')).toBe(0);
+  });
+
+  it('lets the shorter ranges size themselves to the data', () => {
+    expect(chartFixedLengthFor('1d')).toBe(0);
+    expect(chartFixedLengthFor('anything-else')).toBe(0);
+  });
+});
+
+describe('chartEndDateFor', () => {
+  it('uses the end of a custom range', () => {
+    expect(chartEndDateFor('custom', '2026-09-07')).toBe('2026-09-07');
+  });
+
+  it('falls back to today when a custom range has no end yet', () => {
+    const now = new Date(2026, 8, 9, 12, 0, 0);
+    expect(chartEndDateFor('custom', '', now)).toBe('2026-09-09');
+  });
+
+  it('uses today for every relative range', () => {
+    const now = new Date(2026, 8, 9, 12, 0, 0);
+    expect(chartEndDateFor('7d', '', now)).toBe('2026-09-09');
+    expect(chartEndDateFor('month', '', now)).toBe('2026-09-09');
+  });
+
+  it('zero-pads month and day', () => {
+    const now = new Date(2026, 0, 5, 12, 0, 0);
+    expect(chartEndDateFor('7d', '', now)).toBe('2026-01-05');
+  });
+
+  it('reads the local date, not the UTC one', () => {
+    // Late evening local; `toISOString` would already have rolled over to the
+    // next day for anyone west of UTC, labelling the last column tomorrow.
+    const now = new Date(2026, 8, 9, 23, 30, 0);
+    expect(chartEndDateFor('7d', '', now)).toBe('2026-09-09');
+  });
+
+  it('defaults to the current date with no clock passed', () => {
+    const today = new Date();
+    const expected = [
+      today.getFullYear(),
+      String(today.getMonth() + 1).padStart(2, '0'),
+      String(today.getDate()).padStart(2, '0'),
+    ].join('-');
+    expect(chartEndDateFor('7d')).toBe(expected);
+  });
+});
+
+describe('customWindowFor', () => {
+  it('sends nothing for a named range, which the backend resolves itself', () => {
+    expect(customWindowFor('7d', '2026-09-01', '2026-09-07')).toEqual({ from: 0, to: 0 });
+    expect(customWindowFor('week')).toEqual({ from: 0, to: 0 });
+  });
+
+  it('converts a custom range to Unix seconds', () => {
+    const { from, to } = customWindowFor('custom', '2026-09-01', '2026-09-07');
+    expect(from).toBe(Math.floor(new Date('2026-09-01').getTime() / 1000));
+    expect(to).toBe(Math.floor(new Date('2026-09-07').getTime() / 1000));
+  });
+
+  it('leaves a missing end of a custom range at zero', () => {
+    expect(customWindowFor('custom', '', '')).toEqual({ from: 0, to: 0 });
+    const partial = customWindowFor('custom', '2026-09-01', '');
+    expect(partial.from).toBeGreaterThan(0);
+    expect(partial.to).toBe(0);
+  });
+});
+
+describe('statsPalette', () => {
+  it('separates the two series in dark mode', () => {
+    const dark = statsPalette(true);
+    expect(dark.taskChart).toBe('#aec477');
+    expect(dark.messageChart).toBe('#a8a3d9');
+    expect(dark.taskHeatmap).toBe('yellow');
+    expect(dark.messageHeatmap).toBe('violet');
+  });
+
+  it('uses one neutral for both series in light mode', () => {
+    const light = statsPalette(false);
+    expect(light.taskChart).toBe('#27272a');
+    expect(light.messageChart).toBe('#27272a');
+    expect(light.taskHeatmap).toBe('gray');
+    expect(light.messageHeatmap).toBe('gray');
+  });
+});
+
+describe('useStatsRange', () => {
+  /** A fetcher that records how it was called and resolves with a fixture. */
+  function recordingFetch(response = { summary: {}, heatmap: { granularity: 'hour' } }) {
+    const calls = [];
+    return {
+      calls,
+      fetchStats: vi.fn((range, from, to) => {
+        calls.push({ range, from, to });
+        return Promise.resolve(response);
+      }),
+    };
+  }
+
+  it('opens on 7d and starts out loading', () => {
+    const { fetchStats } = recordingFetch();
+    const s = useStatsRange({ fetchStats });
+    expect(s.activeRange.value).toBe('7d');
+    expect(s.loading.value).toBe(true);
+    expect(s.stats.value).toBe(null);
+  });
+
+  it('loads the active range and clears loading', async () => {
+    const { fetchStats, calls } = recordingFetch({ summary: { tasksCompleted: 3 } });
+    const s = useStatsRange({ fetchStats });
+
+    await s.load();
+
+    expect(calls).toEqual([{ range: '7d', from: 0, to: 0 }]);
+    expect(s.stats.value).toEqual({ summary: { tasksCompleted: 3 } });
+    expect(s.loading.value).toBe(false);
+  });
+
+  it('loads immediately when switching to a named range', async () => {
+    const { fetchStats, calls } = recordingFetch();
+    const s = useStatsRange({ fetchStats });
+
+    s.setRange('30d');
+    await nextTick();
+
+    expect(s.activeRange.value).toBe('30d');
+    expect(calls).toEqual([{ range: '30d', from: 0, to: 0 }]);
+  });
+
+  it('does not load when switching to custom, which has no dates yet', async () => {
+    const { fetchStats, calls } = recordingFetch();
+    const s = useStatsRange({ fetchStats });
+
+    s.setRange('custom');
+    await nextTick();
+
+    expect(s.activeRange.value).toBe('custom');
+    expect(calls).toEqual([]);
+  });
+
+  it('applies a custom range only once both ends are set', async () => {
+    const { fetchStats, calls } = recordingFetch();
+    const s = useStatsRange({ fetchStats });
+    s.setRange('custom');
+
+    s.customFrom.value = '2026-09-01';
+    s.apply();
+    await nextTick();
+    expect(calls).toEqual([]);
+
+    s.customTo.value = '2026-09-07';
+    s.apply();
+    await nextTick();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].range).toBe('custom');
+    expect(calls[0].from).toBe(Math.floor(new Date('2026-09-01').getTime() / 1000));
+    expect(calls[0].to).toBe(Math.floor(new Date('2026-09-07').getTime() / 1000));
+  });
+
+  it('ignores apply outside a custom range', async () => {
+    const { fetchStats, calls } = recordingFetch();
+    const s = useStatsRange({ fetchStats });
+    s.customFrom.value = '2026-09-01';
+    s.customTo.value = '2026-09-07';
+
+    s.apply();
+    await nextTick();
+
+    expect(calls).toEqual([]);
+  });
+
+  it('drops stale numbers when a load fails, rather than leaving them on screen', async () => {
+    const boom = new Error('nope');
+    const onError = vi.fn();
+    let shouldFail = false;
+    const s = useStatsRange({
+      fetchStats: () => (shouldFail ? Promise.reject(boom) : Promise.resolve({ summary: { tasksCompleted: 1 } })),
+      onError,
+    });
+
+    await s.load();
+    expect(s.stats.value).toEqual({ summary: { tasksCompleted: 1 } });
+
+    shouldFail = true;
+    await s.load();
+
+    expect(s.stats.value).toBe(null);
+    expect(s.loading.value).toBe(false);
+    expect(onError).toHaveBeenCalledWith(boom);
+  });
+
+  it('reports a failure through console.error when given no handler', async () => {
+    const boom = new Error('nope');
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const s = useStatsRange({ fetchStats: () => Promise.reject(boom) });
+
+    await s.load();
+
+    expect(spy).toHaveBeenCalledWith('Failed to load stats:', boom);
+    expect(s.stats.value).toBe(null);
+    spy.mockRestore();
+  });
+
+  it('exposes the derived chart inputs for the active range', async () => {
+    const { fetchStats } = recordingFetch({ heatmap: { granularity: 'hour' } });
+    const s = useStatsRange({ fetchStats });
+
+    expect(s.chartFixedLength.value).toBe(7);
+    expect(s.rangeOptions).toBe(STATS_RANGE_OPTIONS);
+
+    s.activeRange.value = '30d';
+    expect(s.chartFixedLength.value).toBe(30);
+
+    s.activeRange.value = 'custom';
+    s.customTo.value = '2026-09-07';
+    expect(s.chartEndDate.value).toBe('2026-09-07');
+  });
+
+  it('takes the heatmap granularity from the response, defaulting to day', async () => {
+    const { fetchStats } = recordingFetch({ heatmap: { granularity: 'hour' } });
+    const s = useStatsRange({ fetchStats });
+
+    expect(s.heatmapGranularity.value).toBe('day');
+
+    await s.load();
+    expect(s.heatmapGranularity.value).toBe('hour');
+
+    s.stats.value = { heatmap: {} };
+    expect(s.heatmapGranularity.value).toBe('day');
+    s.stats.value = {};
+    expect(s.heatmapGranularity.value).toBe('day');
+  });
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -63,6 +63,7 @@ export default defineConfig({
         'src/composables/useUiTelemetry.js',
         'src/composables/useWebMCP.js',
         'src/composables/useWorkspaceSettings.js',
+        'src/composables/useStatsRange.js',
         'src/utils/markdown.js',
         'src/webmcp/*.js',
       ],


### PR DESCRIPTION
## What changed

The overview page now has a Performance tab showing overall activity across every workspace you own — the same cards, heatmaps and trend charts as a single workspace's analytics, with the same range selector defaulting to the last 7 days, plus a breakdown of which workspaces drove the totals.

## Why changed

Per-workspace stats answer "how is this one doing"; there was no way to see how the whole account is doing without opening each workspace in turn.

## Test coverage report

- New lines introduced: **100%**. The three new backend functions (`statsWindow` and both `GetDetailedUserStats`) are each at 100%, and the new frontend composable sits behind the suite's existing 100% gate.
- Total coverage impact: **no regression.** Frontend stays at 100% on statements, branches, functions and lines (914 tests, up 31). Backend: 555 tests passing, 0 failures, 7 new test functions.

## Other reports

**The numbers reconcile.** The account view scopes on `telemetries.user_id` — indexed, and set by every writer. Verified against the dev data that this gives exactly the same figure as counting over the user's workspace list (316 completions either way), and confirmed in the running UI: the account shows 51 messages where checkout-service alone shows 45, the difference being blog's 6. The only rows the user scope adds are user-creation events, which no summary card counts.

**Two screens, one implementation.** The panels moved into a shared presentational component and the range behaviour into a shared composable, so both dashboards are thin wrappers differing only in their endpoint. This is the part that keeps them looking identical as they change, rather than a copy that drifts. The five aggregations likewise take their scope as a parameterised predicate rather than being duplicated — a clause, not a column name, so widening the scope can't become a way to inject SQL.

**Screenshots and verification:** https://claude.ai/code/artifact/98cc137b-7b78-40b9-b8c9-444867f3ce81

**Judgement calls, flagged for review:**
- Workspaces with no completions and no messages are dropped from the breakdown. Without the filter it listed eight workspaces, six all-zero — they had rows in range from renames and permission prompts, not work. Nothing numeric is lost.
- A workspace deleted since its telemetry was recorded is kept as an unnamed, non-clickable row. Dropping it would make the breakdown quietly stop adding up to the summary above it.
- The tab is local state, not a route: a URL would mean a second entry in the one route table the desktop build also mounts.

**One pre-existing bug fixed in passing:** the workspace analytics component never reloaded when moving between two workspaces' analytics screens — the route parameter changes without remounting, so the previous workspace's numbers stayed on screen under the new name.

TaskID: 0iNLkKDeQpl
