### PR TITLE
feat(shortcuts): W opens a searchable workspace switcher

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -376,8 +376,9 @@
 
     <!-- Keyboard-driven overlays. Both are shell-level: the finder crosses
          workspaces, and the help sheet describes shortcuts a view may own. -->
-    <CommandPalette :show="isPaletteOpen" :shortcut-label="findTaskLabel" @close="isPaletteOpen = false" />
-    <ShortcutsHelp :show="isHelpOpen" :mac="isMacKeyboard" @close="isHelpOpen = false" />
+    <CommandPalette :show="overlay === 'palette'" :shortcut-label="findTaskLabel" @close="closeOverlay()" />
+    <WorkspaceSwitcher :show="overlay === 'switcher'" :current-workspace-id="currentWorkspaceId ?? ''" @close="closeOverlay()" />
+    <ShortcutsHelp :show="overlay === 'help'" :mac="isMacKeyboard" @close="closeOverlay()" />
   </div>
 </template>
 
@@ -413,6 +414,7 @@ import { forgetCachedTask, forgetEverything } from './composables/useCacheStorag
 import { SWEEP_INTERVAL_MS, sweepIfDue, whenIdle } from './composables/useCacheRetention'
 import CommandPalette from './components/CommandPalette.vue'
 import ShortcutsHelp from './components/ShortcutsHelp.vue'
+import WorkspaceSwitcher from './components/WorkspaceSwitcher.vue'
 import {
   SHORTCUTS,
   formatShortcut,
@@ -573,8 +575,16 @@ function startRetentionSweep(db) {
 // The shell owns the ones that work anywhere. A view registers its own on top
 // of these; see TaskDetailView for the chat/trajectory pair.
 
-const isPaletteOpen = ref(false)
-const isHelpOpen = ref(false)
+/**
+ * Which full-screen overlay is up, if any: 'palette', 'switcher' or 'help'.
+ *
+ * One value rather than a flag each, because they are mutually exclusive and
+ * every opener would otherwise have to remember to close the other two — a
+ * rule that held for two overlays and would not survive a fourth.
+ */
+const overlay = ref(null)
+const openOverlay = (name) => { overlay.value = name }
+const closeOverlay = () => { overlay.value = null }
 
 /** Command on a Mac keyboard, Control everywhere else. */
 const isMacKeyboard = computed(() => usesCommandKey(platformStore.$state))
@@ -584,15 +594,10 @@ const findTaskLabel = computed(() =>
 
 useShortcuts(
   {
-    'find-task': () => {
-      isHelpOpen.value = false
-      isPaletteOpen.value = true
-    },
+    'find-task': () => openOverlay('palette'),
     'new-task': () => router.push(newTaskRoute(currentWorkspaceId.value, workspaces.value)),
-    'show-help': () => {
-      isPaletteOpen.value = false
-      isHelpOpen.value = true
-    },
+    'switch-workspace': () => openOverlay('switcher'),
+    'show-help': () => openOverlay('help'),
   },
   { mac: () => isMacKeyboard.value, onUse: recordShortcutUse }
 )
@@ -612,10 +617,7 @@ function recordShortcutUse() {
 // Escape closes an overlay wherever focus happens to be. The palette handles it
 // on its own input too — this is for the help sheet, which has nothing focused.
 
-const openCommandPaletteHandler = () => {
-  isHelpOpen.value = false
-  isPaletteOpen.value = true
-}
+const openCommandPaletteHandler = () => openOverlay('palette')
 
 onMounted(() => {
   window.addEventListener('open-command-palette', openCommandPaletteHandler)
@@ -627,8 +629,7 @@ onUnmounted(() => {
 
 const closeOverlaysOnEscape = (e) => {
   if (e.key !== 'Escape') return
-  isPaletteOpen.value = false
-  isHelpOpen.value = false
+  closeOverlay()
 }
 
 // Setup Global Event Bus (Global stream receives events for all workspaces)

--- a/frontend/src/components/WorkspaceSwitcher.vue
+++ b/frontend/src/components/WorkspaceSwitcher.vue
@@ -1,0 +1,157 @@
+<script setup>
+/**
+ * The workspace switcher, opened with `W`.
+ *
+ * Deliberately the same box as the task finder — same overlay, same row
+ * geometry, same ↑↓/↵/Esc keys — because it answers the same shape of question
+ * and a second idiom for "search a list and jump to one" would be a second
+ * thing to learn. The matching lives in `useWorkspaceSwitcher`.
+ *
+ * What it does *not* share is the loading: the workspace list is already in the
+ * store (the sidebar renders from it), so this box has nothing to fetch and no
+ * loading state to show.
+ */
+import { computed, nextTick, ref, watch } from 'vue';
+import { useRouter } from 'vue-router';
+
+import {
+  isCurrentWorkspace,
+  matchWorkspaces,
+  workspaceRoute,
+} from '../composables/useWorkspaceSwitcher';
+import { useWorkspaceStore } from '../stores/workspaceStore';
+
+const props = defineProps({
+  show: Boolean,
+  /** The workspace on screen, so its row can be marked rather than hidden. */
+  currentWorkspaceId: { type: String, default: '' },
+});
+const emit = defineEmits(['close']);
+
+const router = useRouter();
+const workspaceStore = useWorkspaceStore();
+
+const query = ref('');
+const highlighted = ref(0);
+const inputRef = ref(null);
+
+const workspaces = computed(() => workspaceStore.workspaces);
+
+/**
+ * Ten rather than the finder's eight: these rows are one line instead of two,
+ * so ten still fits the panel without scrolling, and a switcher that shows the
+ * whole list for most accounts never needs a query at all.
+ */
+const results = computed(() => matchWorkspaces(workspaces.value, query.value, 10));
+
+const hasWorkspaces = computed(() => workspaces.value.length > 0);
+
+watch(
+  () => props.show,
+  async (open) => {
+    if (!open) return;
+    query.value = '';
+    highlighted.value = 0;
+    await nextTick();
+    inputRef.value?.focus();
+  }
+);
+
+// A shorter list can leave the highlight past the end, which would make Enter
+// do nothing on a visible list.
+watch(results, (rows) => {
+  if (highlighted.value >= rows.length) highlighted.value = 0;
+});
+
+function move(delta) {
+  const count = results.value.length;
+  if (count === 0) return;
+  highlighted.value = (highlighted.value + delta + count) % count;
+}
+
+function open(workspace) {
+  emit('close');
+  router.push(workspaceRoute(workspace));
+}
+
+function submit() {
+  const hit = results.value[highlighted.value];
+  if (hit) open(hit);
+}
+
+const isCurrent = (workspace) => isCurrentWorkspace(workspace, props.currentWorkspaceId);
+</script>
+
+<template>
+  <Transition name="fade">
+    <div v-if="show" class="fixed inset-0 z-[150]" role="dialog" aria-modal="true" aria-label="Switch workspace">
+      <div class="fixed inset-0 bg-gray-900/60 backdrop-blur-sm" @click="emit('close')"></div>
+
+      <div class="relative mx-auto mt-[12vh] w-[92%] max-w-xl">
+        <div class="bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-xl shadow-2xl overflow-hidden">
+          <!-- Query -->
+          <div class="flex items-center gap-3 px-4 py-3 border-b border-gray-100 dark:border-zinc-800">
+            <svg class="w-4 h-4 shrink-0 text-gray-400 dark:text-zinc-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+            </svg>
+            <input ref="inputRef" v-model="query" type="text" autocomplete="off" spellcheck="false"
+                   placeholder="Search workspaces by name"
+                   class="grow bg-transparent text-[14px] text-gray-900 dark:text-zinc-100 placeholder:text-gray-400 dark:placeholder:text-zinc-600 focus:outline-none"
+                   @keydown.down.prevent="move(1)"
+                   @keydown.up.prevent="move(-1)"
+                   @keydown.enter.prevent="submit"
+                   @keydown.esc.prevent="emit('close')" />
+            <kbd class="shrink-0 text-[9px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-500 border border-gray-200 dark:border-zinc-700 rounded px-1.5 py-0.5">Esc</kbd>
+          </div>
+
+          <!-- Results -->
+          <ul v-if="results.length" class="max-h-80 overflow-y-auto py-1">
+            <li v-for="(ws, i) in results" :key="ws.id">
+              <button type="button" @click="open(ws)" @mouseenter="highlighted = i"
+                      class="w-full text-left px-4 py-2.5 flex items-center gap-3 transition-colors"
+                      :class="i === highlighted ? 'bg-gray-50 dark:bg-zinc-800' : 'hover:bg-gray-50/60 dark:hover:bg-zinc-800/60'">
+                <!-- The same live dot as the sidebar. Which agents are up is
+                     most of why you switch workspace, so it belongs on the row
+                     you are choosing from. -->
+                <span class="shrink-0 w-1.5 h-1.5 rounded-full"
+                      :class="ws.agentConnected ? 'bg-green-500 dark:bg-green-400' : 'bg-gray-300 dark:bg-zinc-600'"
+                      :title="ws.agentConnected ? 'Agent online' : 'Agent offline'"></span>
+                <span class="grow min-w-0 truncate text-[13px] font-medium text-gray-900 dark:text-zinc-100">{{ ws.name }}</span>
+                <span v-if="ws.archivedAt" class="shrink-0 text-[9px] font-black uppercase tracking-widest text-amber-600/70 dark:text-amber-500/70">Archived</span>
+                <span v-else-if="isCurrent(ws)" class="shrink-0 text-[9px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-500">Current</span>
+              </button>
+            </li>
+          </ul>
+
+          <!-- Empty states -->
+          <div v-else class="px-4 py-6 text-center">
+            <p v-if="!hasWorkspaces" class="text-[12px] text-gray-500 dark:text-zinc-400">
+              No workspaces yet.
+              <span class="block mt-1 text-gray-400 dark:text-zinc-500">Create one from the overview to switch between them.</span>
+            </p>
+            <p v-else class="text-[12px] text-gray-500 dark:text-zinc-400">
+              No workspace matches &ldquo;{{ query }}&rdquo;.
+              <span class="block mt-1 text-gray-400 dark:text-zinc-500">Names are matched anywhere, so a fragment like &ldquo;api&rdquo; finds &ldquo;payments-api&rdquo;.</span>
+            </p>
+          </div>
+
+          <!-- Footer -->
+          <div class="flex items-center justify-between gap-4 px-4 py-2 border-t border-gray-100 dark:border-zinc-800 bg-gray-50/50 dark:bg-zinc-800/30">
+            <span class="flex items-center gap-4 shrink-0">
+              <span class="text-[9px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-500">↑↓ Navigate</span>
+              <span class="text-[9px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-500">↵ Switch</span>
+            </span>
+            <span v-if="hasWorkspaces" class="text-[9px] text-right text-gray-400 dark:text-zinc-500 truncate">
+              {{ workspaces.length }} workspace{{ workspaces.length === 1 ? '' : 's' }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.fade-enter-active, .fade-leave-active { transition: opacity 0.18s ease; }
+.fade-enter-from, .fade-leave-to { opacity: 0; }
+</style>

--- a/frontend/src/composables/useKeyboardShortcuts.js
+++ b/frontend/src/composables/useKeyboardShortcuts.js
@@ -67,6 +67,18 @@ export const SHORTCUTS = [
     scope: 'global',
   },
   {
+    // `W` for workspace, and bare is the only way it could be bound: Cmd/Ctrl+W
+    // closes the tab, which is about the least recoverable thing a shortcut on
+    // this letter could do. Nothing here interferes with it — a bare letter is
+    // ignored the moment any modifier is held — so Cmd+W still closes the tab,
+    // and the page never sees the keystroke it would have to swallow to stop it.
+    id: 'switch-workspace',
+    key: 'w',
+    label: 'Switch workspace',
+    hint: 'Search your workspaces by name and jump to one',
+    scope: 'global',
+  },
+  {
     id: 'show-help',
     key: '?',
     label: 'Show keyboard shortcuts',

--- a/frontend/src/composables/useWorkspaceSwitcher.js
+++ b/frontend/src/composables/useWorkspaceSwitcher.js
@@ -1,0 +1,106 @@
+/**
+ * Switching workspaces from the keyboard.
+ *
+ * Unlike the task finder, this needs no backend at all: the workspace list is
+ * already in the store, because the shell's sidebar and every agent-connection
+ * indicator read from it. So the switcher is pure filtering over data the app
+ * has in hand, and works offline for the same reason the sidebar does.
+ *
+ * The matching lives here rather than in the component so it can be tested as
+ * a function — the same split `useTaskFinder` uses for the Cmd+K palette.
+ */
+
+/**
+ * Workspace IDs are monoflake base62: exactly 11 characters, zero-padded to a
+ * fixed width by `monoflake.ID.String()`, so the length is a property of the
+ * encoding rather than of how many workspaces exist.
+ *
+ * Matching on ID matters less here than in the task finder — nobody remembers a
+ * workspace by ID — but an ID pasted from a URL or an MCP config should still
+ * land, and it costs one comparison.
+ */
+const ID_LENGTH = 11;
+
+/**
+ * Workspaces matching `query`, best match first.
+ *
+ * The ranking is what makes typing two letters land on the right workspace:
+ *
+ * 1. the name exactly, so a workspace whose name is a prefix of another's
+ *    ("blog" alongside "blog-drafts") is still reachable by typing it in full;
+ * 2. a name prefix, which is what a few typed letters usually means;
+ * 3. a name substring, for the middle of a hyphenated name — `api` should find
+ *    `payments-api`, which is most of how these get named;
+ * 4. the ID, for a link or a config pasted in.
+ *
+ * **Archived workspaces are ranked after active ones of the same quality, not
+ * excluded.** The sidebar lists them, so hiding them here would make the
+ * switcher disagree with the navigation beside it; but they are not what
+ * someone switching workspaces to get work done is reaching for, so on an
+ * empty query — where every row ties — they sink to the bottom. An exact name
+ * match still wins outright, archived or not: if you typed the whole name, you
+ * meant that one.
+ *
+ * Ties keep the incoming order, which is the store's: name-sorted.
+ *
+ * @param {Array<{ id: string, name?: string, archivedAt?: string | null }>} workspaces
+ * @param {string} query
+ * @param {number} [limit]
+ */
+export function matchWorkspaces(workspaces, query, limit = 8) {
+  const list = Array.isArray(workspaces) ? workspaces : [];
+  const q = (query ?? '').trim().toLowerCase();
+
+  const rank = (ws) => {
+    const name = String(ws?.name ?? '').toLowerCase();
+    if (!q) return 0;
+    if (name === q) return 0;
+    if (name.startsWith(q)) return 1;
+    if (name.includes(q)) return 2;
+
+    const id = String(ws?.id ?? '').toLowerCase();
+    // A partial ID is not worth matching: it is never typed from memory, so a
+    // prefix would only ever be a paste that got truncated.
+    if (q.length === ID_LENGTH && id === q) return 3;
+    return -1;
+  };
+
+  return list
+    .map((ws, order) => ({ ws, order, rank: rank(ws), archived: ws?.archivedAt ? 1 : 0 }))
+    .filter((row) => row.rank !== -1)
+    .sort((a, b) => a.rank - b.rank || a.archived - b.archived || a.order - b.order)
+    .slice(0, limit)
+    .map((row) => row.ws);
+}
+
+/**
+ * Where the switcher sends you.
+ *
+ * The workspace's own page, which is what its sidebar entry and its card on the
+ * overview both open — switching workspaces should land where clicking the
+ * workspace lands, not on some switcher-only destination.
+ *
+ * @param {{ id?: string } | string | null | undefined} workspace
+ * @returns {string} a route, or the overview when there is nothing to open
+ */
+export function workspaceRoute(workspace) {
+  const id = typeof workspace === 'string' ? workspace : workspace?.id;
+  return id ? `/workspaces/${id}` : '/';
+}
+
+/**
+ * Whether `workspace` is the one already on screen.
+ *
+ * Compared as strings because the two sides arrive differently: a route
+ * parameter is always a string, while the store's copy is whatever the backend
+ * serialised. The switcher marks this row rather than hiding it — a switcher
+ * that silently omits where you are makes you wonder whether it is listing
+ * everything.
+ *
+ * @param {{ id?: string } | null | undefined} workspace
+ * @param {string | number | null | undefined} currentId
+ */
+export function isCurrentWorkspace(workspace, currentId) {
+  if (workspace?.id == null || currentId == null || currentId === '') return false;
+  return String(workspace.id) === String(currentId);
+}

--- a/frontend/test/keyboardShortcuts.test.js
+++ b/frontend/test/keyboardShortcuts.test.js
@@ -50,6 +50,24 @@ describe('SHORTCUTS', () => {
     expect(claimed).toEqual(['k'])
   })
 
+  it('binds no two shortcuts to the same key', () => {
+    // A duplicate would not error — `matchShortcut` takes the first match — so
+    // the second binding would simply never fire.
+    const keys = SHORTCUTS.map((s) => `${s.mod ? 'mod+' : ''}${s.key}`);
+
+    expect(keys).toEqual([...new Set(keys)]);
+  });
+
+  it('leaves Cmd/Ctrl+W to the browser, which closes the tab with it', () => {
+    // `w` is bound bare, and a bare letter never fires with a modifier held.
+    // Answering to Cmd+W here would mean swallowing a keystroke people expect
+    // to close the tab.
+    const w = SHORTCUTS.find((s) => s.key === 'w');
+
+    expect(w).toBeTruthy();
+    expect(w.mod).toBeFalsy();
+  });
+
   it('gives every shortcut an id, a key and a scope the help sheet groups by', () => {
     for (const s of SHORTCUTS) {
       expect(s.id).toBeTruthy()

--- a/frontend/test/workspaceSwitcher.test.js
+++ b/frontend/test/workspaceSwitcher.test.js
@@ -1,0 +1,223 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  isCurrentWorkspace,
+  matchWorkspaces,
+  workspaceRoute,
+} from '../src/composables/useWorkspaceSwitcher';
+
+/** A workspace as the store holds one, with only the fields matching reads. */
+const ws = (name, extra = {}) => ({
+  id: String(name).padEnd(11, '0').slice(0, 11),
+  name,
+  ...extra,
+});
+
+// Name-sorted, which is the order the store keeps them in.
+const WORKSPACES = [
+  ws('blog'),
+  ws('blog-drafts'),
+  ws('changelog'),
+  ws('checkout-service'),
+  ws('payments-api'),
+];
+
+describe('matchWorkspaces', () => {
+  it('lists everything on an empty query, in the order given', () => {
+    expect(matchWorkspaces(WORKSPACES, '').map((w) => w.name)).toEqual([
+      'blog',
+      'blog-drafts',
+      'changelog',
+      'checkout-service',
+      'payments-api',
+    ]);
+  });
+
+  it('treats whitespace as an empty query rather than as a search', () => {
+    expect(matchWorkspaces(WORKSPACES, '   ')).toHaveLength(WORKSPACES.length);
+  });
+
+  it('ranks an exact name above a longer name that starts with it', () => {
+    // The case that makes exact matching worth having: without it, "blog" is
+    // unreachable by typing "blog" whenever "blog-drafts" sorts first.
+    const [first] = matchWorkspaces(WORKSPACES, 'blog');
+
+    expect(first.name).toBe('blog');
+  });
+
+  it('matches a name prefix', () => {
+    expect(matchWorkspaces(WORKSPACES, 'check').map((w) => w.name)).toEqual(['checkout-service']);
+  });
+
+  it('matches the middle of a hyphenated name', () => {
+    // Most of how these get named, so a substring match is the difference
+    // between two keystrokes and giving up.
+    expect(matchWorkspaces(WORKSPACES, 'api').map((w) => w.name)).toEqual(['payments-api']);
+  });
+
+  it('ignores case and surrounding space', () => {
+    expect(matchWorkspaces(WORKSPACES, '  CHECKOUT ').map((w) => w.name)).toEqual([
+      'checkout-service',
+    ]);
+  });
+
+  it('puts prefix matches ahead of substring matches', () => {
+    const list = [ws('my-blog'), ws('blog-drafts')];
+
+    expect(matchWorkspaces(list, 'blog').map((w) => w.name)).toEqual(['blog-drafts', 'my-blog']);
+  });
+
+  it('finds a workspace by a full pasted ID', () => {
+    const target = WORKSPACES[3];
+
+    expect(matchWorkspaces(WORKSPACES, target.id).map((w) => w.name)).toEqual([target.name]);
+  });
+
+  it('does not match a partial ID, which is never typed from memory', () => {
+    // The id is deliberately unlike the name here: the shared `ws()` helper
+    // derives one from the other, which would let a name prefix answer and
+    // hide whether the ID rule did anything.
+    const list = [{ id: '0eCTDeDXETx', name: 'checkout-service' }];
+
+    expect(matchWorkspaces(list, '0eCTDeD')).toEqual([]);
+    // The full ID still lands.
+    expect(matchWorkspaces(list, '0eCTDeDXETx')).toHaveLength(1);
+  });
+
+  it('matches an ID whatever case it is pasted in', () => {
+    const list = [{ id: '0eCTDeDXETx', name: 'checkout-service' }];
+
+    expect(matchWorkspaces(list, '0ectdedxetx')).toHaveLength(1);
+  });
+
+  it('does not match an 11-character query that is not the ID', () => {
+    const list = [{ id: '0eCTDeDXETx', name: 'checkout-service' }];
+
+    expect(matchWorkspaces(list, 'notanywsid1')).toEqual([]);
+  });
+
+  it('returns nothing when no name matches', () => {
+    expect(matchWorkspaces(WORKSPACES, 'nothing-like-this')).toEqual([]);
+  });
+
+  it('honours the limit', () => {
+    expect(matchWorkspaces(WORKSPACES, '', 2)).toHaveLength(2);
+  });
+
+  it('survives a missing or malformed list', () => {
+    expect(matchWorkspaces(undefined, 'blog')).toEqual([]);
+    expect(matchWorkspaces(null, '')).toEqual([]);
+    expect(matchWorkspaces('not a list', '')).toEqual([]);
+  });
+
+  it('survives rows with no name', () => {
+    const list = [{ id: 'aaaaaaaaaaa' }, ws('blog')];
+
+    expect(matchWorkspaces(list, 'blog').map((w) => w.name)).toEqual(['blog']);
+    expect(matchWorkspaces(list, '')).toHaveLength(2);
+  });
+
+  it('survives a row with no id when the query is ID-shaped', () => {
+    // Reaches the ID comparison with nothing to compare: the name checks have
+    // to fail first, which needs a query that is 11 characters *and* matches no
+    // name.
+    const list = [{ name: 'blog' }];
+
+    expect(matchWorkspaces(list, 'zzzzzzzzzzz')).toEqual([]);
+  });
+
+  it('treats a null query as empty', () => {
+    expect(matchWorkspaces(WORKSPACES, null)).toHaveLength(WORKSPACES.length);
+    expect(matchWorkspaces(WORKSPACES, undefined)).toHaveLength(WORKSPACES.length);
+  });
+
+  describe('archived workspaces', () => {
+    const withArchived = [
+      ws('active-one'),
+      ws('archived-one', { archivedAt: '2026-01-01T00:00:00Z' }),
+      ws('active-two'),
+    ];
+
+    it('sinks them to the bottom on an empty query', () => {
+      // The sidebar lists archived workspaces, so hiding them here would make
+      // the switcher disagree with the navigation beside it — but they are not
+      // what someone switching workspaces is reaching for.
+      expect(matchWorkspaces(withArchived, '').map((w) => w.name)).toEqual([
+        'active-one',
+        'active-two',
+        'archived-one',
+      ]);
+    });
+
+    it('still lists them, rather than hiding them', () => {
+      expect(matchWorkspaces(withArchived, 'archived').map((w) => w.name)).toEqual([
+        'archived-one',
+      ]);
+    });
+
+    it('ranks an active workspace first when both match equally well', () => {
+      const both = [
+        ws('shop-archive', { archivedAt: '2026-01-01T00:00:00Z' }),
+        ws('shop-active'),
+      ];
+
+      expect(matchWorkspaces(both, 'shop').map((w) => w.name)).toEqual([
+        'shop-active',
+        'shop-archive',
+      ]);
+    });
+
+    it('lets an exact name win outright, archived or not', () => {
+      // Typing a whole name is unambiguous: it should not be beaten by a
+      // fuzzier match that happens to be active.
+      const both = [ws('shop-active'), ws('shop', { archivedAt: '2026-01-01T00:00:00Z' })];
+
+      expect(matchWorkspaces(both, 'shop').map((w) => w.name)).toEqual(['shop', 'shop-active']);
+    });
+  });
+});
+
+describe('workspaceRoute', () => {
+  it('opens the workspace, where its sidebar entry and its card both go', () => {
+    expect(workspaceRoute({ id: 'ws1' })).toBe('/workspaces/ws1');
+  });
+
+  it('accepts a bare id', () => {
+    expect(workspaceRoute('ws1')).toBe('/workspaces/ws1');
+  });
+
+  it('falls back to the overview when there is nothing to open', () => {
+    expect(workspaceRoute(null)).toBe('/');
+    expect(workspaceRoute(undefined)).toBe('/');
+    expect(workspaceRoute({})).toBe('/');
+    expect(workspaceRoute('')).toBe('/');
+  });
+});
+
+describe('isCurrentWorkspace', () => {
+  it('recognises the workspace on screen', () => {
+    expect(isCurrentWorkspace({ id: 'ws1' }, 'ws1')).toBe(true);
+  });
+
+  it('compares as strings, since a route param is one and the store may not be', () => {
+    expect(isCurrentWorkspace({ id: 42 }, '42')).toBe(true);
+    expect(isCurrentWorkspace({ id: '42' }, 42)).toBe(true);
+  });
+
+  it('is false for a different workspace', () => {
+    expect(isCurrentWorkspace({ id: 'ws1' }, 'ws2')).toBe(false);
+  });
+
+  it('is false when there is no workspace in context', () => {
+    // The overview has no workspace, and marking every row "current" there
+    // would be worse than marking none.
+    expect(isCurrentWorkspace({ id: 'ws1' }, '')).toBe(false);
+    expect(isCurrentWorkspace({ id: 'ws1' }, null)).toBe(false);
+    expect(isCurrentWorkspace({ id: 'ws1' }, undefined)).toBe(false);
+  });
+
+  it('is false when the row has no id', () => {
+    expect(isCurrentWorkspace({}, 'ws1')).toBe(false);
+    expect(isCurrentWorkspace(null, 'ws1')).toBe(false);
+  });
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -64,6 +64,7 @@ export default defineConfig({
         'src/composables/useWebMCP.js',
         'src/composables/useWorkspaceSettings.js',
         'src/composables/useStatsRange.js',
+        'src/composables/useWorkspaceSwitcher.js',
         'src/utils/markdown.js',
         'src/webmcp/*.js',
       ],


### PR DESCRIPTION
## What changed

Pressing W anywhere in the app now opens a searchable list of your workspaces — type part of a name, press Enter, and you land in that workspace. It is the same palette as the existing task finder, so there is nothing new to learn.

## Why changed

Switching workspaces meant going back to the overview and clicking, or hunting the sidebar. With more than a handful of workspaces that is the most repeated navigation in the app.

## Test coverage report

- New lines introduced: **100%** — the new matching composable is covered on statements, branches, functions and lines.
- Total coverage impact: **no regression.** The suite stays at 100% on all four metrics; 945 tests passing, up 31.

## Other reports

**Bare W is the only safe binding.** Cmd/Ctrl+W closes the browser tab, which is about the least recoverable thing a shortcut on this letter could do. A bare letter never fires while a modifier is held, so Cmd+W still closes the tab and the page never has to swallow that keystroke to prevent it. A test pins W as modifier-free so nobody later "improves" it into a chord. The same rule means bare letters pause while a text box has focus, so typing "we" into a reply stays text.

**Nothing is fetched.** The workspace list is already in the store — the sidebar and every agent-connection dot read from it — so the switcher works offline for the same reason the sidebar does, and shows the same live agent dot per row.

**Name matching, in order:** exact name (so `blog` is reachable next to `blog-drafts`), then prefix, then substring (`api` finds `payments-api`), then a full pasted ID. Archived workspaces are ranked after active ones rather than hidden, since the sidebar lists them too; an exact name still wins outright.

**Screenshots and browser verification:** https://claude.ai/code/artifact/9c3f354a-3e13-453a-9769-8bc0a28eec09

Driven against a running instance and read back out of the DOM: W opens the palette, typing "api" narrows to payments-api, Enter navigates and closes, Esc closes, the current workspace is marked, W inside a focused input does nothing, and `?` lists the new row on its own.

**Two things beyond the feature:**
- The shell's two overlay booleans became one `overlay` ref. Three mutually exclusive overlays with each opener remembering to close the other two is where a bug lives; one value makes the invariant structural.
- A new guard fails the suite if any two shortcuts ever share a key — a duplicate would not error, the second binding would just silently never fire.

**No new telemetry needed:** shortcut use is counted at the single point every shortcut dispatches through, so this one was measured the moment it existed.

TaskID: 0iNT8llJ5az
