### PR TITLE
fix: six defects in choosing a model, none of which the tests caught

### DIFF
--- a/backend/internal/controller/mcp/agent_models.go
+++ b/backend/internal/controller/mcp/agent_models.go
@@ -254,9 +254,14 @@ func (ps *WorkspaceServer) publishAgentModels(reported AgentModelsSnapshot) {
 		Payload: map[string]any{
 			"configId":     published.ConfigID,
 			"currentModel": published.CurrentModel,
-			"canSet":       published.CanSet,
-			"models":       models,
-			"workspaceId":  monoflake.ID(ps.workspaceID).String(),
+			// Selectable(), not the raw field, so this agrees with the REST
+			// payload. A gateway willing to switch but naming no config option
+			// to switch through would otherwise light up a picker here that the
+			// workspace payload says does not exist — appearing on an event,
+			// failing on use, and vanishing on the next reload.
+			"canSet":      published.Selectable(),
+			"models":      models,
+			"workspaceId": monoflake.ID(ps.workspaceID).String(),
 		},
 	})
 }
@@ -315,34 +320,33 @@ func pickAgentModels(snapshots map[string]AgentModelsSnapshot, live []string) *A
 // alone cannot say where to send it: its SessionID is the gateway's own ACP
 // session with the agent, a different namespace from the transport session this
 // server would address — the trap HandleAgentModels documents at length.
+// A session that can actually be switched wins over one that merely has models
+// to show. Two gateways on one workspace is a case this file contemplates
+// throughout, and without the preference the answer is decided by session
+// order: an older gateway that reports its models and ignores being told to
+// change one would mask a newer one attached beside it, so the workspace would
+// report canSet false and refuse the switch while something perfectly capable
+// was connected.
+//
+// The fallback keeps a read-only gateway's models on display when that is all
+// there is, which is what every deployment looks like today.
 func pickAgentModelsSession(snapshots map[string]AgentModelsSnapshot, live []string) (string, *AgentModelsSnapshot) {
+	var fallbackID string
+	var fallback *AgentModelsSnapshot
+
 	for _, id := range live {
 		snapshot, ok := snapshots[id]
 		if !ok || len(snapshot.Models) == 0 {
 			continue
 		}
-		return id, &snapshot
+		if snapshot.Selectable() {
+			return id, &snapshot
+		}
+		if fallback == nil {
+			fallbackID, fallback = id, &snapshot
+		}
 	}
-	return "", nil
-}
-
-// SupportsModelSelect reports whether a model can actually be chosen right now,
-// so the interface only offers a picker that would do something.
-//
-// Three things have to hold, and the first two are what a reader would forget.
-// The session must still hold a stream — a session outlives the stream that
-// carried it, which is the trap #504 fixed for the Stop button, and a snapshot
-// keyed to a departed gateway still looks live. The gateway must have said it
-// can set a model: every gateway in the field reports models and none of the
-// older ones will act on being told to change one, so this cannot be assumed
-// from the models being there. And there must be a config option to write the
-// choice back to, which is what ConfigID names.
-func (ps *WorkspaceServer) SupportsModelSelect() bool {
-	ps.agentModelsMu.RLock()
-	defer ps.agentModelsMu.RUnlock()
-
-	_, snapshot := pickAgentModelsSession(ps.agentModels, ps.streamingSessionIDs())
-	return snapshot != nil && snapshot.Selectable()
+	return fallbackID, fallback
 }
 
 // SendSetModelNotification asks the connected agent to switch to a model.

--- a/backend/internal/controller/mcp/agent_models_test.go
+++ b/backend/internal/controller/mcp/agent_models_test.go
@@ -709,9 +709,6 @@ func TestSendSetModelNotification(t *testing.T) {
 		if err := ps.SendSetModelNotification(context.Background(), "a"); !errors.Is(err, ErrModelSelectUnsupported) {
 			t.Errorf("err = %v, want ErrModelSelectUnsupported", err)
 		}
-		if ps.SupportsModelSelect() {
-			t.Error("SupportsModelSelect() = true with nothing reported")
-		}
 	})
 
 	t.Run("refuses a gateway that never said it can set one", func(t *testing.T) {
@@ -726,9 +723,6 @@ func TestSendSetModelNotification(t *testing.T) {
 
 		if err := ps.SendSetModelNotification(context.Background(), "a"); !errors.Is(err, ErrModelSelectUnsupported) {
 			t.Errorf("err = %v, want ErrModelSelectUnsupported", err)
-		}
-		if ps.SupportsModelSelect() {
-			t.Error("SupportsModelSelect() = true for a gateway that never said it can")
 		}
 	})
 
@@ -761,9 +755,6 @@ func TestSendSetModelNotification(t *testing.T) {
 		ps, sessionID, _ := connectedModelsServer(t)
 		ps.HandleAgentModels(context.Background(), sessionID, selectable)
 
-		if !ps.SupportsModelSelect() {
-			t.Fatal("SupportsModelSelect() = false for a gateway that said it can")
-		}
 		if err := ps.SendSetModelNotification(context.Background(), "b"); err != nil {
 			t.Fatalf("SendSetModelNotification() = %v, want nil", err)
 		}
@@ -794,9 +785,6 @@ func TestSendSetModelNotification(t *testing.T) {
 		ps.HandleAgentModels(context.Background(), sessionID, selectable)
 		ps.removeStreamingSession(sessionID)
 
-		if ps.SupportsModelSelect() {
-			t.Error("SupportsModelSelect() = true for a session that has gone off the air")
-		}
 		if err := ps.SendSetModelNotification(context.Background(), "b"); !errors.Is(err, ErrModelSelectUnsupported) {
 			t.Errorf("err = %v, want ErrModelSelectUnsupported", err)
 		}
@@ -856,5 +844,96 @@ func TestHandleAgentModelsPublishesCanSetChange(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("a gateway that began offering selection was not announced")
+	}
+}
+
+// A gateway willing to switch but naming no config option to switch through.
+// Selectable() has always refused it; the live event used to say otherwise, so
+// a picker appeared, failed with a 409 on use, and vanished on the next reload.
+func TestPublishedCanSetFollowsTheSameRuleAsTheWorkspacePayload(t *testing.T) {
+	ps, sessionID, ch := connectedModelsServer(t)
+
+	ps.HandleAgentModels(context.Background(), sessionID, AgentModelsParams{
+		CanSet: true,
+		Models: []AgentModel{{ID: "a"}},
+	})
+
+	select {
+	case raw := <-ch:
+		var evt struct {
+			Payload map[string]any `json:"payload"`
+		}
+		body := strings.TrimSpace(strings.TrimPrefix(string(raw), "data: "))
+		if err := json.Unmarshal([]byte(body), &evt); err != nil {
+			t.Fatalf("unmarshal event: %v", err)
+		}
+		if evt.Payload["canSet"] != false {
+			t.Errorf("canSet = %v, want false — there is no config option to write to", evt.Payload["canSet"])
+		}
+	case <-time.After(time.Second):
+		t.Fatal("the report was not announced")
+	}
+
+	// The two answers have to agree, which is the whole point of the rule.
+	if got := ps.AgentModels(); got == nil || got.Selectable() {
+		t.Errorf("Selectable() = %v, want false", got != nil && got.Selectable())
+	}
+}
+
+// Two gateways on one workspace, the capable one second in session order.
+// Taking the first with a model list would report the older one's inability and
+// refuse a switch that the newer one would have carried out.
+func TestPickAgentModelsPrefersASessionThatCanActuallySwitch(t *testing.T) {
+	readOnly := AgentModelsSnapshot{
+		ConfigID: "model",
+		Models:   []AgentModel{{ID: "old"}},
+	}
+	capable := AgentModelsSnapshot{
+		ConfigID: "model",
+		CanSet:   true,
+		Models:   []AgentModel{{ID: "new"}},
+	}
+	snapshots := map[string]AgentModelsSnapshot{"first": readOnly, "second": capable}
+
+	id, got := pickAgentModelsSession(snapshots, []string{"first", "second"})
+	if got == nil || !got.Selectable() {
+		t.Fatalf("picked %+v, want the session that can switch", got)
+	}
+	if id != "second" {
+		t.Errorf("session = %q, want the capable one so the notification reaches it", id)
+	}
+
+	t.Run("still shows a read-only gateway when that is all there is", func(t *testing.T) {
+		// Every deployment today. Preferring selectable must not mean showing
+		// nothing when nothing is selectable.
+		id, got := pickAgentModelsSession(map[string]AgentModelsSnapshot{"only": readOnly}, []string{"only"})
+		if got == nil || len(got.Models) != 1 || got.Models[0].ID != "old" {
+			t.Fatalf("picked %+v, want the read-only gateway's list", got)
+		}
+		if id != "only" {
+			t.Errorf("session = %q, want %q", id, "only")
+		}
+	})
+}
+
+// The delivery path has to agree with the preference, or the notification is
+// addressed to a gateway that will ignore it while a capable one stands beside.
+func TestSendSetModelReachesTheCapableGatewayOfTwo(t *testing.T) {
+	ps, readOnlyID, _ := connectedModelsServer(t)
+	capableID := connectSession(t, ps, "acp-gateway")
+	streamFor(ps, capableID)
+
+	ps.HandleAgentModels(context.Background(), readOnlyID, AgentModelsParams{
+		ConfigID: "model", CurrentModel: "old", Models: []AgentModel{{ID: "old"}},
+	})
+	ps.HandleAgentModels(context.Background(), capableID, AgentModelsParams{
+		ConfigID: "model", CurrentModel: "new", CanSet: true,
+		Models: []AgentModel{{ID: "new"}, {ID: "newer"}},
+	})
+
+	// "newer" exists only on the capable gateway, so a refusal here would mean
+	// the read-only one was consulted.
+	if err := ps.SendSetModelNotification(context.Background(), "newer"); err != nil {
+		t.Errorf("SendSetModelNotification() = %v, want it to reach the capable gateway", err)
 	}
 }

--- a/frontend/src/composables/useAgentModelPicker.js
+++ b/frontend/src/composables/useAgentModelPicker.js
@@ -138,11 +138,19 @@ export function useAgentModelPicker({ workspace, selectModel, now = () => Date.n
         pendingModelId.value = '';
         return;
       }
-      // A report naming a different model is the agent having its own answer,
-      // which settles the question as surely as agreement would.
+      // A report that names some other model settles the question — the switch
+      // is no longer outstanding, and what just arrived is the truth.
+      //
+      // What it does *not* establish is why. The backend republishes on a
+      // changed config option or a changed list as well as on a switch, so this
+      // fires both for an agent that declined and for an unrelated update that
+      // happened to land mid-flight. Claiming a refusal would be wrong in the
+      // second case, and a later confirming report would then contradict it.
+      // So this says only what is known: which model is running now.
       if (pendingModelId.value && agentModels.value?.currentModel) {
         pendingModelId.value = '';
-        error.value = 'The agent stayed on a different model';
+        const name = currentModelName(agentModels.value);
+        error.value = `The agent is running ${name}`;
       }
     },
   );
@@ -170,7 +178,16 @@ export function useAgentModelPicker({ workspace, selectModel, now = () => Date.n
    */
   async function choose(modelId) {
     error.value = '';
-    if (!modelId || modelId === agentModels.value?.currentModel) return;
+    if (!modelId) return;
+
+    // Choosing the model that is already running is how an outstanding switch
+    // is called off: there is nothing to ask for, but there is something to
+    // stop waiting for. Without this the picker went on showing the abandoned
+    // choice until the timeout, with no way to take it back.
+    if (modelId === agentModels.value?.currentModel) {
+      pendingModelId.value = '';
+      return;
+    }
 
     pendingModelId.value = modelId;
     requestedAt.value = now();

--- a/frontend/src/views/WorkspaceView.vue
+++ b/frontend/src/views/WorkspaceView.vue
@@ -163,7 +163,12 @@
                                  class="text-[9px] font-black uppercase tracking-wider text-green-600 dark:text-green-500 truncate">
                              {{ agentDetails(p).client }}
                            </span>
-                           <template v-if="agentDetails(p).model">
+                           <!-- Or a choice with nothing chosen yet: an agent
+                                may report models without naming a current one,
+                                which the backend explicitly tolerates. Guarding
+                                on the name alone hid the picker exactly where
+                                it was most needed. -->
+                           <template v-if="agentDetails(p).model || canChooseModel(p)">
                              <span v-if="agentDetails(p).client" class="text-[9px] font-black text-gray-300 dark:text-zinc-700 shrink-0">·</span>
                              <!-- The model becomes a control where the agent
                                   will act on being told to switch, and stays

--- a/frontend/test/agentModelPicker.test.js
+++ b/frontend/test/agentModelPicker.test.js
@@ -223,8 +223,10 @@ describe('useAgentModelPicker', () => {
   });
 
   it('takes a report naming a different model as the agent’s answer', async () => {
-    // The agent declined, or a second gateway answered. Either way the request
-    // is over and what arrived is the truth.
+    // The agent declined, or a second gateway answered, or an unrelated update
+    // landed mid-flight. The request is over and what arrived is the truth — but
+    // which of those it was is not knowable here, so the message says only what
+    // is running rather than accusing the agent of refusing.
     const { picker, workspace } = harness();
 
     await picker.choose('b');
@@ -233,7 +235,43 @@ describe('useAgentModelPicker', () => {
 
     expect(picker.isPending.value).toBe(false);
     expect(picker.selectedId.value).toBe('a');
-    expect(picker.error.value).toBe('The agent stayed on a different model');
+    expect(picker.error.value).toBe('The agent is running Model A');
+  });
+
+  it('does not claim a refusal for an unrelated report that lands mid-switch', async () => {
+    // The backend republishes on a changed config option or list, not only on a
+    // switch. Calling that a refusal was wrong, and a later confirming report
+    // would then contradict the message the human had already been shown.
+    const { picker, workspace } = harness();
+
+    await picker.choose('b');
+    // Same current model, different config option — a real republish that says
+    // nothing about the switch.
+    workspace.value = connected({ ...twoModels, configId: 'model_id' });
+    await nextTick();
+    expect(picker.error.value).not.toMatch(/stayed|refus/i);
+
+    // And the switch it was really waiting for still lands correctly.
+    workspace.value = connected({ ...twoModels, currentModel: 'b' });
+    await nextTick();
+    expect(picker.selectedId.value).toBe('b');
+    expect(picker.isPending.value).toBe(false);
+  });
+
+  it('calls off an outstanding switch when the running model is picked again', async () => {
+    // The only way to take back a choice. Without it the picker showed the
+    // abandoned model for the full timeout, with nothing the human could do.
+    const { picker, selectModel } = harness();
+
+    await picker.choose('b');
+    expect(picker.isPending.value).toBe(true);
+
+    await picker.choose('a');
+
+    expect(picker.isPending.value).toBe(false);
+    expect(picker.selectedId.value).toBe('a');
+    // Nothing asked of the agent: it is already running this model.
+    expect(selectModel).toHaveBeenCalledTimes(1);
   });
 
   it('tracks whether a request is in flight', async () => {


### PR DESCRIPTION
## What changed

Six defects in the newly added model-selection feature, found by reviewing everything since the last version bump. They range from a picker that could appear and then refuse to work, to one that stayed hidden from the agents most able to use it.

## Why changed

All six shipped in the last three changes and the test suite was green over every one of them. Fixing them before a release is cheaper than after, and the review is the only thing that looked.

## Test coverage report

New lines introduced: **100%**. Total coverage impact: **unchanged at 100%** — the frontend gate holds on all four metrics (1037 tests across 41 files, up from 1035), and the full backend suite passes.

The two backend fixes were checked against the *old* code first, to confirm the new tests fail on it rather than merely passing on the fix. Worth doing: the first attempt at that check silently did nothing, because a formatting change had shifted the line it was patching, and the test appeared to pass against a bug that was never actually restored.

## Other reports

**What was wrong:**

1. The rule for "can a choice be written back" had a fourth caller that ignored it — the live event published the raw capability flag while the workspace payload published the rule. A gateway willing to switch but naming no config option produced a picker that appeared on an event, failed with a 409 on use, and vanished on reload.
2. With two gateways attached, session order alone decided the answer: an older read-only gateway masked a newer capable one, so the workspace reported no choice and refused a switch that would have worked. The picker now prefers a session that can actually switch, and still falls back to a read-only gateway's list — which is every deployment today.
3. The interface accused the agent of refusing whenever a report still named the old model, but the backend also republishes on a changed config option or list. An unrelated update mid-switch raised an error that the next confirming report contradicted. It now states which model is running — true whichever happened.
4. An outstanding switch could not be called off; picking the running model returned early without clearing the pending one, leaving the picker wrong for the full timeout.
5. The picker sat behind a guard on the current model's *name*, and an agent may report models without naming a current one. A fully selectable agent got no picker at all.
6. A dead predicate — nothing outside its own tests called it, and it duplicated a rule that has to stay in sync with finding 1.

**One finding deliberately not fixed.** The model-selection count goes through `RecordTelemetry`, which spends the shared per-user bucket and re-checks workspace access the handler already checked. The review is right on the merits and this was raised before the code was written; it was settled the other way, so it stays. Recording it here rather than quietly reversing a decision.

## TaskID: 0iS66CQUPrN
