### PR TITLE
feat(mcp): record and expose the slash commands the agent offers

### DIFF
--- a/backend/internal/controller/mcp/agent_commands.go
+++ b/backend/internal/controller/mcp/agent_commands.go
@@ -1,0 +1,202 @@
+package mcp
+
+import (
+	"context"
+	"slices"
+
+	"github.com/mustafaturan/monoflake"
+	zlog "github.com/rs/zerolog/log"
+
+	"github.com/agentrq/agentrq/backend/internal/service/eventbus"
+)
+
+// AgentCommandsNotificationMethod is the channel notification a gateway sends
+// to say which slash commands the agent behind it offers.
+//
+// An ACP agent advertises them whenever context makes them relevant, so the
+// newest list for a session replaces the previous one rather than adding to it.
+const AgentCommandsNotificationMethod = "notifications/claude/channel/commands"
+
+// AgentCommand is one slash command the connected agent offers.
+type AgentCommand struct {
+	// Name is typed as /<name> at the start of a message.
+	Name string `json:"name"`
+	// Description says what the command does, and may be empty: the name is
+	// what gets invoked, and an agent is not obliged to explain itself.
+	Description string `json:"description,omitempty"`
+	// Hint describes the argument, for the commands that take one.
+	Hint string `json:"hint,omitempty"`
+}
+
+// AgentCommandsParams is the payload of a commands notification.
+//
+// snake_case, unlike the REST surface: this is the wire format the gateways
+// already send (acp-gateway's `sendCommandsToWorkspace`), and renaming the
+// fields here would break every gateway in the field to satisfy a convention
+// that governs the HTTP API rather than this channel.
+type AgentCommandsParams struct {
+	TaskID    string         `json:"task_id"`
+	SessionID string         `json:"session_id"`
+	Commands  []AgentCommand `json:"commands"`
+}
+
+// AgentCommandsSnapshot is what one connected session last reported.
+//
+// SessionID is the *agent's* session — see the note on keying in
+// HandleAgentCommands — and is kept because it is the only thing tying a
+// snapshot back to the conversation it came from when more than one session is
+// connected.
+type AgentCommandsSnapshot struct {
+	SessionID string
+	Commands  []AgentCommand
+}
+
+// HandleAgentCommands records the slash commands a session reports it offers.
+//
+// Recorded rather than relayed into the chat, like the models beside it: this
+// is not something that happened during a turn, it is a standing fact about the
+// connected agent, and it belongs with the other live capabilities the
+// interface reads off the workspace.
+func (ps *WorkspaceServer) HandleAgentCommands(ctx context.Context, sessionID string, p AgentCommandsParams) {
+	// Keyed by the MCP transport session, deliberately, and *not* by the
+	// payload's session_id.
+	//
+	// The two are different namespaces: the transport session is this server's
+	// connection to the gateway, while `session_id` is the gateway's own ACP
+	// session with the agent behind it. Keying on the payload would put entries
+	// under IDs that liveSessionIDs never reports, so every snapshot would look
+	// as though it belonged to a session that had gone and none would ever be
+	// advertised. agentModels next door keys the same way for the same reason.
+	//
+	// An empty key is fine rather than something to reject: some transports
+	// leave the session ID blank, and the reader filters against the same list
+	// this is keyed on, so the two stay consistent either way.
+	//
+	// An empty command list is recorded rather than dropped: it is how an agent
+	// says it has withdrawn its commands, and keeping the old list would leave
+	// a menu offering commands the agent no longer accepts.
+	snapshot := AgentCommandsSnapshot{
+		SessionID: p.SessionID,
+		Commands:  p.Commands,
+	}
+
+	ps.agentCommandsMu.Lock()
+	previous, had := ps.agentCommands[sessionID]
+	changed := !had || !slices.Equal(previous.Commands, p.Commands)
+	ps.agentCommands[sessionID] = snapshot
+	pruneAgentCommands(ps.agentCommands, ps.liveSessionIDs())
+	ps.agentCommandsMu.Unlock()
+
+	zlog.Debug().
+		Str("session_id", sessionID).
+		Int("commands", len(p.Commands)).
+		Bool("changed", changed).
+		Msg("recorded the slash commands the agent offers")
+
+	// An agent that re-advertises the same list — which it does whenever the
+	// commands survive a context change — is not news, and telling every open
+	// tab about it would be a broadcast storm for a menu that did not move.
+	if !changed {
+		return
+	}
+	ps.publishAgentCommands(snapshot)
+}
+
+// publishAgentCommands tells the human clients what the workspace now offers.
+//
+// The commands arrive long after any page load — an agent advertises them once
+// its session is up, which is after it has taken a task — so a client that only
+// ever read them from the workspace payload would show an empty menu for the
+// rest of its life. This is the same reason publishAgentConnected exists.
+//
+// What goes out is the list just reported, not the answer AgentCommands would
+// give. The session that reported is connected by definition — it has this
+// instant spoken — whereas the session registry only learns about a transport
+// when it registers its stream, so asking it here answers a question about
+// timing rather than about the agent.
+//
+// A withdrawal is the one case that has to look wider: another session may
+// still be offering commands, and taking the menu away because this one stopped
+// would remove something still live. So an empty report falls back to whatever
+// the workspace would serve, which is an empty list when the answer is nothing.
+func (ps *WorkspaceServer) publishAgentCommands(reported AgentCommandsSnapshot) {
+	commands := reported.Commands
+	if len(commands) == 0 {
+		commands = []AgentCommand{}
+		if snapshot := ps.AgentCommands(); snapshot != nil {
+			commands = snapshot.Commands
+		}
+	}
+
+	// Base62, the way every other event on this bus carries a workspace ID: the
+	// REST API only ever names a workspace that way (see view.Workspace), so a
+	// raw int64 here would match nothing the frontend holds and the menu would
+	// never move off whatever the last page load fetched.
+	ps.bus.Publish(ps.workspaceID, ps.userID, eventbus.Event{
+		Type: "agent.commands",
+		Payload: map[string]any{
+			"commands":    commands,
+			"workspaceId": monoflake.ID(ps.workspaceID).String(),
+		},
+	})
+}
+
+// AgentCommands reports the slash commands the connected agent offers, or nil
+// when nothing connected has said.
+func (ps *WorkspaceServer) AgentCommands() *AgentCommandsSnapshot {
+	ps.agentCommandsMu.RLock()
+	defer ps.agentCommandsMu.RUnlock()
+	return pickAgentCommands(ps.agentCommands, ps.liveSessionIDs())
+}
+
+// pickAgentCommands chooses the snapshot to report from what sessions have said.
+//
+// Only live sessions count. The snapshot arrives by notification and is
+// therefore cached, so without this filter a workspace would go on offering the
+// commands of an agent that disconnected hours ago, and every one of them would
+// fail.
+//
+// A session that reported an empty list is skipped rather than returned: it has
+// withdrawn its commands, and another session may still have some worth
+// showing. `live` is iterated rather than the map so the answer follows the
+// session order the server reports rather than Go's randomised map order, which
+// would otherwise make the choice differ between two identical calls.
+func pickAgentCommands(snapshots map[string]AgentCommandsSnapshot, live []string) *AgentCommandsSnapshot {
+	for _, id := range live {
+		snapshot, ok := snapshots[id]
+		if !ok || len(snapshot.Commands) == 0 {
+			continue
+		}
+		return &snapshot
+	}
+	return nil
+}
+
+// pruneAgentCommands drops the snapshots of sessions that have gone away.
+//
+// There is no disconnect hook to hang this on, and pickAgentCommands already
+// ignores dead sessions, so this is about the map rather than about
+// correctness: a long-lived workspace whose agent reconnects repeatedly would
+// otherwise accumulate one snapshot per session for the life of the process.
+//
+// No live sessions at all means the server is between connections rather than
+// that every snapshot is stale — and dropping them there would discard the very
+// notification being recorded, since a test or an early call can observe the
+// map before the session is visible.
+//
+// The caller must hold the write lock.
+func pruneAgentCommands(snapshots map[string]AgentCommandsSnapshot, live []string) {
+	if len(live) == 0 {
+		return
+	}
+
+	keep := make(map[string]bool, len(live))
+	for _, id := range live {
+		keep[id] = true
+	}
+	for id := range snapshots {
+		if !keep[id] {
+			delete(snapshots, id)
+		}
+	}
+}

--- a/backend/internal/controller/mcp/agent_commands_test.go
+++ b/backend/internal/controller/mcp/agent_commands_test.go
@@ -1,0 +1,530 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/mustafaturan/monoflake"
+
+	"github.com/agentrq/agentrq/backend/internal/service/eventbus"
+)
+
+// The commands an ACP agent advertises used to stop at the gateway. These tests
+// pin the workspace end of that path: that the payload the gateways actually
+// send is understood, that a snapshot never outlives the session that reported
+// it, and that the human's open tabs are told when the menu changes — since the
+// commands arrive long after any page load.
+
+// connectedCommandsServer is a workspace with a real session attached, which
+// the publish tests need: what goes out on the bus is what the workspace would
+// now serve over REST, and that answer is filtered by the live sessions.
+func connectedCommandsServer(t *testing.T) (*WorkspaceServer, string, chan []byte) {
+	t.Helper()
+	replies := 0
+	ps := permissionServer(t, &replies)
+	ps.bus = eventbus.New()
+	ps.agentCommands = make(map[string]AgentCommandsSnapshot)
+	sessionID := connectedServer(t, ps, "acp-gateway")
+
+	ch := ps.bus.Subscribe(ps.workspaceID, "")
+	t.Cleanup(func() { ps.bus.Unsubscribe(ps.workspaceID, "", ch) })
+	return ps, sessionID, ch
+}
+
+func newCommandsServer() *WorkspaceServer {
+	return &WorkspaceServer{
+		workspaceID:   100,
+		bus:           eventbus.New(),
+		agentCommands: make(map[string]AgentCommandsSnapshot),
+	}
+}
+
+// The exact frame acp-gateway puts on the wire (src/acpClient.ts), so a rename
+// on either side fails here rather than in production.
+const gatewayCommandsFrame = `{
+  "jsonrpc": "2.0",
+  "method": "notifications/claude/channel/commands",
+  "params": {
+    "task_id": "0iF1U1qQwS1",
+    "session_id": "01a07404-01a7-7033-a58f-47b119036378",
+    "commands": [
+      {"name": "web", "description": "Search the web for information", "hint": "query to search for"},
+      {"name": "compact"}
+    ]
+  }
+}`
+
+func TestAgentCommandsParamsMatchesTheGatewayWireFormat(t *testing.T) {
+	var frame struct {
+		Method string              `json:"method"`
+		Params AgentCommandsParams `json:"params"`
+	}
+	if err := json.Unmarshal([]byte(gatewayCommandsFrame), &frame); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if frame.Method != AgentCommandsNotificationMethod {
+		t.Errorf("method = %q, want %q", frame.Method, AgentCommandsNotificationMethod)
+	}
+
+	p := frame.Params
+	if p.TaskID != "0iF1U1qQwS1" {
+		t.Errorf("task_id = %q", p.TaskID)
+	}
+	if p.SessionID != "01a07404-01a7-7033-a58f-47b119036378" {
+		t.Errorf("session_id = %q", p.SessionID)
+	}
+	if len(p.Commands) != 2 {
+		t.Fatalf("commands = %d, want 2", len(p.Commands))
+	}
+	want := AgentCommand{Name: "web", Description: "Search the web for information", Hint: "query to search for"}
+	if !reflect.DeepEqual(p.Commands[0], want) {
+		t.Errorf("commands[0] = %+v, want %+v", p.Commands[0], want)
+	}
+	if p.Commands[1].Description != "" || p.Commands[1].Hint != "" {
+		t.Errorf("optional fields should stay zero when absent: %+v", p.Commands[1])
+	}
+}
+
+func TestHandleCustomNotificationRoutesCommands(t *testing.T) {
+	ps := newCommandsServer()
+	ps.HandleCustomNotification(context.Background(), "transport-session", []byte(gatewayCommandsFrame))
+
+	// Keyed by the MCP transport session — the namespace liveSessionIDs
+	// reports — and not by the ACP session the payload names.
+	got, ok := ps.agentCommands["transport-session"]
+	if !ok {
+		t.Fatalf("commands were not recorded; map = %+v", ps.agentCommands)
+	}
+	if _, wrong := ps.agentCommands["01a07404-01a7-7033-a58f-47b119036378"]; wrong {
+		t.Error("keyed by the payload's ACP session, which liveSessionIDs never reports")
+	}
+	if len(got.Commands) != 2 || got.Commands[0].Name != "web" {
+		t.Errorf("recorded = %+v", got)
+	}
+	if got.SessionID != "01a07404-01a7-7033-a58f-47b119036378" {
+		t.Errorf("the agent's session should be kept on the snapshot, got %q", got.SessionID)
+	}
+}
+
+func TestHandleAgentCommands(t *testing.T) {
+	t.Run("records what the session reported", func(t *testing.T) {
+		ps := newCommandsServer()
+		ps.HandleAgentCommands(context.Background(), "sess-1", AgentCommandsParams{
+			Commands: []AgentCommand{{Name: "init"}, {Name: "review", Description: "Review the diff"}},
+		})
+
+		got := ps.agentCommands["sess-1"]
+		if len(got.Commands) != 2 || got.Commands[1].Description != "Review the diff" {
+			t.Errorf("recorded = %+v", got)
+		}
+	})
+
+	t.Run("keys on the transport session, not the agent's", func(t *testing.T) {
+		// The payload's session_id is the gateway's ACP session; the key has to
+		// be the MCP transport session, because that is the namespace
+		// liveSessionIDs reports and therefore the one the reader filters on.
+		// Keying on the payload would file every snapshot under an ID that
+		// never appears live, and none would ever be advertised.
+		ps := newCommandsServer()
+		ps.HandleAgentCommands(context.Background(), "mcp-session", AgentCommandsParams{
+			SessionID: "acp-session",
+			Commands:  []AgentCommand{{Name: "init"}},
+		})
+
+		if _, ok := ps.agentCommands["mcp-session"]; !ok {
+			t.Errorf("expected the transport session as the key, got %+v", ps.agentCommands)
+		}
+		if _, ok := ps.agentCommands["acp-session"]; ok {
+			t.Error("must not key on the agent's own session id")
+		}
+		if got := ps.agentCommands["mcp-session"].SessionID; got != "acp-session" {
+			t.Errorf("the agent's session should still be recorded on the snapshot, got %q", got)
+		}
+	})
+
+	t.Run("records against a blank transport session rather than dropping it", func(t *testing.T) {
+		// Some transports leave the session ID empty. The reader filters
+		// against the same list this is keyed on, so "" is internally
+		// consistent — and dropping it would lose the commands outright.
+		ps := newCommandsServer()
+		ps.HandleAgentCommands(context.Background(), "", AgentCommandsParams{Commands: []AgentCommand{{Name: "init"}}})
+
+		if _, ok := ps.agentCommands[""]; !ok {
+			t.Errorf("expected the commands recorded under the blank key, got %+v", ps.agentCommands)
+		}
+		if got := pickAgentCommands(ps.agentCommands, []string{""}); got == nil {
+			t.Error("a blank-keyed snapshot must still be readable for a blank live session")
+		}
+	})
+
+	t.Run("the newest report replaces the previous one", func(t *testing.T) {
+		ps := newCommandsServer()
+		ps.HandleAgentCommands(context.Background(), "sess-1", AgentCommandsParams{
+			Commands: []AgentCommand{{Name: "a"}, {Name: "b"}},
+		})
+		ps.HandleAgentCommands(context.Background(), "sess-1", AgentCommandsParams{
+			Commands: []AgentCommand{{Name: "c"}},
+		})
+
+		got := ps.agentCommands["sess-1"]
+		if len(got.Commands) != 1 || got.Commands[0].Name != "c" {
+			t.Errorf("expected the second report to win, got %+v", got)
+		}
+	})
+
+	t.Run("an empty list is recorded, because it withdraws the menu", func(t *testing.T) {
+		ps := newCommandsServer()
+		ps.HandleAgentCommands(context.Background(), "sess-1", AgentCommandsParams{Commands: []AgentCommand{{Name: "a"}}})
+		ps.HandleAgentCommands(context.Background(), "sess-1", AgentCommandsParams{Commands: nil})
+
+		got, ok := ps.agentCommands["sess-1"]
+		if !ok {
+			t.Fatal("the withdrawal should still be recorded")
+		}
+		if len(got.Commands) != 0 {
+			t.Errorf("expected the list cleared, got %+v", got.Commands)
+		}
+	})
+}
+
+// The menu changes from outside the app — an agent advertises its commands once
+// its session is up, which is after a page has long since loaded — so the human
+// clients have to be told rather than left to re-fetch.
+func TestHandleAgentCommandsPublishesTheChange(t *testing.T) {
+	// waitForEvent reads one event, or fails: a silent timeout here would look
+	// like a passing test that asserts nothing.
+	waitForEvent := func(t *testing.T, ch chan []byte) map[string]any {
+		t.Helper()
+		select {
+		case raw := <-ch:
+			// The bus frames events for SSE, so what arrives is
+			// "data: {...}\n\n" rather than bare JSON.
+			var evt struct {
+				Type    string         `json:"type"`
+				Payload map[string]any `json:"payload"`
+			}
+			body := bytes.TrimSpace(bytes.TrimPrefix(raw, []byte("data: ")))
+			if err := json.Unmarshal(body, &evt); err != nil {
+				t.Fatalf("unmarshal event %q: %v", raw, err)
+			}
+			if evt.Type != "agent.commands" {
+				t.Fatalf("event type = %q, want agent.commands", evt.Type)
+			}
+			return evt.Payload
+		case <-time.After(time.Second):
+			t.Fatal("no event was published")
+			return nil
+		}
+	}
+
+	t.Run("announces the commands with a base62 workspace id", func(t *testing.T) {
+		// Base62 because that is the only form the frontend ever holds; a raw
+		// int64 would match nothing and the menu would never move.
+		ps, sessionID, ch := connectedCommandsServer(t)
+
+		ps.HandleAgentCommands(context.Background(), sessionID, AgentCommandsParams{
+			Commands: []AgentCommand{{Name: "compact", Description: "Shorten the context"}},
+		})
+
+		payload := waitForEvent(t, ch)
+		want := monoflake.ID(ps.workspaceID).String()
+		if got, ok := payload["workspaceId"].(string); !ok || got != want {
+			t.Errorf("workspaceId = %v, want the base62 form %q", payload["workspaceId"], want)
+		}
+		commands, ok := payload["commands"].([]any)
+		if !ok || len(commands) != 1 {
+			t.Fatalf("commands = %v", payload["commands"])
+		}
+		first, _ := commands[0].(map[string]any)
+		if first["name"] != "compact" || first["description"] != "Shorten the context" {
+			t.Errorf("commands[0] = %v", first)
+		}
+	})
+
+	t.Run("stays quiet when the agent re-advertises the same list", func(t *testing.T) {
+		// An agent repeats its list whenever context shifts without changing
+		// what it offers. Broadcasting that to every open tab would be noise
+		// about a menu that did not move.
+		ps, sessionID, ch := connectedCommandsServer(t)
+
+		same := []AgentCommand{{Name: "init"}, {Name: "review", Hint: "what to review"}}
+		ps.HandleAgentCommands(context.Background(), sessionID, AgentCommandsParams{Commands: same})
+		waitForEvent(t, ch)
+
+		ps.HandleAgentCommands(context.Background(), sessionID, AgentCommandsParams{
+			Commands: []AgentCommand{{Name: "init"}, {Name: "review", Hint: "what to review"}},
+		})
+
+		select {
+		case raw := <-ch:
+			t.Errorf("an identical list was re-announced: %s", raw)
+		case <-time.After(50 * time.Millisecond):
+		}
+	})
+
+	t.Run("announces a withdrawal as an empty list", func(t *testing.T) {
+		// This is what takes the menu away. Without it the composer would go on
+		// offering commands the agent has stopped accepting.
+		ps, sessionID, ch := connectedCommandsServer(t)
+
+		ps.HandleAgentCommands(context.Background(), sessionID, AgentCommandsParams{Commands: []AgentCommand{{Name: "a"}}})
+		waitForEvent(t, ch)
+
+		ps.HandleAgentCommands(context.Background(), sessionID, AgentCommandsParams{Commands: nil})
+
+		payload := waitForEvent(t, ch)
+		if commands, ok := payload["commands"].([]any); !ok || len(commands) != 0 {
+			t.Errorf("commands = %v, want an empty list", payload["commands"])
+		}
+	})
+
+	t.Run("keeps the menu when one session withdraws but another still offers", func(t *testing.T) {
+		// Two gateways can be attached to one workspace. One of them dropping
+		// its commands says nothing about the other's, and clearing the menu
+		// would take away commands that still work.
+		ps, sessionID, ch := connectedCommandsServer(t)
+
+		ps.HandleAgentCommands(context.Background(), sessionID, AgentCommandsParams{
+			Commands: []AgentCommand{{Name: "still-here"}},
+		})
+		waitForEvent(t, ch)
+
+		ps.HandleAgentCommands(context.Background(), "a-second-session", AgentCommandsParams{Commands: nil})
+
+		payload := waitForEvent(t, ch)
+		commands, _ := payload["commands"].([]any)
+		if len(commands) != 1 {
+			t.Fatalf("commands = %v, want the surviving session's", payload["commands"])
+		}
+		first, _ := commands[0].(map[string]any)
+		if first["name"] != "still-here" {
+			t.Errorf("commands[0] = %v", first)
+		}
+	})
+
+	t.Run("announces a changed description, not just a changed name", func(t *testing.T) {
+		ps, sessionID, ch := connectedCommandsServer(t)
+
+		ps.HandleAgentCommands(context.Background(), sessionID, AgentCommandsParams{
+			Commands: []AgentCommand{{Name: "plan", Description: "the old wording"}},
+		})
+		waitForEvent(t, ch)
+
+		ps.HandleAgentCommands(context.Background(), sessionID, AgentCommandsParams{
+			Commands: []AgentCommand{{Name: "plan", Description: "the revised wording"}},
+		})
+
+		payload := waitForEvent(t, ch)
+		commands, _ := payload["commands"].([]any)
+		if len(commands) != 1 {
+			t.Fatalf("commands = %v", payload["commands"])
+		}
+		first, _ := commands[0].(map[string]any)
+		if first["description"] != "the revised wording" {
+			t.Errorf("commands[0] = %v", first)
+		}
+	})
+}
+
+func TestPickAgentCommands(t *testing.T) {
+	snapshots := map[string]AgentCommandsSnapshot{
+		"live":     {SessionID: "acp-live", Commands: []AgentCommand{{Name: "a"}}},
+		"dead":     {SessionID: "acp-dead", Commands: []AgentCommand{{Name: "z"}}},
+		"withdrew": {SessionID: "acp-empty"},
+	}
+
+	t.Run("reports what a live session offers", func(t *testing.T) {
+		got := pickAgentCommands(snapshots, []string{"live"})
+		if got == nil || got.SessionID != "acp-live" {
+			t.Fatalf("got %+v", got)
+		}
+	})
+
+	t.Run("never reports a disconnected session's commands", func(t *testing.T) {
+		// The whole reason for the filter: the snapshot is cached, so a
+		// workspace would otherwise offer commands of an agent that left, and
+		// every one of them would fail.
+		if got := pickAgentCommands(snapshots, []string{"dead-gone"}); got != nil {
+			t.Errorf("got %+v, want nil", got)
+		}
+		if got := pickAgentCommands(snapshots, nil); got != nil {
+			t.Errorf("got %+v, want nil", got)
+		}
+	})
+
+	t.Run("skips a session that withdrew its commands", func(t *testing.T) {
+		if got := pickAgentCommands(snapshots, []string{"withdrew"}); got != nil {
+			t.Errorf("got %+v, want nil", got)
+		}
+	})
+
+	t.Run("passes over an empty offer to find a real one", func(t *testing.T) {
+		got := pickAgentCommands(snapshots, []string{"withdrew", "live"})
+		if got == nil || got.SessionID != "acp-live" {
+			t.Fatalf("got %+v", got)
+		}
+	})
+
+	t.Run("follows session order rather than map order", func(t *testing.T) {
+		// Two identical calls must not disagree, which iterating the map would
+		// allow.
+		for i := 0; i < 50; i++ {
+			got := pickAgentCommands(snapshots, []string{"dead", "live"})
+			if got == nil || got.SessionID != "acp-dead" {
+				t.Fatalf("call %d got %+v, want the first live session's", i, got)
+			}
+		}
+	})
+
+	t.Run("has nothing to report when nothing was recorded", func(t *testing.T) {
+		if got := pickAgentCommands(map[string]AgentCommandsSnapshot{}, []string{"live"}); got != nil {
+			t.Errorf("got %+v, want nil", got)
+		}
+		if got := pickAgentCommands(nil, []string{"live"}); got != nil {
+			t.Errorf("got %+v, want nil", got)
+		}
+	})
+}
+
+func TestPruneAgentCommands(t *testing.T) {
+	t.Run("drops the sessions that have gone", func(t *testing.T) {
+		snapshots := map[string]AgentCommandsSnapshot{"a": {}, "b": {}, "c": {}}
+		pruneAgentCommands(snapshots, []string{"b"})
+
+		if len(snapshots) != 1 {
+			t.Fatalf("snapshots = %+v, want only b", snapshots)
+		}
+		if _, ok := snapshots["b"]; !ok {
+			t.Errorf("kept the wrong one: %+v", snapshots)
+		}
+	})
+
+	t.Run("keeps everything when nothing is connected", func(t *testing.T) {
+		// No live sessions means "between connections", not "all stale" —
+		// pruning there would discard the notification being recorded.
+		snapshots := map[string]AgentCommandsSnapshot{"a": {}}
+		pruneAgentCommands(snapshots, nil)
+
+		if len(snapshots) != 1 {
+			t.Errorf("snapshots = %+v, want a kept", snapshots)
+		}
+	})
+}
+
+func TestAgentCommandsWithoutAnMCPServer(t *testing.T) {
+	// No server means no live sessions, so there is nothing to offer even
+	// though something was recorded earlier.
+	ps := newCommandsServer()
+	ps.agentCommands["sess-1"] = AgentCommandsSnapshot{Commands: []AgentCommand{{Name: "a"}}}
+
+	if got := ps.AgentCommands(); got != nil {
+		t.Errorf("AgentCommands() = %+v, want nil", got)
+	}
+}
+
+// The end-to-end shape: a real session connects, reports its commands, and the
+// workspace offers them only for as long as that session is there. The pure
+// functions above cover the rules; this covers the wiring to the SDK.
+func TestAgentCommandsWithAConnectedSession(t *testing.T) {
+	replies := 0
+	ps := permissionServer(t, &replies)
+	ps.bus = eventbus.New()
+	ps.agentCommands = make(map[string]AgentCommandsSnapshot)
+	sessionID := connectedServer(t, ps, "acp-gateway")
+
+	// Nothing reported yet, so there is no menu. A gateway creates its ACP
+	// session lazily, once it has a task, so this is the ordinary state of a
+	// freshly connected workspace rather than an error.
+	if got := ps.AgentCommands(); got != nil {
+		t.Errorf("AgentCommands() = %+v before any report, want nil", got)
+	}
+
+	ps.HandleAgentCommands(context.Background(), sessionID, AgentCommandsParams{
+		SessionID: "acp-session",
+		Commands:  []AgentCommand{{Name: "init"}, {Name: "compact"}},
+	})
+
+	got := ps.AgentCommands()
+	if got == nil {
+		t.Fatal("AgentCommands() = nil after the session reported")
+	}
+	if len(got.Commands) != 2 || got.SessionID != "acp-session" {
+		t.Errorf("AgentCommands() = %+v", got)
+	}
+}
+
+// A snapshot recorded by a session that is no longer connected is never
+// offered, even though it is still cached — the case the live-session filter
+// exists for.
+func TestAgentCommandsIgnoresADepartedSession(t *testing.T) {
+	replies := 0
+	ps := permissionServer(t, &replies)
+	ps.bus = eventbus.New()
+	ps.agentCommands = map[string]AgentCommandsSnapshot{
+		"a-session-that-left": {Commands: []AgentCommand{{Name: "a"}}},
+	}
+	connectedServer(t, ps, "acp-gateway")
+
+	if got := ps.AgentCommands(); got != nil {
+		t.Errorf("AgentCommands() = %+v, want nil for a departed session", got)
+	}
+}
+
+// Recording a new session's commands evicts a departed one's, so the map does
+// not grow for the life of the process.
+func TestHandleAgentCommandsPrunesDepartedSessions(t *testing.T) {
+	replies := 0
+	ps := permissionServer(t, &replies)
+	ps.bus = eventbus.New()
+	ps.agentCommands = map[string]AgentCommandsSnapshot{
+		"a-session-that-left": {Commands: []AgentCommand{{Name: "old"}}},
+	}
+	sessionID := connectedServer(t, ps, "acp-gateway")
+
+	ps.HandleAgentCommands(context.Background(), sessionID, AgentCommandsParams{
+		Commands: []AgentCommand{{Name: "new"}},
+	})
+
+	if _, ok := ps.agentCommands["a-session-that-left"]; ok {
+		t.Errorf("the departed session should have been pruned: %+v", ps.agentCommands)
+	}
+	if _, ok := ps.agentCommands[sessionID]; !ok {
+		t.Errorf("the live session's commands should have been kept: %+v", ps.agentCommands)
+	}
+}
+
+func TestManagerAgentCommands(t *testing.T) {
+	m := NewManager(func(workspaceID int64, userID string) *WorkspaceServer {
+		return &WorkspaceServer{workspaceID: workspaceID, userID: userID}
+	})
+
+	t.Run("nothing to report for a workspace with no server running", func(t *testing.T) {
+		if got := m.AgentCommands(999); got != nil {
+			t.Errorf("AgentCommands(999) = %+v, want nil", got)
+		}
+	})
+
+	t.Run("asks the workspace's own server", func(t *testing.T) {
+		replies := 0
+		ps := permissionServer(t, &replies)
+		ps.bus = eventbus.New()
+		ps.agentCommands = make(map[string]AgentCommandsSnapshot)
+		sessionID := connectedServer(t, ps, "acp-gateway")
+		ps.HandleAgentCommands(context.Background(), sessionID, AgentCommandsParams{
+			Commands: []AgentCommand{{Name: "init"}},
+		})
+
+		m2 := NewManager(func(int64, string) *WorkspaceServer { return ps })
+		m2.Get(7, "user")
+
+		got := m2.AgentCommands(7)
+		if got == nil || len(got.Commands) != 1 || got.Commands[0].Name != "init" {
+			t.Errorf("AgentCommands(7) = %+v", got)
+		}
+	})
+}

--- a/backend/internal/controller/mcp/manager.go
+++ b/backend/internal/controller/mcp/manager.go
@@ -103,6 +103,19 @@ func (m *Manager) AgentModels(workspaceID int64) *AgentModelsSnapshot {
 	return srv.AgentModels()
 }
 
+// AgentCommands reports the slash commands the workspace's connected agent
+// offers, or nil when there is no server running for it or nothing has reported
+// any.
+func (m *Manager) AgentCommands(workspaceID int64) *AgentCommandsSnapshot {
+	m.mu.RLock()
+	srv, ok := m.servers[workspaceID]
+	m.mu.RUnlock()
+	if !ok || srv == nil {
+		return nil
+	}
+	return srv.AgentCommands()
+}
+
 // SendChannelNotification forwards a channel notification to the appropriate WorkspaceServer.
 func (m *Manager) SendChannelNotification(ctx context.Context, workspaceID int64, userID string, taskID int64, content string) {
 	m.mu.RLock()

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -145,6 +145,8 @@ type WorkspaceServer struct {
 	// sessions so a disconnected agent stops advertising its models.
 	agentModelsMu     sync.RWMutex
 	agentModels       map[string]AgentModelsSnapshot // sessionID -> models last reported
+	agentCommandsMu   sync.RWMutex
+	agentCommands     map[string]AgentCommandsSnapshot // sessionID -> slash commands last reported
 	elicitationsMu    sync.Mutex
 	elicitations      map[string]chan elicitationResponse // requestID -> channel the waiting elicit tool call blocks on
 	metadataMu        sync.RWMutex
@@ -386,6 +388,7 @@ func NewWorkspaceServer(
 		autoDecidedRequests:    make(map[string]struct{}),
 		agentTelemetryMessages: make(map[string]int64),
 		agentModels:            make(map[string]AgentModelsSnapshot),
+		agentCommands:          make(map[string]AgentCommandsSnapshot),
 		elicitations:           make(map[string]chan elicitationResponse),
 		icon:                   icon,
 		name:                   name,
@@ -2230,6 +2233,18 @@ func (ps *WorkspaceServer) HandleCustomNotification(ctx context.Context, session
 			return
 		}
 		ps.HandleAgentModels(ctx, sessionID, models.Params)
+		return
+	}
+
+	if msg.Method == AgentCommandsNotificationMethod {
+		var commands struct {
+			Params AgentCommandsParams `json:"params"`
+		}
+		if err := json.Unmarshal(data, &commands); err != nil {
+			zlog.Error().Err(err).Str("session_id", sessionID).Msg("Failed to unmarshal agent commands notification")
+			return
+		}
+		ps.HandleAgentCommands(ctx, sessionID, commands.Params)
 		return
 	}
 

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -32,6 +32,7 @@ type (
 		AgentConnected        bool
 		AgentSupportsStop     bool
 		AgentModels           *AgentModels
+		AgentCommands         *AgentCommands
 		AutoAllowedTools      []string
 		AllowAllCommands      bool
 		SelfLearningLoopNote  string
@@ -58,6 +59,20 @@ type (
 		Description string
 		Current     bool
 		Group       string
+	}
+
+	// AgentCommands is the set of slash commands the workspace's connected
+	// agent offers. Live state read off the MCP session rather than a stored
+	// column, so it is absent whenever no agent is connected or none has
+	// reported any.
+	AgentCommands struct {
+		Commands []AgentCommand
+	}
+
+	AgentCommand struct {
+		Name        string
+		Description string
+		Hint        string
 	}
 
 	SlackConfig struct {

--- a/backend/internal/data/view/api/view.go
+++ b/backend/internal/data/view/api/view.go
@@ -20,6 +20,7 @@ type (
 		AgentConnected        bool                  `json:"agentConnected"`
 		AgentSupportsStop     bool                  `json:"agentSupportsStop"`
 		AgentModels           *AgentModels          `json:"agentModels,omitempty"`
+		AgentCommands         *AgentCommands        `json:"agentCommands,omitempty"`
 		MCPURL                string                `json:"mcpUrl"`
 		MCPToken              string                `json:"mcpToken,omitempty"`
 		AutoAllowedTools      []string              `json:"autoAllowedTools,omitempty"`
@@ -45,6 +46,19 @@ type (
 		Description string `json:"description,omitempty"`
 		Current     bool   `json:"current,omitempty"`
 		Group       string `json:"group,omitempty"`
+	}
+
+	// AgentCommands is the set of slash commands the connected agent offers.
+	// Omitted entirely when no agent is connected or none has reported any, so
+	// a client can treat its presence as "there is a menu to show".
+	AgentCommands struct {
+		Commands []AgentCommand `json:"commands"`
+	}
+
+	AgentCommand struct {
+		Name        string `json:"name"`
+		Description string `json:"description,omitempty"`
+		Hint        string `json:"hint,omitempty"`
 	}
 
 	SlackConfig struct {

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -620,6 +620,7 @@ func (h *handler) createWorkspace() fiber.Handler {
 		rs.Workspace.AgentConnected = h.mcpManager.IsAgentConnected(rs.Workspace.ID)
 		rs.Workspace.AgentSupportsStop = h.mcpManager.SupportsStop(rs.Workspace.ID)
 		rs.Workspace.AgentModels = agentModelsEntity(h.mcpManager.AgentModels(rs.Workspace.ID))
+		rs.Workspace.AgentCommands = agentCommandsEntity(h.mcpManager.AgentCommands(rs.Workspace.ID))
 		h.enrichWorkspaceSlack(ctx, &rs.Workspace)
 
 		c.Status(http.StatusCreated)
@@ -649,6 +650,7 @@ func (h *handler) getWorkspace() fiber.Handler {
 		rs.Workspace.AgentConnected = h.mcpManager.IsAgentConnected(rs.Workspace.ID)
 		rs.Workspace.AgentSupportsStop = h.mcpManager.SupportsStop(rs.Workspace.ID)
 		rs.Workspace.AgentModels = agentModelsEntity(h.mcpManager.AgentModels(rs.Workspace.ID))
+		rs.Workspace.AgentCommands = agentCommandsEntity(h.mcpManager.AgentCommands(rs.Workspace.ID))
 		h.enrichWorkspaceSlack(ctx, &rs.Workspace)
 
 		c.Status(http.StatusOK)
@@ -677,6 +679,7 @@ func (h *handler) listWorkspaces() fiber.Handler {
 			rs.Workspaces[i].AgentConnected = h.mcpManager.IsAgentConnected(rs.Workspaces[i].ID)
 			rs.Workspaces[i].AgentSupportsStop = h.mcpManager.SupportsStop(rs.Workspaces[i].ID)
 			rs.Workspaces[i].AgentModels = agentModelsEntity(h.mcpManager.AgentModels(rs.Workspaces[i].ID))
+			rs.Workspaces[i].AgentCommands = agentCommandsEntity(h.mcpManager.AgentCommands(rs.Workspaces[i].ID))
 			h.enrichWorkspaceSlack(ctx, &rs.Workspaces[i])
 		}
 
@@ -785,6 +788,7 @@ func (h *handler) updateWorkspace() fiber.Handler {
 		rs.Workspace.AgentConnected = h.mcpManager.IsAgentConnected(rq.Workspace.ID)
 		rs.Workspace.AgentSupportsStop = h.mcpManager.SupportsStop(rq.Workspace.ID)
 		rs.Workspace.AgentModels = agentModelsEntity(h.mcpManager.AgentModels(rq.Workspace.ID))
+		rs.Workspace.AgentCommands = agentCommandsEntity(h.mcpManager.AgentCommands(rq.Workspace.ID))
 		h.enrichWorkspaceSlack(ctx, &rs.Workspace)
 
 		c.Status(http.StatusOK)
@@ -1061,4 +1065,23 @@ func agentModelsEntity(s *mcpctrl.AgentModelsSnapshot) *entity.AgentModels {
 		CurrentModel: s.CurrentModel,
 		Models:       models,
 	}
+}
+
+// agentCommandsEntity converts a live MCP snapshot into the entity the
+// workspace carries, so the API layer keeps its own shape rather than exposing
+// the MCP controller's type through the view.
+func agentCommandsEntity(s *mcpctrl.AgentCommandsSnapshot) *entity.AgentCommands {
+	if s == nil {
+		return nil
+	}
+
+	commands := make([]entity.AgentCommand, len(s.Commands))
+	for i, c := range s.Commands {
+		commands[i] = entity.AgentCommand{
+			Name:        c.Name,
+			Description: c.Description,
+			Hint:        c.Hint,
+		}
+	}
+	return &entity.AgentCommands{Commands: commands}
 }

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -803,3 +803,31 @@ func TestSignInIssuesBothCookies(t *testing.T) {
 		t.Errorf("refresh cookie is not scoped to the route that reads it: %q", joined)
 	}
 }
+
+func TestAgentCommandsEntity(t *testing.T) {
+	t.Run("nil stays nil, so nothing is advertised", func(t *testing.T) {
+		if got := agentCommandsEntity(nil); got != nil {
+			t.Errorf("got %+v, want nil", got)
+		}
+	})
+
+	t.Run("carries the snapshot across into the API layer's own shape", func(t *testing.T) {
+		got := agentCommandsEntity(&mcpctrl.AgentCommandsSnapshot{
+			SessionID: "acp-session",
+			Commands: []mcpctrl.AgentCommand{
+				{Name: "review", Description: "Review the diff", Hint: "what to review"},
+				{Name: "init"},
+			},
+		})
+
+		if got == nil || len(got.Commands) != 2 {
+			t.Fatalf("got %+v", got)
+		}
+		if got.Commands[0].Name != "review" || got.Commands[0].Description != "Review the diff" || got.Commands[0].Hint != "what to review" {
+			t.Errorf("commands[0] = %+v", got.Commands[0])
+		}
+		if got.Commands[1].Description != "" || got.Commands[1].Hint != "" {
+			t.Errorf("optional fields should stay empty: %+v", got.Commands[1])
+		}
+	})
+}

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -33,6 +33,7 @@ var customNotificationMethods = []string{
 	"notifications/claude/channel/permission_request",
 	mcpctrl.AgentTelemetryNotificationMethod,
 	mcpctrl.AgentModelsNotificationMethod,
+	mcpctrl.AgentCommandsNotificationMethod,
 }
 
 // customNotificationMethod reports which of those a request body declares.

--- a/backend/internal/mapper/api/workspace.go
+++ b/backend/internal/mapper/api/workspace.go
@@ -153,6 +153,7 @@ func fromEntityWorkspaceToView(p entity.Workspace, mcpURL string) view.Workspace
 		AgentConnected:        p.AgentConnected,
 		AgentSupportsStop:     p.AgentSupportsStop,
 		AgentModels:           fromEntityAgentModelsToView(p.AgentModels),
+		AgentCommands:         fromEntityAgentCommandsToView(p.AgentCommands),
 		MCPURL:                mcpURL,
 		AutoAllowedTools:      p.AutoAllowedTools,
 		AllowAllCommands:      p.AllowAllCommands,
@@ -227,4 +228,27 @@ func fromEntityAgentModelsToView(m *entity.AgentModels) *view.AgentModels {
 		CurrentModel: m.CurrentModel,
 		Models:       models,
 	}
+}
+
+// fromEntityAgentCommandsToView renders the slash commands the connected agent
+// offers.
+//
+// nil rather than an empty object when nothing is connected or nothing was
+// reported, for the same reason as the models above: the field is omitted from
+// the response entirely, so a client can read its presence as "there is a menu
+// to show here".
+func fromEntityAgentCommandsToView(c *entity.AgentCommands) *view.AgentCommands {
+	if c == nil {
+		return nil
+	}
+
+	commands := make([]view.AgentCommand, len(c.Commands))
+	for i, one := range c.Commands {
+		commands[i] = view.AgentCommand{
+			Name:        one.Name,
+			Description: one.Description,
+			Hint:        one.Hint,
+		}
+	}
+	return &view.AgentCommands{Commands: commands}
 }

--- a/backend/internal/mapper/api/workspace_test.go
+++ b/backend/internal/mapper/api/workspace_test.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"testing"
+
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+)
+
+func TestFromEntityAgentCommandsToView(t *testing.T) {
+	t.Run("nil stays nil, so the field is omitted entirely", func(t *testing.T) {
+		// A client reads the field's presence as "there is a menu to show", so
+		// an empty object here would advertise a menu with nothing in it.
+		if got := fromEntityAgentCommandsToView(nil); got != nil {
+			t.Errorf("got %+v, want nil", got)
+		}
+	})
+
+	t.Run("carries every field across", func(t *testing.T) {
+		got := fromEntityAgentCommandsToView(&entity.AgentCommands{
+			Commands: []entity.AgentCommand{
+				{Name: "web", Description: "Search the web", Hint: "query"},
+				{Name: "compact"},
+			},
+		})
+
+		if got == nil || len(got.Commands) != 2 {
+			t.Fatalf("got %+v", got)
+		}
+		if got.Commands[0].Name != "web" || got.Commands[0].Description != "Search the web" || got.Commands[0].Hint != "query" {
+			t.Errorf("commands[0] = %+v", got.Commands[0])
+		}
+		if got.Commands[1].Description != "" || got.Commands[1].Hint != "" {
+			t.Errorf("optional fields should stay empty: %+v", got.Commands[1])
+		}
+	})
+
+	t.Run("an empty list is still a list, not nil", func(t *testing.T) {
+		got := fromEntityAgentCommandsToView(&entity.AgentCommands{})
+		if got == nil || got.Commands == nil || len(got.Commands) != 0 {
+			t.Errorf("got %+v, want an empty slice", got)
+		}
+	})
+}


### PR DESCRIPTION
## What changed

The workspace now takes in the slash commands its connected agent advertises, keeps them for as long as that agent is attached, serves them on the workspace payload, and pushes an update to open browser tabs whenever the list changes.

## Why changed

The gateway started forwarding those commands, but nothing on this side listened, so they went nowhere. This is the second of four parts putting an agent's commands in front of the human; the composer that offers them comes next.

Three decisions worth a reviewer's attention:

- **The snapshot is keyed on the MCP transport session, not the session id inside the payload.** Those are different namespaces — the payload names the gateway's own conversation with the agent — and keying on it would file every snapshot under an id the live-session list never reports, so all of them would look dead and none would ever be served. The models code beside it documents the same trap.
- **The list is pushed over the event stream, not left to be re-fetched.** Commands arrive once the agent's session is up, which is after it has taken a task and long after any page load. An identical re-advertisement is not published: an agent repeats its list whenever context shifts without the menu actually moving.
- **What gets pushed is the list just reported, rather than the answer the REST reader would give.** The reporting session is connected by definition, whereas the session registry only learns about a transport once it registers its stream — asking it at that moment answers a question about timing, not about the agent. A withdrawal is the exception and does look wider, so one gateway dropping its commands cannot clear a menu another is still serving.

## Test coverage report

- **New lines: 100%** — every new function is 100% covered: the handler, the reader, the publisher (both branches), the pick and prune helpers, the manager accessor, and both layer converters.
- **Total coverage impact:** `internal/...` 42.5% → **42.8%**.
- Full suite green: 29 packages ok, and the new package tests pass under `-count=3` (they exercise a real connected session, so a flaky one would show).
- Tests mirror the models ones, including a raw-JSON test pinned to the exact frame the gateway puts on the wire, so a rename on either side fails here rather than in production. The event-bus tests cover a first announcement, a silent re-advertisement, a withdrawal, a changed description, and a withdrawal from one session while another still offers commands.

## Other reports

Nothing is stored: this is live state read off the MCP session, so a workspace with no agent attached simply omits the field, and a gateway that never sends the notification behaves exactly as before.

TaskID: 0iP05Ba86CX
