### PR TITLE
docs: point the ACP gateway instructions at Antigravity and Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,23 +297,32 @@ When connected, the AI agent has access to:
 
 ## 🌉 ACP Gateway (Bridge for ACP Agents)
 
-While Claude Code has native support for `claude/notifications`, other agents like **Gemini CLI** require a bridge to receive real-time task notifications from AgentRQ. The `@agentrq/acp-gateway` bridges the [Agent Client Protocol (ACP)](https://agentclientprotocol.com) with MCP to enable this.
+While Claude Code has native support for `claude/notifications`, other agents like **Antigravity** and **Codex** require a bridge to receive real-time task notifications from AgentRQ. The `@agentrq/acp-gateway` bridges the [Agent Client Protocol (ACP)](https://agentclientprotocol.com) with MCP to enable this.
 
-### Installation
-
-```bash
-npm install -g @agentrq/acp-gateway
-```
+There is nothing to install — `npx` fetches the gateway, and the gateway fetches
+the agent you name.
 
 ### Usage
 
 1. Ensure you have a [`.mcp.json`](#step-1--mcpjson) in your project root.
-2. Run the gateway followed by your agent's ACP command:
+2. Log in to your agent once, then start the gateway from the same directory as
+   `.mcp.json`:
 
 ```bash
-# Using Gemini CLI
-acp-gateway -- gemini --acp
+# Using Antigravity
+npx @agentrq/acp-gateway@latest --login --agent antigravity-acp --allow-unverified-agent
+npx @agentrq/acp-gateway@latest --agent antigravity-acp --allow-unverified-agent
 ```
+
+```bash
+# Using Codex
+npx @agentrq/acp-gateway@latest --login --agent codex-acp
+npx @agentrq/acp-gateway@latest --agent codex-acp
+```
+
+Antigravity is published as a binary the registry carries no checksum for, so it
+needs `--allow-unverified-agent` on every command; Codex ships as an npm package
+and does not. Sign out again with `--logout` in place of `--login`.
 
 The gateway will automatically:
 - Connect to your AgentRQ workspace via the URL in `.mcp.json`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -271,30 +271,27 @@ AgentRQ 可以接入多种 Agent CLI 或 MCP 客户端。每个 Workspace 的 MC
 - `deleteMemory`：删除某一条 Workspace 记忆。
 - `elicit`：向人类提问并等待回答，支持表单模式和链接确认模式。
 
-### Codex Gateway
+### ACP Gateway（Antigravity / Codex）
 
-Codex 可通过 `@agentrq/codex-gateway` 连接 AgentRQ：
-
-```bash
-npm install -g @agentrq/codex-gateway@latest
-codex-gateway
-```
-
-它通常需要同时配置：
-
-- `.mcp.json`：供 `codex-gateway` 接收 AgentRQ 任务。
-- `.codex/config.toml`：供 Codex agent 在执行任务时直接调用 AgentRQ MCP tools。
-
-详细配置见英文 [README.md](README.md) 的 `Codex Gateway` 部分。
-
-### ACP / Gemini
-
-ACP Agent 可通过 `@agentrq/acp-gateway` 接入，例如 Gemini CLI：
+ACP Agent 通过 `@agentrq/acp-gateway` 接入，无需安装：`npx` 拉取 Gateway，
+Gateway 再拉取你指定的 Agent。先登录一次，然后在 `.mcp.json` 所在目录启动：
 
 ```bash
-npm install -g @agentrq/acp-gateway
-acp-gateway -- gemini --acp
+# Antigravity
+npx @agentrq/acp-gateway@latest --login --agent antigravity-acp --allow-unverified-agent
+npx @agentrq/acp-gateway@latest --agent antigravity-acp --allow-unverified-agent
 ```
+
+```bash
+# Codex
+npx @agentrq/acp-gateway@latest --login --agent codex-acp
+npx @agentrq/acp-gateway@latest --agent codex-acp
+```
+
+Antigravity 以二进制形式发布且 registry 未提供校验和，因此每条命令都需要
+`--allow-unverified-agent`；Codex 以 npm 包发布，不需要该参数。把 `--login`
+换成 `--logout` 即可登出。旧版本的 `@agentrq/codex-gateway` 和
+`.codex/config.toml` 均已不再需要。
 
 详细说明见英文 [README.md](README.md) 的 `ACP Gateway` 部分。
 
@@ -321,8 +318,7 @@ CoreMCP 使用 OAuth2，让管理型 Agent 在当前用户权限范围内查看�
 
 - Claude Code plugin marketplace extension
 - Gemini CLI extension
-- ACP Gateway
-- Codex Gateway
+- ACP Gateway（Antigravity / Codex）
 - DeepSeek Harness plugin
 
 Claude Code 插件安装（Marketplace 已迁移到本仓库；`agentrq` 为 Supervisor，`agentrq-workspace` 为单个 Workspace 的执行 Agent）：


### PR DESCRIPTION
**What changed**

The ACP gateway section of the README now shows how to start Antigravity and Codex through the gateway — a login pass followed by a start command — instead of the old Gemini CLI example, and the global install step is gone. The Chinese README gets the same instructions, with its retired standalone Codex gateway section folded into the ACP one.

**Why changed**

The documented commands no longer worked: the gateway is run with `npx` and resolves the agent from the ACP registry, and each agent needs a login before it will open a session. The README was the last place still telling people to install the gateway globally and pass an agent command through `--`.

**Test coverage report**

Documentation only — no code changed, so no new lines and no change to total coverage.

**Other reports**

The commands match what the in-app workspace setup modal hands out, including `--allow-unverified-agent` for Antigravity: the registry publishes it as a binary with no checksum, and omitting the flag is an error rather than a different behaviour. Codex ships as an npm package and needs no such flag.

TaskID: 0iOZrgL9Yzh

🤖 Generated with [Claude Code](https://claude.com/claude-code)