### PR TITLE
feat(api): deliver a slash command so the agent recognises it

### DIFF
--- a/backend/internal/handler/api/task.go
+++ b/backend/internal/handler/api/task.go
@@ -10,6 +10,7 @@ import (
 
 	zlog "github.com/rs/zerolog/log"
 
+	mcpctrl "github.com/agentrq/agentrq/backend/internal/controller/mcp"
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	view "github.com/agentrq/agentrq/backend/internal/data/view/api"
 	mapper "github.com/agentrq/agentrq/backend/internal/mapper/api"
@@ -230,6 +231,73 @@ func (h *handler) respondToTask() fiber.Handler {
 	}
 }
 
+// replyChannelContent composes what the agent is told when a human replies.
+//
+// Ordinary text is wrapped in an envelope naming the task, which is what gives
+// an agent reading a stream of notifications the context to answer in.
+//
+// A slash command is not wrapped. ACP runs a command as ordinary prompt text
+// and the agent matches the command at the *start* of what it is given (see the
+// spec's "Running commands"), so `[Reply to task 0iOq7fDWLPl] /compact` is not a
+// command at all — it is a sentence mentioning one. Nothing is lost by dropping
+// the envelope: the gateway takes the task from the notification's `chat_id`
+// metadata, never from the prose.
+//
+// The text has to name a command the agent actually advertised. That is the
+// whole guard: without it `/Users/mt/thing is broken` or `/etc/hosts looks
+// wrong` would be delivered stripped of their context on the strength of a
+// leading slash. An agent that advertises nothing — anything that is not an ACP
+// agent — therefore behaves exactly as it did before.
+func replyChannelContent(
+	taskID int64,
+	text string,
+	attachments []entity.Attachment,
+	commands *mcpctrl.AgentCommandsSnapshot,
+) string {
+	// Leading whitespace is trimmed rather than disqualifying: the point is for
+	// the command to lead the prompt, and " /compact" would defeat that while
+	// plainly meaning the same thing.
+	trimmed := strings.TrimLeft(text, " \t\r\n")
+
+	content := fmt.Sprintf("[Reply to task %s] %s", monoflake.ID(taskID).String(), text)
+	if isAdvertisedCommand(trimmed, commands) {
+		content = trimmed
+	}
+
+	// Attachments are listed after the message either way. They are their own
+	// lines, so they never come between the command and the start of the
+	// prompt.
+	if atts := formatAttachments(attachments); atts != "" {
+		content += "\n" + atts
+	}
+	return content
+}
+
+// isAdvertisedCommand reports whether the text opens with a slash command the
+// connected agent said it accepts.
+func isAdvertisedCommand(text string, commands *mcpctrl.AgentCommandsSnapshot) bool {
+	if commands == nil || !strings.HasPrefix(text, "/") {
+		return false
+	}
+
+	// Everything up to the first whitespace, so "/web agent protocol" is the
+	// "web" command carrying an argument.
+	name := strings.TrimPrefix(text, "/")
+	if i := strings.IndexAny(name, " \t\r\n"); i >= 0 {
+		name = name[:i]
+	}
+	if name == "" {
+		return false
+	}
+
+	for _, c := range commands.Commands {
+		if c.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 func (h *handler) replyToTask() fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		c.Set(_headerContentType, _mimeJSON)
@@ -252,10 +320,7 @@ func (h *handler) replyToTask() fiber.Handler {
 
 		// Notify LLM of the human's reply via MCP channel
 		srv := h.mcpManager.Get(rq.WorkspaceID, rq.UserID)
-		content := fmt.Sprintf("[Reply to task %s] %s", monoflake.ID(rq.TaskID).String(), rq.Text)
-		if atts := formatAttachments(rq.Attachments); atts != "" {
-			content += "\n" + atts
-		}
+		content := replyChannelContent(rq.TaskID, rq.Text, rq.Attachments, h.mcpManager.AgentCommands(rq.WorkspaceID))
 		srv.SendChannelNotification(ctx, rq.TaskID, content)
 
 		// Push reply.received SSE event to human subscribers

--- a/backend/internal/handler/api/task_test.go
+++ b/backend/internal/handler/api/task_test.go
@@ -3,6 +3,10 @@ package api
 import (
 	"strings"
 	"testing"
+
+	mcpctrl "github.com/agentrq/agentrq/backend/internal/controller/mcp"
+	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	"github.com/mustafaturan/monoflake"
 )
 
 // isASCII reports whether every byte is one a header value may legally carry.
@@ -118,4 +122,106 @@ func TestRFC5987Encode_LeavesOnlyAttrCharsAlone(t *testing.T) {
 	if got, want := rfc5987Encode("a b"), "a%20b"; got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
+}
+
+// A slash command only reaches an ACP agent if it leads the prompt text, so the
+// envelope that gives an ordinary reply its context is precisely what stops a
+// command being one. These pin which replies lose it.
+func TestReplyChannelContent(t *testing.T) {
+	const taskID = int64(1234)
+	envelope := "[Reply to task " + monoflake.ID(taskID).String() + "] "
+
+	advertised := &mcpctrl.AgentCommandsSnapshot{
+		Commands: []mcpctrl.AgentCommand{
+			{Name: "compact", Description: "Shorten the context"},
+			{Name: "web", Hint: "query"},
+		},
+	}
+
+	t.Run("delivers an advertised command bare", func(t *testing.T) {
+		if got := replyChannelContent(taskID, "/compact", nil, advertised); got != "/compact" {
+			t.Errorf("got %q, want the command alone", got)
+		}
+	})
+
+	t.Run("keeps the command's argument with it", func(t *testing.T) {
+		const text = "/web agent client protocol"
+		if got := replyChannelContent(taskID, text, nil, advertised); got != text {
+			t.Errorf("got %q, want %q", got, text)
+		}
+	})
+
+	t.Run("trims leading whitespace so the command still leads the prompt", func(t *testing.T) {
+		if got := replyChannelContent(taskID, "  /compact", nil, advertised); got != "/compact" {
+			t.Errorf("got %q, want the command at the start", got)
+		}
+	})
+
+	t.Run("keeps the envelope for a path that only looks like a command", func(t *testing.T) {
+		// The guard that matters: these are ordinary sentences, and delivering
+		// them stripped of their task context would be a silent loss.
+		for _, text := range []string{
+			"/Users/mt/thing is broken",
+			"/etc/hosts looks wrong",
+			"/compactify the logs",
+			"/",
+			"/ compact",
+		} {
+			want := envelope + text
+			if got := replyChannelContent(taskID, text, nil, advertised); got != want {
+				t.Errorf("%q: got %q, want the envelope kept", text, got)
+			}
+		}
+	})
+
+	t.Run("keeps the envelope for ordinary text", func(t *testing.T) {
+		const text = "please compact the context"
+		want := envelope + text
+		if got := replyChannelContent(taskID, text, nil, advertised); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("keeps the envelope when no agent has advertised anything", func(t *testing.T) {
+		// Anything that is not an ACP agent reports nothing, so nothing about
+		// its behaviour changes.
+		want := envelope + "/compact"
+		if got := replyChannelContent(taskID, "/compact", nil, nil); got != want {
+			t.Errorf("got %q, want the envelope kept", got)
+		}
+		empty := &mcpctrl.AgentCommandsSnapshot{}
+		if got := replyChannelContent(taskID, "/compact", nil, empty); got != want {
+			t.Errorf("with an empty list: got %q, want the envelope kept", got)
+		}
+	})
+
+	t.Run("matches the advertised name exactly", func(t *testing.T) {
+		// The agent matches what it advertised; a near miss is not a command.
+		for _, text := range []string{"/Compact", "/COMPACT", "/compac"} {
+			want := envelope + text
+			if got := replyChannelContent(taskID, text, nil, advertised); got != want {
+				t.Errorf("%q: got %q, want the envelope kept", text, got)
+			}
+		}
+	})
+
+	t.Run("lists attachments after the message in both branches", func(t *testing.T) {
+		atts := []entity.Attachment{{ID: "att-1", Filename: "log.txt", MimeType: "text/plain"}}
+		listed := formatAttachments(atts)
+		if listed == "" {
+			t.Fatal("expected the attachment to be listed")
+		}
+
+		// After a bare command, the listing is on its own line, so it never
+		// comes between the command and the start of the prompt.
+		got := replyChannelContent(taskID, "/compact", atts, advertised)
+		if got != "/compact\n"+listed {
+			t.Errorf("command branch: got %q", got)
+		}
+
+		got = replyChannelContent(taskID, "look at this", atts, advertised)
+		if got != envelope+"look at this\n"+listed {
+			t.Errorf("envelope branch: got %q", got)
+		}
+	})
 }


### PR DESCRIPTION
## What changed

A reply that begins with a slash command the connected agent has advertised is now delivered to the agent exactly as the human typed it, instead of being wrapped in the envelope that ordinary replies carry.

## Why changed

ACP runs a slash command as ordinary prompt text, and the agent matches it at the *start* of what it is given. Wrapped in an envelope naming the task, `/compact` was never a command — it was a sentence mentioning one — so typing a command did nothing at all, and would still have done nothing once the composer offers a menu of them. This is the third of four parts.

Nothing is lost by dropping the envelope: the gateway reads the task from the notification's metadata, never from the prose.

Matching against the advertised list is the guard that makes this safe. Without it, `/Users/mt/thing is broken` or `/etc/hosts looks wrong` would be delivered stripped of their task context on the strength of a leading slash. An agent that has advertised nothing — anything that is not an ACP agent — keeps the old behaviour exactly.

Two smaller decisions: leading whitespace is trimmed rather than disqualifying, since the point is for the command to lead the prompt and `" /compact"` plainly means the same thing; and the name must match what was advertised exactly, so a near miss like `/compactify` stays an ordinary sentence.

## Test coverage report

- **New lines: 100%** — both new functions are 100% covered.
- **Total coverage impact:** `internal/...` 42.8% → **43.0%**.
- Full suite green: 29 packages ok.
- Cases covered: an advertised command delivered bare; a command keeping its argument; leading whitespace trimmed; paths and near-misses (`/Users/...`, `/etc/hosts`, `/compactify`, `/`, `/ compact`) keeping the envelope; ordinary text keeping the envelope; nothing advertised and an empty list both keeping the envelope; case-sensitive matching; and attachments listed after the message in both branches.

## Other reports

The attachment listing moved into the same function that composes the message, so the whole notification body is built and tested in one place rather than assembled at the call site.

Stacked on #495, which has since merged; this branch is rebased onto main and its diff is only this task's work.

TaskID: 0iP05IXaNub
