### PR TITLE
feat(mcp): tell the open tabs when the agent's model changes

### DIFF
--- a/backend/internal/controller/mcp/agent_models.go
+++ b/backend/internal/controller/mcp/agent_models.go
@@ -2,8 +2,12 @@ package mcp
 
 import (
 	"context"
+	"slices"
 
+	"github.com/mustafaturan/monoflake"
 	zlog "github.com/rs/zerolog/log"
+
+	"github.com/agentrq/agentrq/backend/internal/service/eventbus"
 )
 
 // AgentModelsNotificationMethod is the channel notification a gateway sends to
@@ -99,6 +103,8 @@ func (ps *WorkspaceServer) HandleAgentModels(ctx context.Context, sessionID stri
 	}
 
 	ps.agentModelsMu.Lock()
+	previous, had := ps.agentModels[sessionID]
+	changed := !had || !sameAgentModels(previous, snapshot)
 	ps.agentModels[sessionID] = snapshot
 	pruneAgentModels(ps.agentModels, ps.liveSessionIDs())
 	ps.agentModelsMu.Unlock()
@@ -107,7 +113,89 @@ func (ps *WorkspaceServer) HandleAgentModels(ctx context.Context, sessionID stri
 		Str("session_id", sessionID).
 		Int("models", len(p.Models)).
 		Str("current_model", snapshot.CurrentModel).
+		Bool("changed", changed).
 		Msg("recorded the models the agent offers")
+
+	// An agent re-advertises its models on every session config change, so most
+	// reports say exactly what the last one said — a thinking-effort switch
+	// re-sends the whole model list unchanged. Telling every open tab about
+	// those would be a broadcast storm for a picker that did not move.
+	if !changed {
+		return
+	}
+	ps.publishAgentModels(snapshot)
+}
+
+// sameAgentModels reports whether two snapshots would publish the same thing.
+//
+// Compared on exactly the fields publishAgentModels sends, rather than on the
+// whole snapshot: SessionID is not published, and a gateway that reconnects its
+// ACP session while offering an identical list has not changed anything a
+// reader can see. Comparing it would put that reader through a needless update.
+//
+// CurrentModel is part of the comparison and not merely a function of the list.
+// A gateway may send the top-level field alone, without the per-model `current`
+// flag, and then a model switch changes nothing else — which is precisely the
+// event this whole path exists to carry.
+func sameAgentModels(a, b AgentModelsSnapshot) bool {
+	return a.ConfigID == b.ConfigID &&
+		a.CurrentModel == b.CurrentModel &&
+		slices.Equal(a.Models, b.Models)
+}
+
+// publishAgentModels tells the human clients what the workspace now offers.
+//
+// Without this the models reach a client only in the workspace payload it
+// fetched on load, and an agent reports them well after that — on connecting,
+// and again whenever its session config changes. So the name on the Overview
+// card was fixed at page load and a model switch never showed. This is the same
+// reason publishAgentCommands exists beside it.
+//
+// What goes out is the report just received, not the answer AgentModels would
+// give. The session that reported is connected by definition — it has this
+// instant spoken — whereas the session registry only learns of a transport when
+// it registers its stream, so asking it here answers a question about timing
+// rather than about the agent.
+//
+// A withdrawal is the one case that has to look wider: another session may
+// still be offering models, and taking the picker away because this one stopped
+// would remove something still live. So an empty report falls back to whatever
+// the workspace would serve, which is an empty list when the answer is nothing.
+func (ps *WorkspaceServer) publishAgentModels(reported AgentModelsSnapshot) {
+	published := reported
+	if len(published.Models) == 0 {
+		published = AgentModelsSnapshot{}
+		if snapshot := ps.AgentModels(); snapshot != nil {
+			published = *snapshot
+		}
+	}
+
+	// Never null, always a list: a client that reads the payload straight into
+	// its store would otherwise have to tell "no models" apart from "the field
+	// was absent", and the two mean the same thing here.
+	models := published.Models
+	if models == nil {
+		models = []AgentModel{}
+	}
+
+	// camelCase, unlike the notification this came from. The wire format the
+	// gateways send is snake_case and stays that way, but what goes to a browser
+	// is the REST surface's convention, and these fields are read straight into
+	// the same store slot the workspace payload fills.
+	//
+	// Base62 for the workspace ID, the way every other event on this bus carries
+	// one: the REST API only ever names a workspace that way (see view.Workspace),
+	// so a raw int64 here would match nothing the frontend holds and the picker
+	// would never move off whatever the last page load fetched.
+	ps.bus.Publish(ps.workspaceID, ps.userID, eventbus.Event{
+		Type: "agent.models",
+		Payload: map[string]any{
+			"configId":     published.ConfigID,
+			"currentModel": published.CurrentModel,
+			"models":       models,
+			"workspaceId":  monoflake.ID(ps.workspaceID).String(),
+		},
+	})
 }
 
 // AgentModels reports what the connected agent can switch between, or nil when

--- a/backend/internal/controller/mcp/agent_models_test.go
+++ b/backend/internal/controller/mcp/agent_models_test.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/mustafaturan/monoflake"
+
+	"github.com/agentrq/agentrq/backend/internal/service/eventbus"
 )
 
 // The notification this file handles used to be rejected outright — the SDK
@@ -16,7 +21,14 @@ import (
 // session that reported it.
 
 func newModelsServer() *WorkspaceServer {
-	return &WorkspaceServer{agentModels: make(map[string]AgentModelsSnapshot)}
+	// A bus, because recording a change now announces it: a server without one
+	// panics on the first report rather than failing an assertion, which is a
+	// confusing way to learn that publishing exists.
+	return &WorkspaceServer{
+		workspaceID: 100,
+		bus:         eventbus.New(),
+		agentModels: make(map[string]AgentModelsSnapshot),
+	}
 }
 
 // The exact frame acp-gateway puts on the wire (src/acpClient.ts), so a rename
@@ -314,6 +326,8 @@ func TestAgentModelsWithoutAnMCPServer(t *testing.T) {
 func TestAgentModelsWithAConnectedSession(t *testing.T) {
 	replies := 0
 	ps := permissionServer(t, &replies)
+	// A bus, because recording a report now announces it.
+	ps.bus = eventbus.New()
 	ps.agentModels = make(map[string]AgentModelsSnapshot)
 	sessionID := connectedServer(t, ps, "acp-gateway")
 	streamFor(ps, sessionID)
@@ -440,4 +454,237 @@ func TestAgentModelsWithTwoConnectedSessions(t *testing.T) {
 	if got.CurrentModel != "from-b" {
 		t.Errorf("CurrentModel = %q, want the surviving session's", got.CurrentModel)
 	}
+}
+
+// connectedModelsServer is a workspace with a real session attached, which the
+// publish tests need: what goes out on the bus when a session withdraws is what
+// the workspace would now serve over REST, and that answer is filtered by the
+// live sessions.
+func connectedModelsServer(t *testing.T) (*WorkspaceServer, string, chan []byte) {
+	t.Helper()
+	replies := 0
+	ps := permissionServer(t, &replies)
+	ps.bus = eventbus.New()
+	ps.agentModels = make(map[string]AgentModelsSnapshot)
+	sessionID := connectedServer(t, ps, "acp-gateway")
+	streamFor(ps, sessionID)
+
+	ch := ps.bus.Subscribe(ps.workspaceID, "")
+	t.Cleanup(func() { ps.bus.Unsubscribe(ps.workspaceID, "", ch) })
+	return ps, sessionID, ch
+}
+
+// The model changes from outside the app — an agent reports one when its
+// session comes up, long after any page load, and again every time it is
+// switched — so the human clients have to be told rather than left to
+// re-fetch. Before this the name on the Overview card was fixed at page load.
+func TestHandleAgentModelsPublishesTheChange(t *testing.T) {
+	// waitForEvent reads one event, or fails: a silent timeout here would look
+	// like a passing test that asserts nothing.
+	waitForEvent := func(t *testing.T, ch chan []byte) map[string]any {
+		t.Helper()
+		select {
+		case raw := <-ch:
+			// The bus frames events for SSE, so what arrives is
+			// "data: {...}\n\n" rather than bare JSON.
+			var evt struct {
+				Type    string         `json:"type"`
+				Payload map[string]any `json:"payload"`
+			}
+			body := strings.TrimSpace(strings.TrimPrefix(string(raw), "data: "))
+			if err := json.Unmarshal([]byte(body), &evt); err != nil {
+				t.Fatalf("unmarshal event %q: %v", raw, err)
+			}
+			if evt.Type != "agent.models" {
+				t.Fatalf("event type = %q, want agent.models", evt.Type)
+			}
+			return evt.Payload
+		case <-time.After(time.Second):
+			t.Fatal("no event was published")
+			return nil
+		}
+	}
+
+	expectSilence := func(t *testing.T, ch chan []byte) {
+		t.Helper()
+		select {
+		case raw := <-ch:
+			t.Errorf("an unchanged report was announced: %s", raw)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	t.Run("announces the models with a base62 workspace id", func(t *testing.T) {
+		// Base62 because that is the only form the frontend ever holds; a raw
+		// int64 would match nothing and the picker would never move.
+		ps, sessionID, ch := connectedModelsServer(t)
+
+		ps.HandleAgentModels(context.Background(), sessionID, AgentModelsParams{
+			ConfigID:     "model",
+			CurrentModel: "gemini-2.5-pro",
+			Models: []AgentModel{
+				{ID: "gemini-2.5-pro", Name: "Gemini 2.5 Pro", Group: "Google"},
+				{ID: "gpt-5-codex", Name: "GPT-5 Codex"},
+			},
+		})
+
+		payload := waitForEvent(t, ch)
+		want := monoflake.ID(ps.workspaceID).String()
+		if got, ok := payload["workspaceId"].(string); !ok || got != want {
+			t.Errorf("workspaceId = %v, want the base62 form %q", payload["workspaceId"], want)
+		}
+		// camelCase, matching the REST view rather than the snake_case
+		// notification this came from: the client reads it into the same store
+		// slot the workspace payload fills.
+		if payload["configId"] != "model" {
+			t.Errorf("configId = %v, want %q", payload["configId"], "model")
+		}
+		if payload["currentModel"] != "gemini-2.5-pro" {
+			t.Errorf("currentModel = %v, want %q", payload["currentModel"], "gemini-2.5-pro")
+		}
+		models, ok := payload["models"].([]any)
+		if !ok || len(models) != 2 {
+			t.Fatalf("models = %v", payload["models"])
+		}
+		first, _ := models[0].(map[string]any)
+		if first["id"] != "gemini-2.5-pro" || first["name"] != "Gemini 2.5 Pro" || first["group"] != "Google" {
+			t.Errorf("models[0] = %v", first)
+		}
+	})
+
+	t.Run("stays quiet when the agent re-advertises the same list", func(t *testing.T) {
+		// An agent re-sends its models on every session config change, so a
+		// thinking-effort switch repeats the whole list unchanged. Broadcasting
+		// that to every open tab would be noise about a picker that did not move.
+		ps, sessionID, ch := connectedModelsServer(t)
+
+		same := AgentModelsParams{
+			ConfigID:     "model",
+			CurrentModel: "a",
+			Models:       []AgentModel{{ID: "a", Name: "A"}, {ID: "b", Name: "B"}},
+		}
+		ps.HandleAgentModels(context.Background(), sessionID, same)
+		waitForEvent(t, ch)
+
+		ps.HandleAgentModels(context.Background(), sessionID, AgentModelsParams{
+			ConfigID:     "model",
+			CurrentModel: "a",
+			Models:       []AgentModel{{ID: "a", Name: "A"}, {ID: "b", Name: "B"}},
+		})
+
+		expectSilence(t, ch)
+	})
+
+	t.Run("announces a switch that changes only the current model", func(t *testing.T) {
+		// The event this whole path exists to carry. A gateway may send the
+		// top-level current_model without the per-model `current` flag, and then
+		// a switch leaves the list byte-identical — so comparing lists alone
+		// would call the one change that matters "unchanged".
+		ps, sessionID, ch := connectedModelsServer(t)
+
+		models := []AgentModel{{ID: "a", Name: "A"}, {ID: "b", Name: "B"}}
+		ps.HandleAgentModels(context.Background(), sessionID, AgentModelsParams{
+			ConfigID: "model", CurrentModel: "a", Models: models,
+		})
+		waitForEvent(t, ch)
+
+		ps.HandleAgentModels(context.Background(), sessionID, AgentModelsParams{
+			ConfigID: "model", CurrentModel: "b", Models: models,
+		})
+
+		payload := waitForEvent(t, ch)
+		if payload["currentModel"] != "b" {
+			t.Errorf("currentModel = %v, want the model just switched to", payload["currentModel"])
+		}
+	})
+
+	t.Run("announces a withdrawal as an empty list", func(t *testing.T) {
+		// This is what takes the picker away. Without it the interface would go
+		// on offering models the agent has stopped accepting.
+		ps, sessionID, ch := connectedModelsServer(t)
+
+		ps.HandleAgentModels(context.Background(), sessionID, AgentModelsParams{
+			ConfigID: "model", Models: []AgentModel{{ID: "a"}},
+		})
+		waitForEvent(t, ch)
+
+		ps.HandleAgentModels(context.Background(), sessionID, AgentModelsParams{Models: nil})
+
+		payload := waitForEvent(t, ch)
+		if models, ok := payload["models"].([]any); !ok || len(models) != 0 {
+			t.Errorf("models = %v, want an empty list", payload["models"])
+		}
+	})
+
+	t.Run("keeps the picker when one session withdraws but another still offers", func(t *testing.T) {
+		// Two gateways can be attached to one workspace. One of them dropping
+		// its models says nothing about the other's, and clearing the picker
+		// would take away a choice that still works.
+		ps, sessionID, ch := connectedModelsServer(t)
+
+		ps.HandleAgentModels(context.Background(), sessionID, AgentModelsParams{
+			ConfigID: "model", CurrentModel: "still-here", Models: []AgentModel{{ID: "still-here"}},
+		})
+		waitForEvent(t, ch)
+
+		ps.HandleAgentModels(context.Background(), "a-second-session", AgentModelsParams{Models: nil})
+
+		payload := waitForEvent(t, ch)
+		models, ok := payload["models"].([]any)
+		if !ok || len(models) != 1 {
+			t.Fatalf("models = %v, want the surviving session's list", payload["models"])
+		}
+		first, _ := models[0].(map[string]any)
+		if first["id"] != "still-here" {
+			t.Errorf("models[0] = %v, want the session that is still offering", first)
+		}
+		if payload["currentModel"] != "still-here" {
+			t.Errorf("currentModel = %v, want the surviving session's", payload["currentModel"])
+		}
+	})
+}
+
+func TestSameAgentModels(t *testing.T) {
+	base := AgentModelsSnapshot{
+		SessionID:    "acp-1",
+		ConfigID:     "model",
+		CurrentModel: "a",
+		Models:       []AgentModel{{ID: "a", Name: "A"}, {ID: "b", Name: "B"}},
+	}
+
+	t.Run("a reconnected session offering the same list is not a change", func(t *testing.T) {
+		// SessionID is not published, so a gateway that rebuilt its ACP session
+		// while offering an identical list has changed nothing a reader can see.
+		other := base
+		other.SessionID = "acp-2"
+		if !sameAgentModels(base, other) {
+			t.Error("a new agent session alone should not count as a change")
+		}
+	})
+
+	t.Run("the current model is part of the comparison", func(t *testing.T) {
+		other := base
+		other.CurrentModel = "b"
+		if sameAgentModels(base, other) {
+			t.Error("a switch with an unchanged list must count as a change")
+		}
+	})
+
+	t.Run("the config id is part of the comparison", func(t *testing.T) {
+		// A selection is written back to this option, so a picker holding a
+		// stale one would write to something the agent no longer advertises.
+		other := base
+		other.ConfigID = "model_id"
+		if sameAgentModels(base, other) {
+			t.Error("a different config option must count as a change")
+		}
+	})
+
+	t.Run("the list itself is part of the comparison", func(t *testing.T) {
+		other := base
+		other.Models = []AgentModel{{ID: "a", Name: "A"}}
+		if sameAgentModels(base, other) {
+			t.Error("a shorter list must count as a change")
+		}
+	})
 }

--- a/backend/internal/controller/mcp/permission_rebind_test.go
+++ b/backend/internal/controller/mcp/permission_rebind_test.go
@@ -9,6 +9,7 @@ import (
 
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
 	"github.com/agentrq/agentrq/backend/internal/data/model"
+	"github.com/agentrq/agentrq/backend/internal/service/eventbus"
 	mock_pubsub "github.com/agentrq/agentrq/backend/internal/service/mocks/pubsub"
 	"github.com/golang/mock/gomock"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -24,7 +25,12 @@ func permissionServer(t *testing.T, replies *int) *WorkspaceServer {
 	pubsubMock.EXPECT().Publish(gomock.Any(), gomock.Any()).AnyTimes()
 
 	return &WorkspaceServer{
-		workspaceID:         100,
+		workspaceID: 100,
+		// A real server is never built without a bus (see NewWorkspaceServer),
+		// and the handlers that announce a change publish unconditionally. A
+		// double without one panics on the first report instead of failing an
+		// assertion, which is a confusing way to learn that publishing exists.
+		bus:                 eventbus.New(),
 		pubsub:              pubsubMock,
 		permissionRequests:  make(map[string]string),
 		requestTools:        make(map[string]string),

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -659,6 +659,15 @@ onEvent((event) => {
     workspaceStore.updateAgentCommands(workspaceId, commands)
   }
 
+  // The agent's models, which arrive when its session comes up and again on
+  // every switch. Same reasoning as the commands above: without this the model
+  // named on the Overview card is whatever the last page load fetched, and a
+  // switch never shows.
+  if (event.type === 'agent.models') {
+    const { configId, currentModel, models, workspaceId } = event.payload
+    workspaceStore.updateAgentModels(workspaceId, { configId, currentModel, models })
+  }
+
   // Handle workspace metadata updates
   if (event.type === 'workspace.updated') {
     workspaceStore.updateWorkspaceMetadata(event.payload)

--- a/frontend/src/stores/workspaceStore.js
+++ b/frontend/src/stores/workspaceStore.js
@@ -72,6 +72,30 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     }
   }
 
+  /**
+   * Record the models a workspace's agent is offering.
+   *
+   * Lives here for the same reason `agentCommands` does: it changes from
+   * outside the app — an agent reports its models when its session comes up,
+   * and again every time one is switched — and the name on the Overview card
+   * was otherwise fixed at whatever the last page load fetched. IDs are
+   * compared as strings for the reason `findIndex` gives.
+   *
+   * An empty list clears the field rather than storing an empty object, so
+   * `agentModels` keeps meaning "there is a choice here" — which is what the
+   * REST payload means by omitting it, and what every reader already assumes.
+   */
+  function updateAgentModels(workspaceId, models) {
+    const idx = findIndex(workspaceId);
+    if (idx !== -1) {
+      const list = Array.isArray(models?.models) ? models.models : [];
+      const agentModels = list.length > 0
+        ? { configId: models.configId, currentModel: models.currentModel, models: list }
+        : undefined;
+      workspaces.value[idx] = { ...workspaces.value[idx], agentModels };
+    }
+  }
+
   /** The workspace with this ID, or undefined. */
   function getWorkspace(workspaceId) {
     const idx = findIndex(workspaceId);
@@ -96,6 +120,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     updateWorkspaceMetadata,
     updateAgentStatus,
     updateAgentCommands,
+    updateAgentModels,
     getWorkspace,
     isAgentConnected
   };

--- a/frontend/test/workspaceStore.test.js
+++ b/frontend/test/workspaceStore.test.js
@@ -172,6 +172,81 @@ describe('workspaceStore', () => {
     })
   })
 
+  describe('updateAgentModels', () => {
+    beforeEach(async () => {
+      fetchWorkspaces.mockResolvedValue({ workspaces: [ws('0ZzhYQG2qtl', 'alpha'), ws('0iAx25vra8v', 'beta')] })
+      await useWorkspaceStore().fetchWorkspaces()
+    })
+
+    const modelsOf = (store, id) => store.getWorkspace(id)?.agentModels
+    const twoModels = {
+      configId: 'model',
+      currentModel: 'gemini-2.5-pro',
+      models: [{ id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro' }, { id: 'gpt-5-codex', name: 'GPT-5 Codex' }],
+    }
+
+    it('records the models against the named workspace only', () => {
+      const store = useWorkspaceStore()
+
+      store.updateAgentModels('0ZzhYQG2qtl', twoModels)
+
+      expect(modelsOf(store, '0ZzhYQG2qtl')).toEqual(twoModels)
+      expect(modelsOf(store, '0iAx25vra8v')).toBeUndefined()
+    })
+
+    it('carries the new current model through a switch', () => {
+      // The whole point of the event: the agent switched, and every surface
+      // reading this store has to say so without a reload.
+      const store = useWorkspaceStore()
+      store.updateAgentModels('0ZzhYQG2qtl', twoModels)
+
+      store.updateAgentModels('0ZzhYQG2qtl', { ...twoModels, currentModel: 'gpt-5-codex' })
+
+      expect(modelsOf(store, '0ZzhYQG2qtl').currentModel).toBe('gpt-5-codex')
+    })
+
+    it('takes the choice away when the agent withdraws its models', () => {
+      // An empty list is how an agent says it has stopped offering a choice,
+      // and the field's absence is what every surface reads as "no choice".
+      const store = useWorkspaceStore()
+      store.updateAgentModels('0ZzhYQG2qtl', twoModels)
+
+      store.updateAgentModels('0ZzhYQG2qtl', { configId: 'model', currentModel: '', models: [] })
+
+      expect(modelsOf(store, '0ZzhYQG2qtl')).toBeUndefined()
+    })
+
+    it('takes the choice away when handed nothing at all', () => {
+      const store = useWorkspaceStore()
+      store.updateAgentModels('0ZzhYQG2qtl', twoModels)
+
+      store.updateAgentModels('0ZzhYQG2qtl', undefined)
+
+      expect(modelsOf(store, '0ZzhYQG2qtl')).toBeUndefined()
+    })
+
+    // The same trap updateAgentStatus documents: the ID has to be compared as a
+    // string, because a route parameter and a payload field are not the same
+    // type.
+    it('matches an ID that arrives as a number rather than a string', () => {
+      const store = useWorkspaceStore()
+      store.workspaces = [ws(42, 'numeric')]
+
+      store.updateAgentModels('42', twoModels)
+
+      expect(modelsOf(store, 42)).toEqual(twoModels)
+    })
+
+    it('ignores an ID that names no workspace it holds', () => {
+      const store = useWorkspaceStore()
+
+      store.updateAgentModels(1234567890123, twoModels)
+      store.updateAgentModels(undefined, twoModels)
+
+      expect(store.workspaces.some((w) => w.agentModels)).toBe(false)
+    })
+  })
+
   describe('updateWorkspaceMetadata', () => {
     beforeEach(async () => {
       fetchWorkspaces.mockResolvedValue({ workspaces: [ws('a', 'alpha'), ws('b', 'beta')] })


### PR DESCRIPTION
## What changed

The model an agent is running is now announced to every open tab the moment it changes, instead of only appearing in whatever a page fetched when it loaded.

## Why changed

An agent reports its models when its session starts — long after any page has loaded — and again each time one is switched, and none of that reached a browser that was already open. The Overview card could therefore name a model the agent had stopped using, with no way to find out short of a reload. The slash-commands path next door already worked this way; the models path simply never got the same treatment.

It is also the groundwork for choosing a model from the interface: a selection is confirmed by the agent's own next report, so something has to carry that report to the page.

## Test coverage report

New lines introduced: **100%**. Total coverage impact: **unchanged** — the frontend gate holds at 100% on all four metrics (1008 tests, 40 files), and the backend suite passes in full.

Backend tests cover: the announcement and its base62 workspace ID, silence when an agent re-advertises an identical list, a switch that changes only the current model, a withdrawal published as an empty list, and a withdrawal by one session leaving another's list intact. The comparison itself is tested directly, including that a rebuilt agent session alone is not a change.

Frontend tests cover the new store action: recording against the named workspace only, carrying a switch through, clearing the field on withdrawal and on nothing at all, matching a numeric ID, and ignoring an unknown one.

## Other reports

The tests read the same SSE-framed bytes a browser receives (`data: {...}`), so the payload shape is pinned end to end rather than asserted on a Go struct — which is what catches a camelCase/snake_case slip between the gateway wire format and the REST surface.

One incidental fix: the package's shared test double had no event bus. A real server is never built without one, so a double lacking it panicked on the first report rather than failing an assertion. It now carries one, which is why `permission_rebind_test.go` appears in the diff.

## TaskID: 0iRy7jU4MS1
