### PR TITLE
fix(mcp): report an agent's state per session, not per workspace

### DIFF
--- a/backend/internal/controller/mcp/agent_client.go
+++ b/backend/internal/controller/mcp/agent_client.go
@@ -103,15 +103,18 @@ func (ps *WorkspaceServer) reportedAgent(sessionID string) *AgentClientInfo {
 // session order the server reports is at least stable between two calls — the
 // same reason pickAgentCommands iterates the live list rather than a map.
 //
-// Nothing is reported unless an agent is actually connected. Sessions linger
-// after their stream drops, so without this the workspace would keep naming the
-// gateway that left — and naming it beside an "agent offline" indicator, which
-// is worse than saying nothing.
+// A session that no longer holds a stream is passed over. Sessions linger after
+// their stream drops, so without this the workspace would keep naming a gateway
+// that left — beside an "agent offline" indicator when it was the only one, and
+// in place of a gateway that is still there when it was not.
 func (ps *WorkspaceServer) AgentClient() *AgentClientInfo {
-	if ps.mcpServer == nil || !ps.IsAgentConnected() {
+	if ps.mcpServer == nil {
 		return nil
 	}
 	for sess := range ps.mcpServer.Sessions() {
+		if !ps.isStreaming(sess.ID()) {
+			continue
+		}
 		// What the gateway said it is driving wins over what the gateway calls
 		// itself. A gateway that has not been upgraded reports nothing, and
 		// falls back to naming itself exactly as it did before.

--- a/backend/internal/controller/mcp/agent_client_test.go
+++ b/backend/internal/controller/mcp/agent_client_test.go
@@ -12,15 +12,14 @@ import (
 // connectedIdentityServer is a workspace with a session attached and its
 // connection counted, which is what AgentClient requires before it says
 // anything at all.
-func connectedIdentityServer(t *testing.T, clientName string) (*WorkspaceServer, string) {
+func connectedIdentityServer(t *testing.T, clientName string) (*WorkspaceServer, string, func()) {
 	t.Helper()
 	replies := 0
 	ps := permissionServer(t, &replies)
 	ps.bus = eventbus.New()
 	ps.agentIdentities = make(map[string]AgentClientInfo)
 	sessionID := connectedServer(t, ps, clientName)
-	ps.agentConnections.Add(1) // what the HTTP handler does for a live stream
-	return ps, sessionID
+	return ps, sessionID, streamFor(ps, sessionID)
 }
 
 // What is attached to a workspace comes off the live session rather than a
@@ -32,8 +31,7 @@ func TestAgentClient(t *testing.T) {
 		replies := 0
 		ps := permissionServer(t, &replies)
 		ps.bus = eventbus.New()
-		connectedServer(t, ps, "acp-gateway")
-		ps.agentConnections.Add(1) // what the HTTP handler does for a live stream
+		streamFor(ps, connectedServer(t, ps, "acp-gateway"))
 
 		got := ps.AgentClient()
 		if got == nil {
@@ -54,8 +52,7 @@ func TestAgentClient(t *testing.T) {
 		replies := 0
 		ps := permissionServer(t, &replies)
 		ps.bus = eventbus.New()
-		connectedServer(t, ps, "")
-		ps.agentConnections.Add(1)
+		streamFor(ps, connectedServer(t, ps, ""))
 
 		if got := ps.AgentClient(); got != nil {
 			t.Errorf("AgentClient() = %+v, want nil", got)
@@ -69,13 +66,12 @@ func TestAgentClient(t *testing.T) {
 		replies := 0
 		ps := permissionServer(t, &replies)
 		ps.bus = eventbus.New()
-		connectedServer(t, ps, "acp-gateway")
-		ps.agentConnections.Add(1)
+		drop := streamFor(ps, connectedServer(t, ps, "acp-gateway"))
 		if ps.AgentClient() == nil {
 			t.Fatal("expected the client to be named while its stream is up")
 		}
 
-		ps.agentConnections.Add(-1) // the stream drops; the session lingers
+		drop() // the stream goes; the session lingers
 
 		if got := ps.AgentClient(); got != nil {
 			t.Errorf("AgentClient() = %+v after the stream went, want nil", got)
@@ -195,7 +191,7 @@ func TestHandleAgentIdentity(t *testing.T) {
 
 func TestAgentClientPrefersTheReportedAgent(t *testing.T) {
 	t.Run("names the agent rather than the gateway in front of it", func(t *testing.T) {
-		ps, sessionID := connectedIdentityServer(t, "acp-gateway")
+		ps, sessionID, _ := connectedIdentityServer(t, "acp-gateway")
 		ps.HandleAgentIdentity(context.Background(), sessionID, AgentIdentityParams{
 			Name: "codex", Title: "Codex CLI", Version: "1.10.0",
 		})
@@ -212,7 +208,7 @@ func TestAgentClientPrefersTheReportedAgent(t *testing.T) {
 	t.Run("falls back to the client's own name when no agent was reported", func(t *testing.T) {
 		// A gateway too old to send the notification, and every client that is
 		// not a gateway at all. Both keep working exactly as before.
-		ps, _ := connectedIdentityServer(t, "claude-code")
+		ps, _, _ := connectedIdentityServer(t, "claude-code")
 
 		got := ps.AgentClient()
 		if got == nil || got.Name != "claude-code" {
@@ -222,10 +218,10 @@ func TestAgentClientPrefersTheReportedAgent(t *testing.T) {
 
 	t.Run("still says nothing once the stream has gone", func(t *testing.T) {
 		// The reported agent must not outlive its connection either.
-		ps, sessionID := connectedIdentityServer(t, "acp-gateway")
+		ps, sessionID, drop := connectedIdentityServer(t, "acp-gateway")
 		ps.HandleAgentIdentity(context.Background(), sessionID, AgentIdentityParams{Name: "codex"})
 
-		ps.agentConnections.Add(-1)
+		drop()
 
 		if got := ps.AgentClient(); got != nil {
 			t.Errorf("AgentClient() = %+v after the stream went, want nil", got)
@@ -254,4 +250,33 @@ func TestPruneAgentIdentities(t *testing.T) {
 			t.Errorf("identities = %+v, want a kept", identities)
 		}
 	})
+}
+
+// A client may hold more than one stream at a time, so the session is only off
+// the air when the last of them has gone.
+func TestStreamingSessionCounting(t *testing.T) {
+	ps := &WorkspaceServer{}
+
+	ps.addStreamingSession("sess-1")
+	ps.addStreamingSession("sess-1")
+	if !ps.isStreaming("sess-1") {
+		t.Fatal("expected the session to be streaming")
+	}
+
+	ps.removeStreamingSession("sess-1")
+	if !ps.isStreaming("sess-1") {
+		t.Error("one stream closing must not take the session off the air")
+	}
+
+	ps.removeStreamingSession("sess-1")
+	if ps.isStreaming("sess-1") {
+		t.Error("the last stream closing should")
+	}
+
+	// Removing what was never there is not an error; a handler may unwind a
+	// request it never counted.
+	ps.removeStreamingSession("never-seen")
+	if ps.isStreaming("never-seen") {
+		t.Error("a session nobody opened is not streaming")
+	}
 }

--- a/backend/internal/controller/mcp/agent_commands.go
+++ b/backend/internal/controller/mcp/agent_commands.go
@@ -143,10 +143,16 @@ func (ps *WorkspaceServer) publishAgentCommands(reported AgentCommandsSnapshot) 
 
 // AgentCommands reports the slash commands the connected agent offers, or nil
 // when nothing connected has said.
+//
+// Only sessions that still hold a stream are considered, for the reason
+// AgentModels records: a session outlives its stream, so the session list alone
+// would keep a departed agent's commands on offer. Every one of them would fail
+// — and worse, a reply that opens with one is delivered stripped of the
+// envelope that gives it context, on the strength of a menu nobody is behind.
 func (ps *WorkspaceServer) AgentCommands() *AgentCommandsSnapshot {
 	ps.agentCommandsMu.RLock()
 	defer ps.agentCommandsMu.RUnlock()
-	return pickAgentCommands(ps.agentCommands, ps.liveSessionIDs())
+	return pickAgentCommands(ps.agentCommands, ps.streamingSessionIDs())
 }
 
 // pickAgentCommands chooses the snapshot to report from what sessions have said.

--- a/backend/internal/controller/mcp/agent_commands_test.go
+++ b/backend/internal/controller/mcp/agent_commands_test.go
@@ -29,6 +29,7 @@ func connectedCommandsServer(t *testing.T) (*WorkspaceServer, string, chan []byt
 	ps.bus = eventbus.New()
 	ps.agentCommands = make(map[string]AgentCommandsSnapshot)
 	sessionID := connectedServer(t, ps, "acp-gateway")
+	streamFor(ps, sessionID)
 
 	ch := ps.bus.Subscribe(ps.workspaceID, "")
 	t.Cleanup(func() { ps.bus.Unsubscribe(ps.workspaceID, "", ch) })
@@ -436,6 +437,7 @@ func TestAgentCommandsWithAConnectedSession(t *testing.T) {
 	ps.bus = eventbus.New()
 	ps.agentCommands = make(map[string]AgentCommandsSnapshot)
 	sessionID := connectedServer(t, ps, "acp-gateway")
+	streamFor(ps, sessionID)
 
 	// Nothing reported yet, so there is no menu. A gateway creates its ACP
 	// session lazily, once it has a task, so this is the ordinary state of a
@@ -515,6 +517,7 @@ func TestManagerAgentCommands(t *testing.T) {
 		ps.bus = eventbus.New()
 		ps.agentCommands = make(map[string]AgentCommandsSnapshot)
 		sessionID := connectedServer(t, ps, "acp-gateway")
+		streamFor(ps, sessionID)
 		ps.HandleAgentCommands(context.Background(), sessionID, AgentCommandsParams{
 			Commands: []AgentCommand{{Name: "init"}},
 		})
@@ -527,4 +530,33 @@ func TestManagerAgentCommands(t *testing.T) {
 			t.Errorf("AgentCommands(7) = %+v", got)
 		}
 	})
+}
+
+// Same as the models beside them: the session outlives its stream, so without
+// this the workspace keeps offering commands nobody is behind — and a reply
+// opening with one would be delivered stripped of its envelope on the strength
+// of that menu.
+func TestAgentCommandsStopAtTheStream(t *testing.T) {
+	replies := 0
+	ps := permissionServer(t, &replies)
+	ps.bus = eventbus.New()
+	ps.agentCommands = make(map[string]AgentCommandsSnapshot)
+	sessionID := connectedServer(t, ps, "acp-gateway")
+	drop := streamFor(ps, sessionID)
+
+	ps.HandleAgentCommands(context.Background(), sessionID, AgentCommandsParams{
+		Commands: []AgentCommand{{Name: "compact"}},
+	})
+	if ps.AgentCommands() == nil {
+		t.Fatal("expected the commands while the stream is up")
+	}
+
+	drop()
+
+	if got := ps.AgentCommands(); got != nil {
+		t.Errorf("AgentCommands() = %+v after the stream went, want nil", got)
+	}
+	if _, ok := ps.agentCommands[sessionID]; !ok {
+		t.Error("the snapshot should still be held, only not served")
+	}
 }

--- a/backend/internal/controller/mcp/agent_models.go
+++ b/backend/internal/controller/mcp/agent_models.go
@@ -112,10 +112,20 @@ func (ps *WorkspaceServer) HandleAgentModels(ctx context.Context, sessionID stri
 
 // AgentModels reports what the connected agent can switch between, or nil when
 // nothing connected has said.
+//
+// Only sessions that still hold a stream are considered. The server's session
+// list is not enough on its own: an MCP session outlives the stream that
+// carried it, so after a gateway goes away its session is still listed and the
+// snapshot keyed to it still looks live — which is exactly what the filter
+// below exists to prevent, and what it cannot see by itself.
+//
+// Asking per session rather than "is anything connected" is what makes this
+// right when two gateways are attached: one of them leaving must take its own
+// models with it and leave the other's alone.
 func (ps *WorkspaceServer) AgentModels() *AgentModelsSnapshot {
 	ps.agentModelsMu.RLock()
 	defer ps.agentModelsMu.RUnlock()
-	return pickAgentModels(ps.agentModels, ps.liveSessionIDs())
+	return pickAgentModels(ps.agentModels, ps.streamingSessionIDs())
 }
 
 // liveSessionIDs lists the sessions currently connected to this workspace.

--- a/backend/internal/controller/mcp/agent_models_test.go
+++ b/backend/internal/controller/mcp/agent_models_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // The notification this file handles used to be rejected outright — the SDK
@@ -314,6 +316,7 @@ func TestAgentModelsWithAConnectedSession(t *testing.T) {
 	ps := permissionServer(t, &replies)
 	ps.agentModels = make(map[string]AgentModelsSnapshot)
 	sessionID := connectedServer(t, ps, "acp-gateway")
+	streamFor(ps, sessionID)
 
 	if got := ps.liveSessionIDs(); len(got) != 1 || got[0] != sessionID {
 		t.Fatalf("liveSessionIDs() = %v, want [%s]", got, sessionID)
@@ -372,5 +375,69 @@ func TestHandleAgentModelsPrunesDepartedSessions(t *testing.T) {
 	}
 	if _, ok := ps.agentModels[sessionID]; !ok {
 		t.Errorf("the live session's models should have been kept: %+v", ps.agentModels)
+	}
+}
+
+// The bug this guards: an MCP session outlives the stream that carried it, so
+// the session list still holds a gateway that has gone and the snapshot keyed
+// to it still looks live. A workspace would advertise the models of an agent
+// nobody can reach.
+func TestAgentModelsStopAtTheStream(t *testing.T) {
+	replies := 0
+	ps := permissionServer(t, &replies)
+	ps.agentModels = make(map[string]AgentModelsSnapshot)
+	sessionID := connectedServer(t, ps, "acp-gateway")
+	drop := streamFor(ps, sessionID)
+
+	ps.HandleAgentModels(context.Background(), sessionID, AgentModelsParams{
+		CurrentModel: "gpt-5-codex",
+		Models:       []AgentModel{{ID: "gpt-5-codex"}},
+	})
+	if ps.AgentModels() == nil {
+		t.Fatal("expected the models while the stream is up")
+	}
+
+	drop() // the stream goes; the session lingers
+
+	if got := ps.AgentModels(); got != nil {
+		t.Errorf("AgentModels() = %+v after the stream went, want nil", got)
+	}
+	// The snapshot is still cached — it is the *reader* that has to be honest,
+	// since the agent may come back on a new stream.
+	if _, ok := ps.agentModels[sessionID]; !ok {
+		t.Error("the snapshot should still be held, only not served")
+	}
+}
+
+// Two gateways can be attached to one workspace, and one of them leaving must
+// take its own models with it and leave the other's alone. A workspace-wide
+// "is anything connected" cannot do that: it stays true while the departed
+// session is still listed, and the picker takes the first snapshot it finds.
+func TestAgentModelsWithTwoConnectedSessions(t *testing.T) {
+	replies := 0
+	ps := permissionServer(t, &replies)
+	ps.agentModels = make(map[string]AgentModelsSnapshot)
+	ps.mcpServer = mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+
+	// Two sessions, each having reported its own models.
+	first := connectSession(t, ps, "gateway-a")
+	second := connectSession(t, ps, "gateway-b")
+	dropFirst := streamFor(ps, first)
+	streamFor(ps, second)
+	ps.HandleAgentModels(context.Background(), first, AgentModelsParams{
+		CurrentModel: "from-a", Models: []AgentModel{{ID: "from-a"}},
+	})
+	ps.HandleAgentModels(context.Background(), second, AgentModelsParams{
+		CurrentModel: "from-b", Models: []AgentModel{{ID: "from-b"}},
+	})
+
+	dropFirst() // one goes; the other is still working
+
+	got := ps.AgentModels()
+	if got == nil {
+		t.Fatal("AgentModels() = nil while a session is still streaming")
+	}
+	if got.CurrentModel != "from-b" {
+		t.Errorf("CurrentModel = %q, want the surviving session's", got.CurrentModel)
 	}
 }

--- a/backend/internal/controller/mcp/permission_rebind_test.go
+++ b/backend/internal/controller/mcp/permission_rebind_test.go
@@ -191,11 +191,30 @@ func TestNotifySession_NoServer(t *testing.T) {
 // that delivering a verdict actually goes somewhere. The client introduces
 // itself under clientName, which is what decides whether it can be stopped.
 // Returns the session id.
+// streamFor marks a session as holding a live stream, which is what the HTTP
+// handler does for an SSE request — the in-memory harness never goes through
+// it. Returns the drop, for tests that need the stream to go away while the
+// session lingers, which is the state this all exists to handle.
+func streamFor(ps *WorkspaceServer, sessionID string) func() {
+	ps.agentConnections.Add(1)
+	ps.addStreamingSession(sessionID)
+	return func() {
+		ps.removeStreamingSession(sessionID)
+		ps.agentConnections.Add(-1)
+	}
+}
+
 func connectedServer(t *testing.T, ps *WorkspaceServer, clientName string) string {
 	t.Helper()
+	ps.mcpServer = mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+	return connectSession(t, ps, clientName)
+}
 
-	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
-	ps.mcpServer = server
+// connectSession attaches one more client to the workspace's existing server,
+// so a test can have two gateways on one workspace — which is what tells a
+// per-session answer apart from a workspace-wide one.
+func connectSession(t *testing.T, ps *WorkspaceServer, clientName string) string {
+	t.Helper()
 
 	client := mcp.NewClient(&mcp.Implementation{Name: clientName, Version: "0"}, &mcp.ClientOptions{
 		KeepAlive: 0,
@@ -203,7 +222,7 @@ func connectedServer(t *testing.T, ps *WorkspaceServer, clientName string) strin
 
 	serverTransport, clientTransport := mcp.NewInMemoryTransports()
 	ctx := context.Background()
-	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	serverSession, err := ps.mcpServer.Connect(ctx, serverTransport, nil)
 	if err != nil {
 		t.Fatalf("connect server: %v", err)
 	}
@@ -249,7 +268,7 @@ func TestSendPermissionVerdict_DeliversToALiveSession(t *testing.T) {
 func TestSendCancelNotification_ReachesConnectedAgents(t *testing.T) {
 	replies := 0
 	ps := permissionServer(t, &replies)
-	connectedServer(t, ps, "acp-gateway")
+	streamFor(ps, connectedServer(t, ps, "acp-gateway"))
 
 	if !ps.SendCancelNotification(context.Background(), 42).Stopped {
 		t.Fatal("expected the stop to reach the connected gateway")
@@ -261,7 +280,7 @@ func TestSendCancelNotification_ReachesConnectedAgents(t *testing.T) {
 func TestSendCancelNotification_ClosesTheOutstandingApproval(t *testing.T) {
 	replies := 0
 	ps := permissionServer(t, &replies)
-	connectedServer(t, ps, "acp-gateway")
+	streamFor(ps, connectedServer(t, ps, "acp-gateway"))
 
 	var marked map[string]any
 	ps.updateMessageMetadata = func(ctx context.Context, taskID int64, messageID int64, metadata any) error {
@@ -304,7 +323,7 @@ func TestSendCancelNotification_ClosesTheOutstandingApproval(t *testing.T) {
 func TestSendCancelNotification_SurvivesAToolCallThatWillNotClose(t *testing.T) {
 	replies := 0
 	ps := permissionServer(t, &replies)
-	connectedServer(t, ps, "acp-gateway")
+	streamFor(ps, connectedServer(t, ps, "acp-gateway"))
 
 	ps.updateMessageMetadata = func(ctx context.Context, taskID int64, messageID int64, metadata any) error {
 		return nil
@@ -433,9 +452,23 @@ func TestSupportsStop(t *testing.T) {
 	t.Run("the ACP gateway", func(t *testing.T) {
 		replies := 0
 		ps := permissionServer(t, &replies)
-		connectedServer(t, ps, "acp-gateway")
+		streamFor(ps, connectedServer(t, ps, "acp-gateway"))
 		if !ps.SupportsStop() {
 			t.Fatal("expected true for the ACP gateway")
+		}
+	})
+
+	t.Run("the ACP gateway once its stream has gone", func(t *testing.T) {
+		// A session outlives the stream that carried it, so without checking the
+		// stream the dashboard offered a Stop button with nothing behind it.
+		replies := 0
+		ps := permissionServer(t, &replies)
+		drop := streamFor(ps, connectedServer(t, ps, "acp-gateway"))
+
+		drop()
+
+		if ps.SupportsStop() {
+			t.Fatal("expected false once nothing is streaming")
 		}
 	})
 }

--- a/backend/internal/controller/mcp/server.go
+++ b/backend/internal/controller/mcp/server.go
@@ -149,6 +149,8 @@ type WorkspaceServer struct {
 	agentCommands     map[string]AgentCommandsSnapshot // sessionID -> slash commands last reported
 	agentIdentitiesMu sync.RWMutex
 	agentIdentities   map[string]AgentClientInfo // sessionID -> the agent a gateway says it drives
+	streamingMu       sync.RWMutex
+	streaming         map[string]int // sessionID -> how many streams it currently holds
 	elicitationsMu    sync.Mutex
 	elicitations      map[string]chan elicitationResponse // requestID -> channel the waiting elicit tool call blocks on
 	metadataMu        sync.RWMutex
@@ -392,6 +394,7 @@ func NewWorkspaceServer(
 		agentModels:            make(map[string]AgentModelsSnapshot),
 		agentCommands:          make(map[string]AgentCommandsSnapshot),
 		agentIdentities:        make(map[string]AgentClientInfo),
+		streaming:              make(map[string]int),
 		elicitations:           make(map[string]chan elicitationResponse),
 		icon:                   icon,
 		name:                   name,
@@ -555,11 +558,16 @@ func (ps *WorkspaceServer) Handler() http.Handler {
 		isSSE := r.Header.Get("Accept") == "text/event-stream"
 		if isSSE {
 			count := ps.agentConnections.Add(1)
+			// Which session is streaming, not just how many are — with two
+			// gateways attached, "something is connected" cannot say whose
+			// snapshot is still worth serving.
+			ps.addStreamingSession(sessID)
 			if count == 1 {
 				ps.publishAgentConnected(true)
 				ps.emitTelemetry(r.Context(), ActionMCPConnect, "connect", clientIdentityFromHTTPRequest(r))
 			}
 			defer func() {
+				ps.removeStreamingSession(sessID)
 				if ps.agentConnections.Add(-1) == 0 {
 					ps.publishAgentConnected(false)
 				}
@@ -671,6 +679,61 @@ func clientSupportsStop(sess *mcp.ServerSession) bool {
 	return stopCapableClients[strings.ToLower(strings.TrimSpace(p.ClientInfo.Name))]
 }
 
+// addStreamingSession records that a session has opened a stream.
+//
+// Counted rather than flagged: a client may hold more than one at a time, and
+// the session is only off the air when the last of them has gone.
+func (ps *WorkspaceServer) addStreamingSession(sessID string) {
+	ps.streamingMu.Lock()
+	if ps.streaming == nil {
+		ps.streaming = make(map[string]int)
+	}
+	ps.streaming[sessID]++
+	ps.streamingMu.Unlock()
+}
+
+func (ps *WorkspaceServer) removeStreamingSession(sessID string) {
+	ps.streamingMu.Lock()
+	if ps.streaming[sessID] <= 1 {
+		delete(ps.streaming, sessID)
+	} else {
+		ps.streaming[sessID]--
+	}
+	ps.streamingMu.Unlock()
+}
+
+// isStreaming reports whether a session still has a stream open.
+func (ps *WorkspaceServer) isStreaming(sessID string) bool {
+	ps.streamingMu.RLock()
+	defer ps.streamingMu.RUnlock()
+	return ps.streaming[sessID] > 0
+}
+
+// streamingSessionIDs lists the sessions that are actually reachable.
+//
+// This is what "connected" has to mean for anything the interface reports about
+// an agent. An MCP session outlives the stream that carried it, so the server's
+// own session list holds gateways that have gone — and with more than one
+// attached, a workspace-wide "something is connected" cannot tell which of them
+// a snapshot belongs to. Only the session that is still streaming can answer
+// for its own state.
+//
+// The server's session order is followed rather than the map's, because the
+// readers pick the first session with something to say and two identical calls
+// must not disagree — the reason pickAgentModels iterates this list at all.
+func (ps *WorkspaceServer) streamingSessionIDs() []string {
+	if ps.mcpServer == nil {
+		return nil
+	}
+	var ids []string
+	for sess := range ps.mcpServer.Sessions() {
+		if ps.isStreaming(sess.ID()) {
+			ids = append(ids, sess.ID())
+		}
+	}
+	return ids
+}
+
 // stopCapableSessions lists the connected sessions worth sending a stop to.
 func (ps *WorkspaceServer) stopCapableSessions() []string {
 	if ps.mcpServer == nil {
@@ -678,7 +741,7 @@ func (ps *WorkspaceServer) stopCapableSessions() []string {
 	}
 	var ids []string
 	for sess := range ps.mcpServer.Sessions() {
-		if clientSupportsStop(sess) {
+		if clientSupportsStop(sess) && ps.isStreaming(sess.ID()) {
 			ids = append(ids, sess.ID())
 		}
 	}
@@ -687,6 +750,15 @@ func (ps *WorkspaceServer) stopCapableSessions() []string {
 
 // SupportsStop reports whether anything currently connected can be asked to
 // stop, so the dashboard only offers a Stop button that would do something.
+//
+// "Currently connected" has to mean the stream, not the session: a session
+// outlives the stream that carried it, so a workspace whose gateway had gone
+// went on offering a Stop button with nothing behind it.
+//
+// Only the advertised capability is gated. SendCancelNotification still tries
+// every stop-capable session it can find, because attempting delivery to a
+// session that might yet be reachable costs nothing, while refusing to try is
+// how a stop goes missing.
 func (ps *WorkspaceServer) SupportsStop() bool {
 	return len(ps.stopCapableSessions()) > 0
 }


### PR DESCRIPTION
## What changed

A workspace now answers "what is this agent running, and can it be stopped" per connection rather than for the workspace as a whole, so an agent that has gone stops being reported — even when another one is still attached.

## Why changed

The models, slash commands and stop capability were all still served after an agent left, in the same payload that reported it offline. An MCP session outlives the stream that carried it, so these readers, which filter on the server's session list, still saw a gateway that had gone; `agentConnected` comes from the count of live streams, which does not. The two disagreed, and the cached snapshot was the one that lied.

**The count alone would not have been enough**, which is the substance of this change. With two gateways on one workspace it stays true when one of them leaves, and the readers take the first snapshot they find — so a departed gateway's models were served while a different one was live. What is tracked now is *which* sessions hold a stream, so one gateway leaving takes its own state with it and leaves the other's alone.

The snapshots themselves are still kept; it is the reader that has to be honest. An agent that comes back on a new stream should not have to re-advertise everything it already said.

**Two notes for a reviewer:**

- The ping loop is deliberately untouched. It walks the session list precisely to evict what has gone, so gating it would break the eviction it exists for.
- Stops now only go to a session that can actually receive one. That is a fix rather than a restriction: a stop written into a dead stream counted as delivered, which suppressed the fallback that denies the approvals the task is waiting on. "Nothing reachable" now reaches that fallback, which is the nearest thing to a stop such a task can be given.

## Test coverage report

- **New lines: 100%** — the stream registry, its counting, the session filter and all four readers are at 100.0%.
- **Total coverage impact:** backend `internal/...` unchanged at **43.0%**.
- 29 packages green. Existing tests needed a live stream registered against their session; the in-memory harness never goes through the HTTP handler that does it, so there is now one helper for that, returning the drop.
- New tests: models, commands, client identity and stop capability each stop being reported once the stream drops while the snapshot stays cached; two sessions where one leaves and the survivor's state is served; and the stream counting, since a client may hold more than one at a time.

## Other reports

Verified against a local instance, both cases.

Single connection, the original report:

```
while connected:   connected=true  models=true  client=true  supportsStop=true
after disconnect:  connected=false models=false client=false supportsStop=false
```

Two gateways attached, then one killed:

```
both up:            client=gateway-B  model=MODEL-FROM-B
B killed, A alive:  client=gateway-A  model=gpt-5-codex     ← was still gateway-B before this
both gone:          connected=false, nothing reported
```

TaskID: 0iRavy9lw5B
