### PR TITLE
fix(mcp): route channel notifications by method, not by substring

### DIFF
--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -32,6 +33,34 @@ var customNotificationMethods = []string{
 	"notifications/claude/channel/permission_request",
 	mcpctrl.AgentTelemetryNotificationMethod,
 	mcpctrl.AgentModelsNotificationMethod,
+}
+
+// customNotificationMethod reports which of those a request body declares.
+//
+// The decision comes from the parsed `method` field, never from the raw bytes.
+// Matching the whole body as a substring meant any request that merely
+// *mentioned* one of these names — in a tool argument, in a reply's prose, in a
+// task body — was intercepted, answered with an empty 200 and never executed,
+// with no error on either side. Explaining this subsystem to a human is an
+// ordinary thing for an agent here to do, and it silently cost them the
+// message.
+//
+// A body that is not a single JSON-RPC object — malformed, or a batch array —
+// declares no method and so is not one of these. It falls through to the SDK,
+// which handled it before this interception existed and knows how to report
+// what is wrong with it. Answering it here with an empty 200 would turn a bad
+// request into a lost one.
+func customNotificationMethod(body []byte) (string, bool) {
+	var msg struct {
+		Method string `json:"method"`
+	}
+	if err := json.Unmarshal(body, &msg); err != nil {
+		return "", false
+	}
+	if slices.Contains(customNotificationMethods, msg.Method) {
+		return msg.Method, true
+	}
+	return "", false
 }
 
 type Params struct {
@@ -371,14 +400,12 @@ func (h *handler) streamableHandler() http.Handler {
 			// Custom handling for the channel notifications the SDK does not
 			// know about, because mcp-go (SDK) rejects them as unsupported
 			// methods before any middleware sees them.
-			for _, method := range customNotificationMethods {
-				if strings.Contains(string(body), method) {
-					zlog.Debug().Str("session_id", sessionID).Str("method", method).Msg("Handling custom channel notification")
-					srv.HandleCustomNotification(ctx, sessionID, body)
-					w.Header().Set("Content-Type", "application/json")
-					w.WriteHeader(http.StatusOK)
-					return
-				}
+			if method, ok := customNotificationMethod(body); ok {
+				zlog.Debug().Str("session_id", sessionID).Str("method", method).Msg("Handling custom channel notification")
+				srv.HandleCustomNotification(ctx, sessionID, body)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				return
 			}
 		}
 		srv.Handler().ServeHTTP(w, r.WithContext(ctx))

--- a/backend/internal/handler/mcp/notification_method_test.go
+++ b/backend/internal/handler/mcp/notification_method_test.go
@@ -1,0 +1,99 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	mcpctrl "github.com/agentrq/agentrq/backend/internal/controller/mcp"
+)
+
+// The bug this file guards against: the router used to decide by scanning the
+// whole request body for one of these names, so a request that merely talked
+// about them was intercepted, answered with an empty 200 and never executed.
+// Two agent replies explaining the models rail were lost that way before anyone
+// worked out why.
+
+func TestCustomNotificationMethod_RoutesEachRealNotification(t *testing.T) {
+	for _, method := range customNotificationMethods {
+		t.Run(method, func(t *testing.T) {
+			body := fmt.Appendf(nil, `{"jsonrpc":"2.0","method":%q,"params":{"task_id":"0iOq7fDWLPl"}}`, method)
+
+			got, ok := customNotificationMethod(body)
+			if !ok {
+				t.Fatalf("a genuine %s notification was not recognised", method)
+			}
+			if got != method {
+				t.Errorf("routed as %q, want %q", got, method)
+			}
+		})
+	}
+}
+
+func TestCustomNotificationMethod_IgnoresTheNameInsideAToolCall(t *testing.T) {
+	// The reduced form of the real failure: an agent telling its human how the
+	// models notification works. The name appears in an argument, so a
+	// substring match intercepted the call and the reply vanished.
+	for _, method := range customNotificationMethods {
+		t.Run(method, func(t *testing.T) {
+			args, err := json.Marshal(map[string]any{
+				"chatId": "0iOq7fDWLPl",
+				"text":   "The gateway sends " + method + " whenever the agent's session config changes.",
+			})
+			if err != nil {
+				t.Fatalf("marshalling the arguments: %v", err)
+			}
+			body := fmt.Appendf(nil,
+				`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"reply","arguments":%s}}`, args)
+
+			if got, ok := customNotificationMethod(body); ok {
+				t.Fatalf("a tools/call mentioning %s was intercepted as %q; the caller loses the request", method, got)
+			}
+		})
+	}
+}
+
+func TestCustomNotificationMethod_RoutesByTheMethodItDeclares(t *testing.T) {
+	// A real notification whose payload happens to name a different one. It
+	// belongs to the method it declares, not to whichever name appears first
+	// in the allowlist.
+	body := fmt.Appendf(nil,
+		`{"jsonrpc":"2.0","method":%q,"params":{"note":%q}}`,
+		mcpctrl.AgentTelemetryNotificationMethod, mcpctrl.AgentModelsNotificationMethod)
+
+	got, ok := customNotificationMethod(body)
+	if !ok {
+		t.Fatal("a genuine telemetry notification was not recognised")
+	}
+	if got != mcpctrl.AgentTelemetryNotificationMethod {
+		t.Errorf("routed as %q, want the declared %q", got, mcpctrl.AgentTelemetryNotificationMethod)
+	}
+}
+
+func TestCustomNotificationMethod_FallsThroughToTheSDK(t *testing.T) {
+	// Everything here must reach the SDK handler. It answered these before the
+	// interception existed and it is what reports what is wrong with them;
+	// swallowing one with an empty 200 would turn a bad request into a lost
+	// one.
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"an ordinary tool call", `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"getWorkspace"}}`},
+		{"a method the SDK owns", `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`},
+		{"an unrelated notification", `{"jsonrpc":"2.0","method":"notifications/initialized"}`},
+		{"malformed JSON", `{"jsonrpc":"2.0","method":`},
+		{"a batch array", `[{"jsonrpc":"2.0","method":"` + mcpctrl.AgentModelsNotificationMethod + `"}]`},
+		{"an empty body", ``},
+		{"JSON that is not an object", `"` + mcpctrl.AgentModelsNotificationMethod + `"`},
+		{"a method that only starts the same way", `{"jsonrpc":"2.0","method":"` + mcpctrl.AgentModelsNotificationMethod + `/extra"}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, ok := customNotificationMethod([]byte(tc.body)); ok {
+				t.Errorf("intercepted as %q; it should reach the SDK handler", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

A request to the workspace MCP endpoint is now recognised as an internal channel notification by the method it declares, rather than by whether its raw body happens to contain one of those method names anywhere.

## Why changed

The old substring match meant any request that merely *mentioned* one of those names — in a tool argument, in a reply's text, in a task body — was intercepted, answered with an empty HTTP 200 and never executed, with no error on either side. Talking to a human about this part of the system is an ordinary thing for an agent here to do, and it silently cost them the message: two status replies were lost this way while planning the ACP slash-commands work. It also gets worse with every notification added, since each new name widens the collision surface.

## Test coverage report

- **New lines: 100%** — `customNotificationMethod` is 100% covered (`go tool cover -func`).
- **Total coverage impact:** `internal/handler/mcp` 65.3% → **66.1%**.
- New tests (`internal/handler/mcp/notification_method_test.go`) cover: each real notification still routes; a `tools/call` carrying the name in its arguments is not intercepted; a notification that declares one method while mentioning another routes to the one it declares; and everything that must fall through to the SDK — ordinary calls, malformed JSON, batch arrays, an empty body, non-object JSON, and a method that only shares a prefix.
- Full suite green: `go test ./internal/...`, 28 packages ok.

## Other reports

Reduced repro, captured against the live server before the fix:

```
tools/call getWorkspace {"note":"<a channel notification method name>"}  -> HTTP 200, zero JSON-RPC frames
tools/call getWorkspace {"note":"harmless"}                              -> HTTP 200, one result frame
```

Behaviour deliberately unchanged: genuine notifications still bypass the SDK the same way, since it rejects them as unsupported methods before any middleware sees them.

TaskID: 0iP04yOdLaj
