### PR TITLE
chore: bump patch version to v0.5.19

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.5.18"
+	_appVersion   = "v0.5.19"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.5.18" {
-			t.Errorf("Expected version v0.5.18, got %s", s.Version())
+		if s.Version() != "v0.5.19" {
+			t.Errorf("Expected version v0.5.19, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.5.18",
+      "version": "0.5.19",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.5.18",
+  "version": "0.5.19",
   "description": "AgentRQ desktop app — AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.5.18",
+      "version": "0.5.19",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.5.18",
+  "version": "0.5.19",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
## What changed

The project version moves from 0.5.18 to 0.5.19 across the desktop app, the web frontend and the backend.

## Why changed

To cut the next patch release. Everything in it has already merged; the version sync check runs before any packaging and rejects a tree whose versions disagree, so all of them move together.

The release itself is this version's ACP slash commands, wired end to end: an ACP agent's own commands (`/init`, `/compact`, `/review`) now reach the workspace, are offered in the reply box, and are delivered in the form the agent actually recognises. Alongside them, a fix for channel notifications being routed by a substring match on the whole request body — which silently swallowed any request that merely mentioned one of those method names.

Shipping in this version:

**feat** — the slash-command menu in the composer (#497); delivering a command so the agent recognises it (#496); recording and exposing the commands an agent offers (#495); publishing the Claude Code plugins from this repository (#491).

**fix** — routing channel notifications by the method they declare (#494); advertising the statuses and actions the core MCP server actually accepts (#490).

**docs** — ACP gateway instructions pointed at Antigravity and Codex (#493); copyright year and owner (#492).

## Test coverage report

- **New lines introduced: none** — this is a version-string change only, and the changed lines are all already covered (the backend assertion is exercised by the config test).
- **Total coverage impact: none.**
- Verified: `node desktop/scripts/check-versions.mjs` reports all three at 0.5.19, and the tag form CI runs (`GITHUB_REF=refs/tags/v0.5.19`) confirms both that the sources agree and that the tag matches. The backend config test passes and `npm ci` still resolves cleanly.

## Other reports

Lockfile version fields were edited by hand rather than regenerated, so dependency resolution does not shift underneath a release.

Merging this publishes nothing on its own — the release is cut by tagging `main` with `v0.5.19` and pushing the tag.

TaskID: 0iRTNYwyEfR
