### PR TITLE
feat(ui): choose the model the agent runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,21 @@ keyboard or the mouse. The list comes from the agent and follows it live, so it
 changes as the agent's context does. An agent that advertises none gets no menu
 and nothing changes. See the [Slash Commands Guide](docs/SLASH_COMMANDS.md).
 
+### 🧠 Choosing the agent's model
+
+Where an agent offers a choice of model, you can make it from the interface —
+on a workspace card, and on the form where a task is written, so the model is
+settled before the work starts rather than after. Choosing shows the new model
+straight away but marks it as asked-for until the agent itself confirms; if it
+refuses, or never answers, the interface goes back to what is actually running
+and says so.
+
+The choice appears only where it would do something. An agent that reports no
+models — Claude Code connected directly, among others — shows none, and neither
+does an ACP gateway older than the release that learned to switch on request:
+it says which model it is on without claiming it can change it. Nothing to
+configure either way.
+
 To run it from source:
 
 ```bash

--- a/backend/internal/controller/telemetry/telemetry.go
+++ b/backend/internal/controller/telemetry/telemetry.go
@@ -179,6 +179,8 @@ func (c *controller) recordCRUD(event entity.CRUDEvent) {
 		action = model.ActionIDUICopyMarkdown
 	case entity.ActionUITrajectoryView:
 		action = model.ActionIDUITrajectoryView
+	case entity.ActionAgentModelSelect:
+		action = model.ActionIDAgentModelSelect
 	default:
 		return
 	}

--- a/backend/internal/controller/telemetry/telemetry_test.go
+++ b/backend/internal/controller/telemetry/telemetry_test.go
@@ -333,6 +333,10 @@ func TestUIActionsPersistWithDistinctIDs(t *testing.T) {
 		{entity.ActionUICopyLink, model.ActionIDUICopyLink, "copy link"},
 		{entity.ActionUICopyMarkdown, model.ActionIDUICopyMarkdown, "copy markdown"},
 		{entity.ActionUITrajectoryView, model.ActionIDUITrajectoryView, "trajectory view"},
+		// Backend-emitted rather than browser-reported, unlike everything above
+		// it, but it travels the same bus and needs the same mapping — an
+		// action that reaches here unmapped is dropped in silence.
+		{entity.ActionAgentModelSelect, model.ActionIDAgentModelSelect, "agent model select"},
 	}
 
 	for _, tc := range cases {

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -1017,7 +1017,12 @@ const (
 	ActionMCPPermissionManual        Action = 21
 	ActionMCPPermissionAuto          Action = 22
 	ActionTaskAllowAllCommandsToggle Action = 23
-	ActionEventPublished             Action = 30
+	// A model chosen from the interface. Recorded through the same controller
+	// as the browser reports below, but emitted by the backend right after it
+	// asks the agent to switch — so it stays out of ClientReportableAction,
+	// which exists to say what a browser may claim, and this is not claimed.
+	ActionAgentModelSelect Action = 24
+	ActionEventPublished   Action = 30
 	// Local-AI feature usage, reported by the browser rather than emitted by
 	// the backend: these models run in the user's own tab, so nothing
 	// server-side ever observes them. See ClientReportableAction, which is the
@@ -1105,6 +1110,8 @@ func (a Action) String() string {
 		return "mcp_permission_auto"
 	case ActionTaskAllowAllCommandsToggle:
 		return "task_allow_all_commands_toggle"
+	case ActionAgentModelSelect:
+		return "agent_model_select"
 	case ActionEventPublished:
 		return "event_published"
 	case ActionLocalAITitleGenerate:

--- a/backend/internal/data/model/model.go
+++ b/backend/internal/data/model/model.go
@@ -309,4 +309,8 @@ const (
 	ActionIDUICopyLink
 	ActionIDUICopyMarkdown
 	ActionIDUITrajectoryView
+	// A model chosen from the interface, emitted by the backend when it asks
+	// the agent to switch. On the end like everything else here, for the reason
+	// recorded above.
+	ActionIDAgentModelSelect
 )

--- a/backend/internal/handler/api/api.go
+++ b/backend/internal/handler/api/api.go
@@ -647,6 +647,23 @@ func (h *handler) setAgentModel() fiber.Handler {
 			return c.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": "failed to select the model"})
 		}
 
+		// Counted on the asking, not on the agent's confirmation: what is worth
+		// knowing is how often people reach for this, and an agent that then
+		// refuses is a different question.
+		//
+		// A failure here is logged and no more. The agent has already been
+		// asked, so refusing the request now would report a switch as failed
+		// that in fact happened — and the count is not what the caller came
+		// for.
+		if err := h.crud.RecordTelemetry(ctx, entity.RecordTelemetryRequest{
+			Action:      entity.ActionAgentModelSelect,
+			WorkspaceID: workspaceID,
+			UserID:      userID,
+		}); err != nil {
+			zlog.Warn().Err(err).Int64("workspace_id", workspaceID).
+				Msg("model selection was made but not counted")
+		}
+
 		// Accepted, not OK, and carrying no model: the agent has been asked,
 		// and only its own next models notification says whether it switched.
 		// Answering with the chosen model here would invite a client to render

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -236,6 +236,29 @@ export async function sendPermissionVerdict(workspaceId, taskId, requestId, beha
   return res;
 }
 
+/**
+ * Ask the workspace's connected agent to switch to a different model.
+ *
+ * Answers 202 rather than 200: the agent has been asked, and only its own next
+ * models notification — which arrives over the event stream — says whether it
+ * switched. Callers must not treat this resolving as the model having changed.
+ */
+export async function setAgentModel(workspaceId, modelId) {
+  const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/agent/model`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ modelId })
+  });
+  if (!res.ok) {
+    // The server says why it refused — most usefully that the connected agent
+    // cannot be told to switch, or that it never offered this model — and that
+    // reason is worth more than "failed".
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.error || 'Failed to change the model');
+  }
+  return res.json();
+}
+
 export async function stopTask(workspaceId, taskId) {
   const res = await apiFetch(`${API_BASE_URL}/workspaces/${workspaceId}/tasks/${taskId}/stop`, {
     method: 'POST'

--- a/frontend/src/components/AgentModelPicker.vue
+++ b/frontend/src/components/AgentModelPicker.vue
@@ -1,0 +1,98 @@
+<template>
+  <!-- Nothing at all unless a choice exists and would do something. An agent
+       that reports no models, or one too old to act on being told to switch,
+       leaves the surrounding layout exactly as it was. -->
+  <div v-if="picker.available.value" class="relative" v-click-outside="() => (open = false)">
+    <button type="button"
+            @click.stop="open = !open"
+            :disabled="picker.sending.value"
+            :class="compact
+              ? 'text-[9px] font-medium text-gray-500 dark:text-zinc-400 hover:text-gray-900 dark:hover:text-zinc-100 max-w-[140px]'
+              : 'h-7 px-2 gap-1 rounded-md text-[10px] font-semibold bg-gray-100 dark:bg-zinc-800 text-gray-500 dark:text-zinc-400 hover:text-gray-900 dark:hover:text-zinc-50 hover:bg-gray-200 dark:hover:bg-zinc-700 border border-gray-200 dark:border-zinc-700'"
+            class="flex items-center transition-all disabled:opacity-40 truncate">
+      <span class="truncate">{{ picker.selectedName.value || 'Model' }}</span>
+      <!-- Pending is said, not implied. The agent has been asked and has not
+           answered, and a picker that simply showed the new value would be
+           claiming something nothing has confirmed. -->
+      <span v-if="picker.isPending.value" class="ml-1 shrink-0 opacity-60">…</span>
+    </button>
+
+    <div v-if="open"
+         class="fixed sm:absolute left-4 right-4 sm:left-auto sm:right-0 bottom-4 sm:bottom-full sm:mb-2 w-auto sm:w-[240px] max-h-[320px] overflow-y-auto bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-xl shadow-2xl z-50 p-2"
+         @click.stop>
+      <h3 class="text-[10px] font-bold uppercase tracking-wider text-gray-500 dark:text-zinc-400 px-2 py-1.5">Model</h3>
+
+      <div v-for="group in picker.groups.value" :key="group.name || '_'">
+        <p v-if="group.name" class="text-[9px] font-bold uppercase tracking-wider text-gray-400 dark:text-zinc-600 px-2 pt-2 pb-1">
+          {{ group.name }}
+        </p>
+        <button v-for="model in group.models" :key="model.id"
+                type="button"
+                @click="pick(model.id)"
+                :class="model.id === picker.selectedId.value
+                  ? 'bg-gray-100 dark:bg-zinc-800 text-gray-900 dark:text-white'
+                  : 'text-gray-600 dark:text-zinc-400 hover:bg-gray-50 dark:hover:bg-zinc-800/60'"
+                class="w-full text-left px-2 py-1.5 rounded-md text-[11px] font-semibold transition-colors flex items-center gap-2">
+          <span class="truncate grow">{{ model.name || model.id }}</span>
+          <span v-if="model.id === picker.selectedId.value" class="shrink-0 text-[9px]">●</span>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Choosing the model the workspace's agent runs.
+ *
+ * One component in two places — the workspace card and the task form — because
+ * it is one choice about one agent, and two copies of this markup would drift
+ * on the part that matters: what is shown while the agent has been asked but
+ * has not answered.
+ *
+ * All the logic lives in useAgentModelPicker, which is tested. What is left
+ * here is the markup and the two things a component has to own: the popover,
+ * and the clock that gives up on a switch nothing confirmed.
+ */
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
+
+import { useAgentModelPicker } from '../composables/useAgentModelPicker';
+import { useToasts } from '../composables/useToasts';
+import { setAgentModel } from '../api';
+
+const props = defineProps({
+  /** The workspace whose agent is being asked. Read live, never copied. */
+  workspace: { type: Object, default: null },
+  /** Narrow styling, for the one-line agent summary on a workspace card. */
+  compact: { type: Boolean, default: false },
+});
+
+const open = ref(false);
+const { addToast } = useToasts();
+
+const picker = useAgentModelPicker({
+  workspace: () => props.workspace,
+  selectModel: (modelId) => setAgentModel(props.workspace?.id, modelId),
+});
+
+// A refusal, or an agent that never came back, is mission-critical feedback:
+// the human asked for something and it did not happen. The picker has already
+// reverted to what is true by the time this shows.
+watch(picker.error, (message) => {
+  if (message) addToast(message, 'error');
+});
+
+async function pick(modelId) {
+  open.value = false;
+  await picker.choose(modelId);
+}
+
+// The pending state is bounded by a clock rather than by the request, because
+// what is being waited for is the agent's own report and that arrives — or does
+// not — long after the request resolved.
+let tick;
+onMounted(() => {
+  tick = setInterval(() => picker.expirePending(), 1000);
+});
+onBeforeUnmount(() => clearInterval(tick));
+</script>

--- a/frontend/src/composables/useAgentModelPicker.js
+++ b/frontend/src/composables/useAgentModelPicker.js
@@ -1,0 +1,199 @@
+import { computed, ref, watch } from 'vue';
+
+import { currentModelName } from './useAgentSummary';
+
+/**
+ * Choosing which model the workspace's agent runs.
+ *
+ * The interface never learns from its own request whether a switch happened.
+ * It asks, and the agent answers later with a models notification that arrives
+ * over the event stream — so what is rendered has to be "asked for" until that
+ * report agrees, and must go back to the truth if it never does.
+ *
+ * The pure parts are exported separately because that is what the rest of the
+ * app asks about — whether to draw a picker at all — and because the project
+ * has no component-test harness, so anything worth pinning has to live outside
+ * the SFC.
+ */
+
+/**
+ * How long to wait for the agent to confirm before giving up on a switch.
+ *
+ * Generous on purpose: the agent may be mid-turn, and an answer that arrives
+ * late is still an answer. What this bounds is the pending state, not the
+ * switch — reverting only puts back what the agent last said is true.
+ */
+export const CONFIRMATION_TIMEOUT_MS = 30_000;
+
+/**
+ * Whether a workspace can be offered a model picker at all.
+ *
+ * Three separate things, and all of them have to hold. The agent has to be
+ * attached, because a choice sent to nothing goes nowhere. It has to have
+ * reported models, which is what excludes every client that never mentions
+ * them — Claude Code among them, with no list to maintain. And it has to have
+ * said it will act on being told to switch, which older gateways do not: they
+ * report their models perfectly well and ignore the request, so drawing a
+ * picker on the strength of the list alone would offer a control that silently
+ * does nothing.
+ */
+export function canChooseModel(workspace) {
+  if (!workspace?.agentConnected) return false;
+  const models = workspace?.agentModels;
+  if (models?.canSet !== true) return false;
+  return Array.isArray(models.models) && models.models.length > 0;
+}
+
+/**
+ * The offered models, in the groups the agent put them in.
+ *
+ * Grouping is the agent's own — usually the provider — and models without one
+ * are collected under an unnamed group so a mixed list still renders in one
+ * pass. Order is preserved rather than sorted: the agent listed them the way it
+ * did, and re-ordering would put a different model under the cursor than the
+ * one the agent calls first.
+ */
+export function modelGroups(agentModels) {
+  const models = Array.isArray(agentModels?.models) ? agentModels.models : [];
+  const groups = [];
+  const byName = new Map();
+
+  for (const model of models) {
+    if (!model?.id) continue;
+    const name = typeof model.group === 'string' ? model.group.trim() : '';
+    let group = byName.get(name);
+    if (!group) {
+      group = { name, models: [] };
+      byName.set(name, group);
+      groups.push(group);
+    }
+    group.models.push(model);
+  }
+  return groups;
+}
+
+/**
+ * The model to show as chosen: what was asked for, until the agent answers.
+ *
+ * The requested one wins while it is outstanding, because that is what the
+ * human just did and showing the old value would read as the click having
+ * missed. Once the report agrees — or the request is abandoned — this is the
+ * agent's own answer again.
+ */
+export function displayedModelId(agentModels, pendingModelId) {
+  return pendingModelId || agentModels?.currentModel || '';
+}
+
+/**
+ * Whether the agent has confirmed the model that was asked for.
+ *
+ * Confirmation is only ever the agent saying the model is current. A report
+ * that arrives naming something else is not silence — it is the agent
+ * declining, or a second gateway answering — and either way the request is
+ * over and what it says is the truth.
+ */
+export function isConfirmed(pendingModelId, agentModels) {
+  if (!pendingModelId) return true;
+  return agentModels?.currentModel === pendingModelId;
+}
+
+/**
+ * The picker's state and the one action it takes.
+ *
+ * `workspace` is a getter rather than a value so this follows the store: the
+ * confirming report arrives on the event stream and rewrites the workspace in
+ * place, and a composable holding a snapshot would never see it.
+ */
+export function useAgentModelPicker({ workspace, selectModel, now = () => Date.now(), timeoutMs = CONFIRMATION_TIMEOUT_MS }) {
+  const pendingModelId = ref('');
+  const requestedAt = ref(0);
+  const error = ref('');
+  const sending = ref(false);
+
+  const agentModels = computed(() => workspace()?.agentModels);
+  const available = computed(() => canChooseModel(workspace()));
+  const groups = computed(() => modelGroups(agentModels.value));
+  const selectedId = computed(() => displayedModelId(agentModels.value, pendingModelId.value));
+  const isPending = computed(() => pendingModelId.value !== '');
+
+  /** The name to show for whatever is selected, falling back to its id. */
+  const selectedName = computed(() =>
+    currentModelName({ currentModel: selectedId.value, models: agentModels.value?.models }),
+  );
+
+  // The agent's report is the only thing that ends a pending switch. Watched
+  // rather than checked on click, because the report may arrive at any point
+  // and nothing else is looking for it.
+  //
+  // The whole report is watched, not the model named in it. An agent that
+  // declines re-sends its models with the *same* current model, so watching
+  // that value would see nothing change and leave the picker pending on a
+  // switch that has already been answered — the refusal is exactly the case
+  // this exists to catch. The store rebuilds the object on every event, so its
+  // identity is what moves.
+  watch(
+    agentModels,
+    () => {
+      if (isConfirmed(pendingModelId.value, agentModels.value)) {
+        pendingModelId.value = '';
+        return;
+      }
+      // A report naming a different model is the agent having its own answer,
+      // which settles the question as surely as agreement would.
+      if (pendingModelId.value && agentModels.value?.currentModel) {
+        pendingModelId.value = '';
+        error.value = 'The agent stayed on a different model';
+      }
+    },
+  );
+
+  /**
+   * Give up on a switch nothing ever confirmed.
+   *
+   * Called by whatever is driving the clock rather than by a timer of its own,
+   * so a test can move time without waiting for it and a component can stop
+   * asking when it goes away.
+   */
+  function expirePending() {
+    if (!pendingModelId.value) return;
+    if (now() - requestedAt.value < timeoutMs) return;
+    pendingModelId.value = '';
+    error.value = 'The agent did not confirm the change';
+  }
+
+  /**
+   * Ask the agent to switch.
+   *
+   * The pending model is set before the request and kept whatever the request
+   * answers, because a 202 is only an acknowledgement that the agent was asked.
+   * A refusal is different: nothing was asked, so there is nothing to wait for.
+   */
+  async function choose(modelId) {
+    error.value = '';
+    if (!modelId || modelId === agentModels.value?.currentModel) return;
+
+    pendingModelId.value = modelId;
+    requestedAt.value = now();
+    sending.value = true;
+    try {
+      await selectModel(modelId);
+    } catch (err) {
+      pendingModelId.value = '';
+      error.value = err?.message || 'Could not change the model';
+    } finally {
+      sending.value = false;
+    }
+  }
+
+  return {
+    available,
+    groups,
+    selectedId,
+    selectedName,
+    isPending,
+    sending,
+    error,
+    choose,
+    expirePending,
+  };
+}

--- a/frontend/src/views/TaskFormView.vue
+++ b/frontend/src/views/TaskFormView.vue
@@ -257,6 +257,11 @@
                    </div>
                 </div>
 
+                <!-- Which model the agent will use, chosen before the task is
+                     written rather than after it has started. Absent unless the
+                     connected agent offers a choice and will act on it. -->
+                <AgentModelPicker :workspace="liveWorkspace" />
+
              </div>
 
              <!-- The shortcut, said out loud. Hidden on narrow screens, where
@@ -292,6 +297,8 @@ import { useCron } from '../composables/useCron';
 import { useSpeechToText } from '../composables/useSpeechToText';
 import { useAutoTitle } from '../composables/useAutoTitle';
 import { useTooltipStore } from '../stores/tooltipStore';
+import { useWorkspaceStore } from '../stores/workspaceStore';
+import AgentModelPicker from '../components/AgentModelPicker.vue';
 
 const { getNextRunLabel, daysOptions } = useCron();
 const route = useRoute();
@@ -305,6 +312,17 @@ const isEditMode = computed(() => !!taskId);
 
 const workspace = ref(null);
 const sending = ref(false);
+
+// The model picker reads the *store's* copy of this workspace, not the one
+// fetched above. The agent's confirming report arrives on the event stream and
+// lands in the store, so a picker bound to this view's own snapshot would show
+// a switch as pending forever — the answer would never reach it.
+const workspaceStore = useWorkspaceStore();
+// Falls back to this view's own copy only until the store has one. That copy
+// cannot receive the confirming report, so it is a starting value rather than a
+// source: enough to draw the picker on a cold load, replaced the moment the
+// store knows about this workspace.
+const liveWorkspace = computed(() => workspaceStore.getWorkspace(workspaceId) || workspace.value);
 const fileInput = ref(null);
 
 const newTask = ref({ title: '', body: '', assignee: 'agent', cronSchedule: '', allowAllCommands: false });

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -165,7 +165,14 @@
                            </span>
                            <template v-if="agentDetails(p).model">
                              <span v-if="agentDetails(p).client" class="text-[9px] font-black text-gray-300 dark:text-zinc-700 shrink-0">·</span>
-                             <span class="text-[9px] font-medium text-gray-500 dark:text-zinc-400 truncate">{{ agentDetails(p).model }}</span>
+                             <!-- The model becomes a control where the agent
+                                  will act on being told to switch, and stays
+                                  plain text everywhere else. The card navigates
+                                  on click, so the picker stops its own clicks
+                                  from reaching it — choosing a model must not
+                                  also leave the page. -->
+                             <AgentModelPicker v-if="canChooseModel(p)" :workspace="p" compact @click.stop />
+                             <span v-else class="text-[9px] font-medium text-gray-500 dark:text-zinc-400 truncate">{{ agentDetails(p).model }}</span>
                            </template>
                          </template>
                          <span v-else class="text-[8px] font-black uppercase tracking-widest transition-colors"
@@ -287,6 +294,8 @@ import { useFormat } from '../composables/useFormat';
 import { useTooltipStore } from '../stores/tooltipStore';
 import { usePlatformStore } from '../stores/platformStore';
 import { agentDetails, agentSummary } from '../composables/useAgentSummary';
+import { canChooseModel } from '../composables/useAgentModelPicker';
+import AgentModelPicker from '../components/AgentModelPicker.vue';
 import {
   chooseDirectory,
   directoryPickerState,

--- a/frontend/src/webmcp/tools.js
+++ b/frontend/src/webmcp/tools.js
@@ -389,6 +389,19 @@ export function createToolCatalogue({ api, navigate, currentPage }) {
       run: ({ workspaceId, taskId }) => api.stopTask(workspaceId, taskId),
     }),
     tool({
+      name: 'setAgentModel',
+      description:
+        'Ask the workspace\'s connected agent to switch to a different model. Only offered where ' +
+        'the agent reported models and said it can change them; asking is not the same as it ' +
+        'having changed, which the workspace reports separately.',
+      properties: {
+        workspaceId: WORKSPACE_ID,
+        modelId: str('The id of a model the agent listed as available.'),
+      },
+      required: ['workspaceId', 'modelId'],
+      run: ({ workspaceId, modelId }) => api.setAgentModel(workspaceId, modelId),
+    }),
+    tool({
       name: 'deleteTask',
       description: 'Permanently delete a task and its conversation. This cannot be undone.',
       properties: { workspaceId: WORKSPACE_ID, taskId: TASK_ID },

--- a/frontend/test/agentModelPicker.test.js
+++ b/frontend/test/agentModelPicker.test.js
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi } from 'vitest';
+import { nextTick, ref } from 'vue';
+
+import {
+  CONFIRMATION_TIMEOUT_MS,
+  canChooseModel,
+  displayedModelId,
+  isConfirmed,
+  modelGroups,
+  useAgentModelPicker,
+} from '../src/composables/useAgentModelPicker';
+
+/**
+ * The picker never learns from its own request whether a switch happened: it
+ * asks, and the agent answers later over the event stream. So what is pinned
+ * here is mostly what happens in between, and what happens when the answer
+ * never comes — the states a component cannot be trusted to get right by
+ * inspection.
+ */
+
+const twoModels = {
+  configId: 'model',
+  currentModel: 'a',
+  canSet: true,
+  models: [
+    { id: 'a', name: 'Model A', group: 'Anthropic' },
+    { id: 'b', name: 'Model B', group: 'Google' },
+  ],
+};
+
+const connected = (agentModels = twoModels) => ({ agentConnected: true, agentModels });
+
+describe('canChooseModel', () => {
+  it('offers the picker to an agent that reported models and can switch', () => {
+    expect(canChooseModel(connected())).toBe(true);
+  });
+
+  it('refuses an agent that reports models but cannot be told to switch', () => {
+    // Every gateway older than this feature. The list is perfectly real; the
+    // control would do nothing.
+    expect(canChooseModel(connected({ ...twoModels, canSet: false }))).toBe(false);
+    const { canSet, ...withoutFlag } = twoModels;
+    expect(canChooseModel(connected(withoutFlag))).toBe(false);
+  });
+
+  it('refuses a client that never mentioned models at all', () => {
+    // Claude Code attached directly is in this state, and needs no list of
+    // names to keep it out: it simply never reports any.
+    expect(canChooseModel({ agentConnected: true })).toBe(false);
+    expect(canChooseModel(connected({ ...twoModels, models: [] }))).toBe(false);
+    expect(canChooseModel(connected({ ...twoModels, models: undefined }))).toBe(false);
+  });
+
+  it('refuses when no agent is attached', () => {
+    // A choice sent to nothing goes nowhere.
+    expect(canChooseModel({ agentConnected: false, agentModels: twoModels })).toBe(false);
+    expect(canChooseModel(undefined)).toBe(false);
+  });
+});
+
+describe('modelGroups', () => {
+  it('keeps the agent’s own grouping and order', () => {
+    expect(modelGroups(twoModels)).toEqual([
+      { name: 'Anthropic', models: [twoModels.models[0]] },
+      { name: 'Google', models: [twoModels.models[1]] },
+    ]);
+  });
+
+  it('collects ungrouped models under one unnamed group', () => {
+    const groups = modelGroups({ models: [{ id: 'a' }, { id: 'b', group: '  ' }] });
+    expect(groups).toHaveLength(1);
+    expect(groups[0].name).toBe('');
+    expect(groups[0].models.map((m) => m.id)).toEqual(['a', 'b']);
+  });
+
+  it('gathers a group that appears more than once', () => {
+    const groups = modelGroups({
+      models: [{ id: 'a', group: 'X' }, { id: 'b', group: 'Y' }, { id: 'c', group: 'X' }],
+    });
+    expect(groups.map((g) => g.name)).toEqual(['X', 'Y']);
+    expect(groups[0].models.map((m) => m.id)).toEqual(['a', 'c']);
+  });
+
+  it('skips entries with no id, and copes with nothing at all', () => {
+    expect(modelGroups({ models: [null, { name: 'nameless' }, { id: 'a' }] })).toEqual([
+      { name: '', models: [{ id: 'a' }] },
+    ]);
+    expect(modelGroups(undefined)).toEqual([]);
+    expect(modelGroups({ models: 'not a list' })).toEqual([]);
+  });
+});
+
+describe('displayedModelId', () => {
+  it('shows what was asked for while it is outstanding', () => {
+    // Showing the old value would read as the click having missed.
+    expect(displayedModelId(twoModels, 'b')).toBe('b');
+  });
+
+  it('shows the agent’s own answer when nothing is outstanding', () => {
+    expect(displayedModelId(twoModels, '')).toBe('a');
+    expect(displayedModelId(undefined, '')).toBe('');
+  });
+});
+
+describe('isConfirmed', () => {
+  it('is confirmed only when the agent names the model that was asked for', () => {
+    expect(isConfirmed('b', { currentModel: 'b' })).toBe(true);
+    expect(isConfirmed('b', { currentModel: 'a' })).toBe(false);
+    expect(isConfirmed('b', undefined)).toBe(false);
+  });
+
+  it('has nothing to confirm when nothing was asked', () => {
+    expect(isConfirmed('', { currentModel: 'a' })).toBe(true);
+  });
+});
+
+describe('useAgentModelPicker', () => {
+  /** A workspace the test can rewrite, the way the event stream rewrites it. */
+  function harness({ selectModel = vi.fn().mockResolvedValue({}), clock = { t: 0 } } = {}) {
+    const workspace = ref(connected());
+    const picker = useAgentModelPicker({
+      workspace: () => workspace.value,
+      selectModel,
+      now: () => clock.t,
+    });
+    /** What arrives when the agent reports, replacing the object in place. */
+    const agentReports = async (currentModel) => {
+      workspace.value = connected({ ...twoModels, currentModel });
+      await nextTick();
+    };
+    return { picker, workspace, selectModel, clock, agentReports };
+  }
+
+  it('shows the asked-for model, then the agent’s once it agrees', async () => {
+    const { picker, agentReports } = harness();
+
+    await picker.choose('b');
+    expect(picker.selectedId.value).toBe('b');
+    expect(picker.isPending.value).toBe(true);
+    expect(picker.selectedName.value).toBe('Model B');
+
+    await agentReports('b');
+
+    expect(picker.isPending.value).toBe(false);
+    expect(picker.selectedId.value).toBe('b');
+  });
+
+  it('sends the chosen model exactly once', async () => {
+    const { picker, selectModel } = harness();
+
+    await picker.choose('b');
+
+    expect(selectModel).toHaveBeenCalledTimes(1);
+    expect(selectModel).toHaveBeenCalledWith('b');
+  });
+
+  it('does nothing when the model is already current, or is nothing', async () => {
+    // A round trip whose answer is already on screen.
+    const { picker, selectModel } = harness();
+
+    await picker.choose('a');
+    await picker.choose('');
+
+    expect(selectModel).not.toHaveBeenCalled();
+    expect(picker.isPending.value).toBe(false);
+  });
+
+  it('gives up and says so when the server refuses', async () => {
+    // A refusal means nothing was asked, so there is nothing to wait for — the
+    // picker must not sit pending on a request that never happened.
+    const selectModel = vi.fn().mockRejectedValue(new Error('the connected agent does not offer that model'));
+    const { picker } = harness({ selectModel });
+
+    await picker.choose('b');
+
+    expect(picker.isPending.value).toBe(false);
+    expect(picker.selectedId.value).toBe('a');
+    expect(picker.error.value).toBe('the connected agent does not offer that model');
+  });
+
+  it('still says something when a refusal carries no message', async () => {
+    const { picker } = harness({ selectModel: vi.fn().mockRejectedValue({}) });
+
+    await picker.choose('b');
+
+    expect(picker.error.value).toBe('Could not change the model');
+  });
+
+  it('reverts when the agent never confirms', async () => {
+    // The switch was asked for and nothing came back. Reverting puts back what
+    // the agent last said is true, rather than leaving a model on screen that
+    // nothing ever adopted.
+    const clock = { t: 0 };
+    const { picker } = harness({ clock });
+
+    await picker.choose('b');
+    clock.t = CONFIRMATION_TIMEOUT_MS;
+    picker.expirePending();
+
+    expect(picker.isPending.value).toBe(false);
+    expect(picker.selectedId.value).toBe('a');
+    expect(picker.error.value).toBe('The agent did not confirm the change');
+  });
+
+  it('keeps waiting until the timeout is actually up', async () => {
+    const clock = { t: 0 };
+    const { picker } = harness({ clock });
+
+    await picker.choose('b');
+    clock.t = CONFIRMATION_TIMEOUT_MS - 1;
+    picker.expirePending();
+
+    expect(picker.isPending.value).toBe(true);
+    expect(picker.error.value).toBe('');
+  });
+
+  it('has nothing to expire when nothing is outstanding', () => {
+    const { picker } = harness();
+
+    picker.expirePending();
+
+    expect(picker.error.value).toBe('');
+  });
+
+  it('takes a report naming a different model as the agent’s answer', async () => {
+    // The agent declined, or a second gateway answered. Either way the request
+    // is over and what arrived is the truth.
+    const { picker, workspace } = harness();
+
+    await picker.choose('b');
+    workspace.value = connected({ ...twoModels, currentModel: 'a', models: [...twoModels.models] });
+    await nextTick();
+
+    expect(picker.isPending.value).toBe(false);
+    expect(picker.selectedId.value).toBe('a');
+    expect(picker.error.value).toBe('The agent stayed on a different model');
+  });
+
+  it('tracks whether a request is in flight', async () => {
+    let release;
+    const selectModel = vi.fn(() => new Promise((resolve) => { release = resolve; }));
+    const { picker } = harness({ selectModel });
+
+    const choosing = picker.choose('b');
+    expect(picker.sending.value).toBe(true);
+
+    release({});
+    await choosing;
+    expect(picker.sending.value).toBe(false);
+  });
+
+  it('uses a real clock when none is supplied', async () => {
+    // The component passes no clock, so the default is what actually runs in
+    // the app — and a switch asked for just now is not yet expired.
+    const workspace = ref(connected());
+    const picker = useAgentModelPicker({
+      workspace: () => workspace.value,
+      selectModel: vi.fn().mockResolvedValue({}),
+    });
+
+    await picker.choose('b');
+    picker.expirePending();
+
+    expect(picker.isPending.value).toBe(true);
+  });
+
+  it('exposes the workspace’s own answer to whether a picker belongs', async () => {
+    const { picker, workspace } = harness();
+    expect(picker.available.value).toBe(true);
+    expect(picker.groups.value.map((g) => g.name)).toEqual(['Anthropic', 'Google']);
+
+    workspace.value = { agentConnected: false };
+    await nextTick();
+
+    expect(picker.available.value).toBe(false);
+    expect(picker.groups.value).toEqual([]);
+  });
+});

--- a/frontend/test/webmcpTools.test.js
+++ b/frontend/test/webmcpTools.test.js
@@ -14,6 +14,7 @@ const EVERY_FIELD = {
   eventId: 'e1',
   triggerId: 'tr1',
   workflowId: 'wf1',
+  modelId: 'gemini-2.5-pro',
   stepId: 'st1',
   requestId: 'req1',
   path: '/events',

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -42,6 +42,7 @@ export default defineConfig({
         'src/composables/useTaskGroups.js',
         'src/composables/useTaskStatusStyle.js',
         'src/composables/useAgentTelemetry.js',
+        'src/composables/useAgentModelPicker.js',
         'src/composables/useTaskEvents.js',
         'src/composables/useTrajectory.js',
         'src/composables/useWorkflowLabels.js',


### PR DESCRIPTION
## What changed

You can now choose which model the connected agent runs — from the workspace card, and from the form where a task is written, so the model is settled before the work starts rather than after it has begun.

## Why changed

The workspace could already say which model an agent was on, and could already be told to change it, but nothing offered the choice. Picking the model at task-creation time is the moment it usually matters.

## Test coverage report

New lines introduced: **100%**. Total coverage impact: **unchanged at 100%** — the frontend gate holds on all four metrics (1035 tests across 41 files, up from 1010), and the full backend suite passes.

The new composable carries the whole selection flow and is tested directly: the pending state and its confirmation, an agent that declines, a server refusal, a timeout, grouping, and every reason a picker should or should not appear.

## Other reports

**Asking is not switching.** The request only says the agent was asked; the agent answers later on the event stream. So the chosen model shows at once but reads as asked-for until that report agrees, reverts if the agent declines, and gives up after a bounded wait — saying so rather than leaving a model on screen that nothing adopted.

**Two things worth flagging, both caught while building:**

- Watching for the confirming report means watching *the report*, not the model named in it. An agent that declines re-sends its models with the same current model, so watching the value sees nothing change and the picker hangs pending on a question already answered. A test covers the refusal for this reason.
- In the task form the picker reads the *store's* copy of the workspace, not the view's own. That view fetches a workspace once and the confirming report lands in the store, so a picker bound to the snapshot would wait forever for an answer that had already arrived.

**Nothing appears where it would do nothing.** An agent that reports no models gets no picker — that is every client which never mentions them, with no list of names to maintain — and a gateway that reports models without saying it can change them keeps the plain text it has today.

Also included, because CI or convention requires it: the matching WebMCP tool (the parity test fails without one), the new composable added to the coverage include list, and the telemetry action in its three places. The count goes through `RecordTelemetry`, the one path this project records usage on, but stays out of `ClientReportableAction` — that allowlist governs what a *browser* may claim, and this is emitted by the backend beside the work. A failure to count is logged and nothing more: the agent has already been asked, so answering with an error would report a switch as failed that in fact happened.

**Not yet visible in practice.** No published gateway advertises `can_set`, so the picker stays hidden until acp-gateway#76 is merged and released.

## TaskID: 0iRyF8y6Moz
