### PR TITLE
fix(ui): stop the model list being cut off by the cards it opens from

### DIFF
--- a/frontend/src/components/AgentModelPicker.vue
+++ b/frontend/src/components/AgentModelPicker.vue
@@ -2,9 +2,10 @@
   <!-- Nothing at all unless a choice exists and would do something. An agent
        that reports no models, or one too old to act on being told to switch,
        leaves the surrounding layout exactly as it was. -->
-  <div v-if="picker.available.value" class="relative" v-click-outside="() => (open = false)">
-    <button type="button"
-            @click.stop="open = !open"
+  <div v-if="picker.available.value" class="relative">
+    <button ref="trigger"
+            type="button"
+            @click.stop="toggle"
             :disabled="picker.sending.value"
             :class="compact
               ? 'text-[9px] font-medium text-gray-500 dark:text-zinc-400 hover:text-gray-900 dark:hover:text-zinc-100 max-w-[140px]'
@@ -17,27 +18,37 @@
       <span v-if="picker.isPending.value" class="ml-1 shrink-0 opacity-60">…</span>
     </button>
 
-    <div v-if="open"
-         class="fixed sm:absolute left-4 right-4 sm:left-auto sm:right-0 bottom-4 sm:bottom-full sm:mb-2 w-auto sm:w-[240px] max-h-[320px] overflow-y-auto bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-xl shadow-2xl z-50 p-2"
-         @click.stop>
-      <h3 class="text-[10px] font-bold uppercase tracking-wider text-gray-500 dark:text-zinc-400 px-2 py-1.5">Model</h3>
+    <!-- Rendered into <body>, not beside the button.
+         The workspace cards sit inside a scrolling container, and an absolutely
+         positioned menu is clipped by any ancestor that scrolls — so a menu
+         opening upward from a card lost whatever overflowed the container's
+         edge, heading first. Fixed positioning in the body escapes that
+         entirely, and costs a little arithmetic instead. -->
+    <Teleport to="body">
+      <div v-if="open"
+           ref="menu"
+           :style="{ top: `${position.top}px`, left: `${position.left}px`, maxHeight: `${position.maxHeight}px` }"
+           class="fixed w-[240px] overflow-y-auto bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-xl shadow-2xl z-50 p-2"
+           @click.stop>
+        <h3 class="text-[10px] font-bold uppercase tracking-wider text-gray-500 dark:text-zinc-400 px-2 py-1.5">Model</h3>
 
-      <div v-for="group in picker.groups.value" :key="group.name || '_'">
-        <p v-if="group.name" class="text-[9px] font-bold uppercase tracking-wider text-gray-400 dark:text-zinc-600 px-2 pt-2 pb-1">
-          {{ group.name }}
-        </p>
-        <button v-for="model in group.models" :key="model.id"
-                type="button"
-                @click="pick(model.id)"
-                :class="model.id === picker.selectedId.value
-                  ? 'bg-gray-100 dark:bg-zinc-800 text-gray-900 dark:text-white'
-                  : 'text-gray-600 dark:text-zinc-400 hover:bg-gray-50 dark:hover:bg-zinc-800/60'"
-                class="w-full text-left px-2 py-1.5 rounded-md text-[11px] font-semibold transition-colors flex items-center gap-2">
-          <span class="truncate grow">{{ model.name || model.id }}</span>
-          <span v-if="model.id === picker.selectedId.value" class="shrink-0 text-[9px]">●</span>
-        </button>
+        <div v-for="group in picker.groups.value" :key="group.name || '_'">
+          <p v-if="group.name" class="text-[9px] font-bold uppercase tracking-wider text-gray-400 dark:text-zinc-600 px-2 pt-2 pb-1">
+            {{ group.name }}
+          </p>
+          <button v-for="model in group.models" :key="model.id"
+                  type="button"
+                  @click="pick(model.id)"
+                  :class="model.id === picker.selectedId.value
+                    ? 'bg-gray-100 dark:bg-zinc-800 text-gray-900 dark:text-white'
+                    : 'text-gray-600 dark:text-zinc-400 hover:bg-gray-50 dark:hover:bg-zinc-800/60'"
+                  class="w-full text-left px-2 py-1.5 rounded-md text-[11px] font-semibold transition-colors flex items-center gap-2">
+            <span class="truncate grow">{{ model.name || model.id }}</span>
+            <span v-if="model.id === picker.selectedId.value" class="shrink-0 text-[9px]">●</span>
+          </button>
+        </div>
       </div>
-    </div>
+    </Teleport>
   </div>
 </template>
 
@@ -50,13 +61,14 @@
  * on the part that matters: what is shown while the agent has been asked but
  * has not answered.
  *
- * All the logic lives in useAgentModelPicker, which is tested. What is left
- * here is the markup and the two things a component has to own: the popover,
+ * The selection logic lives in useAgentModelPicker, which is tested, as does
+ * the menu's geometry. What is left here is the markup and the things only a
+ * mounted component can own: the menu's open state, where it currently sits,
  * and the clock that gives up on a switch nothing confirmed.
  */
-import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 
-import { useAgentModelPicker } from '../composables/useAgentModelPicker';
+import { MAX_POPOVER_HEIGHT, popoverPosition, useAgentModelPicker } from '../composables/useAgentModelPicker';
 import { useToasts } from '../composables/useToasts';
 import { setAgentModel } from '../api';
 
@@ -68,12 +80,62 @@ const props = defineProps({
 });
 
 const open = ref(false);
+const trigger = ref(null);
+const menu = ref(null);
+const position = ref({ top: 0, left: 0, maxHeight: MAX_POPOVER_HEIGHT });
 const { addToast } = useToasts();
 
 const picker = useAgentModelPicker({
   workspace: () => props.workspace,
   selectModel: (modelId) => setAgentModel(props.workspace?.id, modelId),
 });
+
+/**
+ * Measure, then place.
+ *
+ * Done after the menu exists rather than from an assumed height: the list is as
+ * long as the agent's, and guessing it is what decides whether the menu opens
+ * upward into a place it does not fit.
+ */
+async function place() {
+  const anchor = trigger.value?.getBoundingClientRect();
+  if (!anchor) return;
+  await nextTick();
+  const box = menu.value?.getBoundingClientRect();
+  position.value = popoverPosition(
+    anchor,
+    { width: box?.width || 240, height: box?.height || 0 },
+    { width: window.innerWidth, height: window.innerHeight },
+  );
+}
+
+async function toggle() {
+  open.value = !open.value;
+  if (open.value) await place();
+}
+
+/**
+ * Closed on scroll, not followed.
+ *
+ * A fixed menu does not move with the container it was opened from, so it would
+ * otherwise hang in place while the card slid away beneath it. Closing is both
+ * simpler and what a person expects from a menu they have scrolled away from.
+ */
+function closeOnScroll() {
+  open.value = false;
+}
+
+/**
+ * The menu is no longer a descendant of this component, so containment has to
+ * be checked against both halves. Relying on `v-click-outside` here would close
+ * the menu on the first click inside it.
+ */
+function onDocumentClick(event) {
+  if (!open.value) return;
+  if (trigger.value?.contains(event.target)) return;
+  if (menu.value?.contains(event.target)) return;
+  open.value = false;
+}
 
 // A refusal, or an agent that never came back, is mission-critical feedback:
 // the human asked for something and it did not happen. The picker has already
@@ -93,6 +155,16 @@ async function pick(modelId) {
 let tick;
 onMounted(() => {
   tick = setInterval(() => picker.expirePending(), 1000);
+  document.addEventListener('click', onDocumentClick);
+  // Capturing, so a scroll inside the cards' own container is seen too — it
+  // does not bubble to the window.
+  window.addEventListener('scroll', closeOnScroll, true);
+  window.addEventListener('resize', closeOnScroll);
 });
-onBeforeUnmount(() => clearInterval(tick));
+onBeforeUnmount(() => {
+  clearInterval(tick);
+  document.removeEventListener('click', onDocumentClick);
+  window.removeEventListener('scroll', closeOnScroll, true);
+  window.removeEventListener('resize', closeOnScroll);
+});
 </script>

--- a/frontend/src/composables/useAgentModelPicker.js
+++ b/frontend/src/composables/useAgentModelPicker.js
@@ -25,6 +25,69 @@ import { currentModelName } from './useAgentSummary';
  */
 export const CONFIRMATION_TIMEOUT_MS = 30_000;
 
+/** Breathing room between the trigger and the menu, and from the viewport edge. */
+export const POPOVER_GAP = 8;
+export const POPOVER_MARGIN = 8;
+
+/**
+ * The tallest the menu may grow, and the least it may be squeezed to.
+ *
+ * The ceiling keeps a long list from becoming a full-height wall; the floor
+ * stops a trigger jammed against an edge from producing a menu too short to
+ * show anything, which is worse than one that overhangs slightly.
+ */
+export const MAX_POPOVER_HEIGHT = 420;
+export const MIN_POPOVER_HEIGHT = 180;
+
+/**
+ * Where to put the menu, in viewport coordinates.
+ *
+ * The menu is rendered into `<body>` and positioned fixed rather than laid out
+ * next to the button, because the workspace cards live inside a scrolling
+ * container: an absolutely positioned menu is clipped by any ancestor that
+ * scrolls, and one opening upward from a card near the top edge simply loses
+ * the part that overflows — the heading and the first models with it. Nothing
+ * about that is visible in a short list, which is why it survived a two-model
+ * agent.
+ *
+ * Above the trigger by preference, since that is where a menu on a card has
+ * room, flipping below when the list does not fit above. The height it may use
+ * comes back with the position: a fixed cap would go on scrolling a list that
+ * had a screenful of empty space beneath it, which is the same complaint as
+ * being clipped — the models are there and you cannot see them.
+ */
+export function popoverPosition(anchor, menu, viewport) {
+  // The menu may not have been measured yet — it is placed once it exists, and
+  // the first pass runs before there is anything to measure. The viewport is
+  // always known, so it is taken as given rather than defended against.
+  const menuWidth = menu?.width || 0;
+  const menuHeight = menu?.height || 0;
+  const { width: viewWidth, height: viewHeight } = viewport;
+
+  const roomAbove = anchor.top - POPOVER_GAP - POPOVER_MARGIN;
+  const roomBelow = viewHeight - anchor.bottom - POPOVER_GAP - POPOVER_MARGIN;
+
+  // Above while the whole list fits there; otherwise whichever side has more
+  // room. Flipping to a side that also overflows would trade a clipped top for
+  // a clipped bottom and gain nothing.
+  const above = menuHeight <= roomAbove || roomAbove >= roomBelow;
+  const available = Math.max(above ? roomAbove : roomBelow, MIN_POPOVER_HEIGHT);
+
+  const maxHeight = Math.min(MAX_POPOVER_HEIGHT, available);
+  const height = Math.min(menuHeight || maxHeight, maxHeight);
+
+  let top = above ? anchor.top - POPOVER_GAP - height : anchor.bottom + POPOVER_GAP;
+  // Clamped so a list too long for the screen is pinned rather than starting
+  // above the fold, where its first rows could not be reached at all.
+  top = Math.min(Math.max(top, POPOVER_MARGIN), Math.max(POPOVER_MARGIN, viewHeight - height - POPOVER_MARGIN));
+
+  // Right edges aligned, the way an absolutely positioned `right-0` menu sat.
+  const rightmost = Math.max(POPOVER_MARGIN, viewWidth - menuWidth - POPOVER_MARGIN);
+  const left = Math.min(Math.max(anchor.right - menuWidth, POPOVER_MARGIN), rightmost);
+
+  return { top, left, maxHeight, placement: above ? 'above' : 'below' };
+}
+
 /**
  * Whether a workspace can be offered a model picker at all.
  *

--- a/frontend/test/agentModelPicker.test.js
+++ b/frontend/test/agentModelPicker.test.js
@@ -3,10 +3,15 @@ import { nextTick, ref } from 'vue';
 
 import {
   CONFIRMATION_TIMEOUT_MS,
+  MAX_POPOVER_HEIGHT,
+  MIN_POPOVER_HEIGHT,
+  POPOVER_GAP,
+  POPOVER_MARGIN,
   canChooseModel,
   displayedModelId,
   isConfirmed,
   modelGroups,
+  popoverPosition,
   useAgentModelPicker,
 } from '../src/composables/useAgentModelPicker';
 
@@ -312,5 +317,104 @@ describe('useAgentModelPicker', () => {
 
     expect(picker.available.value).toBe(false);
     expect(picker.groups.value).toEqual([]);
+  });
+});
+
+/**
+ * Where the menu goes.
+ *
+ * This exists because the menu used to be laid out inside the workspace cards,
+ * which scroll — and an absolutely positioned menu is clipped by a scrolling
+ * ancestor, so one opening upward from a card near the top edge lost everything
+ * that overflowed, heading first. A two-model agent is short enough to fit and
+ * shows none of it, which is exactly how it shipped.
+ */
+describe('popoverPosition', () => {
+  const viewport = { width: 1200, height: 800 };
+  /** A trigger low on the page, with plenty of room above it. */
+  const anchor = { top: 600, bottom: 620, right: 500 };
+
+  it('opens above the trigger when the list fits there', () => {
+    const { top, left, placement } = popoverPosition(anchor, { width: 240, height: 300 }, viewport);
+
+    expect(placement).toBe('above');
+    expect(top).toBe(600 - 300 - POPOVER_GAP);
+    // Right edges aligned, the way the absolutely positioned menu sat.
+    expect(left).toBe(500 - 240);
+  });
+
+  it('flips below when the list is too tall to fit above', () => {
+    // The reported bug's shape: a long list on a trigger near the top of the
+    // page. Above would put the first rows off-screen, so it goes below.
+    const nearTop = { top: 120, bottom: 140, right: 500 };
+
+    const { top, placement } = popoverPosition(nearTop, { width: 240, height: 400 }, viewport);
+
+    expect(placement).toBe('below');
+    expect(top).toBe(140 + POPOVER_GAP);
+  });
+
+  it('stays above when below has even less room', () => {
+    // Flipping to a spot that also overflows trades a clipped top for a clipped
+    // bottom and gains nothing.
+    const nearBottom = { top: 700, bottom: 780, right: 500 };
+
+    const { placement } = popoverPosition(nearBottom, { width: 240, height: 400 }, viewport);
+
+    expect(placement).toBe('above');
+  });
+
+  it('grows into the space that is actually there', () => {
+    // The complaint that started this: a list scrolling inside a short menu
+    // while a screenful of room sat unused below it reads exactly like being
+    // cut off — the models are there and you cannot see them.
+    const nearTop = { top: 120, bottom: 140, right: 500 };
+
+    const { maxHeight } = popoverPosition(nearTop, { width: 240, height: 400 }, viewport);
+
+    expect(maxHeight).toBeGreaterThanOrEqual(400);
+  });
+
+  it('never grows past the ceiling', () => {
+    // A tall window must not turn a long list into a full-height wall.
+    const tall = { width: 1200, height: 2000 };
+
+    const { maxHeight } = popoverPosition({ top: 1800, bottom: 1820, right: 500 }, { width: 240, height: 1500 }, tall);
+
+    expect(maxHeight).toBe(MAX_POPOVER_HEIGHT);
+  });
+
+  it('keeps a usable height when the trigger is jammed against an edge', () => {
+    // A menu squeezed to nothing is worse than one that overhangs a little.
+    const { maxHeight } = popoverPosition({ top: 10, bottom: 30, right: 500 }, { width: 240, height: 400 }, { width: 1200, height: 60 });
+
+    expect(maxHeight).toBe(MIN_POPOVER_HEIGHT);
+  });
+
+  it('never places the menu off the top of the viewport', () => {
+    // A list taller than the window is pinned and scrolls internally. Starting
+    // above the fold would make its first rows unreachable.
+    const { top } = popoverPosition({ top: 30, bottom: 50, right: 500 }, { width: 240, height: 2000 }, { width: 1200, height: 200 });
+
+    expect(top).toBeGreaterThanOrEqual(POPOVER_MARGIN);
+  });
+
+  it('keeps the menu on screen horizontally', () => {
+    // A trigger near the left edge would otherwise put the menu off-screen,
+    // since it is aligned by its right edge.
+    const nearLeft = popoverPosition({ top: 600, bottom: 620, right: 60 }, { width: 240, height: 100 }, viewport);
+    expect(nearLeft.left).toBe(POPOVER_MARGIN);
+
+    const nearRight = popoverPosition({ top: 600, bottom: 620, right: 1198 }, { width: 240, height: 100 }, viewport);
+    expect(nearRight.left).toBe(1200 - 240 - POPOVER_MARGIN);
+  });
+
+  it('copes with a menu it has not measured yet', () => {
+    // The first frame, before the element exists to be measured.
+    const { top, left, maxHeight } = popoverPosition(anchor, undefined, viewport);
+
+    expect(Number.isFinite(top)).toBe(true);
+    expect(Number.isFinite(left)).toBe(true);
+    expect(maxHeight).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## What changed

The list of models no longer gets cut off when opened from a workspace card — the whole list is shown, and it grows into whatever room is actually on screen.

## Why changed

The menu was laid out inside the card, and the cards sit in a scrolling container, which clips anything absolutely positioned that crosses its edge. A menu opening upward lost the part that overflowed — the heading and the first models — so the list began partway down and ended nowhere.

## Test coverage report

New lines introduced: **100%**. Total coverage impact: **unchanged at 100%** — the gate holds on all four metrics (1046 tests across 41 files, up from 1043).

The placement logic is a pure function and is tested directly: opening above when the list fits, flipping below when it does not, staying above when below is worse, growing into available space, respecting the ceiling and the floor, and staying on screen both vertically and horizontally.

## Other reports

**Verified in a real browser, before and after**, driving the actual app with an eight-model agent:

- *Before:* the menu opens upward and is clipped — it starts mid-list at "Opus (1M context)" with the heading and the first two models gone, and is cut off again at the bottom. This reproduces the reported screenshot.
- *After:* all eight models render, grouped, with the heading, nothing clipped, and no scrollbar — confirmed by measuring the element (`teleportedToBody: true`, `height: 375`, `scrolls: false`, 8 rows from "Fable 5.1" to "Haiku 4").

**Why it was not caught earlier:** the agent this was built against offers two models. The menu fitted inside the card, never crossed the container's edge, and nothing looked wrong. It takes a real agent's list to reach the boundary at all.

**Two consequences of leaving the component**, both handled: containment is now checked against the trigger *and* the menu, since `v-click-outside` would otherwise close it on its own first click; and the menu closes on scroll, because a fixed menu does not travel with the card it was opened from.

The task form's picker is unaffected in placement terms — it was never in a scrolling container — and gains the same adaptive height.

## TaskID: 0iTGjcTXIxd
