### PR TITLE
feat(ui): Cmd-Enter creates a task from the description

### DIFF
--- a/frontend/src/views/TaskFormView.vue
+++ b/frontend/src/views/TaskFormView.vue
@@ -57,7 +57,8 @@
           </div>
 
           <!-- Description Textarea -->
-          <textarea v-model="bodyRef" 
+          <textarea v-model="bodyRef"
+                    @keydown="onDescriptionKeydown"
                     placeholder="Provide detailed context or instructions..." 
                     class="w-full px-4 pt-3 pb-2 text-[13px] font-medium text-gray-800 dark:text-zinc-200 bg-transparent outline-none border-none focus:outline-none focus:ring-0 resize-none min-h-[160px] custom-scrollbar"
                     required></textarea>
@@ -258,6 +259,12 @@
 
              </div>
 
+             <!-- The shortcut, said out loud. Hidden on narrow screens, where
+                  there is no keyboard to press it with and no room to say so. -->
+             <span class="hidden sm:inline text-[10px] font-medium text-gray-400 dark:text-zinc-500 mr-2 shrink-0">
+               {{ isEditMode ? 'Cmd ⌘ + Enter to save' : 'Cmd ⌘ + Enter to create' }}
+             </span>
+
              <!-- Submit Button -->
              <button type="submit"
                      :disabled="sending || !newTask.title || !newTask.body"
@@ -312,6 +319,22 @@ const bodyRef = computed({
   get: () => newTask.value.body,
   set: (v) => { newTask.value.body = v; },
 });
+
+/**
+ * Cmd/Ctrl-Enter submits the form from the description.
+ *
+ * Guarded exactly as the button is, so the shortcut and the button agree: a
+ * shortcut that quietly does nothing on an incomplete form is worse than one
+ * that is simply not offered, and worse still if it disagrees with what the
+ * button would have done.
+ */
+function onDescriptionKeydown(event) {
+  if (event.key !== 'Enter' || !(event.metaKey || event.ctrlKey)) return;
+  event.preventDefault();
+  if (sending.value || !newTask.value.title || !newTask.value.body) return;
+  if (isEditMode.value) submitEditProtocol();
+  else submitHumanTask();
+}
 
 // STT
 const {


### PR DESCRIPTION
## What changed

Cmd ⌘ + Enter now creates a task from the description field, and the shortcut is written next to the create button.

## Why changed

The composer inside a task has had this shortcut for a long time; the form that creates one did not, so writing a task always meant reaching for the button. A shortcut nobody can see may as well not exist, hence the hint — hidden on narrow screens, where there is no keyboard to press it with and no room to say so.

The shortcut is guarded exactly as the button is, so the two agree. A shortcut that quietly does nothing on an incomplete form is worse than one that is not offered, and worse still if it disagrees with the button beside it.

## Test coverage report

- **New lines: none measurable** — the change is a handler and a hint inside a Vue component, and components are not in the frontend coverage include list (that list is what the 100% gate covers, and it holds only plain modules).
- **Total coverage impact:** none; the gate still passes at **100%** on all four metrics, 997 tests green.
- Verified in a real browser instead: Cmd ⌘ + Enter fires the create request with a title and description present, and does nothing with the title empty — matching the disabled button.

## Other reports

Split out of #499 at your request, so the slash-command half can be considered separately. That half is stacked on this branch.

TaskID: 0iRVf7ypc5h
