### PR TITLE
feat(mcp): let a model be chosen, where the agent will act on it

### DIFF
--- a/backend/internal/controller/mcp/agent_models.go
+++ b/backend/internal/controller/mcp/agent_models.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"slices"
 
 	"github.com/mustafaturan/monoflake"
@@ -16,6 +17,34 @@ import (
 // It arrives whenever the agent's session config changes, so the newest one for
 // a session replaces the previous rather than adding to it.
 const AgentModelsNotificationMethod = "notifications/claude/channel/models"
+
+// AgentSetModelNotificationMethod is the notification this server sends to ask
+// a gateway to switch the agent behind it to a different model.
+//
+// The second server-to-agent command there is, after cancel. Like that one it
+// is this project's own invention rather than anything MCP defines, so a client
+// not written to listen for it drops it in silence — which is what CanSet
+// exists to detect before a picker is ever offered.
+//
+// snake_case in its payload, like every notification on this channel: the wire
+// format belongs to the gateways, and the REST surface's camelCase stops at the
+// handler.
+const AgentSetModelNotificationMethod = "notifications/claude/channel/set_model"
+
+// Reasons a model cannot be selected, so the handler can say which it was
+// rather than answering every refusal the same way.
+var (
+	// ErrModelSelectUnsupported means nothing connected will act on a
+	// selection: no models reported, none of the reporting sessions still
+	// holding a stream, or a gateway too old to have said it can set one.
+	ErrModelSelectUnsupported = errors.New("the connected agent does not support choosing a model")
+	// ErrModelNotOffered means the agent is selectable but was asked for a
+	// model it never advertised.
+	ErrModelNotOffered = errors.New("the connected agent does not offer that model")
+	// ErrModelSetNotDelivered means the session that offered the choice could
+	// not be reached to be told of it.
+	ErrModelSetNotDelivered = errors.New("the connected agent could not be reached")
+)
 
 // AgentModel is one model the connected agent offers.
 type AgentModel struct {
@@ -38,6 +67,19 @@ type AgentModelsParams struct {
 	ConfigID     string       `json:"config_id"`
 	CurrentModel string       `json:"current_model"`
 	Models       []AgentModel `json:"models"`
+	// CanSet is the gateway saying it will act on a set_model notification.
+	//
+	// Absent means no, which is what makes this safe to add: every gateway
+	// already in the field reports its models and none of them can be told to
+	// change one, so reading silence as "yes" would offer a picker that does
+	// nothing on every deployment that exists today.
+	//
+	// It has to come from the gateway rather than from a list of client names
+	// here, because the question is about the gateway's *version*, and the
+	// handshake name — "acp-gateway" either way — cannot tell two versions
+	// apart. stopCapableClients can be a name list precisely because stopping
+	// has been there since that client's first release.
+	CanSet bool `json:"can_set,omitempty"`
 }
 
 // AgentModelsSnapshot is what one connected session last reported.
@@ -52,6 +94,24 @@ type AgentModelsSnapshot struct {
 	ConfigID     string
 	CurrentModel string
 	Models       []AgentModel
+	// CanSet reports whether the session that sent this will act on a
+	// set_model notification. See the field on AgentModelsParams.
+	CanSet bool
+}
+
+// Selectable reports whether a choice can actually be written back.
+//
+// The one definition of that rule, because it is asked in three places — the
+// predicate the interface reads, the guard on the notification, and the flag on
+// the workspace payload — and three copies of "CanSet && ConfigID != \"\"" would
+// eventually disagree about whether a gateway that forgot its config option
+// counts.
+//
+// ConfigID is half of it because a selection is a write to that session config
+// option: a snapshot without one describes models nobody can switch to, however
+// willing the gateway says it is.
+func (s AgentModelsSnapshot) Selectable() bool {
+	return s.CanSet && s.ConfigID != ""
 }
 
 // currentModelID is the model the payload says is selected.
@@ -100,6 +160,7 @@ func (ps *WorkspaceServer) HandleAgentModels(ctx context.Context, sessionID stri
 		ConfigID:     p.ConfigID,
 		CurrentModel: p.currentModelID(),
 		Models:       p.Models,
+		CanSet:       p.CanSet,
 	}
 
 	ps.agentModelsMu.Lock()
@@ -140,6 +201,7 @@ func (ps *WorkspaceServer) HandleAgentModels(ctx context.Context, sessionID stri
 func sameAgentModels(a, b AgentModelsSnapshot) bool {
 	return a.ConfigID == b.ConfigID &&
 		a.CurrentModel == b.CurrentModel &&
+		a.CanSet == b.CanSet &&
 		slices.Equal(a.Models, b.Models)
 }
 
@@ -192,6 +254,7 @@ func (ps *WorkspaceServer) publishAgentModels(reported AgentModelsSnapshot) {
 		Payload: map[string]any{
 			"configId":     published.ConfigID,
 			"currentModel": published.CurrentModel,
+			"canSet":       published.CanSet,
 			"models":       models,
 			"workspaceId":  monoflake.ID(ps.workspaceID).String(),
 		},
@@ -241,13 +304,101 @@ func (ps *WorkspaceServer) liveSessionIDs() []string {
 // order the server reports rather than Go's randomised map order, which would
 // otherwise make the choice differ between two identical calls.
 func pickAgentModels(snapshots map[string]AgentModelsSnapshot, live []string) *AgentModelsSnapshot {
+	_, snapshot := pickAgentModelsSession(snapshots, live)
+	return snapshot
+}
+
+// pickAgentModelsSession is pickAgentModels, also naming the transport session
+// that reported the answer.
+//
+// Selecting a model has to reach *that* session and no other. The snapshot
+// alone cannot say where to send it: its SessionID is the gateway's own ACP
+// session with the agent, a different namespace from the transport session this
+// server would address — the trap HandleAgentModels documents at length.
+func pickAgentModelsSession(snapshots map[string]AgentModelsSnapshot, live []string) (string, *AgentModelsSnapshot) {
 	for _, id := range live {
 		snapshot, ok := snapshots[id]
 		if !ok || len(snapshot.Models) == 0 {
 			continue
 		}
-		return &snapshot
+		return id, &snapshot
 	}
+	return "", nil
+}
+
+// SupportsModelSelect reports whether a model can actually be chosen right now,
+// so the interface only offers a picker that would do something.
+//
+// Three things have to hold, and the first two are what a reader would forget.
+// The session must still hold a stream — a session outlives the stream that
+// carried it, which is the trap #504 fixed for the Stop button, and a snapshot
+// keyed to a departed gateway still looks live. The gateway must have said it
+// can set a model: every gateway in the field reports models and none of the
+// older ones will act on being told to change one, so this cannot be assumed
+// from the models being there. And there must be a config option to write the
+// choice back to, which is what ConfigID names.
+func (ps *WorkspaceServer) SupportsModelSelect() bool {
+	ps.agentModelsMu.RLock()
+	defer ps.agentModelsMu.RUnlock()
+
+	_, snapshot := pickAgentModelsSession(ps.agentModels, ps.streamingSessionIDs())
+	return snapshot != nil && snapshot.Selectable()
+}
+
+// SendSetModelNotification asks the connected agent to switch to a model.
+//
+// Addressed to the one session that offered the choice, deliberately, and not
+// broadcast the way a stop is. A stop is broadcast because any session may be
+// the one holding the turn and the point of the button is that it works; a
+// model selection is the opposite — it is a write against one gateway's session
+// config, and sending it to a second gateway would change a model nobody asked
+// about on an agent the human was not looking at.
+//
+// The model is checked against what that session actually advertised. Refusing
+// here is what keeps a stale picker honest: a tab that loaded before the agent
+// narrowed its list would otherwise write an ID the agent no longer accepts,
+// and the failure would surface as silence rather than as a message.
+func (ps *WorkspaceServer) SendSetModelNotification(ctx context.Context, modelID string) error {
+	ps.agentModelsMu.RLock()
+	sessID, snapshot := pickAgentModelsSession(ps.agentModels, ps.streamingSessionIDs())
+	ps.agentModelsMu.RUnlock()
+
+	if snapshot == nil || !snapshot.Selectable() {
+		return ErrModelSelectUnsupported
+	}
+	if !slices.ContainsFunc(snapshot.Models, func(m AgentModel) bool { return m.ID == modelID }) {
+		return ErrModelNotOffered
+	}
+
+	// snake_case, the wire format every gateway already speaks on this channel.
+	// session_id is the gateway's own ACP session, which is what it needs to
+	// write the config option against; sessID above is this server's transport
+	// to that gateway, which is how the notification finds it. The two are
+	// different namespaces and both are needed.
+	params := map[string]any{
+		"session_id": snapshot.SessionID,
+		"config_id":  snapshot.ConfigID,
+		"model_id":   modelID,
+	}
+	// Narrow but real: streamingSessionIDs and notifySession read the same
+	// session list, so a session named by the first is addressable by the
+	// second — unless the gateway disconnects between the two, which is exactly
+	// when a human is most likely to be clicking. Reported rather than
+	// swallowed, so the picker reverts instead of appearing to have worked.
+	if !ps.notifySession(ctx, sessID, AgentSetModelNotificationMethod, params) {
+		return ErrModelSetNotDelivered
+	}
+
+	// Deliberately not recorded as the new current model here. The agent
+	// answers with a models notification once the switch has actually happened,
+	// and that report is the only thing that knows whether it did. Writing the
+	// snapshot optimistically would make the interface claim a switch that the
+	// agent may have refused.
+	zlog.Info().
+		Int64("workspace_id", ps.workspaceID).
+		Str("session_id", sessID).
+		Str("model_id", modelID).
+		Msg("asked the connected agent to switch model")
 	return nil
 }
 

--- a/backend/internal/controller/mcp/agent_models_test.go
+++ b/backend/internal/controller/mcp/agent_models_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -687,4 +688,173 @@ func TestSameAgentModels(t *testing.T) {
 			t.Error("a shorter list must count as a change")
 		}
 	})
+}
+
+// Choosing a model is the second thing this server ever asks an agent to do,
+// after stopping. These pin the three ways it can refuse — because a picker
+// that silently does nothing is the failure this whole capability gate exists
+// to prevent — and that the request reaches exactly one session.
+func TestSendSetModelNotification(t *testing.T) {
+	selectable := AgentModelsParams{
+		SessionID:    "acp-session-1",
+		ConfigID:     "model",
+		CurrentModel: "a",
+		CanSet:       true,
+		Models:       []AgentModel{{ID: "a"}, {ID: "b"}},
+	}
+
+	t.Run("refuses when nothing has reported any models", func(t *testing.T) {
+		ps, _, _ := connectedModelsServer(t)
+
+		if err := ps.SendSetModelNotification(context.Background(), "a"); !errors.Is(err, ErrModelSelectUnsupported) {
+			t.Errorf("err = %v, want ErrModelSelectUnsupported", err)
+		}
+		if ps.SupportsModelSelect() {
+			t.Error("SupportsModelSelect() = true with nothing reported")
+		}
+	})
+
+	t.Run("refuses a gateway that never said it can set one", func(t *testing.T) {
+		// Every gateway in the field reports models and none of the older ones
+		// will act on being told to change one. Reading silence as consent is
+		// what would offer a picker that does nothing on every deployment that
+		// exists today.
+		ps, sessionID, _ := connectedModelsServer(t)
+		params := selectable
+		params.CanSet = false
+		ps.HandleAgentModels(context.Background(), sessionID, params)
+
+		if err := ps.SendSetModelNotification(context.Background(), "a"); !errors.Is(err, ErrModelSelectUnsupported) {
+			t.Errorf("err = %v, want ErrModelSelectUnsupported", err)
+		}
+		if ps.SupportsModelSelect() {
+			t.Error("SupportsModelSelect() = true for a gateway that never said it can")
+		}
+	})
+
+	t.Run("refuses a willing gateway that named no config option", func(t *testing.T) {
+		// A selection is a write to that option. Willingness without somewhere
+		// to write is a promise that cannot be kept.
+		ps, sessionID, _ := connectedModelsServer(t)
+		params := selectable
+		params.ConfigID = ""
+		ps.HandleAgentModels(context.Background(), sessionID, params)
+
+		if err := ps.SendSetModelNotification(context.Background(), "a"); !errors.Is(err, ErrModelSelectUnsupported) {
+			t.Errorf("err = %v, want ErrModelSelectUnsupported", err)
+		}
+	})
+
+	t.Run("refuses a model the agent never offered", func(t *testing.T) {
+		// A tab that loaded before the agent narrowed its list would otherwise
+		// write an ID the agent no longer accepts, and the failure would reach
+		// the human as silence rather than as a message.
+		ps, sessionID, _ := connectedModelsServer(t)
+		ps.HandleAgentModels(context.Background(), sessionID, selectable)
+
+		if err := ps.SendSetModelNotification(context.Background(), "not-offered"); !errors.Is(err, ErrModelNotOffered) {
+			t.Errorf("err = %v, want ErrModelNotOffered", err)
+		}
+	})
+
+	t.Run("sends to the session that offered the choice", func(t *testing.T) {
+		ps, sessionID, _ := connectedModelsServer(t)
+		ps.HandleAgentModels(context.Background(), sessionID, selectable)
+
+		if !ps.SupportsModelSelect() {
+			t.Fatal("SupportsModelSelect() = false for a gateway that said it can")
+		}
+		if err := ps.SendSetModelNotification(context.Background(), "b"); err != nil {
+			t.Fatalf("SendSetModelNotification() = %v, want nil", err)
+		}
+	})
+
+	t.Run("does not record the switch it only asked for", func(t *testing.T) {
+		// The agent answers with a models notification once it has actually
+		// switched, and that report is the only thing that knows whether it
+		// did. Recording it here would make the interface claim a switch the
+		// agent may have refused.
+		ps, sessionID, _ := connectedModelsServer(t)
+		ps.HandleAgentModels(context.Background(), sessionID, selectable)
+
+		if err := ps.SendSetModelNotification(context.Background(), "b"); err != nil {
+			t.Fatalf("SendSetModelNotification() = %v", err)
+		}
+
+		if got := ps.AgentModels().CurrentModel; got != "a" {
+			t.Errorf("CurrentModel = %q, want the agent's last report %q", got, "a")
+		}
+	})
+
+	t.Run("stops offering the choice once the session drops its stream", func(t *testing.T) {
+		// The trap #504 fixed for the Stop button: a session outlives the
+		// stream that carried it, so a snapshot keyed to a departed gateway
+		// still looks live to anything reading the session list alone.
+		ps, sessionID, _ := connectedModelsServer(t)
+		ps.HandleAgentModels(context.Background(), sessionID, selectable)
+		ps.removeStreamingSession(sessionID)
+
+		if ps.SupportsModelSelect() {
+			t.Error("SupportsModelSelect() = true for a session that has gone off the air")
+		}
+		if err := ps.SendSetModelNotification(context.Background(), "b"); !errors.Is(err, ErrModelSelectUnsupported) {
+			t.Errorf("err = %v, want ErrModelSelectUnsupported", err)
+		}
+	})
+}
+
+func TestAgentModelsSelectable(t *testing.T) {
+	cases := []struct {
+		name     string
+		snapshot AgentModelsSnapshot
+		want     bool
+	}{
+		{"willing and with somewhere to write", AgentModelsSnapshot{CanSet: true, ConfigID: "model"}, true},
+		{"willing but naming no config option", AgentModelsSnapshot{CanSet: true}, false},
+		{"a config option but never said it can set", AgentModelsSnapshot{ConfigID: "model"}, false},
+		{"an older gateway, saying neither", AgentModelsSnapshot{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.snapshot.Selectable(); got != tc.want {
+				t.Errorf("Selectable() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// can_set is what turns the picker on, so a gateway starting to advertise it
+// has to reach the open tabs — even when the list it comes with is unchanged.
+func TestHandleAgentModelsPublishesCanSetChange(t *testing.T) {
+	ps, sessionID, ch := connectedModelsServer(t)
+
+	models := []AgentModel{{ID: "a"}}
+	ps.HandleAgentModels(context.Background(), sessionID, AgentModelsParams{
+		ConfigID: "model", CurrentModel: "a", Models: models,
+	})
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("the first report was not announced")
+	}
+
+	ps.HandleAgentModels(context.Background(), sessionID, AgentModelsParams{
+		ConfigID: "model", CurrentModel: "a", Models: models, CanSet: true,
+	})
+
+	select {
+	case raw := <-ch:
+		var evt struct {
+			Payload map[string]any `json:"payload"`
+		}
+		body := strings.TrimSpace(strings.TrimPrefix(string(raw), "data: "))
+		if err := json.Unmarshal([]byte(body), &evt); err != nil {
+			t.Fatalf("unmarshal event: %v", err)
+		}
+		if evt.Payload["canSet"] != true {
+			t.Errorf("canSet = %v, want true", evt.Payload["canSet"])
+		}
+	case <-time.After(time.Second):
+		t.Fatal("a gateway that began offering selection was not announced")
+	}
 }

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -52,6 +52,10 @@ type (
 		ConfigID     string
 		CurrentModel string
 		Models       []AgentModel
+		// CanSet reports whether the connected agent will act on one of these
+		// being chosen. False for every gateway too old to say so, which is
+		// what keeps a picker from being offered where it would do nothing.
+		CanSet bool
 	}
 
 	AgentModel struct {

--- a/backend/internal/data/view/api/view.go
+++ b/backend/internal/data/view/api/view.go
@@ -39,6 +39,10 @@ type (
 		ConfigID     string       `json:"configId"`
 		CurrentModel string       `json:"currentModel,omitempty"`
 		Models       []AgentModel `json:"models"`
+		// CanSet says whether choosing one of these would do anything. A
+		// client shows a picker only when it is true; false is an agent that
+		// reports what it is running but cannot be told to change it.
+		CanSet bool `json:"canSet"`
 	}
 
 	AgentModel struct {
@@ -281,6 +285,14 @@ type (
 	SendPermissionVerdictRequest struct {
 		RequestID string `json:"requestId"`
 		Behavior  string `json:"behavior"` // "allow" | "deny"
+	}
+
+	// SetAgentModelRequest asks the workspace's connected agent to switch
+	// model. Only the model is named: which session and which config option to
+	// write it to are the server's business, resolved from what the agent
+	// itself reported, and are deliberately not the browser's to choose.
+	SetAgentModelRequest struct {
+		ModelID string `json:"modelId"`
 	}
 
 	RespondToElicitationRequest struct {

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -16,6 +17,7 @@ import (
 	pushctrl "github.com/agentrq/agentrq/backend/internal/controller/push"
 	slackctrl "github.com/agentrq/agentrq/backend/internal/controller/slack"
 	entity "github.com/agentrq/agentrq/backend/internal/data/entity/crud"
+	view "github.com/agentrq/agentrq/backend/internal/data/view/api"
 	mapper "github.com/agentrq/agentrq/backend/internal/mapper/api"
 	"github.com/agentrq/agentrq/backend/internal/service/auth"
 	"github.com/agentrq/agentrq/backend/internal/service/eventbus"
@@ -595,7 +597,62 @@ func (h *handler) registerWorkspaceRoutes() error {
 	r.Get("/:id/memories/:name", h.getWorkspaceMemory())
 	r.Put("/:id/slack", h.setWorkspaceSlackChannel())
 	r.Delete("/:id/slack", h.removeWorkspaceSlackChannel())
+	r.Post("/:id/agent/model", h.setAgentModel())
 	return nil
+}
+
+// setAgentModel asks the workspace's connected agent to switch model.
+//
+// Under /workspaces rather than under a task: the models are a standing fact
+// about the agent attached to the workspace, and the session that offers them
+// serves every task in it. Hanging this off one task would imply a choice that
+// applied only there.
+//
+// It refuses with a reason worth reading, the way stopTask does. "Failed" is
+// useless to someone whose picker just did nothing; which of "nothing connected
+// can do this" and "that model is not on offer" it was, is the whole content of
+// the answer.
+func (h *handler) setAgentModel() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		var rq view.SetAgentModelRequest
+		if err := c.BodyParser(&rq); err != nil {
+			return c.Status(http.StatusBadRequest).JSON(fiber.Map{"error": "invalid request payload"})
+		}
+		if strings.TrimSpace(rq.ModelID) == "" {
+			return c.Status(http.StatusBadRequest).JSON(fiber.Map{"error": "modelId is required"})
+		}
+
+		workspaceID := monoflake.IDFromBase62(c.Params("id")).Int64()
+		userID := c.Locals("user_id").(string)
+
+		ctx, cancel := newContext(c)
+		defer cancel()
+		if ok, err := h.crud.CheckWorkspaceAccess(ctx, workspaceID, userID); err != nil || !ok {
+			return c.Status(http.StatusForbidden).JSON(fiber.Map{"error": "forbidden"})
+		}
+
+		srv := h.mcpManager.Get(workspaceID, userID)
+		if srv == nil {
+			return c.Status(http.StatusNotFound).JSON(fiber.Map{"error": "mcp server not found"})
+		}
+
+		switch err := srv.SendSetModelNotification(c.Context(), rq.ModelID); {
+		case errors.Is(err, mcpctrl.ErrModelSelectUnsupported):
+			return c.Status(http.StatusConflict).JSON(fiber.Map{"error": err.Error()})
+		case errors.Is(err, mcpctrl.ErrModelNotOffered):
+			return c.Status(http.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+		case errors.Is(err, mcpctrl.ErrModelSetNotDelivered):
+			return c.Status(http.StatusConflict).JSON(fiber.Map{"error": err.Error()})
+		case err != nil:
+			return c.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": "failed to select the model"})
+		}
+
+		// Accepted, not OK, and carrying no model: the agent has been asked,
+		// and only its own next models notification says whether it switched.
+		// Answering with the chosen model here would invite a client to render
+		// it as settled — the one thing this flow must not claim.
+		return c.Status(http.StatusAccepted).JSON(fiber.Map{"requested": rq.ModelID})
+	}
 }
 
 func (h *handler) createWorkspace() fiber.Handler {
@@ -1068,6 +1125,10 @@ func agentModelsEntity(s *mcpctrl.AgentModelsSnapshot) *entity.AgentModels {
 		ConfigID:     s.ConfigID,
 		CurrentModel: s.CurrentModel,
 		Models:       models,
+		// The rule, not the raw field: a gateway willing to switch but
+		// advertising no config option to switch through cannot be obeyed, and
+		// a picker offered on that promise would do nothing.
+		CanSet: s.Selectable(),
 	}
 }
 

--- a/backend/internal/handler/api/api_test.go
+++ b/backend/internal/handler/api/api_test.go
@@ -846,3 +846,123 @@ func TestAgentClientEntity(t *testing.T) {
 		}
 	})
 }
+
+// Choosing a model is refused with a reason worth reading, and refused before
+// anything reaches a workspace server when the caller has no business there.
+// "Failed" tells someone whose picker just did nothing precisely nothing.
+
+func TestSetAgentModel_RefusesACallerWithoutAccess(t *testing.T) {
+	app := fiber.New()
+	crudCtrl := &mockCrudWorkspaceAccess{
+		checkWorkspaceAccessFunc: func(ctx context.Context, id int64, userID string) (bool, error) {
+			return false, nil
+		},
+	}
+	// Intentionally no MCPManager: an unauthorized request must be refused
+	// before anything reaches a workspace server.
+	h := &handler{crud: crudCtrl}
+
+	app.Post("/api/v1/workspaces/:id/agent/model", func(c *fiber.Ctx) error {
+		c.Locals("user_id", monoflake.ID(100).String())
+		return h.setAgentModel()(c)
+	})
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/workspaces/"+monoflake.ID(1).String()+"/agent/model",
+		strings.NewReader(`{"modelId":"gemini-2.5-pro"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestSetAgentModel_RejectsARequestNamingNoModel(t *testing.T) {
+	// Checked before the access lookup would matter, and worth its own answer:
+	// an empty modelId is a client bug, and reporting it as "no agent" would
+	// send someone looking at their gateway.
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"an empty model id", `{"modelId":""}`},
+		{"a model id of only spaces", `{"modelId":"   "}`},
+		{"no model id at all", `{}`},
+		{"a body that is not JSON", `not json`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := fiber.New()
+			crudCtrl := &mockCrudWorkspaceAccess{
+				checkWorkspaceAccessFunc: func(ctx context.Context, id int64, userID string) (bool, error) {
+					return true, nil
+				},
+			}
+			h := &handler{crud: crudCtrl}
+
+			app.Post("/api/v1/workspaces/:id/agent/model", func(c *fiber.Ctx) error {
+				c.Locals("user_id", monoflake.ID(100).String())
+				return h.setAgentModel()(c)
+			})
+
+			req := httptest.NewRequest(
+				http.MethodPost,
+				"/api/v1/workspaces/"+monoflake.ID(1).String()+"/agent/model",
+				strings.NewReader(tc.body),
+			)
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := app.Test(req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Errorf("expected 400, got %d", resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestSetAgentModel_ReportsThatNothingIsConnected(t *testing.T) {
+	// No MCP server for the workspace at all. 404 rather than a 409, because
+	// the distinction is real: nothing is running to be asked, as against
+	// something running that will not act.
+	app := fiber.New()
+	crudCtrl := &mockCrudWorkspaceAccess{
+		checkWorkspaceAccessFunc: func(ctx context.Context, id int64, userID string) (bool, error) {
+			return true, nil
+		},
+	}
+	// A manager that builds no server for the workspace, which is what "nothing
+	// is connected" looks like from here.
+	h := &handler{crud: crudCtrl, mcpManager: mcpctrl.NewManager(
+		func(workspaceID int64, userID string) *mcpctrl.WorkspaceServer { return nil },
+	)}
+
+	app.Post("/api/v1/workspaces/:id/agent/model", func(c *fiber.Ctx) error {
+		c.Locals("user_id", monoflake.ID(100).String())
+		return h.setAgentModel()(c)
+	})
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/workspaces/"+monoflake.ID(1).String()+"/agent/model",
+		strings.NewReader(`{"modelId":"gemini-2.5-pro"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}

--- a/backend/internal/mapper/api/workspace.go
+++ b/backend/internal/mapper/api/workspace.go
@@ -228,6 +228,7 @@ func fromEntityAgentModelsToView(m *entity.AgentModels) *view.AgentModels {
 		ConfigID:     m.ConfigID,
 		CurrentModel: m.CurrentModel,
 		Models:       models,
+		CanSet:       m.CanSet,
 	}
 }
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -515,6 +515,67 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/SimpleError' }
 
+  /workspaces/{id}/agent/model:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+    post:
+      tags: [Workspaces]
+      summary: Ask the connected agent to switch model
+      description: |
+        A request, not a state change. The agent is asked over its MCP channel
+        and answers with a fresh models notification once it has actually
+        switched, which is the only thing that knows whether it did — so a
+        `202` means asked, never settled.
+
+        Only the model is named. Which session to address and which config
+        option to write it to are resolved from what the agent itself reported,
+        and are deliberately not the caller's to choose.
+
+        Available only where `agentModels.canSet` is true on the workspace. An
+        agent that reports what it is running but cannot be told to change it —
+        every gateway older than this feature, and every client that never
+        reports models at all — refuses with a `409`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [modelId]
+              properties:
+                modelId:
+                  type: string
+                  description: One of the ids the agent advertised in `agentModels.models`.
+      responses:
+        '202':
+          description: The agent was asked to switch
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  requested: { type: string }
+        '400':
+          description: No model named, or a model the agent does not offer
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SimpleError' }
+        '403':
+          description: Not your workspace
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SimpleError' }
+        '404':
+          description: No agent connected for this workspace
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SimpleError' }
+        '409':
+          description: The connected agent does not support choosing a model, or could not be reached
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SimpleError' }
+
   # ── Tasks ───────────────────────────────────────────────────────────────────
   /tasks:
     get:
@@ -1742,6 +1803,13 @@ components:
             The agent session config option these were advertised under, which
             is what a selection would have to be written back to.
         currentModel: { type: string }
+        canSet:
+          type: boolean
+          description: |
+            Whether choosing one of these would do anything. False for an agent
+            that reports what it is running but cannot be told to change it,
+            which includes every gateway older than this feature — so a client
+            shows a picker only when this is true.
         models:
           type: array
           items: { $ref: '#/components/schemas/AgentModel' }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -664,8 +664,8 @@ onEvent((event) => {
   // named on the Overview card is whatever the last page load fetched, and a
   // switch never shows.
   if (event.type === 'agent.models') {
-    const { configId, currentModel, models, workspaceId } = event.payload
-    workspaceStore.updateAgentModels(workspaceId, { configId, currentModel, models })
+    const { configId, currentModel, canSet, models, workspaceId } = event.payload
+    workspaceStore.updateAgentModels(workspaceId, { configId, currentModel, canSet, models })
   }
 
   // Handle workspace metadata updates

--- a/frontend/src/stores/workspaceStore.js
+++ b/frontend/src/stores/workspaceStore.js
@@ -90,7 +90,16 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     if (idx !== -1) {
       const list = Array.isArray(models?.models) ? models.models : [];
       const agentModels = list.length > 0
-        ? { configId: models.configId, currentModel: models.currentModel, models: list }
+        ? {
+            configId: models.configId,
+            currentModel: models.currentModel,
+            // Carried through explicitly, and defaulted to false rather than
+            // left undefined: this is what decides whether a picker is offered
+            // at all, and an event that dropped it would take the picker away
+            // from an agent that can still be told to switch.
+            canSet: models.canSet === true,
+            models: list,
+          }
         : undefined;
       workspaces.value[idx] = { ...workspaces.value[idx], agentModels };
     }

--- a/frontend/test/workspaceStore.test.js
+++ b/frontend/test/workspaceStore.test.js
@@ -182,6 +182,7 @@ describe('workspaceStore', () => {
     const twoModels = {
       configId: 'model',
       currentModel: 'gemini-2.5-pro',
+      canSet: true,
       models: [{ id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro' }, { id: 'gpt-5-codex', name: 'GPT-5 Codex' }],
     }
 
@@ -203,6 +204,28 @@ describe('workspaceStore', () => {
       store.updateAgentModels('0ZzhYQG2qtl', { ...twoModels, currentModel: 'gpt-5-codex' })
 
       expect(modelsOf(store, '0ZzhYQG2qtl').currentModel).toBe('gpt-5-codex')
+    })
+
+    it('keeps a read-only agent read-only', () => {
+      // An agent that reports what it is running but cannot be told to change
+      // it. The field has to survive as false rather than vanish, because its
+      // absence is what a picker would read as "no opinion".
+      const store = useWorkspaceStore()
+
+      store.updateAgentModels('0ZzhYQG2qtl', { ...twoModels, canSet: false })
+
+      expect(modelsOf(store, '0ZzhYQG2qtl').canSet).toBe(false)
+    })
+
+    it('treats a missing canSet as no', () => {
+      // Every gateway older than this feature sends no such field, and reading
+      // silence as consent would offer a picker that does nothing.
+      const store = useWorkspaceStore()
+      const { canSet, ...withoutCanSet } = twoModels
+
+      store.updateAgentModels('0ZzhYQG2qtl', withoutCanSet)
+
+      expect(modelsOf(store, '0ZzhYQG2qtl').canSet).toBe(false)
     })
 
     it('takes the choice away when the agent withdraws its models', () => {


### PR DESCRIPTION
> **Stacked on #507.** Based on `feat/agent-models-sse`, because the change-detection this adds to is introduced there. Merge #507 first and GitHub will retarget this to `main`.

## What changed

The server can now ask a connected agent to switch to a different model, and the interface can tell in advance whether asking would do anything.

## Why changed

Choosing a model needs a way to say so — until now the only thing this server could ask an agent to do was stop. It also needs a way to know when saying so would be pointless: every gateway already deployed reports its models and none of them will act on being told to change one, so offering the choice on the strength of the models being there would mean a picker that silently does nothing everywhere it exists today.

## Test coverage report

New lines introduced: **100%**. Total coverage impact: **unchanged** — the frontend gate holds at 100% on all four metrics (1010 tests, 40 files), and the full backend suite passes.

Backend: every way the request can be refused (nothing reported, a gateway that never said it can, a willing gateway naming no config option, a model never offered, a session that has dropped its stream), that it reaches the session which offered the choice, and that nothing is recorded as switched. `Selectable()` is tested across its four combinations, and the endpoint's auth, empty/malformed-body and no-agent answers are covered.

Frontend: the new flag survives a live update, and is read as "no" when a gateway omits it.

## Other reports

**The capability is declared, not guessed.** A gateway that can switch sends `can_set`; absence means no. A client-name allowlist — the shape `stopCapableClients` uses — cannot work here, because the question is about the gateway's *version* and the handshake name is `acp-gateway` either way. Agents that never report models at all, Claude Code among them, are excluded for free: no models, no picker.

**One notification recipient, not a broadcast.** A stop is broadcast because any session may hold the turn. A model selection is a write against one gateway's session config, so sending it to a second gateway would change a model nobody asked about on an agent the human was not looking at.

**`202`, never `200` with the model.** The agent's own next models notification is the only thing that knows whether the switch happened, so the response says what was asked, not what is in use.

Also included: the OpenAPI spec, since the route-parity test requires it, and the `canSet` field now travels on the live event — the store defaults it to `false` rather than `undefined`, or an update would take the picker away from an agent that can still be told to switch.

## TaskID: 0iRyABXxIgr
