### PR TITLE
feat(mcp): name the agent behind the gateway, not the gateway

### DIFF
--- a/backend/internal/controller/mcp/agent_client.go
+++ b/backend/internal/controller/mcp/agent_client.go
@@ -1,10 +1,34 @@
 package mcp
 
 import (
+	"context"
 	"strings"
+
+	zlog "github.com/rs/zerolog/log"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+// AgentIdentityNotificationMethod is the channel notification a gateway sends
+// to say which agent is behind it.
+//
+// A gateway's MCP client is the gateway, so without this a workspace can only
+// ever name the bridge. The agent named itself during its own ACP handshake and
+// this carries that across.
+const AgentIdentityNotificationMethod = "notifications/claude/channel/agent"
+
+// AgentIdentityParams is the payload of an agent notification.
+//
+// snake_case, unlike the REST surface: this is the wire format the gateways
+// send (acp-gateway's `sendAgentToWorkspace`), the same reasoning the models
+// and commands payloads beside it record.
+type AgentIdentityParams struct {
+	TaskID    string `json:"task_id"`
+	SessionID string `json:"session_id"`
+	Name      string `json:"name"`
+	Title     string `json:"title"`
+	Version   string `json:"version"`
+}
 
 // AgentClientInfo is what the client attached to a workspace said it was when
 // it connected.
@@ -16,11 +40,59 @@ import (
 // go on naming a client that had already left. AgentClient checks the same
 // signal the workspace uses to say an agent is live.
 type AgentClientInfo struct {
-	// Name is the client's own name for itself — "claude-code" for Claude Code
-	// attached directly, "acp-gateway" for anything reached through the gateway.
+	// Name is the agent behind the connection when a gateway has said which one
+	// it is driving, and otherwise the client's own name for itself —
+	// "claude-code" for Claude Code attached directly, "acp-gateway" for a
+	// gateway too old to report its agent.
 	Name string
+	// Title is a longer human-readable name, when the agent gave one.
+	Title string
 	// Version is what it reported, when it reported one.
 	Version string
+}
+
+// HandleAgentIdentity records which agent a gateway says it is driving.
+//
+// Keyed by the MCP transport session, deliberately, and *not* by the payload's
+// session_id — the trap agent_commands.go documents at length. The two are
+// different namespaces: the transport session is this server's connection to
+// the gateway, while session_id is the gateway's own ACP session with the agent
+// behind it. Keying on the payload would file every identity under an ID the
+// session list never reports.
+//
+// A nameless payload is ignored rather than recorded. The name is the entire
+// point of this notification, and an empty one would replace a perfectly good
+// client name with nothing.
+func (ps *WorkspaceServer) HandleAgentIdentity(ctx context.Context, sessionID string, p AgentIdentityParams) {
+	name := strings.TrimSpace(p.Name)
+	if name == "" {
+		zlog.Debug().Str("session_id", sessionID).Msg("ignoring an agent notification that named nobody")
+		return
+	}
+
+	ps.agentIdentitiesMu.Lock()
+	ps.agentIdentities[sessionID] = AgentClientInfo{
+		Name:    name,
+		Title:   strings.TrimSpace(p.Title),
+		Version: strings.TrimSpace(p.Version),
+	}
+	// Same housekeeping as the commands next door: nothing else drops these, so
+	// a long-lived workspace whose gateway reconnects repeatedly would collect
+	// one entry per session for the life of the process.
+	pruneAgentIdentities(ps.agentIdentities, ps.liveSessionIDs())
+	ps.agentIdentitiesMu.Unlock()
+
+	zlog.Debug().Str("session_id", sessionID).Str("agent", name).Msg("recorded the agent behind the gateway")
+}
+
+// reportedAgent returns what a session said it was driving, if anything.
+func (ps *WorkspaceServer) reportedAgent(sessionID string) *AgentClientInfo {
+	ps.agentIdentitiesMu.RLock()
+	defer ps.agentIdentitiesMu.RUnlock()
+	if info, ok := ps.agentIdentities[sessionID]; ok {
+		return &info
+	}
+	return nil
 }
 
 // AgentClient reports what is attached to this workspace, or nil when nothing
@@ -40,6 +112,12 @@ func (ps *WorkspaceServer) AgentClient() *AgentClientInfo {
 		return nil
 	}
 	for sess := range ps.mcpServer.Sessions() {
+		// What the gateway said it is driving wins over what the gateway calls
+		// itself. A gateway that has not been upgraded reports nothing, and
+		// falls back to naming itself exactly as it did before.
+		if agent := ps.reportedAgent(sess.ID()); agent != nil {
+			return agent
+		}
 		if info := clientInfoFrom(sess.InitializeParams()); info != nil {
 			return info
 		}
@@ -65,4 +143,28 @@ func clientInfoFrom(p *mcp.InitializeParams) *AgentClientInfo {
 		return nil
 	}
 	return &AgentClientInfo{Name: name, Version: strings.TrimSpace(p.ClientInfo.Version)}
+}
+
+// pruneAgentIdentities drops what sessions that have gone away reported.
+//
+// No live sessions at all means the server is between connections rather than
+// that every entry is stale, so nothing is dropped there — the same reasoning
+// pruneAgentCommands records, and the same reason: an early call can observe
+// the map before its own session is visible.
+//
+// The caller must hold the write lock.
+func pruneAgentIdentities(identities map[string]AgentClientInfo, live []string) {
+	if len(live) == 0 {
+		return
+	}
+
+	keep := make(map[string]bool, len(live))
+	for _, id := range live {
+		keep[id] = true
+	}
+	for id := range identities {
+		if !keep[id] {
+			delete(identities, id)
+		}
+	}
 }

--- a/backend/internal/controller/mcp/agent_client_test.go
+++ b/backend/internal/controller/mcp/agent_client_test.go
@@ -1,12 +1,27 @@
 package mcp
 
 import (
+	"context"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/agentrq/agentrq/backend/internal/service/eventbus"
 )
+
+// connectedIdentityServer is a workspace with a session attached and its
+// connection counted, which is what AgentClient requires before it says
+// anything at all.
+func connectedIdentityServer(t *testing.T, clientName string) (*WorkspaceServer, string) {
+	t.Helper()
+	replies := 0
+	ps := permissionServer(t, &replies)
+	ps.bus = eventbus.New()
+	ps.agentIdentities = make(map[string]AgentClientInfo)
+	sessionID := connectedServer(t, ps, clientName)
+	ps.agentConnections.Add(1) // what the HTTP handler does for a live stream
+	return ps, sessionID
+}
 
 // What is attached to a workspace comes off the live session rather than a
 // cached notification, so unlike the models and commands beside it there is no
@@ -106,6 +121,137 @@ func TestClientInfoFrom(t *testing.T) {
 			if got := clientInfoFrom(p); got != nil {
 				t.Errorf("clientInfoFrom(%+v) = %+v, want nil", p, got)
 			}
+		}
+	})
+}
+
+// The gateway's MCP client is the gateway, so left to the handshake alone a
+// workspace can only ever name the bridge. These cover the notification that
+// tells it what is really behind there.
+
+const gatewayAgentFrame = `{
+  "jsonrpc": "2.0",
+  "method": "notifications/claude/channel/agent",
+  "params": {
+    "task_id": "0iF1U1qQwS1",
+    "session_id": "01a07404-01a7-7033-a58f-47b119036378",
+    "name": "codex",
+    "title": "Codex CLI",
+    "version": "1.10.0"
+  }
+}`
+
+func TestHandleCustomNotificationRoutesAgentIdentity(t *testing.T) {
+	ps := &WorkspaceServer{agentIdentities: make(map[string]AgentClientInfo)}
+	ps.HandleCustomNotification(context.Background(), "transport-session", []byte(gatewayAgentFrame))
+
+	// Keyed by the MCP transport session, not the ACP session in the payload.
+	got, ok := ps.agentIdentities["transport-session"]
+	if !ok {
+		t.Fatalf("the agent was not recorded; map = %+v", ps.agentIdentities)
+	}
+	if _, wrong := ps.agentIdentities["01a07404-01a7-7033-a58f-47b119036378"]; wrong {
+		t.Error("keyed by the payload's ACP session, which the session list never reports")
+	}
+	if got.Name != "codex" || got.Title != "Codex CLI" || got.Version != "1.10.0" {
+		t.Errorf("recorded = %+v", got)
+	}
+}
+
+func TestHandleAgentIdentity(t *testing.T) {
+	t.Run("trims what the gateway sent", func(t *testing.T) {
+		ps := &WorkspaceServer{agentIdentities: make(map[string]AgentClientInfo)}
+		ps.HandleAgentIdentity(context.Background(), "sess-1", AgentIdentityParams{
+			Name: "  gemini  ", Title: "  Gemini CLI  ", Version: "  2.0  ",
+		})
+
+		got := ps.agentIdentities["sess-1"]
+		if got.Name != "gemini" || got.Title != "Gemini CLI" || got.Version != "2.0" {
+			t.Errorf("recorded = %+v", got)
+		}
+	})
+
+	t.Run("ignores a payload that named nobody", func(t *testing.T) {
+		// The name is the entire point of this notification, and an empty one
+		// would replace a perfectly good client name with nothing.
+		ps := &WorkspaceServer{agentIdentities: make(map[string]AgentClientInfo)}
+		ps.HandleAgentIdentity(context.Background(), "sess-1", AgentIdentityParams{Name: "   "})
+
+		if len(ps.agentIdentities) != 0 {
+			t.Errorf("recorded %+v, want nothing", ps.agentIdentities)
+		}
+	})
+
+	t.Run("the newest report replaces the previous one", func(t *testing.T) {
+		ps := &WorkspaceServer{agentIdentities: make(map[string]AgentClientInfo)}
+		ps.HandleAgentIdentity(context.Background(), "sess-1", AgentIdentityParams{Name: "codex"})
+		ps.HandleAgentIdentity(context.Background(), "sess-1", AgentIdentityParams{Name: "gemini"})
+
+		if got := ps.agentIdentities["sess-1"].Name; got != "gemini" {
+			t.Errorf("Name = %q, want the second report", got)
+		}
+	})
+}
+
+func TestAgentClientPrefersTheReportedAgent(t *testing.T) {
+	t.Run("names the agent rather than the gateway in front of it", func(t *testing.T) {
+		ps, sessionID := connectedIdentityServer(t, "acp-gateway")
+		ps.HandleAgentIdentity(context.Background(), sessionID, AgentIdentityParams{
+			Name: "codex", Title: "Codex CLI", Version: "1.10.0",
+		})
+
+		got := ps.AgentClient()
+		if got == nil {
+			t.Fatal("AgentClient() = nil")
+		}
+		if got.Name != "codex" || got.Title != "Codex CLI" || got.Version != "1.10.0" {
+			t.Errorf("AgentClient() = %+v, want the agent behind the gateway", got)
+		}
+	})
+
+	t.Run("falls back to the client's own name when no agent was reported", func(t *testing.T) {
+		// A gateway too old to send the notification, and every client that is
+		// not a gateway at all. Both keep working exactly as before.
+		ps, _ := connectedIdentityServer(t, "claude-code")
+
+		got := ps.AgentClient()
+		if got == nil || got.Name != "claude-code" {
+			t.Errorf("AgentClient() = %+v, want the client's own name", got)
+		}
+	})
+
+	t.Run("still says nothing once the stream has gone", func(t *testing.T) {
+		// The reported agent must not outlive its connection either.
+		ps, sessionID := connectedIdentityServer(t, "acp-gateway")
+		ps.HandleAgentIdentity(context.Background(), sessionID, AgentIdentityParams{Name: "codex"})
+
+		ps.agentConnections.Add(-1)
+
+		if got := ps.AgentClient(); got != nil {
+			t.Errorf("AgentClient() = %+v after the stream went, want nil", got)
+		}
+	})
+}
+
+func TestPruneAgentIdentities(t *testing.T) {
+	t.Run("drops the sessions that have gone", func(t *testing.T) {
+		identities := map[string]AgentClientInfo{"a": {Name: "x"}, "b": {Name: "y"}}
+		pruneAgentIdentities(identities, []string{"b"})
+
+		if len(identities) != 1 {
+			t.Fatalf("identities = %+v, want only b", identities)
+		}
+		if _, ok := identities["b"]; !ok {
+			t.Errorf("kept the wrong one: %+v", identities)
+		}
+	})
+
+	t.Run("keeps everything when nothing is connected", func(t *testing.T) {
+		identities := map[string]AgentClientInfo{"a": {Name: "x"}}
+		pruneAgentIdentities(identities, nil)
+
+		if len(identities) != 1 {
+			t.Errorf("identities = %+v, want a kept", identities)
 		}
 	})
 }

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -147,6 +147,8 @@ type WorkspaceServer struct {
 	agentModels       map[string]AgentModelsSnapshot // sessionID -> models last reported
 	agentCommandsMu   sync.RWMutex
 	agentCommands     map[string]AgentCommandsSnapshot // sessionID -> slash commands last reported
+	agentIdentitiesMu sync.RWMutex
+	agentIdentities   map[string]AgentClientInfo // sessionID -> the agent a gateway says it drives
 	elicitationsMu    sync.Mutex
 	elicitations      map[string]chan elicitationResponse // requestID -> channel the waiting elicit tool call blocks on
 	metadataMu        sync.RWMutex
@@ -389,6 +391,7 @@ func NewWorkspaceServer(
 		agentTelemetryMessages: make(map[string]int64),
 		agentModels:            make(map[string]AgentModelsSnapshot),
 		agentCommands:          make(map[string]AgentCommandsSnapshot),
+		agentIdentities:        make(map[string]AgentClientInfo),
 		elicitations:           make(map[string]chan elicitationResponse),
 		icon:                   icon,
 		name:                   name,
@@ -2233,6 +2236,18 @@ func (ps *WorkspaceServer) HandleCustomNotification(ctx context.Context, session
 			return
 		}
 		ps.HandleAgentModels(ctx, sessionID, models.Params)
+		return
+	}
+
+	if msg.Method == AgentIdentityNotificationMethod {
+		var identity struct {
+			Params AgentIdentityParams `json:"params"`
+		}
+		if err := json.Unmarshal(data, &identity); err != nil {
+			zlog.Error().Err(err).Str("session_id", sessionID).Msg("Failed to unmarshal agent identity notification")
+			return
+		}
+		ps.HandleAgentIdentity(ctx, sessionID, identity.Params)
 		return
 	}
 

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -81,6 +81,7 @@ type (
 	// connected.
 	AgentClient struct {
 		Name    string
+		Title   string
 		Version string
 	}
 

--- a/backend/internal/data/view/api/view.go
+++ b/backend/internal/data/view/api/view.go
@@ -67,6 +67,7 @@ type (
 	// it reads agentConnected.
 	AgentClient struct {
 		Name    string `json:"name"`
+		Title   string `json:"title,omitempty"`
 		Version string `json:"version,omitempty"`
 	}
 

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -1096,5 +1096,5 @@ func agentClientEntity(c *mcpctrl.AgentClientInfo) *entity.AgentClient {
 	if c == nil {
 		return nil
 	}
-	return &entity.AgentClient{Name: c.Name, Version: c.Version}
+	return &entity.AgentClient{Name: c.Name, Title: c.Title, Version: c.Version}
 }

--- a/backend/internal/handler/mcp/mcp.go
+++ b/backend/internal/handler/mcp/mcp.go
@@ -34,6 +34,7 @@ var customNotificationMethods = []string{
 	mcpctrl.AgentTelemetryNotificationMethod,
 	mcpctrl.AgentModelsNotificationMethod,
 	mcpctrl.AgentCommandsNotificationMethod,
+	mcpctrl.AgentIdentityNotificationMethod,
 }
 
 // customNotificationMethod reports which of those a request body declares.

--- a/backend/internal/mapper/api/workspace.go
+++ b/backend/internal/mapper/api/workspace.go
@@ -263,5 +263,5 @@ func fromEntityAgentClientToView(c *entity.AgentClient) *view.AgentClient {
 	if c == nil {
 		return nil
 	}
-	return &view.AgentClient{Name: c.Name, Version: c.Version}
+	return &view.AgentClient{Name: c.Name, Title: c.Title, Version: c.Version}
 }


### PR DESCRIPTION
## What changed

The workspace now names the agent actually behind a gateway — `codex`, `gemini`, `antigravity` — instead of naming the gateway itself, falling back to the old behaviour for anything that does not report one.

## Why changed

A workspace can only see its MCP client, and for anything reached through the gateway that client *is* the gateway. So the Overview said `acp-gateway`, which answers "what is connected" with the name of the bridge rather than the agent. The gateway now passes on what the agent said about itself during its own handshake ([acp-gateway#70](https://github.com/agentrq/acp-gateway/pull/70)), and this consumes it.

Three things worth a reviewer's attention:

- **Recorded per MCP transport session, not per the `session_id` in the payload.** Those are different namespaces — the payload names the gateway's own conversation with the agent — and keying on it would file every entry under an id the session list never reports. Same trap the commands code documents.
- **A nameless payload is ignored rather than recorded.** The name is the whole point of the notification, and an empty one would replace a perfectly good client name with nothing.
- **The reported agent is under the same guard as the client name**, so it cannot outlive the stream that reported it — the staleness this code already had to defend against.

Backwards compatible in both directions: a gateway too old to send the notification, and every client that is not a gateway at all, are named exactly as they are today.

## Test coverage report

- **New lines: 100%** — every function in the file is at 100.0%: the handler, the lookup, the reader, the parser and the prune helper.
- **Total coverage impact:** backend `internal/...` unchanged at **43.0%**.
- 29 packages green.
- Cases covered: the raw wire frame routed to the right key; trimming; a nameless payload ignored; the newest report winning; the agent preferred over the gateway; the fallback when nothing was reported; nothing reported once the stream drops; and the prune helper.

## Other reports

Verified end to end against a local instance with a real MCP client attached that reports an agent the way the upgraded gateway does. The API returned `{"name":"codex","title":"Codex CLI","version":"1.10.0"}` and the Overview card read `CODEX · GPT-5 Codex` where it had said `ACP-GATEWAY · GPT-5 Codex`.

`title` is carried through to the API without being displayed, matching `version`, which is already carried the same way.

**Stacked on #501**, which adds the reader this builds on. The base retargets to `main` once that merges. The related staleness in `agentModels` and `agentCommands` is deliberately left alone here — it is task 0iRavy9lw5B.

TaskID: 0iRZcRtxS5Z
