### PR TITLE
feat(plugins): publish the Claude Code plugins from this repository

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,30 @@
+{
+  "name": "agentrq",
+  "description": "Task manager for AI agents. Orchestrate multiple agents, trigger agentic flows with events on your desired language.",
+  "owner": {
+    "name": "AgentRQ",
+    "email": "hi@agentrq.com"
+  },
+  "plugins": [
+    {
+      "name": "agentrq",
+      "source": "./plugins/claude/agentrq",
+      "description": "Human-in-the-loop agent orchestration for managing multiple agents with specialized tasks.",
+      "author": {
+        "name": "Mustafa Turan",
+        "email": "dev@agentrq.com",
+        "url": "https://github.com/mustafaturan"
+      }
+    },
+    {
+      "name": "agentrq-workspace",
+      "source": "./plugins/claude/agentrq-workspace",
+      "description": "Human-in-the-loop task manager for AI agents",
+      "author": {
+        "name": "Mustafa Turan",
+        "email": "dev@agentrq.com",
+        "url": "https://github.com/mustafaturan"
+      }
+    }
+  ]
+}

--- a/.github/workflows/plugin-claude.yml
+++ b/.github/workflows/plugin-claude.yml
@@ -1,0 +1,124 @@
+name: Claude Code Plugins
+
+# The two Claude Code plugins are installed straight from this repository — a
+# marketplace is a git URL, not a published package — so there is nothing to
+# build and nothing to publish. What can break is the manifests parsing, a
+# source path pointing at a directory that is not there, and the documented
+# tool lists drifting from the servers. All three are checked here.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.claude-plugin/**'
+      - 'plugins/claude/**'
+      - 'backend/internal/handler/coremcp/**'
+      - 'backend/internal/controller/mcp/**'
+      - '.github/workflows/plugin-claude.yml'
+  pull_request:
+    paths:
+      - '.claude-plugin/**'
+      - 'plugins/claude/**'
+      - 'backend/internal/handler/coremcp/**'
+      - 'backend/internal/controller/mcp/**'
+      - '.github/workflows/plugin-claude.yml'
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  manifests:
+    name: Manifests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Every manifest must parse, every plugin the marketplace lists must
+      # exist at the path it names and carry its own plugin.json, and the two
+      # version fields in each plugin must agree — an installed plugin whose
+      # package.json and plugin.json disagree gives two different answers to
+      # "which version is this".
+      - name: Validate marketplace and plugin manifests
+        run: |
+          python3 - <<'PY'
+          import json, pathlib, sys
+
+          root = pathlib.Path('.')
+          problems = []
+
+          market = json.loads((root / '.claude-plugin' / 'marketplace.json').read_text())
+          listed = market.get('plugins', [])
+          if not listed:
+              problems.append('marketplace.json lists no plugins')
+
+          names = [p.get('name') for p in listed]
+          if len(names) != len(set(names)):
+              problems.append(f'duplicate plugin names in marketplace.json: {names}')
+
+          for entry in listed:
+              name, source = entry.get('name'), entry.get('source', '')
+              if not name or not source:
+                  problems.append(f'marketplace entry missing name or source: {entry}')
+                  continue
+
+              d = (root / source).resolve()
+              if not d.is_dir():
+                  problems.append(f'{name}: source {source} is not a directory')
+                  continue
+
+              manifest = d / '.claude-plugin' / 'plugin.json'
+              if not manifest.is_file():
+                  problems.append(f'{name}: no .claude-plugin/plugin.json under {source}')
+                  continue
+
+              plugin = json.loads(manifest.read_text())
+              if plugin.get('name') != name:
+                  problems.append(
+                      f'{name}: plugin.json calls itself {plugin.get("name")!r}; '
+                      'the marketplace and the plugin must agree'
+                  )
+
+              pkg = d / 'package.json'
+              if pkg.is_file():
+                  pv = json.loads(pkg.read_text()).get('version')
+                  mv = plugin.get('version')
+                  if pv != mv:
+                      problems.append(f'{name}: package.json is {pv}, plugin.json is {mv}')
+
+              # A plugin with no skill has nothing to tell the agent.
+              if not list(d.glob('skills/*/SKILL.md')):
+                  problems.append(f'{name}: no skills/*/SKILL.md')
+
+          for p in problems:
+              print(f'::error::{p}')
+          if problems:
+              sys.exit(1)
+          print(f'{len(listed)} plugin(s) validated: {", ".join(names)}')
+          PY
+
+  docs:
+    name: Documented tools match the servers
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      # Walks up to the repository root to find the plugin docs, so it reads the
+      # files this commit actually ships rather than a copy.
+      - name: Check plugin docs against the MCP servers
+        working-directory: backend
+        run: go test ./internal/handler/coremcp/ -run 'TestPluginDocs' -v

--- a/README.md
+++ b/README.md
@@ -410,13 +410,19 @@ When you first run Claude with this server, it will provide a link to authentica
 AgentRQ provides official extensions for major AI agent CLI tools to simplify setup and integration with its supervisor MCP. The sub agents MCPs should use their own workspace specific MCP server URLs.
 
 ### 🍊 Claude Code
-The AgentRQ plugin for Claude Code is distributed via our official marketplace. It provides built-in skills and pre-configured MCP access.
+Two plugins for Claude Code are published from this repository's own marketplace, each with a skill and pre-configured MCP access:
+
+- [`agentrq`](plugins/claude/agentrq/README.md) — the **supervisor**, talking to the account-level MCP server so one agent can orchestrate work across every workspace you own.
+- [`agentrq-workspace`](plugins/claude/agentrq-workspace/README.md) — the **workspace agent**, connected to a single workspace's MCP server to work its queue.
 
 **Installation:**
 ```bash
-/plugin marketplace add https://github.com/agentrq/agentrq-claude-extension
+/plugin marketplace add https://github.com/agentrq/agentrq
 /plugin install agentrq@agentrq
+/plugin install agentrq-workspace@agentrq
 ```
+
+> Previously these lived in a separate `agentrq-claude-extension` repository. The marketplace URL is now this repository; if you added the old one, re-add the marketplace at the URL above.
 
 ### ♊ Gemini CLI
 The Gemini CLI extension allows you to manage AgentRQ workspaces and tasks directly from your terminal using Google's Gemini models.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -325,11 +325,12 @@ CoreMCP 使用 OAuth2，让管理型 Agent 在当前用户权限范围内查看�
 - Codex Gateway
 - DeepSeek Harness plugin
 
-Claude Code 扩展安装：
+Claude Code 插件安装（Marketplace 已迁移到本仓库；`agentrq` 为 Supervisor，`agentrq-workspace` 为单个 Workspace 的执行 Agent）：
 
 ```bash
-/plugin marketplace add https://github.com/agentrq/agentrq-claude-extension
+/plugin marketplace add https://github.com/agentrq/agentrq
 /plugin install agentrq@agentrq
+/plugin install agentrq-workspace@agentrq
 ```
 
 Gemini CLI 扩展安装：

--- a/backend/internal/handler/coremcp/plugin_docs_test.go
+++ b/backend/internal/handler/coremcp/plugin_docs_test.go
@@ -1,0 +1,164 @@
+package coremcp
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"testing"
+)
+
+// The Claude Code plugins shipped from this repository document the tools their
+// MCP server offers, in a markdown table per plugin. Those tables are the only
+// description an agent reads before deciding what it can do, and they have gone
+// wrong in every direction available: a tool that had been removed
+// (`getTaskMessages`) was still listed, six that existed were not, and the task
+// statuses were copied from a schema that advertised three values the server
+// rejects.
+//
+// So the tables are checked against the servers here. It is the same shape as
+// the parity test guarding the frontend's WebMCP catalogue: documentation that
+// cannot drift is worth more than documentation that is merely correct today.
+
+// repoRoot walks up from the test's working directory to the directory holding
+// the plugins, so the test does not care where `go test` was invoked from.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("cannot read working directory: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".claude-plugin", "marketplace.json")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find the repository root above %s", dir)
+		}
+		dir = parent
+	}
+}
+
+var (
+	// `mcp.AddTool(s.server, &mcp.Tool{Name: "x"` — the supervisor server.
+	coreToolRe = regexp.MustCompile(`mcp\.AddTool\(s\.server, &mcp\.Tool\{Name:\s*"([^"]+)"`)
+	// `mcp.AddTool(mcpSrv, &mcp.Tool{\n\tName: "x"` — the per-workspace server.
+	workspaceToolRe = regexp.MustCompile(`mcp\.AddTool\(mcpSrv, &mcp\.Tool\{\s*Name:\s*"([^"]+)"`)
+	// A leading table cell holding a backticked identifier.
+	docRowRe = regexp.MustCompile("(?m)^\\| `([a-zA-Z]+)`")
+)
+
+func namesIn(t *testing.T, path string, re *regexp.Regexp) []string {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("cannot read %s: %v", path, err)
+	}
+	var names []string
+	for _, m := range re.FindAllStringSubmatch(string(body), -1) {
+		names = append(names, m[1])
+	}
+	if len(names) == 0 {
+		t.Fatalf("found no names in %s — has its format changed?", path)
+	}
+	return names
+}
+
+func TestPluginDocsListExactlyTheRegisteredTools(t *testing.T) {
+	root := repoRoot(t)
+
+	tests := []struct {
+		plugin string
+		server string
+		re     *regexp.Regexp
+		docs   []string
+	}{
+		{
+			plugin: "agentrq",
+			server: "backend/internal/handler/coremcp/server.go",
+			re:     coreToolRe,
+			docs: []string{
+				"plugins/claude/agentrq/README.md",
+				"plugins/claude/agentrq/skills/agentrq/SKILL.md",
+			},
+		},
+		{
+			plugin: "agentrq-workspace",
+			server: "backend/internal/controller/mcp/server.go",
+			re:     workspaceToolRe,
+			docs: []string{
+				"plugins/claude/agentrq-workspace/README.md",
+				"plugins/claude/agentrq-workspace/skills/agentrq-workspace/SKILL.md",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		registered := namesIn(t, filepath.Join(root, tt.server), tt.re)
+
+		for _, doc := range tt.docs {
+			t.Run(tt.plugin+"/"+filepath.Base(filepath.Dir(doc))+"/"+filepath.Base(doc), func(t *testing.T) {
+				documented := namesIn(t, filepath.Join(root, doc), docRowRe)
+
+				for _, name := range registered {
+					if !slices.Contains(documented, name) {
+						t.Errorf("%s registers %q, but %s has no row for it", tt.server, name, doc)
+					}
+				}
+				for _, name := range documented {
+					if !slices.Contains(registered, name) {
+						t.Errorf("%s documents %q, which %s does not register", doc, name, tt.server)
+					}
+				}
+			})
+		}
+	}
+}
+
+// The statuses the plugin docs tell agents to use must be ones the server
+// accepts. This is what the supervisor skill got wrong in the way that mattered
+// most: its human-in-the-loop rule said to signal being stuck by setting the
+// status to `waiting`, which fails, so an agent following the instruction could
+// not report being blocked at all.
+func TestPluginDocsDoNotNameInvalidStatuses(t *testing.T) {
+	root := repoRoot(t)
+
+	// Values that were advertised at some point and are not accepted. Written
+	// out rather than derived, because the point is to catch these specific
+	// ghosts coming back.
+	retired := []string{"waiting", "done", "failed"}
+	// `deny` was advertised by respondToTask and has never been handled.
+	retiredActions := []string{"deny"}
+	// A tool that was folded into getTask.
+	retiredTools := []string{"getTaskMessages", "getNextTask"}
+
+	docs := []string{
+		"plugins/claude/agentrq/README.md",
+		"plugins/claude/agentrq/skills/agentrq/SKILL.md",
+		"plugins/claude/agentrq-workspace/README.md",
+		"plugins/claude/agentrq-workspace/skills/agentrq-workspace/SKILL.md",
+	}
+
+	for _, doc := range docs {
+		t.Run(doc, func(t *testing.T) {
+			body, err := os.ReadFile(filepath.Join(root, doc))
+			if err != nil {
+				t.Fatalf("cannot read %s: %v", doc, err)
+			}
+			text := string(body)
+
+			for _, bad := range slices.Concat(retired, retiredActions) {
+				// Backticked, so prose like "the task is done" does not trip it.
+				if regexp.MustCompile("`" + bad + "`").MatchString(text) {
+					t.Errorf("%s offers `%s`, which the server rejects", doc, bad)
+				}
+			}
+			for _, bad := range retiredTools {
+				if regexp.MustCompile(`\b` + bad + `\b`).MatchString(text) {
+					t.Errorf("%s mentions %s, which no longer exists", doc, bad)
+				}
+			}
+		})
+	}
+}

--- a/plugins/claude/README.md
+++ b/plugins/claude/README.md
@@ -1,0 +1,35 @@
+# Claude Code plugins
+
+The two plugins AgentRQ publishes for [Claude Code](https://claude.com/claude-code), served
+from this repository's own marketplace.
+
+| Plugin | Connects to | For |
+|---|---|---|
+| [`agentrq`](agentrq/README.md) | the account-level supervisor MCP server | orchestrating work across every workspace you own |
+| [`agentrq-workspace`](agentrq-workspace/README.md) | one workspace's own MCP server | working a single workspace's task queue |
+
+```bash
+/plugin marketplace add https://github.com/agentrq/agentrq
+/plugin install agentrq@agentrq
+/plugin install agentrq-workspace@agentrq
+```
+
+A Claude marketplace is a git URL rather than a published package, so the manifest that
+lists these lives at the repository root — [`.claude-plugin/marketplace.json`](../../.claude-plugin/marketplace.json)
+— and its `source` paths point back here.
+
+## Keeping them honest
+
+Each plugin's README and skill document the tools its server offers. Those tables are the
+only description an agent reads before deciding what it can do, and they have been wrong in
+every direction: a tool that had been removed was still listed, six that existed were not,
+and the task statuses were copied from a schema that advertised three values the server
+rejects — including a human-in-the-loop instruction that told agents to report being stuck
+with a status that fails.
+
+So they are checked rather than trusted. `backend/internal/handler/coremcp/plugin_docs_test.go`
+compares every table against the `AddTool` calls in the server it describes, in both
+directions, and refuses the specific retired names that have shipped here before. The
+[workflow](../../.github/workflows/plugin-claude.yml) runs it on changes to these plugins
+*or to either MCP server*, so adding a tool to a server fails the build until it is
+documented here.

--- a/plugins/claude/agentrq-workspace/.claude-plugin/plugin.json
+++ b/plugins/claude/agentrq-workspace/.claude-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "agentrq-workspace",
+  "description": "Workspace agent that executes tasks assigned by humans or supervisors, communicates progress via reply, and manages task lifecycle within a specific AgentRQ workspace",
+  "version": "1.0.2",
+  "userConfig": {
+    "agentrq_workspace_mcp_url": {
+      "type": "string",
+      "title": "Workspace MCP URL",
+      "description": "Your unique AgentRQ Workspace MCP URL (e.g., https://<WORKSPACEID>.mcp.agentrq.com/?token=...)",
+      "required": true
+    }
+  },
+  "mcpServers": {
+    "agentrq-workspace": {
+      "type": "http",
+      "url": "${user_config.agentrq_workspace_mcp_url}"
+    }
+  },
+  "author": {
+    "name": "Mustafa Turan",
+    "email": "dev@agentrq.com",
+    "url": "https://github.com/mustafaturan"
+  }
+}

--- a/plugins/claude/agentrq-workspace/README.md
+++ b/plugins/claude/agentrq-workspace/README.md
@@ -1,0 +1,37 @@
+# AgentRQ Workspace plugin for Claude Code
+
+The **workspace** plugin: it connects to one workspace's own MCP server and works the
+queue there — picking up tasks, reporting progress, and asking the human when it needs
+something.
+
+Installed from this repository's marketplace:
+
+```bash
+/plugin marketplace add https://github.com/agentrq/agentrq
+/plugin install agentrq-workspace@agentrq
+```
+
+Each workspace has its own MCP URL and token, both shown in the workspace's **Setup** tab.
+
+To supervise several workspaces from one session, see [`agentrq`](../agentrq/README.md).
+
+## Tools
+
+
+| Tool | Description |
+| --- | --- |
+| `createTask` | Create a task for the human user. Returns the task ID. |
+| `updateTaskStatus` | Update the status of a task. Useful for moving tasks to ongoing or completed. |
+| `reply` | Send a message to the current ongoing task. You can optionally include attachments. |
+| `downloadAttachment` | Download the content of an attachment by its ID |
+| `getWorkspace` | Returns the workspace title and mission description. |
+| `getTask` | Fetch a task. With no taskId, returns the next available "not started" task assigned to the agent (dequeues the work queue). With a taskId, returns that specific task. Set `includeConversation=true` to also include the task's chat history. |
+| `publishEvent` | Publish a named event so that subscriber workspaces are notified and their trigger tasks are created automatically. |
+| `loadMemory` | Read what the workspace remembers. With no name it reads `memory.md`, the index of everything remembered there. |
+| `saveMemory` | Write something worth remembering, so the next task starts with it. Replaces the named memory entirely. |
+| `deleteMemory` | Delete one of the workspace's memories. |
+| `elicit` | Ask the human a question and wait for the answer — a form, or a link for them to confirm. |
+
+The tables here are checked against the server in CI — see
+`backend/internal/handler/coremcp/plugin_docs_test.go`. A tool added to the server
+without a row here fails the build.

--- a/plugins/claude/agentrq-workspace/package.json
+++ b/plugins/claude/agentrq-workspace/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "agentrq-workspace",
+  "version": "1.0.2",
+  "description": "AgentRQ Workspace Plugin for Claude Code",
+  "keywords": [
+    "claude-plugin",
+    "agentrq",
+    "mcp",
+    "task manager",
+    "tasks",
+    "human-in-the-loop",
+    "orchestration"
+  ],
+  "author": "Mustafa Turan",
+  "license": "Apache-2.0"
+}

--- a/plugins/claude/agentrq-workspace/skills/agentrq-workspace/SKILL.md
+++ b/plugins/claude/agentrq-workspace/skills/agentrq-workspace/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: agentrq
+description: Execute tasks assigned by humans or supervisor agents within a specific AgentRQ workspace. Use when you receive channel messages or need to report progress on tasks.
+---
+
+# AgentRQ Workspace Agent Guidelines
+
+You are a **workspace agent** executing tasks within a specific AgentRQ workspace. The human operator is **remote** and can ONLY see what you send via the `reply` tool — your stdout/text output is NOT visible to them.
+
+## How This Works
+
+- Messages from the human arrive as `<channel source="agentrq" chat_id="...">` notifications.
+- You reply using the `reply` tool, passing the `chat_id` from the tag.
+- Use `createTask` to assign sub-tasks back to the human or another agent.
+- The human is REMOTE and can ONLY see what you send via `reply`.
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `createTask` | Create a task for the human or another agent. Supports optional cron schedules and attachments. |
+| `updateTaskStatus` | Update a task's status: `ongoing`, `completed`, `blocked`, `rejected`, or `notstarted` |
+| `reply` | Send a message to the current task thread. Supports optional attachments. The human can ONLY see what you send via this tool. |
+| `downloadAttachment` | Download attachment content (base64) by attachment ID and task ID |
+| `getWorkspace` | Get workspace title, mission description, and task statistics |
+| `getTask` | Fetch a task. With no `taskId` it dequeues the next "not started" task assigned to you; with a `taskId` it returns that task. Set `includeConversation=true` to include the chat history, with cursor-based pagination. |
+| `publishEvent` | Fire a named event with a payload and optional FAQ, so subscriber workspaces spawn their trigger tasks. |
+| `loadMemory` | Read what this workspace remembers. With no name it reads `memory.md`, the index of everything remembered here — start there. |
+| `saveMemory` | Write something worth remembering, so the next task starts with it. Replaces the named memory entirely; there is no append. |
+| `deleteMemory` | Delete one of the workspace's memories. |
+| `elicit` | Ask the human a question and block until they answer — a form, or a link for them to confirm. |
+## Core Rules (Follow Strictly)
+
+1. **START**: When you receive a task, IMMEDIATELY call `updateTaskStatus` to set it to `ongoing`. Then call `getWorkspace` to see the mission context.
+
+2. **SHARE EVERYTHING**: The human cannot see your screen. You MUST proactively share via `reply`:
+   - What you're about to do and why
+   - File paths you're reading or editing
+   - Commands you're running and their output (especially errors)
+   - Key decisions and trade-offs you're making
+   - Code snippets or diffs when relevant
+   - Any unexpected findings or issues
+
+3. **PROGRESS UPDATES**: Send a `reply` every few steps or at every significant milestone. Do NOT go silent for long stretches.
+
+4. **ASK VIA REPLY**: If you need permission, clarification, or more info, use `reply` to ask. Do NOT ask in your text output — the human won't see it.
+
+5. **COMPLETE**: When done, send a summary of all changes via `reply`, then set the task status to `completed`. Use `blocked` if you are stuck and need human help.
+
+## Example Workflows
+
+### 1. Starting a Task
+When you receive a channel message with a task:
+```json
+// Step 1: Mark task as ongoing
+{ "taskId": "zX9vW7tS5rQ", "status": "ongoing" }
+
+// Step 2: Get workspace context
+// Call getWorkspace (no params needed)
+
+// Step 3: Read task messages for full context
+{ "taskId": "zX9vW7tS5rQ", "cursor": 0, "limit": 10 }
+```
+
+### 2. Sending Progress Updates
+Keep the human informed at every milestone:
+```json
+{
+  "chatId": "zX9vW7tS5rQ",
+  "text": "Reading src/api/handler.go to understand the current structure. Found the bug: the nil check on line 42 is missing. Fixing now."
+}
+```
+
+### 3. Creating a Sub-Task for the Human
+When you need the human to do something:
+```json
+{
+  "title": "Review database migration script",
+  "body": "I've prepared the migration in db/migrations/003_add_index.sql. Please review and approve before I apply it to production.",
+  "assignee": "human"
+}
+```
+
+### 4. Creating a Scheduled Task
+Set up recurring tasks with cron expressions:
+```json
+{
+  "title": "Daily health check",
+  "body": "Run system health checks and report any issues.",
+  "assignee": "agent",
+  "cronSchedule": "30 9 * * *"
+}
+```
+
+### 5. Completing a Task
+Always send a summary before marking as completed:
+```json
+// Step 1: Send summary via reply
+{
+  "chatId": "zX9vW7tS5rQ",
+  "text": "Done! Changes made:\n- Fixed nil check in handler.go:42\n- Added unit test in handler_test.go\n- All 15 tests pass\n- No breaking changes"
+}
+
+// Step 2: Mark as completed
+{ "taskId": "zX9vW7tS5rQ", "status": "completed" }
+```
+
+### 6. Downloading an Attachment
+When a task or message includes an attachment:
+```json
+{
+  "attachmentId": "att_abc123",
+  "taskId": "zX9vW7tS5rQ"
+}
+```

--- a/plugins/claude/agentrq/.claude-plugin/plugin.json
+++ b/plugins/claude/agentrq/.claude-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "agentrq",
+  "description": "Human-in-the-loop task supervisor for AI agents",
+  "version": "1.0.1",
+  "userConfig": {
+    "agentrq_supervisor_mcp_url": {
+      "type": "string",
+      "title": "Supervisor MCP URL",
+      "description": "AgentRQ Supervisor MCP URL (e.g., https://mcp.agentrq.com/mcp)",
+      "required": true,
+      "default": "https://mcp.agentrq.com/mcp"
+    }
+  },
+  "mcpServers": {
+    "agentrq": {
+      "type": "http",
+      "url": "${user_config.agentrq_supervisor_mcp_url}"
+    }
+  },
+  "author": {
+    "name": "Mustafa Turan",
+    "email": "dev@agentrq.com",
+    "url": "https://github.com/mustafaturan"
+  }
+}

--- a/plugins/claude/agentrq/README.md
+++ b/plugins/claude/agentrq/README.md
@@ -1,0 +1,47 @@
+# AgentRQ plugin for Claude Code
+
+The **supervisor** plugin: it talks to the account-level MCP server, so one agent can
+orchestrate work across every workspace you own.
+
+Installed from this repository's marketplace:
+
+```bash
+/plugin marketplace add https://github.com/agentrq/agentrq
+/plugin install agentrq@agentrq
+```
+
+The supervisor MCP URL is a plugin setting (`agentrq_supervisor_mcp_url`), defaulting to
+`https://mcp.agentrq.com/mcp`.
+
+For a single workspace rather than the whole account, see
+[`agentrq-workspace`](../agentrq-workspace/README.md).
+
+Human-in-the-loop task manager for agents. Connects to the AgentRQ supervisor MCP server (account-level — manage workspaces and tasks across all of them).
+
+**Tools:**
+
+| Tool | Description |
+| --- | --- |
+| `listWorkspaces` | List all workspaces for the authenticated user |
+| `createWorkspace` | Create a new workspace |
+| `getWorkspace` | Get a workspace by ID |
+| `updateWorkspace` | Update a workspace |
+| `getWorkspaceStats` | Get statistics for a workspace |
+| `listTasks` | List tasks in a specific workspace |
+| `listAllTasks` | List all tasks across all workspaces |
+| `createTask` | Create a new task in a workspace |
+| `getTask` | Get a specific task by ID |
+| `respondToTask` | Answer a permission request: allow, allow_all, reject, or text |
+| `replyToTask` | Post a message to a task thread |
+| `updateTaskStatus` | Update a task's status |
+| `updateTaskOrder` | Update a task's sort order |
+| `updateTaskAssignee` | Update a task's assignee |
+| `updateTaskAllowAll` | Toggle allow_all_commands for a task |
+| `updateScheduledTask` | Update a scheduled/cron task |
+| `getAttachment` | Get attachment data as base64 and metadata |
+| `listMemories` | List a workspace's memories: name, size and when each was last changed |
+| `getMemory` | Get one of a workspace's memories in full, by name |
+
+The tables here are checked against the server in CI — see
+`backend/internal/handler/coremcp/plugin_docs_test.go`. A tool added to the server
+without a row here fails the build.

--- a/plugins/claude/agentrq/package.json
+++ b/plugins/claude/agentrq/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "agentrq",
+  "version": "1.0.1",
+  "description": "AgentRQ Supervisor Plugin for Claude Code",
+  "keywords": [
+    "claude-plugin",
+    "agentrq",
+    "mcp",
+    "task manager",
+    "tasks",
+    "multi-agent",
+    "human-in-the-loop",
+    "agent-orchestration",
+    "orchestration"
+  ],
+  "author": "Mustafa Turan",
+  "license": "Apache-2.0"
+}

--- a/plugins/claude/agentrq/skills/agentrq/SKILL.md
+++ b/plugins/claude/agentrq/skills/agentrq/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: agentrq
+description: Lead multiple agents to accomplish big tasks with specialized workspaces/agents by assigning tasks to specialized agents.
+---
+
+# AgentRQ Supervisor Guidelines
+
+You are a **supervisor agent** orchestrating work across multiple specialized workspaces and agents via the AgentRQ platform. Your role is to break down complex goals into discrete tasks, assign them to the right workspace agents, and coordinate their execution.
+
+## Core Concepts
+
+- **Workspace**: A project or domain-specific context (e.g., "Backend API", "Frontend App", "DevOps"). Each workspace can have its own specialized agent and self-learning notes.
+- **Task**: A unit of work within a workspace. Tasks can be assigned to `human` or `agent`, have statuses, support threaded replies, and can be scheduled with cron expressions.
+- **Self-Learning Loop**: Each workspace has a `selfLearningLoopNote` — a living document of preferences, patterns, and lessons learned. Always read and update these notes to share knowledge across sessions.
+
+## Available Tools
+
+### Workspace Management
+| Tool | Description |
+|------|-------------|
+| `listWorkspaces` | List all workspaces (optionally include archived) |
+| `createWorkspace` | Create a new workspace with name, description, notification settings, and self-learning notes |
+| `getWorkspace` | Get workspace details by ID |
+| `updateWorkspace` | Update workspace name, description, notification settings, or self-learning notes |
+| `getWorkspaceStats` | Get workspace statistics for a given time range (`7d` or `30d`) |
+
+### Task Management
+| Tool | Description |
+|------|-------------|
+| `listTasks` | List tasks in a specific workspace (filterable by status, creator; supports pagination) |
+| `listAllTasks` | List tasks across all workspaces (same filters as `listTasks`) |
+| `createTask` | Create a task with title, body, assignee (`human`/`agent`), optional cron schedule, and optional parent task |
+| `getTask` | Get full task details including messages |
+| `replyToTask` | Post a message to a task's thread |
+| `respondToTask` | Answer a permission request: `allow`, `allow_all`, `reject`, or `text` to reply without deciding |
+| `updateTaskStatus` | Update status: `notstarted`, `ongoing`, `blocked`, `completed`, `rejected`. (`cron` is set by the server for scheduled tasks.) |
+| `updateTaskAssignee` | Reassign a task to `agent` or `human` |
+| `updateTaskOrder` | Update a task's sort order |
+| `updateTaskAllowAll` | Toggle `allow_all_commands` for a task |
+| `updateScheduledTask` | Update a scheduled/cron task's title, body, or cron expression |
+
+### Attachments
+| Tool | Description |
+|------|-------------|
+| `getAttachment` | Retrieve attachment data (base64) and metadata by ID |
+
+### Workspace Memory
+| Tool | Description |
+|------|-------------|
+| `listMemories` | List a workspace's memories: name, size and when each changed. Content is not included |
+| `getMemory` | Read one memory in full, by name. `MEMORY.md` is the index the others hang off |
+
+## Core Guidelines
+
+1. **Discover Before Creating**: Always use `listWorkspaces` or `listAllTasks` to find existing workspaces and tasks before creating new ones. Avoid duplicates.
+2. **Gather Full Context**: Before acting on a task, use `getTask` to read the full task details and message thread.
+3. **Keep Humans in the Loop**: When blocked or needing approval, set the task status to `blocked` and use `replyToTask` to explain what you need. `blocked` is the status the interface surfaces as needing attention.
+4. **Leverage Self-Learning Notes**: Always read a workspace's `selfLearningLoopNote` before starting work. Update it with new preferences, patterns, or lessons learned using `updateWorkspace`.
+5. **Use Sub-Tasks for Complex Work**: Break large goals into sub-tasks using `parentId` when creating tasks. This creates a clear hierarchy of work.
+6. **Track Status Accurately**: Update task statuses as work progresses — `ongoing` when starting, `completed` when finished, `rejected` if the work should not be done. There is no separate failure status: say what went wrong with `replyToTask` and leave the task `blocked` so a human sees it.
+
+## Example Workflows
+
+### 1. Creating a Task for a Specialized Agent
+Break down work and assign it to the appropriate workspace agent:
+```json
+{
+  "workspaceId": "aB3dE5gH7jK",
+  "title": "Optimize database connection pooling",
+  "body": "We are seeing intermittent connection timeouts during peak hours. Analyze logs from the last 7 days and propose connection pool configuration changes.",
+  "assignee": "agent"
+}
+```
+
+### 2. Creating a Scheduled/Cron Task
+Set up recurring tasks with cron expressions:
+```json
+{
+  "workspaceId": "aB3dE5gH7jK",
+  "title": "Daily health check report",
+  "body": "Run system health checks and post a summary of any issues found.",
+  "assignee": "agent",
+  "cronSchedule": "0 9 * * *"
+}
+```
+
+### 3. Replying to a Task Thread
+Provide updates, ask questions, or share findings in a task's thread:
+```json
+{
+  "workspaceId": "aB3dE5gH7jK",
+  "taskId": "zX9vW7tS5rQ",
+  "text": "Analysis complete. The connection pool exhausts at 50 concurrent connections. Recommend increasing max pool size to 100 and adding a 30s idle timeout."
+}
+```
+
+### 4. Updating Self-Learning Notes
+Capture workspace-specific knowledge for future sessions:
+```json
+{
+  "id": "aB3dE5gH7jK",
+  "selfLearningLoopNote": "- Database changes require DBA team review before applying.\n- Preferred connection pool library: pgxpool.\n- Alert threshold: >5s p99 latency."
+}
+```
+
+### 5. Responding to a Task
+Answer a permission request a task is waiting on. `action` is `allow`, `allow_all`, `reject`, or `text`:
+```json
+{
+  "workspaceId": "aB3dE5gH7jK",
+  "taskId": "zX9vW7tS5rQ",
+  "action": "allow",
+  "text": "Approved. Proceed with the proposed changes."
+}
+```
+
+### 6. Updating Task Status
+Track progress by updating status as work progresses:
+```json
+{
+  "workspaceId": "aB3dE5gH7jK",
+  "taskId": "zX9vW7tS5rQ",
+  "status": "completed"
+}
+```


### PR DESCRIPTION
## What changed

Both Claude Code plugins now live in this repository and are installed from its own marketplace, the way the DeepSeek Harness bundle already is — with a README each and a workflow that checks their manifests and their documented tool lists.

## Why changed

Keeping them in a separate repository meant their documentation could not be checked against the servers it describes, and it had drifted badly.

## Test coverage report

- New lines introduced: **100%** — both new test functions run in the default suite, covering all 8 subtests (2 plugins × 2 documents each, plus 4 for the retired-name check).
- Total coverage impact: **no regression.** Full backend suite passes with 0 failures across 28 packages. The moved plugin content is markdown and JSON manifests with no runtime code, so there is nothing there to cover — the workflow validates it structurally instead.

## Other reports

**⚠️ The marketplace URL changes, and that is the one cost here.** It is now `https://github.com/agentrq/agentrq`. Both READMEs say so and tell anyone who added the old marketplace to re-add it at the new URL.

**The old repository is untouched by this PR.** It still serves the marketplace it always has, so nothing breaks the moment this merges — but the two copies drift from here. It should be pointed at the new URL and retired as a follow-up; say the word and I will open that.

**Why the manifest is at the repository root.** A Claude marketplace is a git URL, not a published package, so `/plugin marketplace add <repo>` looks for `.claude-plugin/marketplace.json` at the root. The `source` paths inside it are unchanged, because the plugin directories keep their names — this is a move, not a rewrite.

**What being in the monorepo actually buys.** The plugin docs are now checked against the servers they describe, which the separate repository could not do:

- Both README tables and both skills are diffed against the `AddTool` calls in `handler/coremcp` and `controller/mcp`, in both directions — 19/19 for the supervisor, 11/11 for the workspace agent.
- A second test refuses the specific ghosts that have actually shipped in these files: `getTaskMessages` and `getNextTask`, which no longer exist, and `waiting`, `done`, `failed` and `deny`, which the server rejects. The supervisor skill's human-in-the-loop rule told agents to signal being stuck with `waiting` — so an agent following it could not report being blocked at all.
- **Verified the tests bite**, rather than trusting that they pass: injecting a removed tool and a rejected status into a README produces
  ```
  registers "getMemory", but plugins/agentrq/README.md has no row for it
  documents "getTaskMessages", which ... does not register
  offers `waiting`, which the server rejects
  ```

**The workflow runs on changes to the plugins *or to either MCP server*,** so adding a tool to a server fails the build until the plugins document it. It also validates the manifests: everything parses, every listed plugin exists at the path it names with a matching `plugin.json` name, its `package.json` and `plugin.json` versions agree, and it ships a skill. Both the YAML and the validator were run locally before pushing.

**Namespaced under `plugins/claude/`**, so the layout reads as `plugins/claude/agentrq`, `plugins/claude/agentrq-workspace` and `plugins/deepseek-harness` — the host tool names the directory. The namespace has a README of its own explaining what the two plugins are and how they are kept honest. Every dependent path moved with them: the marketplace `source` fields, the parity test's document paths, the workflow's path filters (now one `plugins/claude/**` entry instead of two), and the root READMEs' links. Verified afterwards that all four manifests still validate, every markdown link under `plugins/claude/` resolves, and no reference to the old paths survives.

TaskID: 0iOQZ79Gggz
