### PR TITLE
feat: show what agent is connected, and what it is running

### DIFF
--- a/backend/internal/controller/mcp/agent_client.go
+++ b/backend/internal/controller/mcp/agent_client.go
@@ -1,0 +1,68 @@
+package mcp
+
+import (
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// AgentClientInfo is what the client attached to a workspace said it was when
+// it connected.
+//
+// Not a cached notification like the models and commands beside it — it is read
+// off the session itself — but that alone is not enough to keep it current. An
+// MCP session outlives the stream that carried it: after a gateway goes away
+// its session is still listed, so a reader that trusted the session list would
+// go on naming a client that had already left. AgentClient checks the same
+// signal the workspace uses to say an agent is live.
+type AgentClientInfo struct {
+	// Name is the client's own name for itself — "claude-code" for Claude Code
+	// attached directly, "acp-gateway" for anything reached through the gateway.
+	Name string
+	// Version is what it reported, when it reported one.
+	Version string
+}
+
+// AgentClient reports what is attached to this workspace, or nil when nothing
+// is.
+//
+// The first session that named itself wins. More than one client can attach to
+// a workspace, but the interface has one line to say what is connected, and the
+// session order the server reports is at least stable between two calls — the
+// same reason pickAgentCommands iterates the live list rather than a map.
+//
+// Nothing is reported unless an agent is actually connected. Sessions linger
+// after their stream drops, so without this the workspace would keep naming the
+// gateway that left — and naming it beside an "agent offline" indicator, which
+// is worse than saying nothing.
+func (ps *WorkspaceServer) AgentClient() *AgentClientInfo {
+	if ps.mcpServer == nil || !ps.IsAgentConnected() {
+		return nil
+	}
+	for sess := range ps.mcpServer.Sessions() {
+		if info := clientInfoFrom(sess.InitializeParams()); info != nil {
+			return info
+		}
+	}
+	return nil
+}
+
+// clientInfoFrom reads a client's identity out of the initialize handshake.
+//
+// This is the handshake SEP-2575 eventually replaces with per-request metadata,
+// which is why the telemetry path deliberately does not read it. It is still
+// the right source here: this server is pinned below that revision for as long
+// as it needs to push notifications, and the question being asked — "what is
+// attached to this workspace" — is about the session rather than about any one
+// request. When the handshake goes, this reads whatever replaces it; until
+// then, a request-scoped identity would answer a different question.
+func clientInfoFrom(p *mcp.InitializeParams) *AgentClientInfo {
+	if p == nil || p.ClientInfo == nil {
+		return nil
+	}
+	name := strings.TrimSpace(p.ClientInfo.Name)
+	if name == "" {
+		return nil
+	}
+	return &AgentClientInfo{Name: name, Version: strings.TrimSpace(p.ClientInfo.Version)}
+}

--- a/backend/internal/controller/mcp/agent_client_test.go
+++ b/backend/internal/controller/mcp/agent_client_test.go
@@ -1,0 +1,111 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/agentrq/agentrq/backend/internal/service/eventbus"
+)
+
+// What is attached to a workspace comes off the live session rather than a
+// cached notification, so unlike the models and commands beside it there is no
+// way for this to describe a client that has gone.
+
+func TestAgentClient(t *testing.T) {
+	t.Run("names the connected client", func(t *testing.T) {
+		replies := 0
+		ps := permissionServer(t, &replies)
+		ps.bus = eventbus.New()
+		connectedServer(t, ps, "acp-gateway")
+		ps.agentConnections.Add(1) // what the HTTP handler does for a live stream
+
+		got := ps.AgentClient()
+		if got == nil {
+			t.Fatal("AgentClient() = nil with a session attached")
+		}
+		if got.Name != "acp-gateway" {
+			t.Errorf("Name = %q, want acp-gateway", got.Name)
+		}
+		if got.Version != "0" {
+			t.Errorf("Version = %q, want the version the client sent", got.Version)
+		}
+	})
+
+	t.Run("has nothing to report when the attached client named nobody", func(t *testing.T) {
+		// The loop runs and finds a session, but nothing worth showing. A name
+		// is the only thing this field is for, so an anonymous client is the
+		// same as none.
+		replies := 0
+		ps := permissionServer(t, &replies)
+		ps.bus = eventbus.New()
+		connectedServer(t, ps, "")
+		ps.agentConnections.Add(1)
+
+		if got := ps.AgentClient(); got != nil {
+			t.Errorf("AgentClient() = %+v, want nil", got)
+		}
+	})
+
+	t.Run("stops naming a client once its stream has gone", func(t *testing.T) {
+		// An MCP session outlives the stream that carried it, so the session
+		// list still holds the departed gateway. Reported against a workspace
+		// the interface is calling offline, that name is worse than silence.
+		replies := 0
+		ps := permissionServer(t, &replies)
+		ps.bus = eventbus.New()
+		connectedServer(t, ps, "acp-gateway")
+		ps.agentConnections.Add(1)
+		if ps.AgentClient() == nil {
+			t.Fatal("expected the client to be named while its stream is up")
+		}
+
+		ps.agentConnections.Add(-1) // the stream drops; the session lingers
+
+		if got := ps.AgentClient(); got != nil {
+			t.Errorf("AgentClient() = %+v after the stream went, want nil", got)
+		}
+	})
+
+	t.Run("has nothing to report with no server running", func(t *testing.T) {
+		ps := &WorkspaceServer{}
+		if got := ps.AgentClient(); got != nil {
+			t.Errorf("AgentClient() = %+v, want nil", got)
+		}
+	})
+
+	t.Run("has nothing to report when nothing is attached", func(t *testing.T) {
+		replies := 0
+		ps := permissionServer(t, &replies)
+		ps.bus = eventbus.New()
+		// A server with no session: the same state a workspace is in between
+		// connections.
+		if got := ps.AgentClient(); got != nil {
+			t.Errorf("AgentClient() = %+v, want nil", got)
+		}
+	})
+}
+
+func TestClientInfoFrom(t *testing.T) {
+	t.Run("reads the name and version a client sent", func(t *testing.T) {
+		got := clientInfoFrom(&mcp.InitializeParams{
+			ClientInfo: &mcp.Implementation{Name: "  claude-code  ", Version: " 1.2.3 "},
+		})
+		if got == nil || got.Name != "claude-code" || got.Version != "1.2.3" {
+			t.Errorf("got %+v, want the trimmed name and version", got)
+		}
+	})
+
+	t.Run("reads nothing from a handshake that named nobody", func(t *testing.T) {
+		for _, p := range []*mcp.InitializeParams{
+			nil,
+			{},
+			{ClientInfo: &mcp.Implementation{}},
+			{ClientInfo: &mcp.Implementation{Name: "   "}},
+		} {
+			if got := clientInfoFrom(p); got != nil {
+				t.Errorf("clientInfoFrom(%+v) = %+v, want nil", p, got)
+			}
+		}
+	})
+}

--- a/backend/internal/controller/mcp/manager.go
+++ b/backend/internal/controller/mcp/manager.go
@@ -116,6 +116,18 @@ func (m *Manager) AgentCommands(workspaceID int64) *AgentCommandsSnapshot {
 	return srv.AgentCommands()
 }
 
+// AgentClient reports what is attached to the workspace, or nil when there is
+// no server running for it or nothing has connected.
+func (m *Manager) AgentClient(workspaceID int64) *AgentClientInfo {
+	m.mu.RLock()
+	srv, ok := m.servers[workspaceID]
+	m.mu.RUnlock()
+	if !ok || srv == nil {
+		return nil
+	}
+	return srv.AgentClient()
+}
+
 // SendChannelNotification forwards a channel notification to the appropriate WorkspaceServer.
 func (m *Manager) SendChannelNotification(ctx context.Context, workspaceID int64, userID string, taskID int64, content string) {
 	m.mu.RLock()

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -33,6 +33,7 @@ type (
 		AgentSupportsStop     bool
 		AgentModels           *AgentModels
 		AgentCommands         *AgentCommands
+		AgentClient           *AgentClient
 		AutoAllowedTools      []string
 		AllowAllCommands      bool
 		SelfLearningLoopNote  string
@@ -73,6 +74,14 @@ type (
 		Name        string
 		Description string
 		Hint        string
+	}
+
+	// AgentClient is what the client attached to the workspace said it was.
+	// Live state read off the MCP session, so it is absent whenever nothing is
+	// connected.
+	AgentClient struct {
+		Name    string
+		Version string
 	}
 
 	SlackConfig struct {

--- a/backend/internal/data/view/api/view.go
+++ b/backend/internal/data/view/api/view.go
@@ -21,6 +21,7 @@ type (
 		AgentSupportsStop     bool                  `json:"agentSupportsStop"`
 		AgentModels           *AgentModels          `json:"agentModels,omitempty"`
 		AgentCommands         *AgentCommands        `json:"agentCommands,omitempty"`
+		AgentClient           *AgentClient          `json:"agentClient,omitempty"`
 		MCPURL                string                `json:"mcpUrl"`
 		MCPToken              string                `json:"mcpToken,omitempty"`
 		AutoAllowedTools      []string              `json:"autoAllowedTools,omitempty"`
@@ -59,6 +60,14 @@ type (
 		Name        string `json:"name"`
 		Description string `json:"description,omitempty"`
 		Hint        string `json:"hint,omitempty"`
+	}
+
+	// AgentClient names what is attached to the workspace right now. Omitted
+	// when nothing is connected, so a client can read its presence the same way
+	// it reads agentConnected.
+	AgentClient struct {
+		Name    string `json:"name"`
+		Version string `json:"version,omitempty"`
 	}
 
 	SlackConfig struct {

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -621,6 +621,7 @@ func (h *handler) createWorkspace() fiber.Handler {
 		rs.Workspace.AgentSupportsStop = h.mcpManager.SupportsStop(rs.Workspace.ID)
 		rs.Workspace.AgentModels = agentModelsEntity(h.mcpManager.AgentModels(rs.Workspace.ID))
 		rs.Workspace.AgentCommands = agentCommandsEntity(h.mcpManager.AgentCommands(rs.Workspace.ID))
+		rs.Workspace.AgentClient = agentClientEntity(h.mcpManager.AgentClient(rs.Workspace.ID))
 		h.enrichWorkspaceSlack(ctx, &rs.Workspace)
 
 		c.Status(http.StatusCreated)
@@ -651,6 +652,7 @@ func (h *handler) getWorkspace() fiber.Handler {
 		rs.Workspace.AgentSupportsStop = h.mcpManager.SupportsStop(rs.Workspace.ID)
 		rs.Workspace.AgentModels = agentModelsEntity(h.mcpManager.AgentModels(rs.Workspace.ID))
 		rs.Workspace.AgentCommands = agentCommandsEntity(h.mcpManager.AgentCommands(rs.Workspace.ID))
+		rs.Workspace.AgentClient = agentClientEntity(h.mcpManager.AgentClient(rs.Workspace.ID))
 		h.enrichWorkspaceSlack(ctx, &rs.Workspace)
 
 		c.Status(http.StatusOK)
@@ -680,6 +682,7 @@ func (h *handler) listWorkspaces() fiber.Handler {
 			rs.Workspaces[i].AgentSupportsStop = h.mcpManager.SupportsStop(rs.Workspaces[i].ID)
 			rs.Workspaces[i].AgentModels = agentModelsEntity(h.mcpManager.AgentModels(rs.Workspaces[i].ID))
 			rs.Workspaces[i].AgentCommands = agentCommandsEntity(h.mcpManager.AgentCommands(rs.Workspaces[i].ID))
+			rs.Workspaces[i].AgentClient = agentClientEntity(h.mcpManager.AgentClient(rs.Workspaces[i].ID))
 			h.enrichWorkspaceSlack(ctx, &rs.Workspaces[i])
 		}
 
@@ -789,6 +792,7 @@ func (h *handler) updateWorkspace() fiber.Handler {
 		rs.Workspace.AgentSupportsStop = h.mcpManager.SupportsStop(rq.Workspace.ID)
 		rs.Workspace.AgentModels = agentModelsEntity(h.mcpManager.AgentModels(rq.Workspace.ID))
 		rs.Workspace.AgentCommands = agentCommandsEntity(h.mcpManager.AgentCommands(rq.Workspace.ID))
+		rs.Workspace.AgentClient = agentClientEntity(h.mcpManager.AgentClient(rq.Workspace.ID))
 		h.enrichWorkspaceSlack(ctx, &rs.Workspace)
 
 		c.Status(http.StatusOK)
@@ -1084,4 +1088,13 @@ func agentCommandsEntity(s *mcpctrl.AgentCommandsSnapshot) *entity.AgentCommands
 		}
 	}
 	return &entity.AgentCommands{Commands: commands}
+}
+
+// agentClientEntity converts the live MCP client identity into the entity the
+// workspace carries.
+func agentClientEntity(c *mcpctrl.AgentClientInfo) *entity.AgentClient {
+	if c == nil {
+		return nil
+	}
+	return &entity.AgentClient{Name: c.Name, Version: c.Version}
 }

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -831,3 +831,18 @@ func TestAgentCommandsEntity(t *testing.T) {
 		}
 	})
 }
+
+func TestAgentClientEntity(t *testing.T) {
+	t.Run("nil stays nil, so nothing is advertised", func(t *testing.T) {
+		if got := agentClientEntity(nil); got != nil {
+			t.Errorf("got %+v, want nil", got)
+		}
+	})
+
+	t.Run("carries the live identity into the API layer's own shape", func(t *testing.T) {
+		got := agentClientEntity(&mcpctrl.AgentClientInfo{Name: "claude-code", Version: "2.0.1"})
+		if got == nil || got.Name != "claude-code" || got.Version != "2.0.1" {
+			t.Errorf("got %+v", got)
+		}
+	})
+}

--- a/backend/internal/mapper/api/workspace.go
+++ b/backend/internal/mapper/api/workspace.go
@@ -154,6 +154,7 @@ func fromEntityWorkspaceToView(p entity.Workspace, mcpURL string) view.Workspace
 		AgentSupportsStop:     p.AgentSupportsStop,
 		AgentModels:           fromEntityAgentModelsToView(p.AgentModels),
 		AgentCommands:         fromEntityAgentCommandsToView(p.AgentCommands),
+		AgentClient:           fromEntityAgentClientToView(p.AgentClient),
 		MCPURL:                mcpURL,
 		AutoAllowedTools:      p.AutoAllowedTools,
 		AllowAllCommands:      p.AllowAllCommands,
@@ -251,4 +252,16 @@ func fromEntityAgentCommandsToView(c *entity.AgentCommands) *view.AgentCommands 
 		}
 	}
 	return &view.AgentCommands{Commands: commands}
+}
+
+// fromEntityAgentClientToView names what is attached to the workspace.
+//
+// nil rather than an empty object when nothing is connected, so the field's
+// absence means the same thing as everywhere else on this view: there is
+// nothing to show.
+func fromEntityAgentClientToView(c *entity.AgentClient) *view.AgentClient {
+	if c == nil {
+		return nil
+	}
+	return &view.AgentClient{Name: c.Name, Version: c.Version}
 }

--- a/backend/internal/mapper/api/workspace_test.go
+++ b/backend/internal/mapper/api/workspace_test.go
@@ -41,3 +41,18 @@ func TestFromEntityAgentCommandsToView(t *testing.T) {
 		}
 	})
 }
+
+func TestFromEntityAgentClientToView(t *testing.T) {
+	t.Run("nil stays nil, so the field is omitted", func(t *testing.T) {
+		if got := fromEntityAgentClientToView(nil); got != nil {
+			t.Errorf("got %+v, want nil", got)
+		}
+	})
+
+	t.Run("carries the name and version across", func(t *testing.T) {
+		got := fromEntityAgentClientToView(&entity.AgentClient{Name: "acp-gateway", Version: "0.2.13"})
+		if got == nil || got.Name != "acp-gateway" || got.Version != "0.2.13" {
+			t.Errorf("got %+v", got)
+		}
+	})
+}

--- a/frontend/src/composables/useAgentSummary.js
+++ b/frontend/src/composables/useAgentSummary.js
@@ -1,0 +1,77 @@
+/**
+ * What to say about the agent attached to a workspace, beyond that it is there.
+ *
+ * The Overview has one short line per workspace, so this is deliberately a
+ * summary rather than a panel: who is connected, and what it is running. Both
+ * halves are optional and often only one is known — a client always names
+ * itself on connecting, while a model is only known once the agent has
+ * reported one, which an agent that offers no choice never does.
+ *
+ * Extracted from the view so it can be tested: the project has no
+ * component-test harness, and what is worth pinning here is which of the two
+ * halves appear and what a missing one does.
+ */
+
+/** Joins the halves the way the card renders them. */
+const SEPARATOR = ' · ';
+
+/**
+ * The display name of the model the agent is running, or undefined.
+ *
+ * The agent reports an ID and, usually, a list that gives that ID a
+ * human-readable name. The name is preferred because it is what the agent
+ * itself calls the model; the raw ID is the fallback rather than nothing, since
+ * `gpt-5-codex` still tells a reader more than a blank does.
+ */
+export function currentModelName(agentModels) {
+  const currentId = agentModels?.currentModel;
+  if (!currentId) return undefined;
+
+  const models = Array.isArray(agentModels.models) ? agentModels.models : [];
+  const match = models.find((m) => m && m.id === currentId);
+  const name = typeof match?.name === 'string' ? match.name.trim() : '';
+  return name || currentId;
+}
+
+/**
+ * The client's own name for itself, or undefined.
+ *
+ * Shown verbatim wherever it is rendered. Prettifying it would mean a lookup
+ * table of names this project does not own, which would be wrong for every
+ * client not in it.
+ */
+export function agentClientName(workspace) {
+  const client = workspace?.agentClient?.name;
+  if (typeof client !== 'string') return undefined;
+  const name = client.trim();
+  return name || undefined;
+}
+
+/**
+ * The two halves the card lays out, or null when there is nothing to lay out.
+ *
+ * Returned as parts rather than one string because the card gives each its own
+ * end of a row: two short values that can each truncate on their own read
+ * better in a narrow card than one long line that truncates as a whole, losing
+ * whichever half happened to be last.
+ *
+ * null rather than empty parts when nothing is known: a connected agent that
+ * has said nothing about itself is an ordinary state — every non-ACP client is
+ * in it — and the card drops the whole row rather than drawing an empty one.
+ */
+export function agentDetails(workspace) {
+  const client = agentClientName(workspace);
+  const model = currentModelName(workspace?.agentModels);
+  if (!client && !model) return null;
+  return { client, model };
+}
+
+/**
+ * Both halves on one line, for the places that have room for only one string —
+ * the card's tooltip, where truncation has hidden something.
+ */
+export function agentSummary(workspace) {
+  const details = agentDetails(workspace);
+  if (!details) return '';
+  return [details.client, details.model].filter(Boolean).join(SEPARATOR);
+}

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -151,8 +151,24 @@
                      
                      <div class="min-w-0">
                        <h3 class="font-black text-sm text-gray-800 dark:text-zinc-200 truncate group-hover:text-black dark:group-hover:text-white transition-colors leading-none">{{ toKebabCase(p.name) }}</h3>
-                       <div class="flex items-center gap-1.5 mt-1">
-                         <span class="text-[8px] font-black uppercase tracking-widest transition-colors"
+                       <!-- The dot already says an agent is live, so when the
+                            workspace can say *what* is live the line spends its
+                            width on that instead of repeating the dot. Falls
+                            back to the plain state whenever nothing is known,
+                            which is every agent that reports nothing about
+                            itself. -->
+                       <div class="flex items-baseline gap-1.5 mt-1 min-w-0" :title="agentSummary(p)">
+                         <template v-if="p.agentConnected && agentDetails(p)">
+                           <span v-if="agentDetails(p).client"
+                                 class="text-[9px] font-black uppercase tracking-wider text-green-600 dark:text-green-500 truncate">
+                             {{ agentDetails(p).client }}
+                           </span>
+                           <template v-if="agentDetails(p).model">
+                             <span v-if="agentDetails(p).client" class="text-[9px] font-black text-gray-300 dark:text-zinc-700 shrink-0">·</span>
+                             <span class="text-[9px] font-medium text-gray-500 dark:text-zinc-400 truncate">{{ agentDetails(p).model }}</span>
+                           </template>
+                         </template>
+                         <span v-else class="text-[8px] font-black uppercase tracking-widest transition-colors"
                                :class="p.agentConnected ? 'text-green-600 dark:text-green-500' : 'text-gray-400 dark:text-zinc-500'">
                            {{ p.agentConnected ? 'Agent Live' : 'Agent Offline' }}
                          </span>
@@ -164,6 +180,7 @@
                      <svg class="w-4 h-4 text-gray-900 dark:text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" /></svg>
                    </div>
                  </div>
+
             </div>
           </div>
         </section>
@@ -269,6 +286,7 @@ import { useWorkspaceStore } from '../stores/workspaceStore';
 import { useFormat } from '../composables/useFormat';
 import { useTooltipStore } from '../stores/tooltipStore';
 import { usePlatformStore } from '../stores/platformStore';
+import { agentDetails, agentSummary } from '../composables/useAgentSummary';
 import {
   chooseDirectory,
   directoryPickerState,

--- a/frontend/test/agentSummary.test.js
+++ b/frontend/test/agentSummary.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  agentClientName,
+  agentDetails,
+  agentSummary,
+  currentModelName,
+} from '../src/composables/useAgentSummary'
+
+describe('currentModelName', () => {
+  it('prefers the name the agent gave the model', () => {
+    expect(
+      currentModelName({
+        currentModel: 'claude-sonnet-4-5',
+        models: [{ id: 'claude-sonnet-4-5', name: 'Claude Sonnet 4.5' }],
+      })
+    ).toBe('Claude Sonnet 4.5')
+  })
+
+  it('falls back to the id, which still tells a reader something', () => {
+    expect(currentModelName({ currentModel: 'gpt-5-codex', models: [] })).toBe('gpt-5-codex')
+    expect(currentModelName({ currentModel: 'gpt-5-codex' })).toBe('gpt-5-codex')
+    expect(
+      currentModelName({ currentModel: 'x', models: [{ id: 'x', name: '   ' }] })
+    ).toBe('x')
+    expect(currentModelName({ currentModel: 'x', models: [{ id: 'x', name: 7 }] })).toBe('x')
+  })
+
+  it('ignores entries that are not the current one', () => {
+    expect(
+      currentModelName({
+        currentModel: 'b',
+        models: [null, { id: 'a', name: 'A' }, { id: 'b', name: 'B' }],
+      })
+    ).toBe('B')
+  })
+
+  it('has nothing to say when no model is selected', () => {
+    // Normal: an agent that offers no choice never reports one.
+    expect(currentModelName({ models: [{ id: 'a', name: 'A' }] })).toBeUndefined()
+    expect(currentModelName({ currentModel: '' })).toBeUndefined()
+    expect(currentModelName(undefined)).toBeUndefined()
+  })
+})
+
+describe('agentSummary', () => {
+  it('names the client and the model it is running', () => {
+    expect(
+      agentSummary({
+        agentClient: { name: 'acp-gateway', version: '0.2.13' },
+        agentModels: { currentModel: 'gpt-5-codex', models: [{ id: 'gpt-5-codex', name: 'GPT-5 Codex' }] },
+      })
+    ).toBe('acp-gateway · GPT-5 Codex')
+  })
+
+  it('says just the client when no model has been reported', () => {
+    expect(agentSummary({ agentClient: { name: 'claude-code' } })).toBe('claude-code')
+  })
+
+  it('says just the model when the client did not name itself', () => {
+    expect(
+      agentSummary({ agentModels: { currentModel: 'x', models: [{ id: 'x', name: 'X' }] } })
+    ).toBe('X')
+  })
+
+  it('says nothing at all when nothing is known', () => {
+    // A connected agent that has said nothing about itself is ordinary, and
+    // "Unknown agent" would read as a fault rather than as silence.
+    expect(agentSummary({})).toBe('')
+    expect(agentSummary(undefined)).toBe('')
+    expect(agentSummary({ agentClient: { name: '   ' } })).toBe('')
+    expect(agentSummary({ agentClient: { name: 42 } })).toBe('')
+  })
+})
+
+describe('agentClientName', () => {
+  it('gives the client its own name, trimmed', () => {
+    expect(agentClientName({ agentClient: { name: '  acp-gateway  ' } })).toBe('acp-gateway')
+  })
+
+  it('has nothing to give when the client did not name itself', () => {
+    expect(agentClientName({ agentClient: { name: '   ' } })).toBeUndefined()
+    expect(agentClientName({ agentClient: { name: 42 } })).toBeUndefined()
+    expect(agentClientName({ agentClient: {} })).toBeUndefined()
+    expect(agentClientName({})).toBeUndefined()
+    expect(agentClientName(undefined)).toBeUndefined()
+  })
+})
+
+describe('agentDetails', () => {
+  it('hands the card each half separately, so each can truncate on its own', () => {
+    expect(
+      agentDetails({
+        agentClient: { name: 'acp-gateway' },
+        agentModels: { currentModel: 'x', models: [{ id: 'x', name: 'GPT-5 Codex' }] },
+      })
+    ).toEqual({ client: 'acp-gateway', model: 'GPT-5 Codex' })
+  })
+
+  it('gives just the half it knows', () => {
+    expect(agentDetails({ agentClient: { name: 'claude-code' } })).toEqual({
+      client: 'claude-code',
+      model: undefined,
+    })
+    expect(agentDetails({ agentModels: { currentModel: 'x' } })).toEqual({
+      client: undefined,
+      model: 'x',
+    })
+  })
+
+  it('is null when there is nothing to lay out, so the card drops the row', () => {
+    expect(agentDetails({})).toBeNull()
+    expect(agentDetails(undefined)).toBeNull()
+    expect(agentDetails({ agentClient: { name: '  ' }, agentModels: {} })).toBeNull()
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -62,6 +62,7 @@ export default defineConfig({
         'src/composables/useMemories.js',
         'src/composables/useUiTelemetry.js',
         'src/composables/useWebMCP.js',
+        'src/composables/useAgentSummary.js',
         'src/composables/useSlashCommands.js',
         'src/composables/useWorkspaceSettings.js',
         'src/composables/useStatsRange.js',


### PR DESCRIPTION
## What changed

The Overview now says which client is attached to each live workspace and which model that agent is running, instead of only that an agent is live.

## Why changed

"Agent live" tells you something is there but not what. The model was already on the workspace payload and had never been shown anywhere; the client identity is new. Together they answer "what is actually running in here" at a glance.

Both halves are optional and often only one is known, so the line says what it has and nothing more. A connected agent that has reported nothing about itself is an ordinary state — every non-ACP client is in it — and inventing "Unknown agent" for it would read as a fault rather than as silence. The client name is shown verbatim rather than prettified, because a lookup table of names this project does not own would be wrong for every client not in it.

**One trap worth a reviewer's attention, found by disconnecting an agent and watching what the API kept saying.** An MCP session outlives the stream that carried it, so the session list still holds a gateway that has gone. Reading that list alone would have named a departed client next to an "agent offline" indicator. The reader therefore checks the same signal the workspace uses to say an agent is live, and there is a test that drops the stream and asserts the name goes with it.

**A known limitation.** For anything reached through the gateway this reports `acp-gateway` rather than `codex` or `gemini`, because the gateway is the MCP client — it knows its agent's real name from the ACP handshake but never passes it on. That is a separate change in a separate repo, tracked as task 0iRZcRtxS5Z.

## Test coverage report

- **New lines: 100%** — every new function is 100% covered: the reader, the pure parser of the handshake, both layer converters, and the frontend summary.
- **Total coverage impact:** backend `internal/...` unchanged at **43.0%**; the frontend gate still passes at **100%** on all four metrics, 997 tests green (up from 989).
- Backend: 29 packages green.
- The frontend logic lives in a small module rather than the view so it falls under the 100% gate, which is also what makes "new lines 100%" reachable — components are not in that list.

## Other reports

Verified end to end against a local instance with a real MCP client attached — one that holds its stream open and answers pings, since without that the session is evicted and there is nothing to display. The card read `AGENT LIVE · acp-gateway · GPT-5 Codex`, and dropping the client's stream returned it to `AGENT LIVE`-less silence with the API reporting no client at all.

Related, pre-existing, and deliberately not changed here: `agentModels` has the same staleness — still returned after the agent disconnects, because it filters on the session list rather than on whether a stream is up. Nothing shows it today, since the card is gated on the connection state, and it is noted in the follow-up task.

TaskID: 0iRW26JhWnB
