### PR TITLE
fix(mcp): stop counting automatic approvals as manual ones

### DIFF
--- a/backend/internal/controller/mcp/permission_telemetry_test.go
+++ b/backend/internal/controller/mcp/permission_telemetry_test.go
@@ -1,0 +1,285 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/agentrq/agentrq/backend/internal/data/model"
+	mock_pubsub "github.com/agentrq/agentrq/backend/internal/service/mocks/pubsub"
+	"github.com/agentrq/agentrq/backend/internal/service/pubsub"
+	"github.com/golang/mock/gomock"
+)
+
+// approvalTelemetry collects the method names of every MCP telemetry event the
+// server publishes, which is what the approval counters are computed from.
+type approvalTelemetry struct {
+	mu      sync.Mutex
+	methods []string
+}
+
+func (r *approvalTelemetry) record(req pubsub.PublishRequest) {
+	ev, ok := req.Event.(MCPEvent)
+	if !ok {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.methods = append(r.methods, ev.Method)
+}
+
+func (r *approvalTelemetry) count(method string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n := 0
+	for _, m := range r.methods {
+		if m == method {
+			n++
+		}
+	}
+	return n
+}
+
+func (r *approvalTelemetry) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.methods...)
+}
+
+// approvalServer builds a workspace server that answers permission requests and
+// reports what it published, with `autoAllowed` pre-approved.
+func approvalServer(t *testing.T, autoAllowed []string) (*WorkspaceServer, *approvalTelemetry) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	rec := &approvalTelemetry{}
+	pubsubMock := mock_pubsub.NewMockService(ctrl)
+	pubsubMock.EXPECT().Publish(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req pubsub.PublishRequest) (*pubsub.PublishResponse, error) {
+			rec.record(req)
+			return &pubsub.PublishResponse{}, nil
+		}).AnyTimes()
+
+	ps := &WorkspaceServer{
+		workspaceID:         100,
+		userID:              "12345",
+		pubsub:              pubsubMock,
+		autoAllowedTools:    autoAllowed,
+		permissionRequests:  make(map[string]string),
+		requestTools:        make(map[string]string),
+		requestParams:       make(map[string]*PermissionRequestParams),
+		sessionTasks:        map[string]int64{"sess-1": 42},
+		requestTaskIDs:      make(map[string]int64),
+		permissionResponses: make(map[string]int64),
+		toolCallIDs:         make(map[string]int64),
+		undeliveredVerdicts: make(map[string]string),
+		getTask: func(ctx context.Context, taskID int64) (model.Task, error) {
+			return model.Task{ID: taskID}, nil
+		},
+		listTasks: func(ctx context.Context, filter ListTasksFilter) ([]model.Task, error) {
+			return []model.Task{{ID: 42}}, nil
+		},
+		reply: func(ctx context.Context, chatID, text string, a []entity.Attachment, metadata any) (int64, error) {
+			return 700, nil
+		},
+	}
+	return ps, rec
+}
+
+func permissionNotification(requestID, toolName string) []byte {
+	body, _ := json.Marshal(map[string]any{
+		"method": "notifications/claude/channel/permission_request",
+		"params": map[string]any{
+			"request_id":    requestID,
+			"tool_name":     toolName,
+			"description":   "read a file",
+			"input_preview": `{"file_path":"/tmp/x"}`,
+		},
+	})
+	return body
+}
+
+// An auto-allowed tool call is one approval, and it is an automatic one.
+//
+// It used to be counted twice: the auto-allow path emits `permission_auto_allow`
+// itself and *also* calls SendPermissionVerdict to answer the agent, which
+// emitted `permission_manual_allow` unconditionally because it was written for
+// the human-driven path. So every auto-allowed call also incremented the manual
+// approval counter — the one number on the analytics screen that is supposed to
+// mean "a human stopped and decided this".
+func TestAutoAllowedRequestIsNotCountedAsAManualApproval(t *testing.T) {
+	ps, rec := approvalServer(t, []string{"Read"})
+
+	ps.HandleCustomNotification(context.Background(), "sess-1", permissionNotification("req-1", "Read"))
+
+	// The verdict is sent from a goroutine after a short settle delay; wait for
+	// it to have actually passed the point where it used to over-report.
+	waitForVerdictDelivered(t, ps, "req-1")
+
+	if got := rec.count("permission_auto_allow"); got != 1 {
+		t.Errorf("expected 1 auto approval, got %d (all: %v)", got, rec.snapshot())
+	}
+	if got := rec.count("permission_manual_allow"); got != 0 {
+		t.Errorf("an auto-allowed call must not count as a manual approval, got %d (all: %v)",
+			got, rec.snapshot())
+	}
+}
+
+// The same, through the middleware rather than the out-of-band notification:
+// both paths auto-allow, and both answered by way of SendPermissionVerdict.
+func TestAutoAllowedViaTaskAllowAllIsNotCountedAsManual(t *testing.T) {
+	ps, rec := approvalServer(t, nil)
+	// Nothing is pre-approved by rule; the task itself allows everything.
+	ps.getTask = func(ctx context.Context, taskID int64) (model.Task, error) {
+		return model.Task{ID: taskID, AllowAllCommands: true}, nil
+	}
+
+	ps.HandleCustomNotification(context.Background(), "sess-1", permissionNotification("req-2", "Read"))
+
+	waitForVerdictDelivered(t, ps, "req-2")
+
+	if got := rec.count("permission_auto_allow"); got != 1 {
+		t.Errorf("expected 1 auto approval, got %d (all: %v)", got, rec.snapshot())
+	}
+	if got := rec.count("permission_manual_allow"); got != 0 {
+		t.Errorf("a task-level auto-allow must not count as a manual approval, got %d (all: %v)",
+			got, rec.snapshot())
+	}
+}
+
+// The counter still has to work: a verdict a human actually gave is manual.
+func TestHumanVerdictIsCountedAsAManualApproval(t *testing.T) {
+	ps, rec := approvalServer(t, nil)
+	ps.permissionRequests["req-3"] = "sess-1"
+
+	_ = ps.SendPermissionVerdict(context.Background(), 42, "req-3", "allow")
+
+	if got := rec.count("permission_manual_allow"); got != 1 {
+		t.Errorf("expected 1 manual approval, got %d (all: %v)", got, rec.snapshot())
+	}
+	if got := rec.count("permission_auto_allow"); got != 0 {
+		t.Errorf("a human verdict is not an automatic one, got %d auto (all: %v)",
+			got, rec.snapshot())
+	}
+}
+
+// A human denial is a denial, and still not an approval of either kind.
+func TestHumanDenialIsCountedAsAManualDenial(t *testing.T) {
+	ps, rec := approvalServer(t, nil)
+	ps.permissionRequests["req-4"] = "sess-1"
+
+	_ = ps.SendPermissionVerdict(context.Background(), 42, "req-4", "deny")
+
+	if got := rec.count("permission_manual_deny"); got != 1 {
+		t.Errorf("expected 1 manual denial, got %d (all: %v)", got, rec.snapshot())
+	}
+	if got := rec.count("permission_manual_allow"); got != 0 {
+		t.Errorf("a denial must not count as an approval, got %d (all: %v)", got, rec.snapshot())
+	}
+}
+
+// "Allow always" is a human decision made once, so it counts as one manual
+// approval — the automatic ones it licenses are counted as they happen.
+func TestAllowAlwaysIsCountedAsAManualApproval(t *testing.T) {
+	ps, rec := approvalServer(t, nil)
+	ps.permissionRequests["req-5"] = "sess-1"
+	ps.requestTools["req-5"] = "Read"
+	ps.requestParams["req-5"] = &PermissionRequestParams{RequestID: "req-5", ToolName: "Read"}
+
+	_ = ps.SendPermissionVerdict(context.Background(), 42, "req-5", "allow_always")
+
+	if got := rec.count("permission_manual_allow"); got != 1 {
+		t.Errorf("expected 1 manual approval, got %d (all: %v)", got, rec.snapshot())
+	}
+	if got := rec.count("permission_auto_allow"); got != 0 {
+		t.Errorf("the decision itself is manual, got %d auto (all: %v)", got, rec.snapshot())
+	}
+}
+
+// Re-delivering a verdict the agent missed is not a second decision.
+//
+// When an agent reconnects it re-sends the request it was waiting on, and the
+// server answers with the verdict it already has rather than asking the human
+// again. That replay went through the same delivery path, so it reported a
+// second manual approval for one decision — an agent that reconnected twice
+// turned one click into three.
+func TestReplayedVerdictIsNotCountedAgain(t *testing.T) {
+	ps, rec := approvalServer(t, nil)
+	ps.permissionRequests["req-6"] = "sess-1"
+	ps.requestTaskIDs["req-6"] = 42
+	// rebind only treats a request as a re-send if the human was asked about it,
+	// which is recorded by the message posted to the task.
+	ps.permissionResponses["req-6"] = 900
+
+	// The human decides, and the agent is gone, so the verdict is kept.
+	ps.rememberUndeliveredVerdict("req-6", "allow")
+	_ = ps.SendPermissionVerdict(context.Background(), 42, "req-6", "allow")
+
+	if got := rec.count("permission_manual_allow"); got != 1 {
+		t.Fatalf("the decision itself should count once, got %d (all: %v)", got, rec.snapshot())
+	}
+
+	// The agent comes back on a new session and asks again.
+	if !ps.rebindPermissionRequest(context.Background(), "sess-2",
+		PermissionRequestParams{RequestID: "req-6", ToolName: "Read"}) {
+		t.Fatal("a re-sent request should be recognised as a re-send")
+	}
+
+	if got := rec.count("permission_manual_allow"); got != 1 {
+		t.Errorf("re-delivering one decision must not count it twice, got %d (all: %v)",
+			got, rec.snapshot())
+	}
+	if got := rec.count("permission_auto_allow"); got != 0 {
+		t.Errorf("a replay is not an automatic approval either, got %d (all: %v)",
+			got, rec.snapshot())
+	}
+}
+
+// Stopping a task refuses what it was waiting on, on the human's behalf — so
+// that is a manual denial, not an automatic one.
+func TestStopRefusingOutstandingRequestsCountsAsManual(t *testing.T) {
+	ps, rec := approvalServer(t, nil)
+	ps.permissionRequests["req-7"] = "sess-1"
+	ps.requestTaskIDs["req-7"] = 42
+
+	// The return value counts refusals actually delivered to an agent, and this
+	// harness has no live session; the verdict is still recorded, which is what
+	// this test is about.
+	ps.denyOutstandingRequests(context.Background(), 42)
+
+	if got := rec.count("permission_manual_deny"); got != 1 {
+		t.Errorf("expected 1 manual denial, got %d (all: %v)", got, rec.snapshot())
+	}
+}
+
+// waitForVerdictDelivered blocks until the auto-allow goroutine has actually
+// run its verdict through sendVerdict.
+//
+// Waiting on the auto-allow telemetry would not do: that is published
+// synchronously, before the goroutine has even started its settle sleep, so the
+// wait would return immediately and only a fixed sleep would stand between the
+// assertions and the emit they are checking for — a test that passes on a
+// loaded machine whether or not the bug is present.
+//
+// This harness has no live agent session, so delivery always fails and the
+// goroutine always records the verdict as undelivered. That write happens after
+// the point where the manual event would have been emitted, which makes it an
+// exact signal that the goroutine is past it.
+func waitForVerdictDelivered(t *testing.T, ps *WorkspaceServer, requestID string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		ps.undeliveredVerdictsMu.RLock()
+		_, arrived := ps.undeliveredVerdicts[requestID]
+		ps.undeliveredVerdictsMu.RUnlock()
+		if arrived {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("the verdict for %s never reached delivery", requestID)
+}

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -1684,7 +1684,7 @@ func (ps *WorkspaceServer) notificationMiddleware(next mcp.MethodHandler) mcp.Me
 				zlog.Info().Str("request_id", p.RequestID).Str("tool", p.ToolName).Msg("auto-allowing permission request")
 				go func() {
 					time.Sleep(100 * time.Millisecond) // Give session time to stabilize if needed
-					_ = ps.SendPermissionVerdict(context.Background(), 0, p.RequestID, "allow")
+					_ = ps.sendVerdict(context.Background(), 0, p.RequestID, "allow", verdictAutomatic)
 				}()
 				ps.emitTelemetry(context.Background(), ActionMCPNotification, "permission_auto_allow", clientIdentityFromRequest(req))
 				if ok {
@@ -1699,7 +1699,7 @@ func (ps *WorkspaceServer) notificationMiddleware(next mcp.MethodHandler) mcp.Me
 					zlog.Info().Str("request_id", p.RequestID).Int64("task_id", taskID).Msg("auto-allowing permission request (task level)")
 					go func() {
 						time.Sleep(100 * time.Millisecond) // Give session time to stabilize if needed
-						_ = ps.SendPermissionVerdict(context.Background(), taskID, p.RequestID, "allow")
+						_ = ps.sendVerdict(context.Background(), taskID, p.RequestID, "allow", verdictAutomatic)
 					}()
 					ps.emitTelemetry(context.Background(), ActionMCPNotification, "permission_auto_allow", clientIdentityFromRequest(req))
 					ps.persistToolCall(ctx, taskID, p, "auto_allowed")
@@ -1851,13 +1851,55 @@ func (ps *WorkspaceServer) cleanupRequest(requestID string) {
 	ps.toolCallIDsMu.Unlock()
 }
 
+// verdictOrigin says where a permission verdict came from, which is what
+// decides whether answering the agent counts as a human approval.
+//
+// It exists because one function delivers every verdict, but only some of them
+// represent a person stopping to decide something — and the approval counters
+// on the analytics screen are only meaningful if "manual" means exactly that.
+type verdictOrigin uint8
+
+const (
+	// A person allowed or denied this, just now: through the web UI, a Slack
+	// button, or by stopping a task and refusing what it was waiting on.
+	verdictFromHuman verdictOrigin = iota
+	// A rule or a task setting allowed it with nobody asked. The auto approval
+	// is reported by the caller at the point the decision is made rather than
+	// here: that call site always runs, whereas delivery can bail out early
+	// when the request has already been cleaned up, and an approval that
+	// happened must not go uncounted because the delivery missed.
+	//
+	// This suppresses the manual count only, and does not make the automatic
+	// count exactly-once. An auto-allowed request never posts a message to the
+	// task, so permissionResponses has no entry for it and
+	// rebindPermissionRequest does not recognise a re-send: an agent that
+	// reconnects and asks again re-runs the auto-allow branch, reporting a
+	// second automatic approval and writing a second tool_call row for the one
+	// call. That is a separate gap from the one this type fixes, and it is in
+	// the automatic counter rather than the manual one.
+	verdictAutomatic
+	// A verdict already given, being re-delivered because the agent reconnected
+	// and asked again. It was counted when the human decided; counting it again
+	// would report one decision as two.
+	verdictReplayed
+)
+
 // SendPermissionVerdict hands a human decision to the agent that asked for it.
 //
 // The request is only forgotten once the agent has actually been told. A
 // verdict that could not be delivered — because the agent's connection went
 // away between asking and being answered — is held for its next connection
 // rather than discarded, which used to lose the decision silently.
+//
+// Every caller outside this file is a human-driven one — the HTTP route, the
+// Slack button, a Stop that refuses outstanding approvals — so this reports a
+// manual decision. The paths that answer on nobody's behalf call sendVerdict
+// directly and say so.
 func (ps *WorkspaceServer) SendPermissionVerdict(ctx context.Context, taskID int64, requestID string, behavior string) error {
+	return ps.sendVerdict(ctx, taskID, requestID, behavior, verdictFromHuman)
+}
+
+func (ps *WorkspaceServer) sendVerdict(ctx context.Context, taskID int64, requestID string, behavior string, origin verdictOrigin) error {
 	ps.permissionRequestsMu.RLock()
 	sessID, ok := ps.permissionRequests[requestID]
 	ps.permissionRequestsMu.RUnlock()
@@ -1941,13 +1983,20 @@ func (ps *WorkspaceServer) SendPermissionVerdict(ctx context.Context, taskID int
 		}
 	}
 
-	// No inbound MCP request is available here (this is a human-triggered verdict, not
-	// itself a request handler), so client identity is unknown for these two events.
-	switch effectiveBehavior {
-	case "allow":
-		ps.emitTelemetry(ctx, ActionMCPNotification, "permission_manual_allow", clientIdentity{})
-	case "deny":
-		ps.emitTelemetry(ctx, ActionMCPNotification, "permission_manual_deny", clientIdentity{})
+	// Only a decision a person actually made is reported here, and only once.
+	// An automatic allow is counted by the caller at the point it decides, and a
+	// re-delivery was counted when the human first answered — reporting either
+	// of them again is what inflated the manual approval count.
+	//
+	// No inbound MCP request is available here (this is a verdict, not itself a
+	// request handler), so client identity is unknown for these two events.
+	if origin == verdictFromHuman {
+		switch effectiveBehavior {
+		case "allow":
+			ps.emitTelemetry(ctx, ActionMCPNotification, "permission_manual_allow", clientIdentity{})
+		case "deny":
+			ps.emitTelemetry(ctx, ActionMCPNotification, "permission_manual_deny", clientIdentity{})
+		}
 	}
 
 	if ps.updateToolCallStatus != nil {
@@ -2088,7 +2137,7 @@ func (ps *WorkspaceServer) rebindPermissionRequest(
 		ps.requestTaskIDsMu.RUnlock()
 		zlog.Info().Str("request_id", p.RequestID).Str("behavior", behavior).
 			Msg("delivering the verdict the agent missed while it was away")
-		_ = ps.SendPermissionVerdict(ctx, taskID, p.RequestID, behavior)
+		_ = ps.sendVerdict(ctx, taskID, p.RequestID, behavior, verdictReplayed)
 	}
 
 	return true
@@ -2163,7 +2212,7 @@ func (ps *WorkspaceServer) HandleCustomNotification(ctx context.Context, session
 			zlog.Info().Str("request_id", p.RequestID).Str("tool", p.ToolName).Msg("auto-allowing permission request (via custom notification)")
 			go func() {
 				time.Sleep(100 * time.Millisecond)
-				_ = ps.SendPermissionVerdict(context.Background(), 0, p.RequestID, "allow")
+				_ = ps.sendVerdict(context.Background(), 0, p.RequestID, "allow", verdictAutomatic)
 			}()
 			// No mcp.Request here (custom out-of-band notification), so client identity is unknown.
 			ps.emitTelemetry(context.Background(), ActionMCPNotification, "permission_auto_allow", clientIdentity{})
@@ -2181,7 +2230,7 @@ func (ps *WorkspaceServer) HandleCustomNotification(ctx context.Context, session
 				zlog.Info().Str("request_id", p.RequestID).Int64("task_id", taskID).Str("session_id", sessionID).Msg("auto-allowing permission request (task level, custom notification)")
 				go func() {
 					time.Sleep(100 * time.Millisecond)
-					_ = ps.SendPermissionVerdict(context.Background(), taskID, p.RequestID, "allow")
+					_ = ps.sendVerdict(context.Background(), taskID, p.RequestID, "allow", verdictAutomatic)
 				}()
 				ps.emitTelemetry(context.Background(), ActionMCPNotification, "permission_auto_allow", clientIdentity{})
 				ps.persistToolCall(ctx, taskID, p, "auto_allowed")


### PR DESCRIPTION
## What changed

The manual approval count on the analytics screens was counting approvals nobody gave — automatic ones, and repeats of a single decision. It now counts only a decision a person actually made, once.

## Why changed

That figure is what tells you whether an agent is stopping to ask too often. Inflated by automatic approvals, it told you the opposite of the truth.

## Test coverage report

- New lines introduced: **100%** — every branch of the new origin check is exercised (human allow, human deny, automatic, and replay all hit it).
- Total coverage impact: **none negative.** Full backend suite passes with 0 failures; the mcp package gains 7 test cases.

## Other reports

**Yes, there was a bug — two, in the same place.** One function delivers every permission verdict, and it reported `permission_manual_allow` unconditionally because it was written for the human-driven path. Two other kinds of verdict also go through it:

1. **An automatic allow** (a saved auto-allow rule, or a task's allow-all setting). That path already reports `permission_auto_allow` itself, so each auto-allowed tool call was counted **twice** — once correctly as automatic, once as though a human had decided it.
2. **A re-delivery.** When an agent reconnects it re-sends the request it was waiting on, and the server answers with the verdict it already holds rather than asking again. That replay reported another manual approval, so one click became two, or three if the agent reconnected twice.

**Reproduced before fixing.** A new test drives the auto-allow path and reads back what was published: on the previous code it is `[permission_auto_allow, permission_manual_allow]` — both, for one automatic approval. It passes now, and three control tests confirm genuine human allow, deny and allow-always still count as manual.

**How much real data is affected is not something I can state precisely, and I would rather say so than guess.** In the dev database the busiest workspace shows 316 automatic against 1 manual, so the phantom manual events were clearly *not* landing on every auto-allow — the extra emit often died on the "unknown request ID (expired)" early return before reaching telemetry, and one of the two auto-allow entry points registers the request unconditionally while the other only does so when a session id was resolved. So the effect was intermittent rather than a clean doubling, and past manual counts should be read as "at most this many, possibly fewer" rather than corrected by any fixed factor.

**Design note.** The exported `SendPermissionVerdict` still means "a human decided", so every caller outside the file — the HTTP route, the Slack button, a Stop refusing outstanding approvals — keeps counting as manual with no signature churn across packages, and the safe reading is the default. The automatic and replay paths call the unexported form and declare what they are. Human-decision telemetry is now emitted in exactly one place, so it cannot be double-reported again.

The automatic count deliberately stays at the point of decision rather than moving into delivery: that call site always runs, whereas delivery can bail out early, and an approval that really happened must not go uncounted because its delivery missed.

Both the per-workspace analytics and the public stats page read these same event names, so both are corrected by this.

## Code review

`/code-review` ran against this PR and confirmed the fix, having verified it by mutation: replacing the new guard with `if true` fails three of the tests with exactly the reported symptom. It raised two low-severity findings, both now addressed in this branch.

- **The two auto-allow tests could not reliably observe what they guard.** Their wait keyed on the automatic telemetry event, which is published *synchronously* before the verdict goroutine has even begun its settle sleep — so the wait returned on its first iteration and only a fixed 250 ms sleep stood between the assertions and the emit they exist to catch. On a loaded machine they would have passed with the bug re-introduced. They now poll for the goroutine's own write to `undeliveredVerdicts`, which in this harness always happens and always after the emit point. Defeating the guard now fails three tests in 0.1 s rather than on a timer.
- **The new comment claimed more than the change delivers.** It suppresses the *manual* count; it does not make the *automatic* count exactly-once. An auto-allowed request never posts a task message, so `permissionResponses` has no entry for it and a re-send is not recognised as one: the branch runs again, reporting a second automatic approval and writing a second `tool_call` row for one call. I verified this directly (auto count goes 1 → 2 on a re-send) and the comment now states it as the separate gap it is.

That second finding is a **real, pre-existing bug in the automatic counter** — the mirror image of the one fixed here. I have deliberately not fixed it in this PR: it is a different counter, out of the reported scope, and closing it means teaching `rebindPermissionRequest` to recognise auto-allowed requests, which changes delivery behaviour and the duplicate `tool_call` write as well. Happy to take it as a follow-up.

TaskID: 0iNobWESPcf
