### PR TITLE
fix(mcp): count a re-sent auto-allowed request once

### DIFF
--- a/backend/internal/controller/mcp/permission_telemetry_test.go
+++ b/backend/internal/controller/mcp/permission_telemetry_test.go
@@ -49,6 +49,43 @@ func (r *approvalTelemetry) snapshot() []string {
 	return append([]string(nil), r.methods...)
 }
 
+// recordedToolCalls collects the tool_calls rows a server would have written.
+type recordedToolCalls struct {
+	mu   sync.Mutex
+	rows []model.ToolCall
+}
+
+func (r *recordedToolCalls) add(tc model.ToolCall) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.rows = append(r.rows, tc)
+}
+
+func (r *recordedToolCalls) len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.rows)
+}
+
+// withToolCallRecording makes the server persist tool calls into `rows` instead
+// of a database, so a test can tell how many rows one call produced.
+func withToolCallRecording(ps *WorkspaceServer, rows *recordedToolCalls) {
+	var next int64
+	ps.idgen = stubIDGen{next: &next}
+	ps.recordToolCall = func(ctx context.Context, tc model.ToolCall) (model.ToolCall, error) {
+		rows.add(tc)
+		return tc, nil
+	}
+}
+
+// stubIDGen hands out increasing ids without a real generator.
+type stubIDGen struct{ next *int64 }
+
+func (s stubIDGen) NextID() int64 {
+	*s.next++
+	return *s.next
+}
+
 // approvalServer builds a workspace server that answers permission requests and
 // reports what it published, with `autoAllowed` pre-approved.
 func approvalServer(t *testing.T, autoAllowed []string) (*WorkspaceServer, *approvalTelemetry) {
@@ -253,6 +290,108 @@ func TestStopRefusingOutstandingRequestsCountsAsManual(t *testing.T) {
 
 	if got := rec.count("permission_manual_deny"); got != 1 {
 		t.Errorf("expected 1 manual denial, got %d (all: %v)", got, rec.snapshot())
+	}
+}
+
+// An auto-allowed tool call is one approval and one tool call, however many
+// times the agent has to ask for it.
+//
+// An agent that reconnects re-sends the request it was waiting on. For a
+// request a human was asked about, rebindPermissionRequest recognises that and
+// re-delivers the verdict already given. An auto-allowed request never posts a
+// message to the task, so it had no such record and was not recognised: the
+// auto-allow branch simply ran again, reporting a second automatic approval and
+// writing a second tool_calls row for the one call.
+func TestResentAutoAllowedRequestIsCountedOnce(t *testing.T) {
+	ps, rec := approvalServer(t, []string{"Read"})
+	rows := &recordedToolCalls{}
+	withToolCallRecording(ps, rows)
+
+	ps.HandleCustomNotification(context.Background(), "sess-1", permissionNotification("req-8", "Read"))
+	waitForVerdictDelivered(t, ps, "req-8")
+
+	if got := rec.count("permission_auto_allow"); got != 1 {
+		t.Fatalf("expected 1 automatic approval to begin with, got %d (all: %v)", got, rec.snapshot())
+	}
+	if got := rows.len(); got != 1 {
+		t.Fatalf("expected 1 tool call row to begin with, got %d", got)
+	}
+
+	// The agent reconnects and asks for the very same request again.
+	ps.HandleCustomNotification(context.Background(), "sess-2", permissionNotification("req-8", "Read"))
+	waitForVerdictDelivered(t, ps, "req-8")
+
+	if got := rec.count("permission_auto_allow"); got != 1 {
+		t.Errorf("a re-sent request is the same approval, got %d automatic (all: %v)",
+			got, rec.snapshot())
+	}
+	if got := rec.count("permission_manual_allow"); got != 0 {
+		t.Errorf("and it is certainly not a manual one, got %d (all: %v)", got, rec.snapshot())
+	}
+	if got := rows.len(); got != 1 {
+		t.Errorf("a re-sent request is the same tool call, got %d rows", got)
+	}
+}
+
+// Recognising a re-send is only half the job: the agent has to be answered.
+//
+// It re-sent the request because it never saw the verdict, so a fix that merely
+// stops re-deciding would leave it holding a question forever — trading a
+// double count for a stalled agent, which is the worse bug.
+func TestResentAutoAllowedRequestIsAnsweredAgain(t *testing.T) {
+	ps, rec := approvalServer(t, []string{"Read"})
+
+	ps.HandleCustomNotification(context.Background(), "sess-1", permissionNotification("req-9", "Read"))
+	waitForVerdictDelivered(t, ps, "req-9")
+
+	// Delivery failed (this harness has no live agent), so the verdict is being
+	// held. Clear that record so a second delivery attempt is observable rather
+	// than indistinguishable from the first.
+	ps.undeliveredVerdictsMu.Lock()
+	delete(ps.undeliveredVerdicts, "req-9")
+	ps.undeliveredVerdictsMu.Unlock()
+
+	// The agent comes back and asks again.
+	ps.HandleCustomNotification(context.Background(), "sess-2", permissionNotification("req-9", "Read"))
+
+	// It is answered: the verdict reaches delivery a second time.
+	waitForVerdictDelivered(t, ps, "req-9")
+
+	ps.undeliveredVerdictsMu.RLock()
+	behavior := ps.undeliveredVerdicts["req-9"]
+	ps.undeliveredVerdictsMu.RUnlock()
+	if behavior != "allow" {
+		t.Errorf("the re-sent request should have been allowed again, got %q", behavior)
+	}
+
+	// And answering it again is still not another approval.
+	if got := rec.count("permission_auto_allow"); got != 1 {
+		t.Errorf("expected 1 automatic approval, got %d (all: %v)", got, rec.snapshot())
+	}
+	if got := rec.count("permission_manual_allow"); got != 0 {
+		t.Errorf("expected no manual approval, got %d (all: %v)", got, rec.snapshot())
+	}
+}
+
+// A request the human was asked about keeps its old behaviour: the auto-decided
+// signal must widen what rebind recognises, not replace it.
+func TestManualRequestStillRebindsWithoutTheAutoSignal(t *testing.T) {
+	ps, rec := approvalServer(t, nil)
+	ps.permissionRequests["req-10"] = "sess-1"
+	ps.requestTaskIDs["req-10"] = 42
+	ps.permissionResponses["req-10"] = 900
+
+	if ps.wasAutoDecided("req-10") {
+		t.Fatal("a request nobody auto-allowed must not be marked auto-decided")
+	}
+
+	ps.rememberUndeliveredVerdict("req-10", "allow")
+	if !ps.rebindPermissionRequest(context.Background(), "sess-2",
+		PermissionRequestParams{RequestID: "req-10", ToolName: "Read"}) {
+		t.Fatal("a request the human answered should still be recognised as a re-send")
+	}
+	if got := rec.count("permission_manual_allow"); got != 0 {
+		t.Errorf("a replay reports nothing, got %d (all: %v)", got, rec.snapshot())
 	}
 }
 

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -127,6 +127,15 @@ type WorkspaceServer struct {
 	undeliveredVerdicts   map[string]string // requestID -> verdict the agent never received
 	toolCallIDsMu         sync.RWMutex
 	toolCallIDs           map[string]int64 // requestID -> ToolCall row ID (manual requests only, until resolved)
+	// Requests allowed without asking anyone, so a re-send is recognised as the
+	// same request rather than decided a second time.
+	//
+	// This cannot be folded into permissionResponses: that map means "the human
+	// was asked", holds the id of the message they were asked in, and is what
+	// sendVerdict rewrites to show the verdict. An auto-allowed request has no
+	// such message, so it needs a record of its own.
+	autoDecidedRequestsMu sync.RWMutex
+	autoDecidedRequests   map[string]struct{}
 	// The chat message standing for a plan or for a task's usage counters, so
 	// each revision rewrites that message instead of appending another one.
 	agentTelemetryMessagesMu sync.RWMutex
@@ -370,6 +379,7 @@ func NewWorkspaceServer(
 		permissionResponses:    make(map[string]int64),
 		undeliveredVerdicts:    make(map[string]string),
 		toolCallIDs:            make(map[string]int64),
+		autoDecidedRequests:    make(map[string]struct{}),
 		agentTelemetryMessages: make(map[string]int64),
 		agentModels:            make(map[string]AgentModelsSnapshot),
 		elicitations:           make(map[string]chan elicitationResponse),
@@ -1686,6 +1696,7 @@ func (ps *WorkspaceServer) notificationMiddleware(next mcp.MethodHandler) mcp.Me
 					time.Sleep(100 * time.Millisecond) // Give session time to stabilize if needed
 					_ = ps.sendVerdict(context.Background(), 0, p.RequestID, "allow", verdictAutomatic)
 				}()
+				ps.markAutoDecided(p.RequestID)
 				ps.emitTelemetry(context.Background(), ActionMCPNotification, "permission_auto_allow", clientIdentityFromRequest(req))
 				if ok {
 					ps.persistToolCall(ctx, taskID, p, "auto_allowed")
@@ -1701,6 +1712,7 @@ func (ps *WorkspaceServer) notificationMiddleware(next mcp.MethodHandler) mcp.Me
 						time.Sleep(100 * time.Millisecond) // Give session time to stabilize if needed
 						_ = ps.sendVerdict(context.Background(), taskID, p.RequestID, "allow", verdictAutomatic)
 					}()
+					ps.markAutoDecided(p.RequestID)
 					ps.emitTelemetry(context.Background(), ActionMCPNotification, "permission_auto_allow", clientIdentityFromRequest(req))
 					ps.persistToolCall(ctx, taskID, p, "auto_allowed")
 					return nil, nil
@@ -1846,6 +1858,10 @@ func (ps *WorkspaceServer) cleanupRequest(requestID string) {
 	delete(ps.undeliveredVerdicts, requestID)
 	ps.undeliveredVerdictsMu.Unlock()
 
+	ps.autoDecidedRequestsMu.Lock()
+	delete(ps.autoDecidedRequests, requestID)
+	ps.autoDecidedRequestsMu.Unlock()
+
 	ps.toolCallIDsMu.Lock()
 	delete(ps.toolCallIDs, requestID)
 	ps.toolCallIDsMu.Unlock()
@@ -1869,14 +1885,11 @@ const (
 	// when the request has already been cleaned up, and an approval that
 	// happened must not go uncounted because the delivery missed.
 	//
-	// This suppresses the manual count only, and does not make the automatic
-	// count exactly-once. An auto-allowed request never posts a message to the
-	// task, so permissionResponses has no entry for it and
-	// rebindPermissionRequest does not recognise a re-send: an agent that
-	// reconnects and asks again re-runs the auto-allow branch, reporting a
-	// second automatic approval and writing a second tool_call row for the one
-	// call. That is a separate gap from the one this type fixes, and it is in
-	// the automatic counter rather than the manual one.
+	// A re-send does not re-report this. An auto-allowed request has no message
+	// to point at, so it is recorded in autoDecidedRequests instead, and
+	// rebindPermissionRequest treats that as "already decided" — the agent is
+	// answered again, through verdictReplayed below, without the approval or
+	// its tool_calls row being written a second time.
 	verdictAutomatic
 	// A verdict already given, being re-delivered because the agent reconnected
 	// and asked again. It was counted when the human decided; counting it again
@@ -2101,6 +2114,28 @@ func (ps *WorkspaceServer) rememberUndeliveredVerdict(requestID, behavior string
 //
 // Reports whether this was such a re-send, in which case there is nothing
 // further to do.
+// markAutoDecided records that a request was allowed without anyone being asked.
+//
+// The map is created on first use rather than relied on: this runs on every
+// auto-allowed tool call, and the struct is also built by hand in tests, so a
+// construction path that forgot the map would panic on a hot path instead of
+// merely mis-counting.
+func (ps *WorkspaceServer) markAutoDecided(requestID string) {
+	ps.autoDecidedRequestsMu.Lock()
+	defer ps.autoDecidedRequestsMu.Unlock()
+	if ps.autoDecidedRequests == nil {
+		ps.autoDecidedRequests = make(map[string]struct{})
+	}
+	ps.autoDecidedRequests[requestID] = struct{}{}
+}
+
+func (ps *WorkspaceServer) wasAutoDecided(requestID string) bool {
+	ps.autoDecidedRequestsMu.RLock()
+	defer ps.autoDecidedRequestsMu.RUnlock()
+	_, ok := ps.autoDecidedRequests[requestID]
+	return ok
+}
+
 func (ps *WorkspaceServer) rebindPermissionRequest(
 	ctx context.Context,
 	sessionID string,
@@ -2110,10 +2145,15 @@ func (ps *WorkspaceServer) rebindPermissionRequest(
 		return false
 	}
 
+	// A request already decided, either way: the human was asked and answered,
+	// or a rule answered for them. Both mean this re-send is the same request
+	// arriving again, not a new one — and deciding it again would report a
+	// second approval and write a second tool_calls row for one tool call.
 	ps.permissionResponsesMu.RLock()
 	_, alreadyAsked := ps.permissionResponses[p.RequestID]
 	ps.permissionResponsesMu.RUnlock()
-	if !alreadyAsked {
+	autoDecided := ps.wasAutoDecided(p.RequestID)
+	if !alreadyAsked && !autoDecided {
 		return false
 	}
 
@@ -2131,12 +2171,22 @@ func (ps *WorkspaceServer) rebindPermissionRequest(
 	ps.undeliveredVerdictsMu.RLock()
 	behavior, waiting := ps.undeliveredVerdicts[p.RequestID]
 	ps.undeliveredVerdictsMu.RUnlock()
+
+	// An auto-decided request is always an allow, and re-sending it means the
+	// agent never saw that answer — so it is answered again rather than left
+	// holding the question. Recognising the re-send without answering it would
+	// trade a double count for a stalled agent.
+	if !waiting && autoDecided {
+		behavior, waiting = "allow", true
+	}
+
 	if waiting {
 		ps.requestTaskIDsMu.RLock()
 		taskID := ps.requestTaskIDs[p.RequestID]
 		ps.requestTaskIDsMu.RUnlock()
 		zlog.Info().Str("request_id", p.RequestID).Str("behavior", behavior).
 			Msg("delivering the verdict the agent missed while it was away")
+		// verdictReplayed: this decision was counted when it was first made.
 		_ = ps.sendVerdict(ctx, taskID, p.RequestID, behavior, verdictReplayed)
 	}
 
@@ -2215,6 +2265,7 @@ func (ps *WorkspaceServer) HandleCustomNotification(ctx context.Context, session
 				_ = ps.sendVerdict(context.Background(), 0, p.RequestID, "allow", verdictAutomatic)
 			}()
 			// No mcp.Request here (custom out-of-band notification), so client identity is unknown.
+			ps.markAutoDecided(p.RequestID)
 			ps.emitTelemetry(context.Background(), ActionMCPNotification, "permission_auto_allow", clientIdentity{})
 			if ok {
 				ps.persistToolCall(ctx, taskID, p, "auto_allowed")
@@ -2232,6 +2283,7 @@ func (ps *WorkspaceServer) HandleCustomNotification(ctx context.Context, session
 					time.Sleep(100 * time.Millisecond)
 					_ = ps.sendVerdict(context.Background(), taskID, p.RequestID, "allow", verdictAutomatic)
 				}()
+				ps.markAutoDecided(p.RequestID)
 				ps.emitTelemetry(context.Background(), ActionMCPNotification, "permission_auto_allow", clientIdentity{})
 				ps.persistToolCall(ctx, taskID, p, "auto_allowed")
 				return


### PR DESCRIPTION
## What changed

An automatically approved tool call is now counted once, and written once, even when the agent disconnects and asks for it again.

## Why changed

An agent that reconnects re-sends the request it was waiting on. Automatic approvals were re-decided rather than recognised, so each reconnection added another approval to the Auto figure and another duplicate row to the tool call list.

## Test coverage report

- New lines introduced: **100%** — `markAutoDecided`, `wasAutoDecided` and `rebindPermissionRequest` are all at 100%.
- Total coverage impact: **no regression.** Full backend suite passes with 0 failures; the mcp package gains 3 test cases and passes under `-race -count=2`.

## Other reports

**The bug.** A request the human was asked about is recorded in `permissionResponses`, and rebinding uses that to recognise a re-send and re-deliver the verdict already given. An auto-allowed request never posts a message to the task, so it had no such record: the re-send fell through to the normal path, hit the auto-allow branch a second time, and emitted another `permission_auto_allow` plus another `persistToolCall(..., "auto_allowed")`. One reconnection turned one approval into two, and one tool call into two rows.

Reproduced before fixing, both halves:
```
a re-sent request is the same approval, got 2 automatic ([permission_auto_allow permission_auto_allow])
a re-sent request is the same tool call, got 2 rows
```

**Design choice.** Auto-decided requests get their own set rather than being written into `permissionResponses`. That map means *the human was asked*, holds the id of the message they were asked in, and is what `sendVerdict` rewrites to show the verdict — an auto-allowed request has none of those, so overloading it would have broken all three meanings to save one field.

**The part the original task description missed, and which matters more than the count.** Recognising the re-send is only half the job: the agent re-sent *because* it never saw the answer. A fix that only stopped re-deciding would leave it holding the question forever — trading a double count for a stalled agent, which is the worse bug. An auto-decided re-send is therefore answered again, through the replay path that already suppresses re-counting. There is a dedicated test for this.

**A latent panic found on the way.** `markAutoDecided` creates its map on first use rather than trusting the constructor. It runs on every auto-allowed tool call and `WorkspaceServer` is built by hand in several test harnesses; the first run of the new test panicked with `assignment to entry in nil map`, which in a construction path that missed the field would have been a crash on a hot path rather than a mis-count.

**Verified by mutation**, not just by passing: with the new signal ignored (`if !alreadyAsked` alone), the two re-send tests fail with `got 2 automatic` and `got 2 rows`. The tests genuinely hold the fix in place.

The stale comment on `verdictAutomatic` from #487, which documented this as an open gap, is updated to describe the closed behaviour.

TaskID: 0iNvHtBB37B
