### PR TITLE
fix(mcp): do not name the bridge where the agent should be

### DIFF
--- a/backend/internal/controller/mcp/agent_client.go
+++ b/backend/internal/controller/mcp/agent_client.go
@@ -115,17 +115,38 @@ func (ps *WorkspaceServer) AgentClient() *AgentClientInfo {
 		if !ps.isStreaming(sess.ID()) {
 			continue
 		}
-		// What the gateway said it is driving wins over what the gateway calls
-		// itself. A gateway that has not been upgraded reports nothing, and
-		// falls back to naming itself exactly as it did before.
+		// What a bridge says it is driving wins over what the bridge calls
+		// itself, because the question is which agent is attached.
 		if agent := ps.reportedAgent(sess.ID()); agent != nil {
 			return agent
 		}
-		if info := clientInfoFrom(sess.InitializeParams()); info != nil {
-			return info
+		info := clientInfoFrom(sess.InitializeParams())
+		if info == nil || isBridge(info.Name) {
+			continue
 		}
+		return info
 	}
 	return nil
+}
+
+// bridgeClients names the MCP clients that are a way through to an agent rather
+// than an agent themselves, keyed by the lowercased name from the handshake.
+//
+// Naming one of these answers the wrong question. "acp-gateway" tells a human
+// how their agent is plumbed in, not what it is, and it appears in the one
+// place the interface has to say which agent is working — so when a bridge has
+// not said what is behind it, the workspace says nothing rather than naming the
+// pipe. A client that is not a bridge is the agent, and is named.
+//
+// The same shape as stopCapableClients above, and for the same reason: the
+// handshake name is the only thing distinguishing these clients, and there is
+// exactly one of them today.
+var bridgeClients = map[string]bool{
+	"acp-gateway": true,
+}
+
+func isBridge(clientName string) bool {
+	return bridgeClients[strings.ToLower(strings.TrimSpace(clientName))]
 }
 
 // clientInfoFrom reads a client's identity out of the initialize handshake.

--- a/backend/internal/controller/mcp/agent_client_test.go
+++ b/backend/internal/controller/mcp/agent_client_test.go
@@ -27,21 +27,35 @@ func connectedIdentityServer(t *testing.T, clientName string) (*WorkspaceServer,
 // way for this to describe a client that has gone.
 
 func TestAgentClient(t *testing.T) {
-	t.Run("names the connected client", func(t *testing.T) {
+	t.Run("names a client that is itself the agent", func(t *testing.T) {
 		replies := 0
 		ps := permissionServer(t, &replies)
 		ps.bus = eventbus.New()
-		streamFor(ps, connectedServer(t, ps, "acp-gateway"))
+		streamFor(ps, connectedServer(t, ps, "claude-code"))
 
 		got := ps.AgentClient()
 		if got == nil {
 			t.Fatal("AgentClient() = nil with a session attached")
 		}
-		if got.Name != "acp-gateway" {
-			t.Errorf("Name = %q, want acp-gateway", got.Name)
+		if got.Name != "claude-code" {
+			t.Errorf("Name = %q, want claude-code", got.Name)
 		}
 		if got.Version != "0" {
 			t.Errorf("Version = %q, want the version the client sent", got.Version)
+		}
+	})
+
+	t.Run("does not name a bridge that has not said what is behind it", func(t *testing.T) {
+		// "acp-gateway" says how an agent is plumbed in, not what it is, and it
+		// would sit in the one place the interface has to name the agent. Better
+		// nothing than the pipe.
+		replies := 0
+		ps := permissionServer(t, &replies)
+		ps.bus = eventbus.New()
+		streamFor(ps, connectedServer(t, ps, "acp-gateway"))
+
+		if got := ps.AgentClient(); got != nil {
+			t.Errorf("AgentClient() = %+v, want nil until the gateway names its agent", got)
 		}
 	})
 
@@ -66,7 +80,7 @@ func TestAgentClient(t *testing.T) {
 		replies := 0
 		ps := permissionServer(t, &replies)
 		ps.bus = eventbus.New()
-		drop := streamFor(ps, connectedServer(t, ps, "acp-gateway"))
+		drop := streamFor(ps, connectedServer(t, ps, "claude-code"))
 		if ps.AgentClient() == nil {
 			t.Fatal("expected the client to be named while its stream is up")
 		}
@@ -205,14 +219,24 @@ func TestAgentClientPrefersTheReportedAgent(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to the client's own name when no agent was reported", func(t *testing.T) {
-		// A gateway too old to send the notification, and every client that is
-		// not a gateway at all. Both keep working exactly as before.
+	t.Run("falls back to the client's own name when it is the agent", func(t *testing.T) {
+		// Claude Code attached directly is the agent, so its own name is the
+		// answer and nothing needs to report one.
 		ps, _, _ := connectedIdentityServer(t, "claude-code")
 
 		got := ps.AgentClient()
 		if got == nil || got.Name != "claude-code" {
 			t.Errorf("AgentClient() = %+v, want the client's own name", got)
+		}
+	})
+
+	t.Run("says nothing for a bridge too old to report its agent", func(t *testing.T) {
+		// Rather than naming the bridge. The interface shows a plain "agent
+		// live" for it, which is all anyone actually knows.
+		ps, _, _ := connectedIdentityServer(t, "acp-gateway")
+
+		if got := ps.AgentClient(); got != nil {
+			t.Errorf("AgentClient() = %+v, want nil", got)
 		}
 	})
 
@@ -278,5 +302,22 @@ func TestStreamingSessionCounting(t *testing.T) {
 	ps.removeStreamingSession("never-seen")
 	if ps.isStreaming("never-seen") {
 		t.Error("a session nobody opened is not streaming")
+	}
+}
+
+func TestIsBridge(t *testing.T) {
+	// Names arrive as the client chose to write them, the same reason
+	// clientSupportsStop folds case and trims.
+	for name, want := range map[string]bool{
+		"acp-gateway":   true,
+		"ACP-Gateway":   true,
+		" acp-gateway ": true,
+		"claude-code":   false,
+		"":              false,
+		"acp":           false,
+	} {
+		if got := isBridge(name); got != want {
+			t.Errorf("isBridge(%q) = %v, want %v", name, got, want)
+		}
 	}
 }


### PR DESCRIPTION
## What changed

A workspace no longer shows `acp-gateway` where the agent's name belongs; when the gateway has not yet said which agent is behind it, the interface simply shows that an agent is live.

## Why changed

The Overview has one line to say which agent is working, and for anything reached through the gateway it was filling that line with the name of the bridge — which tells a human how their agent is plumbed in, not what it is. That is an answer to a question nobody asked, in the place the real answer goes.

A client that is *not* a bridge is still named, because it is the agent: Claude Code attached directly is itself the thing doing the work.

Bridges are keyed by handshake name, the same shape and for the same reason as the stop-capable clients beside them — the name is the only thing distinguishing these clients, and there is exactly one of them today.

## Test coverage report

- **New lines: 100%** — the reader and the bridge check are both at 100.0%.
- **Total coverage impact:** backend `internal/...` unchanged at **43.0%**.
- 29 packages green.
- Tests cover: a client that is itself the agent is named; a bridge that has not reported its agent is not; a bridge that has reported one shows the agent; and the name folding (case and whitespace), since names arrive as the client chose to write them.

## Other reports

This pairs with acp-gateway#72, which makes the gateway name its agent as soon as it connects rather than waiting for the first task. With both, a workspace using a registry agent shows the real name immediately; without the gateway change it shows a plain "agent live" until the first task, which is the honest answer rather than the bridge's name.

TaskID: 0iRZcRtxS5Z
