### PR TITLE
chore: bump patch version to v0.5.20

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.5.19"
+	_appVersion   = "v0.5.20"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.5.19" {
-			t.Errorf("Expected version v0.5.19, got %s", s.Version())
+		if s.Version() != "v0.5.20" {
+			t.Errorf("Expected version v0.5.20, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.5.19",
+      "version": "0.5.20",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.5.19",
+  "version": "0.5.20",
   "description": "AgentRQ desktop app — AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.5.19",
+      "version": "0.5.20",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.5.19",
+  "version": "0.5.20",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
## What changed

The application version moves from 0.5.19 to 0.5.20 everywhere it is declared — the desktop and web packages and their lockfiles, the backend constant, and the test that asserts it.

## Why changed

Five changes have landed since the last release and none of them is shipped until the version is bumped: the tag build refuses to package a tree whose version sources disagree, and the desktop updater compares this number against the published release.

Shipping in this version, since v0.5.19:

**feat**
- Cmd-Enter creates a task straight from the description field (#500)
- the Overview shows which agent is connected and what it is running (#501)
- an agent reached through a gateway is named by what it is, not by the gateway that carries it (#503)

**fix**
- an agent's connected state is tracked per MCP session rather than per workspace, so one gateway leaving no longer leaves another's models, slash commands and Stop button behind (#504)
- a client that is only a bridge is no longer named in the line meant for the agent (#505)

## Test coverage report

No new lines of logic — the change is nine literal version strings, one of which *is* a test assertion, so the new lines are 100% covered by construction. Total coverage is unchanged.

## Other reports

Version sync verified in both the forms CI runs:

```
$ node desktop/scripts/check-versions.mjs
✓ desktop, frontend and backend are all at 0.5.20

$ GITHUB_REF=refs/tags/v0.5.20 node desktop/scripts/check-versions.mjs
✓ desktop, frontend and backend are all at 0.5.20
✓ tag v0.5.20 matches version 0.5.20
```

`go test ./internal/service/config/...` passes, and `npm ci` still resolves in both `desktop/` and `frontend/` — the lockfile version fields were edited by hand, so no dependency resolution shifted underneath the release.

The unrelated `"source-map-support": "^0.5.19"` dependency range, and the version numbers used as fixtures and comment examples in the desktop tests and release workflow, were deliberately left alone.

## TaskID: 0iRvwssJzfN
