### PR TITLE
fix(coremcp): advertise the statuses and actions the server actually accepts

### DIFF
--- a/backend/internal/controller/crud/task.go
+++ b/backend/internal/controller/crud/task.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -854,12 +855,38 @@ func (c *controller) UpdateScheduledTask(ctx context.Context, req entity.UpdateS
 	return &entity.UpdateScheduledTaskResponse{Task: c.fromModelTaskToEntity(updated)}, nil
 }
 
+// ValidTaskStatuses is every status a task may be moved to.
+//
+// Exported because it is also what the MCP tool schemas advertise to agents,
+// and those are struct tags — which the compiler will not let us build from a
+// slice, so they have to repeat the list by hand. This is the list they are
+// tested against (see TestToolSchemaEnumsMatchTheValidators), so the copy in a
+// tag cannot drift from what the server actually accepts. It has: an agent was
+// once told it could use `done` and `failed`, neither of which validates, and
+// never told about `blocked`, which is how it asks a human for help.
+var ValidTaskStatuses = []string{
+	"notstarted",
+	"ongoing",
+	"blocked",
+	"completed",
+	"rejected",
+	"cron",
+}
+
+// ValidTaskResponseActions is every action RespondToTask accepts. Kept here
+// beside the statuses, and tested against the tool schema, for the same reason.
+//
+// Note `reject` rather than `deny`: the schema advertised `deny` for a while,
+// which the switch in RespondToTask has never handled.
+var ValidTaskResponseActions = []string{
+	"allow",
+	"allow_all",
+	"reject",
+	"text",
+}
+
 func isValidTaskStatus(status string) bool {
-	switch status {
-	case "notstarted", "ongoing", "completed", "rejected", "cron", "blocked":
-		return true
-	}
-	return false
+	return slices.Contains(ValidTaskStatuses, status)
 }
 
 func validateCronForContext(ctx context.Context, cronSchedule string) error {

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -198,7 +198,11 @@ type PublishEventFAQ struct {
 // UpdateTaskStatusParams is the input to the update_task_status tool.
 type UpdateTaskStatusParams struct {
 	TaskID string `json:"taskId" jsonschema:"The ID of the task to update"`
-	Status string `json:"status" jsonschema:"New status: 'ongoing', 'completed', 'blocked', 'rejected', or 'notstarted'"`
+	// Prose rather than an enum because `cron` needs a caveat: it is what the
+	// server sets on a task that has a schedule, not a state an agent moves a
+	// task into. The other five are the agent's to use, and `blocked` is how it
+	// asks a human for something.
+	Status string `json:"status" jsonschema:"New status: 'ongoing', 'blocked' (waiting on the human), 'completed', 'rejected', or 'notstarted'. Scheduled tasks are set to 'cron' by the server; you do not need to set it."`
 }
 
 // ReplyParams is the input to the reply tool.
@@ -450,7 +454,7 @@ func NewWorkspaceServer(
 
 	mcp.AddTool(mcpSrv, &mcp.Tool{
 		Name:        "updateTaskStatus",
-		Description: "Update the status of a task. Useful for moving tasks to ongoing or completed.",
+		Description: "Update the status of a task: 'ongoing' when you start, 'completed' when you finish, or 'blocked' when you need something from the human.",
 	}, ps.handleUpdateTaskStatus)
 
 	mcp.AddTool(mcpSrv, &mcp.Tool{

--- a/backend/internal/handler/coremcp/schema_enum_test.go
+++ b/backend/internal/handler/coremcp/schema_enum_test.go
@@ -1,0 +1,124 @@
+package coremcp
+
+import (
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/agentrq/agentrq/backend/internal/controller/crud"
+)
+
+// enumValues reads the `jsonschema:"enum: a, b, c"` tag off one field of a
+// parameter struct, the way the MCP SDK does when it builds the tool schema an
+// agent sees.
+//
+// Read by reflection rather than by parsing the source, so the test is checking
+// the tag that actually ships.
+func enumValues(t *testing.T, params any, field string) []string {
+	t.Helper()
+
+	f, ok := reflect.TypeOf(params).FieldByName(field)
+	if !ok {
+		t.Fatalf("%T has no field %s", params, field)
+	}
+	tag := f.Tag.Get("jsonschema")
+	const prefix = "enum:"
+	if !strings.HasPrefix(tag, prefix) {
+		t.Fatalf("%T.%s has no enum in its jsonschema tag (got %q)", params, field, tag)
+	}
+
+	var values []string
+	for _, v := range strings.Split(strings.TrimPrefix(tag, prefix), ",") {
+		if v = strings.TrimSpace(v); v != "" {
+			values = append(values, v)
+		}
+	}
+	if len(values) == 0 {
+		t.Fatalf("%T.%s declares an empty enum", params, field)
+	}
+	return values
+}
+
+// The enums an agent is shown must be the values the server accepts.
+//
+// A struct tag has to be a compile-time constant, so it cannot be built from
+// the canonical slice in the controller — the list is written out twice by
+// necessity. This is what stops the two copies drifting, and they had: the
+// status enum advertised `waiting`, `done` and `failed`, none of which
+// validate, and omitted `blocked` and `rejected`, both of which do. The action
+// enum offered `deny`, which RespondToTask has never handled — one of only two
+// values it advertised, so half of that tool's documented surface failed.
+//
+// Compared as sets: order is presentation, and pinning it would fail for a
+// reordering that changes nothing.
+func TestToolSchemaEnumsMatchTheValidators(t *testing.T) {
+	tests := []struct {
+		name   string
+		params any
+		field  string
+		want   []string
+	}{
+		{
+			name:   "updateTaskStatus offers the statuses the controller accepts",
+			params: UpdateTaskStatusParams{},
+			field:  "Status",
+			want:   crud.ValidTaskStatuses,
+		},
+		{
+			name:   "respondToTask offers the actions the controller handles",
+			params: RespondToTaskParams{},
+			field:  "Action",
+			want:   crud.ValidTaskResponseActions,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := enumValues(t, tt.params, tt.field)
+
+			for _, v := range got {
+				if !slices.Contains(tt.want, v) {
+					t.Errorf("schema offers %q, which the server rejects (accepted: %v)", v, tt.want)
+				}
+			}
+			for _, v := range tt.want {
+				if !slices.Contains(got, v) {
+					t.Errorf("server accepts %q, but the schema does not offer it (offered: %v)", v, got)
+				}
+			}
+		})
+	}
+}
+
+// The assignee enums were already correct, and there are two of them — one on
+// createTask and one on updateTaskAssignee — so they are pinned here to keep
+// them agreeing with each other as well as with the controller.
+func TestAssigneeEnumsAgree(t *testing.T) {
+	want := []string{"agent", "human"}
+
+	for _, tt := range []struct {
+		name   string
+		params any
+	}{
+		{"createTask", CreateTaskParams{}},
+		{"updateTaskAssignee", UpdateTaskAssigneeParams{}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := enumValues(t, tt.params, "Assignee")
+			slices.Sort(got)
+			if !slices.Equal(got, want) {
+				t.Errorf("expected assignees %v, got %v", want, got)
+			}
+		})
+	}
+}
+
+// `blocked` is the status an agent uses to say it needs a human, so it earns an
+// assertion of its own: a schema that omits it leaves an agent no way to ask,
+// which is the whole point of the platform.
+func TestStatusEnumOffersBlocked(t *testing.T) {
+	if got := enumValues(t, UpdateTaskStatusParams{}, "Status"); !slices.Contains(got, "blocked") {
+		t.Errorf("the status enum must offer 'blocked' so an agent can ask for help, got %v", got)
+	}
+}

--- a/backend/internal/handler/coremcp/server.go
+++ b/backend/internal/handler/coremcp/server.go
@@ -175,8 +175,9 @@ type GetTaskParams struct {
 type RespondToTaskParams struct {
 	WorkspaceID string `json:"workspaceId"`
 	TaskID      string `json:"taskId"`
-	Action      string `json:"action" jsonschema:"enum: allow, deny"`
-	Text        string `json:"text,omitempty"`
+	// Must match crud.ValidTaskResponseActions. `reject`, not `deny`.
+	Action string `json:"action" jsonschema:"enum: allow, allow_all, reject, text"`
+	Text   string `json:"text,omitempty"`
 }
 
 type ReplyToTaskParams struct {
@@ -188,7 +189,9 @@ type ReplyToTaskParams struct {
 type UpdateTaskStatusParams struct {
 	WorkspaceID string `json:"workspaceId"`
 	TaskID      string `json:"taskId"`
-	Status      string `json:"status" jsonschema:"enum: notstarted, ongoing, waiting, completed, done, cron, failed"`
+	// Must match crud.ValidTaskStatuses — a struct tag cannot be built from that
+	// slice, so a test compares them instead.
+	Status string `json:"status" jsonschema:"enum: notstarted, ongoing, blocked, completed, rejected, cron"`
 }
 
 type UpdateTaskOrderParams struct {
@@ -244,7 +247,7 @@ func (s *WorkspaceServer) registerTools() {
 	mcp.AddTool(s.server, &mcp.Tool{Name: "listAllTasks", Description: "List all tasks across all workspaces"}, s.handleListAllTasks)
 	mcp.AddTool(s.server, &mcp.Tool{Name: "createTask", Description: "Create a new task in a workspace"}, s.handleCreateTask)
 	mcp.AddTool(s.server, &mcp.Tool{Name: "getTask", Description: "Get a specific task by ID"}, s.handleGetTask)
-	mcp.AddTool(s.server, &mcp.Tool{Name: "respondToTask", Description: "Submit an allow/deny response to a task"}, s.handleRespondToTask)
+	mcp.AddTool(s.server, &mcp.Tool{Name: "respondToTask", Description: "Answer a permission request a task is waiting on: allow, allow_all, reject, or text to reply without deciding"}, s.handleRespondToTask)
 	mcp.AddTool(s.server, &mcp.Tool{Name: "replyToTask", Description: "Post a message to a task thread"}, s.handleReplyToTask)
 	mcp.AddTool(s.server, &mcp.Tool{Name: "updateTaskStatus", Description: "Update a task's status"}, s.handleUpdateTaskStatus)
 	mcp.AddTool(s.server, &mcp.Tool{Name: "updateTaskOrder", Description: "Update a task's sort order"}, s.handleUpdateTaskOrder)


### PR DESCRIPTION
## What changed

Two of the supervisor's task tools now offer agents exactly the values the server accepts, instead of a list that included values it rejects and left out ones it takes.

## Why changed

An agent trusting the tool schema would pick a status or a response that fails — and had no way to discover the status that means "I need a human".

## Test coverage report

- New lines introduced: **100%** — `isValidTaskStatus` is at 100%; the two new exported slices are declarations with no branches, and both are read by the new test.
- Total coverage impact: **no regression.** Full backend suite passes with 0 failures across 28 packages; `handler/coremcp` gains 3 test cases.

## Other reports

**Two bugs, not one.** The task described the status enum; the action enum turned out to be worse.

| Tool | Advertised | Accepted | Effect |
|---|---|---|---|
| `updateTaskStatus` | `notstarted, ongoing, waiting, completed, done, cron, failed` | `notstarted, ongoing, blocked, completed, rejected, cron` | 3 values fail; `blocked` and `rejected` undiscoverable |
| `respondToTask` | `allow, deny` | `allow, allow_all, reject, text` | **`deny` has never worked** — half the tool's documented surface |

`deny` is the sharper of the two: `handleRespondToTask` passes the action straight through to a switch whose default answers `unknown action: deny`. The tool advertised only two values and the one an agent would reach for to refuse a permission request was the broken one. The tool's description said "allow/deny" as well, and now names what it actually takes.

**One source of truth, and a test to hold the copies together.** Accepted values are now declared once as `crud.ValidTaskStatuses` and `crud.ValidTaskResponseActions`, with `isValidTaskStatus` reading the former. A struct tag must be a compile-time constant, so the schema tags still repeat the list by hand — that cannot be avoided — but the new test reads the *shipping* tags by reflection (not by parsing source) and compares them to those slices in both directions.

Run against the previous tags it names all nine defects individually:
```
schema offers "waiting", which the server rejects
schema offers "done", which the server rejects
schema offers "failed", which the server rejects
server accepts "blocked", but the schema does not offer it
server accepts "rejected", but the schema does not offer it
schema offers "deny", which the server rejects
server accepts "allow_all", but the schema does not offer it
server accepts "reject", but the schema does not offer it
server accepts "text", but the schema does not offer it
```
That is the guard nobody had — the mismatch was invisible until two files were read side by side.

**The assignee enums were already correct**, and are now pinned anyway: there are two of them (`createTask` and `updateTaskAssignee`) and they should keep agreeing with each other as well as with the controller.

**The per-workspace server was checked too, and deliberately left as prose.** Its status guidance is a sentence rather than an enum and contained no invented values, but it omitted `cron` and its tool description mentioned only "ongoing or completed". It now names all six and says plainly that `cron` is set by the server for scheduled tasks rather than a state an agent moves a task into — accurate without inviting misuse. Keeping it prose is why the parity test covers the enum schemas only; a machine-checked enum could not carry that caveat.

**Follow-up:** the Claude extension's skill (`agentrq/agentrq-claude-extension` PR #3) carries a note saying this schema is wrong. Once this merges that note is stale and should be removed — happy to do it as a small follow-up.

TaskID: 0iOMipNf0kL
