### PR TITLE
feat(ui): offer the agent's slash commands in the composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,15 @@ your permissions and nothing more, and they are withdrawn when you sign out.
 Nothing to install or configure; a browser without WebMCP simply sees no tools.
 See the [WebMCP Guide](docs/WEBMCP.md).
 
+### ⌨️ Agent slash commands
+
+Agents connected through the ACP gateway advertise commands of their own —
+`/init`, `/compact`, `/review`, whatever they ship with. Type `/` in a task and
+they appear above the reply box, filtered as you type and chosen with the
+keyboard or the mouse. The list comes from the agent and follows it live, so it
+changes as the agent's context does. An agent that advertises none gets no menu
+and nothing changes. See the [Slash Commands Guide](docs/SLASH_COMMANDS.md).
+
 To run it from source:
 
 ```bash

--- a/docs/SLASH_COMMANDS.md
+++ b/docs/SLASH_COMMANDS.md
@@ -1,0 +1,69 @@
+# Slash commands: running the agent's own commands from a task
+
+Some agents come with commands of their own — `/init`, `/compact`, `/review`
+and whatever else they have been built with. When your workspace is connected
+through the [ACP gateway](https://github.com/agentrq/acp-gateway), those
+commands are offered in the reply box.
+
+Type `/` in a task and the agent's commands appear above the composer. Keep
+typing to narrow the list, then press Enter or Tab to choose one — or click it.
+Arrow keys move the highlight, Escape puts the menu away.
+
+Nothing to install and nothing to configure. If the agent has commands, the
+menu is there; if it has none, nothing changes.
+
+---
+
+## Where the list comes from
+
+The agent, not AgentRQ. An ACP agent announces what it accepts once its session
+is up, and revises the list whenever its context makes different commands
+relevant — so the menu can gain or lose entries while you are working, and the
+descriptions can change under you. That is the agent talking, and the menu
+follows it live rather than waiting for a page reload.
+
+Two consequences worth knowing:
+
+- **A freshly connected workspace has no commands yet.** The agent's session
+  starts when it takes its first task, and it advertises its commands then. An
+  idle workspace with an attached agent may show nothing until there is work.
+- **An agent can withdraw them.** If the list goes away, so does the menu.
+  Better that than offering commands that would be refused.
+
+Only agents speaking ACP announce commands at all. Every other agent — Claude
+Code connected directly, anything on plain MCP — simply has no menu, and the
+reply box behaves exactly as it always has.
+
+## How a command reaches the agent
+
+A command is not a special kind of message. ACP runs one as ordinary prompt
+text, and the agent recognises it by the command sitting at the *start* of what
+it receives.
+
+That is why an ordinary reply and a command are delivered differently. Your
+replies normally reach the agent wrapped in a short line naming the task, which
+is what lets an agent reading a stream of notifications know what it is
+answering. A command cannot carry that wrapper — with anything in front of it,
+`/compact` is a sentence mentioning a command rather than a command — so a
+reply that starts with one is sent exactly as you typed it.
+
+**The text has to name a command the agent actually advertised.** This is what
+keeps a message like `/Users/me/notes.txt is out of date` an ordinary message:
+it starts with a slash, but nothing offered it, so it is delivered with its
+context intact like any other reply. Only names from the menu are treated as
+commands.
+
+Attachments still travel with the message either way. They are listed on their
+own lines after it, so they never come between the command and the start of the
+prompt.
+
+## If the menu does not appear
+
+- **Check the agent is connected.** The workspace header shows it.
+- **Check the agent has run something.** Commands arrive with the agent's
+  session, which starts with its first task.
+- **Check what you are connected through.** The menu needs an ACP agent behind
+  the gateway; see the gateway's README for which agents those are.
+- **Check the gateway's version.** Forwarding commands was added to
+  `@agentrq/acp-gateway` after 0.2.12; an older gateway never sends them, and
+  everything else keeps working as before.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -651,6 +651,14 @@ onEvent((event) => {
     workspaceStore.updateAgentStatus(workspaceId, connected)
   }
 
+  // The agent's slash commands, which arrive once its session is up rather
+  // than with the page. Same reasoning as the status above: reacting to the
+  // event is what keeps every surface current.
+  if (event.type === 'agent.commands') {
+    const { commands, workspaceId } = event.payload
+    workspaceStore.updateAgentCommands(workspaceId, commands)
+  }
+
   // Handle workspace metadata updates
   if (event.type === 'workspace.updated') {
     workspaceStore.updateWorkspaceMetadata(event.payload)

--- a/frontend/src/composables/useSlashCommands.js
+++ b/frontend/src/composables/useSlashCommands.js
@@ -1,0 +1,186 @@
+import { computed, ref, toValue, watch } from 'vue';
+
+/**
+ * The `/` menu in the composer: which of the agent's slash commands a
+ * half-typed message is asking for, and what accepting one does to the text.
+ *
+ * The commands come from the connected agent, not from us — an ACP agent
+ * advertises what it accepts (`/init`, `/compact`, `/review`, …) and revises
+ * the list as context makes them relevant. A workspace whose agent advertises
+ * nothing gets no menu at all, which is every agent that is not an ACP one.
+ *
+ * The logic lives here rather than in the view because the view is a large
+ * component wired to a router, a store and network calls, and the project has
+ * no component-test harness. What is worth testing is the matching and the
+ * text-editing, and both are here.
+ */
+
+/** Whitespace ends the command name, so it is what closes the menu. */
+const WHITESPACE = /\s/;
+
+/**
+ * The command name being typed, or null when the text is not asking for one.
+ *
+ * A message is asking for a command only while the caret is still inside the
+ * first token: `/comp` is, `/compact do the thing` is not, because by then the
+ * command has been chosen and what follows is its argument.
+ */
+export function commandQuery(text) {
+  if (typeof text !== 'string' || !text.startsWith('/')) return null;
+  const name = text.slice(1);
+  if (WHITESPACE.test(name)) return null;
+  return name;
+}
+
+/**
+ * The commands worth offering for what has been typed, best first.
+ *
+ * Commands that *start* with the query come first, because that is what typing
+ * a prefix means; the rest are those that merely contain it, which is what
+ * makes `/pact` still find `compact` rather than leaving the human staring at
+ * an empty menu. Within each group the order the agent gave is kept — it knows
+ * which of its commands matter more than we do.
+ *
+ * Matching is case-insensitive so that typing `/Com` still finds `compact`,
+ * even though sending it needs the name exactly as advertised — which is what
+ * accepting from this menu produces.
+ */
+export function matchCommands(commands, query) {
+  if (!Array.isArray(commands)) return [];
+  const usable = commands.filter((c) => c && typeof c.name === 'string' && c.name !== '');
+  if (!query) return usable;
+
+  const wanted = query.toLowerCase();
+  const starts = [];
+  const contains = [];
+  for (const command of usable) {
+    const name = command.name.toLowerCase();
+    if (name.startsWith(wanted)) starts.push(command);
+    else if (name.includes(wanted)) contains.push(command);
+  }
+  return [...starts, ...contains];
+}
+
+/**
+ * The message text after choosing a command.
+ *
+ * A command that takes an argument gets a trailing space, so the caret is
+ * already where the argument goes — and, incidentally, so the menu closes,
+ * since a space ends the first token. One that takes no argument is left bare
+ * and ready to send.
+ */
+export function applyCommand(command) {
+  return command?.input?.hint || command?.hint ? `/${command.name} ` : `/${command.name}`;
+}
+
+/**
+ * @param {object} options
+ * @param {import('vue').Ref<string>|(() => string)} options.text  the composer's contents
+ * @param {import('vue').Ref<Array>|(() => Array)} options.commands  what the agent advertises
+ */
+export function useSlashCommands({ text, commands }) {
+  /**
+   * The text the menu was last dismissed for.
+   *
+   * Dismissing has to be remembered against *something*, or Escape would be
+   * undone by the next keystroke — and accepting a command would leave the menu
+   * open over the very command it just inserted. Keying it to the text means
+   * typing anything else brings the menu back, which is what a human who
+   * changed their mind expects.
+   */
+  const dismissedFor = ref(null);
+
+  const query = computed(() => commandQuery(toValue(text)));
+  const matches = computed(() =>
+    query.value === null ? [] : matchCommands(toValue(commands), query.value)
+  );
+
+  /**
+   * Open only when there is something to show. An empty menu is worse than no
+   * menu: it covers the composer to say nothing.
+   */
+  const open = computed(
+    () => matches.value.length > 0 && toValue(text) !== dismissedFor.value
+  );
+
+  const selected = ref(0);
+
+  // Whatever was highlighted has no meaning once the list changes underneath
+  // it, so the best match is highlighted again rather than whichever row
+  // happens to sit at the old index.
+  watch(matches, () => {
+    selected.value = 0;
+  });
+
+  /** The highlighted command, or null when the menu is closed. */
+  const active = computed(() => (open.value ? matches.value[selected.value] ?? null : null));
+
+  /** Moves the highlight, wrapping, so holding one arrow key cannot dead-end. */
+  function move(delta) {
+    if (!open.value) return;
+    const count = matches.value.length;
+    selected.value = (selected.value + delta + count) % count;
+  }
+
+  function highlight(index) {
+    if (index >= 0 && index < matches.value.length) selected.value = index;
+  }
+
+  /** Closes the menu for the current text, until it changes again. */
+  function dismiss() {
+    dismissedFor.value = toValue(text);
+  }
+
+  /**
+   * The text after accepting a command, or null when there is nothing to
+   * accept — which is how the caller knows the keystroke was not the menu's and
+   * should do whatever it normally does.
+   */
+  function accept(command = active.value) {
+    if (!open.value || !command) return null;
+    const applied = applyCommand(command);
+    dismissedFor.value = applied;
+    return applied;
+  }
+
+  /**
+   * The composer's keydown, when the menu wants it.
+   *
+   * Returns null for every key the menu is not claiming, which is *all* of them
+   * while it is shut — the caret keys have to keep moving the caret, Escape has
+   * to stay the composer's, and Enter has to keep doing whatever Enter does.
+   * That is the whole reason this decides rather than the template: a
+   * `@keydown.down.prevent` in the markup takes the key whether the menu is
+   * open or not.
+   *
+   * A claimed key comes back as `{ text }` — the new composer contents when the
+   * keystroke chose a command, and null when it only moved the highlight.
+   */
+  function handleKeydown(event) {
+    if (!open.value) return null;
+
+    switch (event.key) {
+      case 'ArrowDown':
+        move(1);
+        return { text: null };
+      case 'ArrowUp':
+        move(-1);
+        return { text: null };
+      case 'Escape':
+        dismiss();
+        return { text: null };
+      case 'Tab':
+        return { text: accept() };
+      case 'Enter':
+        // Cmd/Ctrl-Enter sends, and always did; a modifier means the keystroke
+        // was never aimed at the menu. Shift-Enter is a newline for the same
+        // reason.
+        if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return null;
+        return { text: accept() };
+      default:
+        return null;
+    }
+  }
+
+  return { open, matches, selected, active, move, highlight, dismiss, accept, handleKeydown };
+}

--- a/frontend/src/stores/workspaceStore.js
+++ b/frontend/src/stores/workspaceStore.js
@@ -55,6 +55,23 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     }
   }
 
+  /**
+   * Record the slash commands a workspace's agent is offering.
+   *
+   * Lives here for the same reason `agentConnected` does: it changes from
+   * outside the app — an agent advertises its commands once its session is up,
+   * long after any page load — and the composer is not the only surface that
+   * will want them. IDs are compared as strings for the reason `findIndex`
+   * gives.
+   */
+  function updateAgentCommands(workspaceId, commands) {
+    const idx = findIndex(workspaceId);
+    if (idx !== -1) {
+      const agentCommands = Array.isArray(commands) && commands.length > 0 ? { commands } : undefined;
+      workspaces.value[idx] = { ...workspaces.value[idx], agentCommands };
+    }
+  }
+
   /** The workspace with this ID, or undefined. */
   function getWorkspace(workspaceId) {
     const idx = findIndex(workspaceId);
@@ -78,6 +95,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     fetchWorkspaces,
     updateWorkspaceMetadata,
     updateAgentStatus,
+    updateAgentCommands,
     getWorkspace,
     isAgentConnected
   };

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -562,6 +562,29 @@
         </div>
       </div>
 
+      <!-- The agent's slash commands. Sits above the composer so it never covers
+           what is being typed, and is keyboard-first: the pointer is a
+           convenience, the arrow keys are the interface. -->
+      <div v-if="slashMenu.open.value"
+           class="mb-2 max-h-52 overflow-y-auto rounded-sm border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 shadow-sm custom-scrollbar">
+        <ul ref="slashListRef" role="listbox" aria-label="Agent commands">
+          <li v-for="(command, i) in slashMenu.matches.value" :key="command.name"
+              role="option" :aria-selected="i === slashMenu.selected.value"
+              @mouseenter="slashMenu.highlight(i)"
+              @mousedown.prevent="acceptSlashCommand(command)"
+              :class="i === slashMenu.selected.value ? 'bg-gray-105 dark:bg-zinc-700/60' : ''"
+              class="flex items-baseline gap-2 px-3 py-1.5 cursor-pointer transition-colors">
+            <span class="text-[12px] font-bold text-gray-900 dark:text-zinc-100 shrink-0">/{{ command.name }}</span>
+            <span v-if="command.description"
+                  class="text-[11px] font-medium text-gray-500 dark:text-zinc-400 truncate">{{ command.description }}</span>
+            <!-- The argument it expects, kept to the right so the name and what
+                 the command does read as one line. -->
+            <span v-if="command.input?.hint || command.hint"
+                  class="ml-auto pl-3 text-[10px] font-medium text-gray-400 dark:text-zinc-500 shrink-0">{{ command.input?.hint || command.hint }}</span>
+          </li>
+        </ul>
+      </div>
+
       <form @submit.prevent="submitReply">
         <input type="file" ref="fileInput" multiple class="hidden" @change="handleFileUpload" />
 
@@ -573,6 +596,7 @@
             @input="adjustTextareaHeight"
             @keydown.meta.enter="submitReply"
             @keydown.ctrl.enter="submitReply"
+            @keydown="onComposerKeydown"
             rows="1"
             :disabled="offline || (!workspace.agentConnected && task.assignee !== 'human' && task.status !== 'pending')"
             :placeholder="offline ? 'Offline — reconnect to reply' : ((!workspace.agentConnected && task.assignee !== 'human' && task.status !== 'pending') ? 'Waiting for agent...' : 'Type instructions... (Cmd ⌘ + Enter to send)')"
@@ -756,6 +780,7 @@ import { usePendingSend } from '../composables/usePendingSend';
 import { scrollToBottom as scrollContainerToBottom, shouldScrollOnViewChange } from '../composables/useChatScroll';
 import { useEventBus } from '../useEventBus';
 import { useWorkspaceStore } from '../stores/workspaceStore';
+import { useSlashCommands } from '../composables/useSlashCommands';
 import { renderMarkdown } from '../utils/markdown';
 import {
   contextGauge,
@@ -804,6 +829,42 @@ const task = ref(null);
 const user = ref(null);
 const descExpanded = ref(false);
 const replyText = ref('');
+
+// The agent's own slash commands, offered as you type `/`. An agent that
+// advertises none — anything that is not an ACP agent — gets no menu at all.
+const agentCommands = computed(() => workspace.value?.agentCommands?.commands ?? []);
+const slashMenu = useSlashCommands({ text: replyText, commands: agentCommands });
+const slashListRef = ref(null);
+
+/** Puts the chosen command in the composer, for a click on the menu. */
+function acceptSlashCommand(command) {
+  const applied = slashMenu.accept(command);
+  if (applied !== null) setReplyText(applied);
+}
+
+/** The menu's keys while it is open; everything else stays the composer's. */
+function onComposerKeydown(event) {
+  const claimed = slashMenu.handleKeydown(event);
+  if (!claimed) return;
+  event.preventDefault();
+  if (claimed.text !== null) setReplyText(claimed.text);
+  else keepSelectionInView();
+}
+
+function setReplyText(text) {
+  replyText.value = text;
+  nextTick(() => {
+    adjustTextareaHeight();
+    textareaRef.value?.focus();
+  });
+}
+
+/** Keeps the highlighted row visible when the list is longer than the menu. */
+function keepSelectionInView() {
+  nextTick(() => {
+    slashListRef.value?.children?.[slashMenu.selected.value]?.scrollIntoView({ block: 'nearest' });
+  });
+}
 const replyAttachments = ref([]);
 // A held message is addressed to the task it was written in, so switching tasks
 // cannot redirect it. See usePendingSend.

--- a/frontend/test/slashCommands.test.js
+++ b/frontend/test/slashCommands.test.js
@@ -1,0 +1,273 @@
+import { describe, it, expect } from 'vitest'
+import { nextTick, ref } from 'vue'
+
+import {
+  applyCommand,
+  commandQuery,
+  matchCommands,
+  useSlashCommands,
+} from '../src/composables/useSlashCommands'
+
+const COMMANDS = [
+  { name: 'compact', description: 'Shorten the context' },
+  { name: 'init', description: 'Set the project up' },
+  { name: 'web', description: 'Search the web', hint: 'query to search for' },
+]
+
+/** The composable driven by a text ref, the way the composer drives it. */
+function composer(text = '', commands = COMMANDS) {
+  const textRef = ref(text)
+  const commandsRef = ref(commands)
+  return { textRef, commandsRef, menu: useSlashCommands({ text: textRef, commands: commandsRef }) }
+}
+
+describe('commandQuery', () => {
+  it('reads the name being typed', () => {
+    expect(commandQuery('/comp')).toBe('comp')
+    expect(commandQuery('/')).toBe('')
+  })
+
+  it('is not asking for a command once the first token is finished', () => {
+    // By then the command has been chosen and what follows is its argument.
+    expect(commandQuery('/web agent protocol')).toBeNull()
+    expect(commandQuery('/compact\n')).toBeNull()
+  })
+
+  it('is not asking for a command when the text does not start with one', () => {
+    expect(commandQuery('please /compact')).toBeNull()
+    expect(commandQuery(' /compact')).toBeNull()
+    expect(commandQuery('')).toBeNull()
+    expect(commandQuery(undefined)).toBeNull()
+    expect(commandQuery(42)).toBeNull()
+  })
+})
+
+describe('matchCommands', () => {
+  it('offers everything for a bare slash', () => {
+    expect(matchCommands(COMMANDS, '').map((c) => c.name)).toEqual(['compact', 'init', 'web'])
+  })
+
+  it('puts the commands that start with the query first', () => {
+    // "pact" is inside "compact" but starts nothing, so a prefix match wins.
+    const named = matchCommands([{ name: 'pact' }, { name: 'compact' }], 'pact')
+    expect(named.map((c) => c.name)).toEqual(['pact', 'compact'])
+  })
+
+  it('still finds a command from the middle of its name', () => {
+    expect(matchCommands(COMMANDS, 'pact').map((c) => c.name)).toEqual(['compact'])
+  })
+
+  it('keeps the order the agent gave within each group', () => {
+    const ordered = matchCommands([{ name: 'ab' }, { name: 'aa' }], 'a')
+    expect(ordered.map((c) => c.name)).toEqual(['ab', 'aa'])
+  })
+
+  it('matches without regard to case', () => {
+    expect(matchCommands(COMMANDS, 'COMP').map((c) => c.name)).toEqual(['compact'])
+  })
+
+  it('offers nothing when nothing matches', () => {
+    expect(matchCommands(COMMANDS, 'zzz')).toEqual([])
+  })
+
+  it('ignores entries that could never be invoked', () => {
+    const messy = [null, undefined, {}, { name: '' }, { name: 7 }, { name: 'real' }]
+    expect(matchCommands(messy, '').map((c) => c.name)).toEqual(['real'])
+  })
+
+  it('has nothing to offer when the agent advertised nothing', () => {
+    expect(matchCommands(undefined, 'a')).toEqual([])
+    expect(matchCommands([], 'a')).toEqual([])
+  })
+})
+
+describe('applyCommand', () => {
+  it('leaves a command that takes an argument ready for one', () => {
+    expect(applyCommand({ name: 'web', hint: 'query' })).toBe('/web ')
+    expect(applyCommand({ name: 'web', input: { hint: 'query' } })).toBe('/web ')
+  })
+
+  it('leaves a command that takes no argument ready to send', () => {
+    expect(applyCommand({ name: 'compact' })).toBe('/compact')
+    expect(applyCommand({ name: 'compact', hint: '' })).toBe('/compact')
+  })
+})
+
+describe('useSlashCommands', () => {
+  it('stays shut for an ordinary message', () => {
+    const { menu } = composer('please compact the context')
+    expect(menu.open.value).toBe(false)
+    expect(menu.active.value).toBeNull()
+  })
+
+  it('opens on a slash and narrows as you type', async () => {
+    const { textRef, menu } = composer('/')
+    expect(menu.open.value).toBe(true)
+    expect(menu.matches.value).toHaveLength(3)
+
+    textRef.value = '/comp'
+    await nextTick()
+    expect(menu.matches.value.map((c) => c.name)).toEqual(['compact'])
+  })
+
+  it('never shows an empty menu', () => {
+    // Covering the composer to say nothing is worse than not appearing.
+    const { menu } = composer('/zzz')
+    expect(menu.open.value).toBe(false)
+  })
+
+  it('shows no menu at all when the agent advertises nothing', () => {
+    // Every agent that is not an ACP one, so nothing changes for them.
+    expect(composer('/', []).menu.open.value).toBe(false)
+    // `null` rather than `undefined`, which the helper's default would swallow.
+    expect(composer('/', null).menu.open.value).toBe(false)
+  })
+
+  it('moves the highlight and wraps at both ends', () => {
+    const { menu } = composer('/')
+    expect(menu.active.value.name).toBe('compact')
+
+    menu.move(1)
+    expect(menu.active.value.name).toBe('init')
+
+    menu.move(-1)
+    menu.move(-1)
+    expect(menu.active.value.name).toBe('web')
+
+    menu.move(1)
+    expect(menu.active.value.name).toBe('compact')
+  })
+
+  it('ignores movement while shut', () => {
+    const { menu } = composer('hello')
+    menu.move(1)
+    expect(menu.selected.value).toBe(0)
+  })
+
+  it('has no highlighted command in the instant before the list settles', () => {
+    // The reset runs on the next tick, so for one synchronous moment the
+    // highlight can point past the end of a list that just got shorter.
+    // Reading it then must give nothing rather than an undefined row.
+    const { textRef, menu } = composer('/')
+    menu.move(2)
+
+    textRef.value = '/i'
+    expect(menu.matches.value).toHaveLength(1)
+    expect(menu.active.value).toBeNull()
+  })
+
+  it('highlights the best match again when the list changes underneath', async () => {
+    const { textRef, menu } = composer('/')
+    menu.move(2)
+    expect(menu.selected.value).toBe(2)
+
+    textRef.value = '/i'
+    await nextTick()
+    expect(menu.selected.value).toBe(0)
+    expect(menu.active.value.name).toBe('init')
+  })
+
+  it('highlights a row the pointer names, and ignores one that does not exist', () => {
+    const { menu } = composer('/')
+    menu.highlight(2)
+    expect(menu.active.value.name).toBe('web')
+
+    menu.highlight(9)
+    menu.highlight(-1)
+    expect(menu.active.value.name).toBe('web')
+  })
+
+  it('accepts the highlighted command', () => {
+    const { menu } = composer('/i')
+    expect(menu.accept()).toBe('/init')
+  })
+
+  it('accepts a command named outright, for a click', () => {
+    const { menu } = composer('/')
+    expect(menu.accept(COMMANDS[2])).toBe('/web ')
+  })
+
+  it('closes over the command it just inserted', async () => {
+    const { textRef, menu } = composer('/comp')
+    textRef.value = menu.accept()
+    await nextTick()
+
+    expect(textRef.value).toBe('/compact')
+    expect(menu.open.value).toBe(false)
+  })
+
+  it('has nothing to accept while shut, so the keystroke stays the caller"s', () => {
+    // This is how Enter still sends an ordinary message.
+    const { menu } = composer('hello')
+    expect(menu.accept()).toBeNull()
+    expect(composer('/zzz').menu.accept()).toBeNull()
+  })
+
+  it('accepts nothing when handed nothing', () => {
+    const { menu } = composer('/')
+    expect(menu.accept(null)).toBeNull()
+  })
+
+  it('stays shut once dismissed, until the text changes again', async () => {
+    const { textRef, menu } = composer('/comp')
+    menu.dismiss()
+    await nextTick()
+    expect(menu.open.value).toBe(false)
+
+    // Changing one's mind brings it back, rather than the dismissal sticking
+    // for the rest of the message.
+    textRef.value = '/compa'
+    await nextTick()
+    expect(menu.open.value).toBe(true)
+  })
+
+  describe('handleKeydown', () => {
+    const key = (k, mods = {}) => ({ key: k, ...mods })
+
+    it('claims the arrow keys to move the highlight', () => {
+      const { menu } = composer('/')
+      expect(menu.handleKeydown(key('ArrowDown'))).toEqual({ text: null })
+      expect(menu.active.value.name).toBe('init')
+      expect(menu.handleKeydown(key('ArrowUp'))).toEqual({ text: null })
+      expect(menu.active.value.name).toBe('compact')
+    })
+
+    it('claims Escape to shut the menu', async () => {
+      const { menu } = composer('/comp')
+      expect(menu.handleKeydown(key('Escape'))).toEqual({ text: null })
+      await nextTick()
+      expect(menu.open.value).toBe(false)
+    })
+
+    it('claims Enter and Tab to choose the highlighted command', () => {
+      expect(composer('/i').menu.handleKeydown(key('Enter'))).toEqual({ text: '/init' })
+      expect(composer('/i').menu.handleKeydown(key('Tab'))).toEqual({ text: '/init' })
+    })
+
+    it('leaves Cmd-Enter and Ctrl-Enter alone, so sending still sends', () => {
+      // The composer's existing shortcut. A modifier means the keystroke was
+      // never aimed at the menu.
+      const { menu } = composer('/i')
+      expect(menu.handleKeydown(key('Enter', { metaKey: true }))).toBeNull()
+      expect(menu.handleKeydown(key('Enter', { ctrlKey: true }))).toBeNull()
+    })
+
+    it('leaves Shift-Enter alone, so it is still a newline', () => {
+      expect(composer('/i').menu.handleKeydown(key('Enter', { shiftKey: true }))).toBeNull()
+      expect(composer('/i').menu.handleKeydown(key('Enter', { altKey: true }))).toBeNull()
+    })
+
+    it('claims nothing at all while the menu is shut', () => {
+      // Otherwise the arrow keys would stop moving the caret in an ordinary
+      // message, which is what a `.prevent` in the markup would have done.
+      const { menu } = composer('write me a haiku')
+      for (const k of ['ArrowDown', 'ArrowUp', 'Escape', 'Enter', 'Tab']) {
+        expect(menu.handleKeydown(key(k))).toBeNull()
+      }
+    })
+
+    it('leaves ordinary typing alone', () => {
+      expect(composer('/i').menu.handleKeydown(key('a'))).toBeNull()
+    })
+  })
+})

--- a/frontend/test/workspaceStore.test.js
+++ b/frontend/test/workspaceStore.test.js
@@ -113,6 +113,65 @@ describe('workspaceStore', () => {
     })
   })
 
+  describe('updateAgentCommands', () => {
+    beforeEach(async () => {
+      fetchWorkspaces.mockResolvedValue({ workspaces: [ws('0ZzhYQG2qtl', 'alpha'), ws('0iAx25vra8v', 'beta')] })
+      await useWorkspaceStore().fetchWorkspaces()
+    })
+
+    const commandsOf = (store, id) => store.getWorkspace(id)?.agentCommands
+
+    it('records the commands against the named workspace only', () => {
+      const store = useWorkspaceStore()
+
+      store.updateAgentCommands('0ZzhYQG2qtl', [{ name: 'compact' }])
+
+      expect(commandsOf(store, '0ZzhYQG2qtl')).toEqual({ commands: [{ name: 'compact' }] })
+      expect(commandsOf(store, '0iAx25vra8v')).toBeUndefined()
+    })
+
+    it('takes the menu away when the agent withdraws its commands', () => {
+      // An empty list is how an agent says it has stopped accepting them, and
+      // the field's absence is what every surface reads as "no menu".
+      const store = useWorkspaceStore()
+      store.updateAgentCommands('0ZzhYQG2qtl', [{ name: 'compact' }])
+
+      store.updateAgentCommands('0ZzhYQG2qtl', [])
+
+      expect(commandsOf(store, '0ZzhYQG2qtl')).toBeUndefined()
+    })
+
+    it('takes the menu away when handed nothing at all', () => {
+      const store = useWorkspaceStore()
+      store.updateAgentCommands('0ZzhYQG2qtl', [{ name: 'compact' }])
+
+      store.updateAgentCommands('0ZzhYQG2qtl', undefined)
+
+      expect(commandsOf(store, '0ZzhYQG2qtl')).toBeUndefined()
+    })
+
+    // The same trap updateAgentStatus documents: the ID has to be compared as a
+    // string, because a route parameter and a payload field are not the same
+    // type.
+    it('matches an ID that arrives as a number rather than a string', () => {
+      const store = useWorkspaceStore()
+      store.workspaces = [ws(42, 'numeric')]
+
+      store.updateAgentCommands('42', [{ name: 'init' }])
+
+      expect(commandsOf(store, 42)).toEqual({ commands: [{ name: 'init' }] })
+    })
+
+    it('ignores an ID that names no workspace it holds', () => {
+      const store = useWorkspaceStore()
+
+      store.updateAgentCommands(1234567890123, [{ name: 'init' }])
+      store.updateAgentCommands(undefined, [{ name: 'init' }])
+
+      expect(store.workspaces.some((w) => w.agentCommands)).toBe(false)
+    })
+  })
+
   describe('updateWorkspaceMetadata', () => {
     beforeEach(async () => {
       fetchWorkspaces.mockResolvedValue({ workspaces: [ws('a', 'alpha'), ws('b', 'beta')] })

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -62,6 +62,7 @@ export default defineConfig({
         'src/composables/useMemories.js',
         'src/composables/useUiTelemetry.js',
         'src/composables/useWebMCP.js',
+        'src/composables/useSlashCommands.js',
         'src/composables/useWorkspaceSettings.js',
         'src/composables/useStatsRange.js',
         'src/composables/useWorkspaceSwitcher.js',


### PR DESCRIPTION
## What changed

Typing `/` in a task's reply box now offers the commands the connected agent advertises — filtered as you type, chosen with the arrow keys and Enter or Tab, or with the mouse.

## Why changed

Agents connected through the ACP gateway announce commands of their own, and until now there was no way to see or run them. This is the last of four parts; the workspace already receives the list and already delivers a chosen command in the form the agent recognises.

The list comes from the agent and follows it live, so it changes as the agent's context does. An agent that advertises none gets no menu at all, which is every agent that is not an ACP one — nothing changes for them.

Three things worth a reviewer's attention:

- **The keyboard contract lives in the composable, not the template.** That is not tidiness: `@keydown.down.prevent` in the markup takes the key whether the menu is open or not, so the arrow keys stopped moving the caret in an ordinary message. The composable decides, and claims nothing at all while the menu is shut — including Enter, so Cmd-Enter still sends and Shift-Enter is still a newline.
- **No new API function.** The commands ride the workspace payload that is already fetched, so there is no new API surface, no WebMCP catalogue entry, and no exemption needed in the catalogue's mirror test.
- **Dismissal is remembered against the text**, so Escape is not undone by the next keystroke and accepting a command does not leave the menu open over the command it just inserted — while typing anything else brings it back.

## Test coverage report

- **New lines: 100%** — the composable and the new store action are both fully covered; the composable is in the coverage include list, so the 100% gate now enforces it.
- **Total coverage impact:** the gate is all-or-nothing and still passes at **100%** across lines, branches, functions and statements.
- 989 tests pass (39 files), up from 949. 41 new tests cover the query parsing, the matching and ranking, the text a chosen command produces, the open/dismiss rules, the keyboard contract, and the store action.

## Other reports

Verified in a real browser as well as in tests, driving a local instance: the menu renders above the composer and filters as you type, the arrow keys move the highlight, Enter inserts the command and closes the menu, a message mentioning `/etc/hosts` opens nothing, and an arrow key with the menu shut still moves the caret rather than being swallowed.

User-facing documentation added and linked from the README.

TaskID: 0iP05P25aM5
