### PR TITLE
chore: bump patch version to v0.5.17

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.5.16"
+	_appVersion   = "v0.5.17"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.5.16" {
-			t.Errorf("Expected version v0.5.16, got %s", s.Version())
+		if s.Version() != "v0.5.17" {
+			t.Errorf("Expected version v0.5.17, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.5.16",
+  "version": "0.5.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.5.16",
+      "version": "0.5.17",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.5.16",
+  "version": "0.5.17",
   "description": "AgentRQ desktop app — AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.5.16",
+  "version": "0.5.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.5.16",
+      "version": "0.5.17",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.5.16",
+  "version": "0.5.17",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
## What changed

Bumped the patch version from 0.5.16 to 0.5.17 across the desktop app, the frontend and the backend, so all three report the same version and the release can be cut.

## Why changed

The W workspace-switcher shortcut has landed since 0.5.16 and needs a version to ship under. The release pipeline refuses to package a tree whose versions disagree, so all six declarations move together.

## Test coverage report

- New lines introduced: **none** — this only changes version strings, so there are no new lines to cover.
- Total coverage impact: **none.** Frontend stays at 100% on statements, branches, functions and lines (945 tests). Desktop 461 tests passing. `go test ./internal/service/config/...` passes with the updated assertion.

## Other reports

- Branch is rebased directly onto the merge of #484, so this version ships that feature rather than an empty range.
- Version sync verified both ways after the rebase: `node desktop/scripts/check-versions.mjs` reports all three at 0.5.17, and the tag form CI runs (`GITHUB_REF=refs/tags/v0.5.17`) additionally confirms the tag matches.
- Lockfile versions edited by hand rather than regenerated, so no dependency resolution shifted underneath the release. `npm ci --dry-run` resolves cleanly in both packages.
- Swept for stray `0.5.16` strings: the only remaining match is the `adm-zip: ^0.5.16` dependency range, which is not a declaration of this app's version and was correctly left alone.

## Included in this version

**feat**
- W opens a searchable workspace switcher (#484).

TaskID: 0iNT8llJ5az
