### PR TITLE
feat: offer slash commands when creating a task

### DIFF
--- a/backend/internal/controller/mcp/agent_commands.go
+++ b/backend/internal/controller/mcp/agent_commands.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"slices"
+	"strings"
 
 	"github.com/mustafaturan/monoflake"
 	zlog "github.com/rs/zerolog/log"
@@ -153,6 +154,43 @@ func (ps *WorkspaceServer) AgentCommands() *AgentCommandsSnapshot {
 	ps.agentCommandsMu.RLock()
 	defer ps.agentCommandsMu.RUnlock()
 	return pickAgentCommands(ps.agentCommands, ps.streamingSessionIDs())
+}
+
+// LeadsWithCommand reports whether the text opens with a slash command this
+// agent advertised, and returns the text with any leading whitespace removed.
+//
+// It lives on the snapshot because every caller needs the same answer and the
+// list is the only thing that makes the question answerable. Matching the
+// advertised names is the guard: without it any line starting with a slash — a
+// path, a fraction, a date — would be treated as a command and delivered
+// stripped of the context that explains it.
+//
+// Leading whitespace is trimmed rather than disqualifying, since the point is
+// only that the command leads the prompt, and " /compact" plainly means the
+// same thing. The name must match exactly: the agent matches what it
+// advertised, so a near miss is not a command.
+func (s *AgentCommandsSnapshot) LeadsWithCommand(text string) (string, bool) {
+	trimmed := strings.TrimLeft(text, " \t\r\n")
+	if s == nil || !strings.HasPrefix(trimmed, "/") {
+		return trimmed, false
+	}
+
+	// Everything up to the first whitespace, so "/web agent protocol" is the
+	// "web" command carrying an argument.
+	name := strings.TrimPrefix(trimmed, "/")
+	if i := strings.IndexAny(name, " \t\r\n"); i >= 0 {
+		name = name[:i]
+	}
+	if name == "" {
+		return trimmed, false
+	}
+
+	for _, c := range s.Commands {
+		if c.Name == name {
+			return trimmed, true
+		}
+	}
+	return trimmed, false
 }
 
 // pickAgentCommands chooses the snapshot to report from what sessions have said.

--- a/backend/internal/controller/mcp/agent_commands_test.go
+++ b/backend/internal/controller/mcp/agent_commands_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -487,6 +488,7 @@ func TestHandleAgentCommandsPrunesDepartedSessions(t *testing.T) {
 		"a-session-that-left": {Commands: []AgentCommand{{Name: "old"}}},
 	}
 	sessionID := connectedServer(t, ps, "acp-gateway")
+	streamFor(ps, sessionID)
 
 	ps.HandleAgentCommands(context.Background(), sessionID, AgentCommandsParams{
 		Commands: []AgentCommand{{Name: "new"}},
@@ -528,6 +530,94 @@ func TestManagerAgentCommands(t *testing.T) {
 		got := m2.AgentCommands(7)
 		if got == nil || len(got.Commands) != 1 || got.Commands[0].Name != "init" {
 			t.Errorf("AgentCommands(7) = %+v", got)
+		}
+	})
+}
+
+func TestLeadsWithCommand(t *testing.T) {
+	advertised := &AgentCommandsSnapshot{
+		Commands: []AgentCommand{{Name: "compact"}, {Name: "web", Hint: "query"}},
+	}
+
+	t.Run("recognises an advertised command, with or without an argument", func(t *testing.T) {
+		for _, text := range []string{"/compact", "/web agent protocol", "/compact\nmore"} {
+			if _, ok := advertised.LeadsWithCommand(text); !ok {
+				t.Errorf("%q should be a command", text)
+			}
+		}
+	})
+
+	t.Run("trims leading whitespace so the command still leads the prompt", func(t *testing.T) {
+		trimmed, ok := advertised.LeadsWithCommand("  \n/compact")
+		if !ok || trimmed != "/compact" {
+			t.Errorf("got %q, ok=%v", trimmed, ok)
+		}
+	})
+
+	t.Run("is not fooled by anything that merely starts with a slash", func(t *testing.T) {
+		// The guard: these are ordinary text, and treating them as commands
+		// would deliver them stripped of the context that explains them.
+		for _, text := range []string{"/Users/mt/thing", "/etc/hosts", "/compactify", "/Compact", "/", "/ compact", "please /compact"} {
+			if _, ok := advertised.LeadsWithCommand(text); ok {
+				t.Errorf("%q should not be a command", text)
+			}
+		}
+	})
+
+	t.Run("recognises nothing when the agent advertised nothing", func(t *testing.T) {
+		var missing *AgentCommandsSnapshot
+		if _, ok := missing.LeadsWithCommand("/compact"); ok {
+			t.Error("a nil snapshot advertises nothing")
+		}
+		if _, ok := (&AgentCommandsSnapshot{}).LeadsWithCommand("/compact"); ok {
+			t.Error("an empty snapshot advertises nothing")
+		}
+	})
+
+	t.Run("returns the trimmed text even when it is not a command", func(t *testing.T) {
+		// The caller uses it either way, so it must not come back empty.
+		trimmed, ok := advertised.LeadsWithCommand("  hello")
+		if ok || trimmed != "hello" {
+			t.Errorf("got %q, ok=%v", trimmed, ok)
+		}
+	})
+}
+
+// A task pushed by the poller and one pushed at creation have to behave the
+// same, or whether a command runs would depend on something as arbitrary as
+// whether an agent was attached when the task was written.
+func TestNextTaskContent(t *testing.T) {
+	const taskID = int64(1234)
+	naming := "Next assigned task:\nID: " + monoflake.ID(taskID).String() + "\nTitle: Fix the flake"
+
+	t.Run("names the task first for an ordinary body", func(t *testing.T) {
+		ps := newCommandsServer()
+		got := ps.nextTaskContent(taskID, "Fix the flake", "the retry test is flaky")
+		if got != naming+"\nDetails: the retry test is flaky" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("puts an advertised command first, and the naming block after it", func(t *testing.T) {
+		ps, sessionID, _ := connectedCommandsServer(t)
+		ps.HandleAgentCommands(context.Background(), sessionID, AgentCommandsParams{
+			Commands: []AgentCommand{{Name: "review"}},
+		})
+
+		got := ps.nextTaskContent(taskID, "Fix the flake", "/review the auth changes")
+		if !strings.HasPrefix(got, "/review the auth changes") {
+			t.Errorf("the command must lead: %q", got)
+		}
+		if !strings.Contains(got, monoflake.ID(taskID).String()) {
+			t.Errorf("the task ID is missing from %q", got)
+		}
+	})
+
+	t.Run("names the task first when nothing is advertised", func(t *testing.T) {
+		ps := newCommandsServer()
+		got := ps.nextTaskContent(taskID, "Fix the flake", "/review")
+		if got != naming+"\nDetails: /review" {
+			t.Errorf("got %q", got)
 		}
 	})
 }

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -973,7 +973,7 @@ func (ps *WorkspaceServer) StartPoller(repo base.Repository) {
 				// The ID is part of the push because a task body can instruct the
 				// agent to quote it back when publishing an event, and this path
 				// is how workflow-step tasks are delivered.
-				msg := fmt.Sprintf("Next assigned task:\nID: %s\nTitle: %s\nDetails: %s", monoflake.ID(nextTask.ID).String(), nextTask.Title, nextTask.Body)
+				msg := ps.nextTaskContent(nextTask.ID, nextTask.Title, nextTask.Body)
 				if atts := formatModelAttachments(nextTask.Attachments); atts != "" {
 					msg += "\n" + atts
 				}
@@ -981,6 +981,27 @@ func (ps *WorkspaceServer) StartPoller(repo base.Repository) {
 			}
 		}
 	}()
+}
+
+// nextTaskContent composes the push that hands an agent its next task.
+//
+// The ID is part of it because a task body can instruct the agent to quote it
+// back when publishing an event, and this path is how workflow-step tasks are
+// delivered.
+//
+// A task whose body *is* a slash command has to lead with it, though: ACP runs
+// a command as ordinary prompt text and the agent matches it at the start of
+// what it is given, so anything in front stops it being a command. The naming
+// block therefore follows it — see taskChannelContent in the API handler, which
+// makes the same choice for the same reason, so a task delivered here and one
+// delivered there behave the same way rather than depending on whether an agent
+// happened to be attached when it was created.
+func (ps *WorkspaceServer) nextTaskContent(taskID int64, title, body string) string {
+	naming := fmt.Sprintf("Next assigned task:\nID: %s\nTitle: %s", monoflake.ID(taskID).String(), title)
+	if trimmed, isCommand := ps.AgentCommands().LeadsWithCommand(body); isCommand {
+		return fmt.Sprintf("%s\n\n%s", trimmed, naming)
+	}
+	return fmt.Sprintf("%s\nDetails: %s", naming, body)
 }
 
 func (ps *WorkspaceServer) UpdateMetadata(name, description, icon string) {

--- a/backend/internal/handler/api/task.go
+++ b/backend/internal/handler/api/task.go
@@ -109,7 +109,8 @@ func (h *handler) createTask() fiber.Handler {
 
 			if shouldNotifyMCP {
 				srv := h.mcpManager.Get(rq.Task.WorkspaceID, rq.UserID)
-				content := fmt.Sprintf("[Task %s] %s\n%s", monoflake.ID(rs.Task.ID).String(), rs.Task.Title, rs.Task.Body)
+				content := taskChannelContent(rs.Task.ID, rs.Task.Title, rs.Task.Body,
+					h.mcpManager.AgentCommands(rq.Task.WorkspaceID))
 				if atts := formatAttachments(rs.Task.Attachments); atts != "" {
 					content += "\n" + atts
 				}
@@ -257,10 +258,10 @@ func replyChannelContent(
 	// Leading whitespace is trimmed rather than disqualifying: the point is for
 	// the command to lead the prompt, and " /compact" would defeat that while
 	// plainly meaning the same thing.
-	trimmed := strings.TrimLeft(text, " \t\r\n")
+	trimmed, isCommand := commands.LeadsWithCommand(text)
 
 	content := fmt.Sprintf("[Reply to task %s] %s", monoflake.ID(taskID).String(), text)
-	if isAdvertisedCommand(trimmed, commands) {
+	if isCommand {
 		content = trimmed
 	}
 
@@ -273,29 +274,26 @@ func replyChannelContent(
 	return content
 }
 
-// isAdvertisedCommand reports whether the text opens with a slash command the
-// connected agent said it accepts.
-func isAdvertisedCommand(text string, commands *mcpctrl.AgentCommandsSnapshot) bool {
-	if commands == nil || !strings.HasPrefix(text, "/") {
-		return false
+// taskChannelContent composes what the agent is told about a new task.
+//
+// A task normally leads with the line naming it, because that ID is the only
+// way the agent can move the task on or reply to it afterwards.
+//
+// A task whose body *is* a slash command cannot lead with anything: ACP runs a
+// command as ordinary prompt text and the agent matches it at the start of what
+// it is given. So the command goes first and the naming line follows it.
+//
+// The trade-off is deliberate and worth knowing: everything after the command
+// name is that command's argument, so the naming line lands there too. Putting
+// it first instead would stop the command being a command at all, and dropping
+// it would leave the agent unable to report on the task it was given — of the
+// three, a slightly noisy argument is the one that still works.
+func taskChannelContent(taskID int64, title, body string, commands *mcpctrl.AgentCommandsSnapshot) string {
+	naming := fmt.Sprintf("[Task %s] %s", monoflake.ID(taskID).String(), title)
+	if trimmed, isCommand := commands.LeadsWithCommand(body); isCommand {
+		return fmt.Sprintf("%s\n\n%s", trimmed, naming)
 	}
-
-	// Everything up to the first whitespace, so "/web agent protocol" is the
-	// "web" command carrying an argument.
-	name := strings.TrimPrefix(text, "/")
-	if i := strings.IndexAny(name, " \t\r\n"); i >= 0 {
-		name = name[:i]
-	}
-	if name == "" {
-		return false
-	}
-
-	for _, c := range commands.Commands {
-		if c.Name == name {
-			return true
-		}
-	}
-	return false
+	return fmt.Sprintf("%s\n%s", naming, body)
 }
 
 func (h *handler) replyToTask() fiber.Handler {

--- a/backend/internal/handler/api/task_test.go
+++ b/backend/internal/handler/api/task_test.go
@@ -225,3 +225,58 @@ func TestReplyChannelContent(t *testing.T) {
 		}
 	})
 }
+
+// A task body that *is* a slash command has the same problem a reply did: the
+// agent matches the command at the start of what it is given. It also has one a
+// reply does not — the naming line is the only place the agent learns the task
+// ID, so it cannot simply be dropped.
+func TestTaskChannelContent(t *testing.T) {
+	const taskID = int64(1234)
+	naming := "[Task " + monoflake.ID(taskID).String() + "] Fix the flake"
+
+	advertised := &mcpctrl.AgentCommandsSnapshot{
+		Commands: []mcpctrl.AgentCommand{{Name: "review"}, {Name: "compact"}},
+	}
+
+	t.Run("names the task first for an ordinary body", func(t *testing.T) {
+		got := taskChannelContent(taskID, "Fix the flake", "the retry test is flaky", advertised)
+		if got != naming+"\nthe retry test is flaky" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("puts an advertised command first, and the naming line after it", func(t *testing.T) {
+		got := taskChannelContent(taskID, "Fix the flake", "/review", advertised)
+		if got != "/review\n\n"+naming {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("keeps the task ID reachable even then", func(t *testing.T) {
+		// Dropping it would leave the agent unable to move the task on or reply
+		// to it, which is worse than a noisy argument.
+		got := taskChannelContent(taskID, "Fix the flake", "/review the auth changes", advertised)
+		if !strings.Contains(got, monoflake.ID(taskID).String()) {
+			t.Errorf("the task ID is missing from %q", got)
+		}
+		if !strings.HasPrefix(got, "/review the auth changes") {
+			t.Errorf("the command must lead: %q", got)
+		}
+	})
+
+	t.Run("leaves a body that only looks like a command alone", func(t *testing.T) {
+		for _, body := range []string{"/Users/mt/thing is broken", "/reviewer notes", "/"} {
+			got := taskChannelContent(taskID, "Fix the flake", body, advertised)
+			if got != naming+"\n"+body {
+				t.Errorf("%q: got %q", body, got)
+			}
+		}
+	})
+
+	t.Run("names the task first when no agent has advertised anything", func(t *testing.T) {
+		got := taskChannelContent(taskID, "Fix the flake", "/review", nil)
+		if got != naming+"\n/review" {
+			t.Errorf("got %q", got)
+		}
+	})
+}

--- a/docs/SLASH_COMMANDS.md
+++ b/docs/SLASH_COMMANDS.md
@@ -9,6 +9,10 @@ Type `/` in a task and the agent's commands appear above the composer. Keep
 typing to narrow the list, then press Enter or Tab to choose one — or click it.
 Arrow keys move the highlight, Escape puts the menu away.
 
+The same menu is in the description when you create a task, so a task can *be* a
+command. Cmd ⌘ + Enter creates the task from there without reaching for the
+button.
+
 Nothing to install and nothing to configure. If the agent has commands, the
 menu is there; if it has none, nothing changes.
 
@@ -56,6 +60,16 @@ commands.
 Attachments still travel with the message either way. They are listed on their
 own lines after it, so they never come between the command and the start of the
 prompt.
+
+**A task whose body is a command is delivered the same way, with one
+difference.** A task notification also carries the line naming the task, and
+that line is the only place the agent learns the task's ID — which it needs to
+move the task on or reply to it. So the command goes first and the naming line
+follows it. The trade-off is worth knowing: everything after a command's name is
+that command's argument, so the naming line lands there too. Putting it first
+instead would stop the command being a command, and leaving it out would leave
+the agent unable to report back; of the three, a slightly noisy argument is the
+one that still works.
 
 ## If the menu does not appear
 

--- a/frontend/src/views/TaskFormView.vue
+++ b/frontend/src/views/TaskFormView.vue
@@ -58,10 +58,32 @@
 
           <!-- Description Textarea -->
           <textarea v-model="bodyRef"
+                    ref="bodyTextareaRef"
                     @keydown="onDescriptionKeydown"
                     placeholder="Provide detailed context or instructions..." 
                     class="w-full px-4 pt-3 pb-2 text-[13px] font-medium text-gray-800 dark:text-zinc-200 bg-transparent outline-none border-none focus:outline-none focus:ring-0 resize-none min-h-[160px] custom-scrollbar"
                     required></textarea>
+
+          <!-- The agent's slash commands. Below the description here rather than
+               above it: this box is the top of the form, so a menu above would
+               push the whole card down as you type. -->
+          <div v-if="slashMenu.open.value"
+               class="mx-4 mb-2 max-h-52 overflow-y-auto rounded-sm border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 shadow-sm custom-scrollbar">
+            <ul ref="slashListRef" role="listbox" aria-label="Agent commands">
+              <li v-for="(command, i) in slashMenu.matches.value" :key="command.name"
+                  role="option" :aria-selected="i === slashMenu.selected.value"
+                  @mouseenter="slashMenu.highlight(i)"
+                  @mousedown.prevent="acceptSlashCommand(command)"
+                  :class="i === slashMenu.selected.value ? 'bg-gray-105 dark:bg-zinc-700/60' : ''"
+                  class="flex items-baseline gap-2 px-3 py-1.5 cursor-pointer transition-colors">
+                <span class="text-[12px] font-bold text-gray-900 dark:text-zinc-100 shrink-0">/{{ command.name }}</span>
+                <span v-if="command.description"
+                      class="text-[11px] font-medium text-gray-500 dark:text-zinc-400 truncate">{{ command.description }}</span>
+                <span v-if="command.input?.hint || command.hint"
+                      class="ml-auto pl-3 text-[10px] font-medium text-gray-400 dark:text-zinc-500 shrink-0">{{ command.input?.hint || command.hint }}</span>
+              </li>
+            </ul>
+          </div>
 
           <!-- Attachments Preview -->
           <div v-if="newTaskAttachments.length > 0" class="flex flex-wrap gap-2 px-4 pb-2 border-t border-gray-50 dark:border-zinc-800/50 pt-2">
@@ -284,7 +306,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted } from 'vue';
+import { ref, computed, watch, onMounted, nextTick } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { getWorkspace, createTask, updateScheduledTask, getTask, fetchEvents, fetchWorkflows } from '../api';
 import { useToasts } from '../composables/useToasts';
@@ -292,6 +314,7 @@ import { useCron } from '../composables/useCron';
 import { useSpeechToText } from '../composables/useSpeechToText';
 import { useAutoTitle } from '../composables/useAutoTitle';
 import { useTooltipStore } from '../stores/tooltipStore';
+import { useSlashCommands } from '../composables/useSlashCommands';
 
 const { getNextRunLabel, daysOptions } = useCron();
 const route = useRoute();
@@ -320,20 +343,56 @@ const bodyRef = computed({
   set: (v) => { newTask.value.body = v; },
 });
 
+// The agent's own slash commands, offered in the description the same way the
+// task chat offers them. A workspace whose agent advertises none gets no menu.
+const agentCommands = computed(() => workspace.value?.agentCommands?.commands ?? []);
+const slashMenu = useSlashCommands({ text: bodyRef, commands: agentCommands });
+const slashListRef = ref(null);
+const bodyTextareaRef = ref(null);
+
+/** Puts the chosen command in the description, for a click on the menu. */
+function acceptSlashCommand(command) {
+  const applied = slashMenu.accept(command);
+  if (applied !== null) setBody(applied);
+}
+
 /**
- * Cmd/Ctrl-Enter submits the form from the description.
+ * The menu's keys while it is open, then Cmd/Ctrl-Enter to create.
  *
- * Guarded exactly as the button is, so the shortcut and the button agree: a
- * shortcut that quietly does nothing on an incomplete form is worse than one
- * that is simply not offered, and worse still if it disagrees with what the
- * button would have done.
+ * Order matters: the menu is asked first, so Enter over a highlighted command
+ * chooses it rather than doing anything else.
  */
 function onDescriptionKeydown(event) {
-  if (event.key !== 'Enter' || !(event.metaKey || event.ctrlKey)) return;
-  event.preventDefault();
+  const claimed = slashMenu.handleKeydown(event);
+  if (claimed) {
+    event.preventDefault();
+    if (claimed.text !== null) setBody(claimed.text);
+    else keepSelectionInView();
+    return;
+  }
+  if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+    event.preventDefault();
+    submitFromKeyboard();
+  }
+}
+
+/** Cmd/Ctrl-Enter submits, but only what the button would accept. */
+function submitFromKeyboard() {
   if (sending.value || !newTask.value.title || !newTask.value.body) return;
   if (isEditMode.value) submitEditProtocol();
   else submitHumanTask();
+}
+
+function setBody(text) {
+  bodyRef.value = text;
+  nextTick(() => bodyTextareaRef.value?.focus());
+}
+
+/** Keeps the highlighted row visible when the list is longer than the menu. */
+function keepSelectionInView() {
+  nextTick(() => {
+    slashListRef.value?.children?.[slashMenu.selected.value]?.scrollIntoView({ block: 'nearest' });
+  });
 }
 
 // STT


### PR DESCRIPTION
## What changed

The agent's slash commands are now offered in the task description when you create a task, the same way they already are in a task's chat — and a task whose body is a command now actually runs as one.

## Why changed

Asked for. Offering the menu there is only worth anything if the command then runs, and it would not have: a task reaches the agent wrapped in the line naming it, and ACP matches a command at the start of the prompt, so a task body of `/compact` was prose in a sentence — the same bug replies had before it was fixed.

Both task delivery paths now put an advertised command first and the naming line after it: the one used when an agent is attached at creation, and the poller's, so whether a command runs does not depend on whether anyone was listening when the task was written.

**One trade-off worth a reviewer's eye.** Unlike a reply, the naming line is kept rather than dropped, because it is the only place a new task's ID appears and the agent needs it to move the task on or reply to it. The cost is that it lands inside the command's argument. Of the three options — the command not running, the agent unable to report back, or a slightly noisy argument — the last is the only one that works. Happy to change it if you would rather the ID went somewhere else.

The rule for what counts as a command now lives in one place beside the advertised list, so the reply path and both task paths cannot drift apart.

## Test coverage report

- **New lines: 100%** — all four composers are at 100.0%: the shared matcher, the reply content, the task content, and the poller's.
- **Total coverage impact:** backend `internal/...` unchanged at **43.0%**; the frontend gate still passes at **100%** on all four metrics.
- Backend: 29 packages green. Frontend: 989 tests green.
- Cases covered: an advertised command leading a task body; a body that only looks like one (`/Users/…`, `/reviewer`, `/`); no agent advertising anything; the task ID still reachable when the command leads; and the poller and creation paths agreeing.

## Other reports

Verified in a real browser against a local instance: the menu opens and filters in the description, and the arrow keys and Enter choose a command.

Documentation updated to cover creating a task as a command, including the argument trade-off above.

**Stacked on #500**, which carries the Cmd ⌘ + Enter shortcut this was originally bundled with. Split at your request so this half can be considered on its own; the base retargets to `main` automatically once #500 merges.

TaskID: 0iRVf7ypc5h
