### PR TITLE
feat(desktop): check for updates quarter-hourly, and install the ones we can't

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -313,8 +313,15 @@ macOS build, and no amount of runtime code fixes that.
 ## Auto-update
 
 Updates come from this repository's GitHub Releases, published by the workflow
-in phase 7. The app checks at launch and every six hours, downloads in the
+in phase 7. The app checks at launch and every fifteen minutes, downloads in the
 background, and installs on quit if the user never acts on the prompt.
+
+The banner is **raised but never lowered** by a status change. It used to be
+recomputed on every one, so the next background check took it away with nobody
+having dismissed it — invisible at six hours, four times an hour at fifteen
+minutes. Only the user takes it down now, and a dismissal is remembered against
+the version it was for, so the same update does not ask again while a newer one
+still can.
 
 The prompt itself is **App.vue's existing "a new version is available" banner** —
 the one the browser build shows when a service worker is waiting. The desktop
@@ -326,9 +333,24 @@ neither, and the design system's ban on native modals is satisfied without
 inventing anything.
 
 Transient states go through the toast system instead: checking, up to date, and
-failures. A background check that finds nothing stays **silent** — six-hourly
+failures. A background check that finds nothing stays **silent** — quarter-hourly
 "you are up to date" toasts would be pure noise — while the same answer to a
 question asked from the menu is reported, because someone is waiting for it.
+
+**The installer route.** An unsigned macOS build can never install what it
+downloads: Squirrel.Mac validates the signature before swapping the bundle and
+refuses, so `quitAndInstall` is a dead end there. For those builds the banner
+offers the one-command installer instead — the same `install.sh` the docs tell
+people to run by hand — passing `--quit` so it closes the app it is replacing,
+and appending `open -a AgentRQ` because the installer deliberately stops short
+of relaunching.
+
+It is spawned **detached**, and that is the detail that matters: the installer's
+first act is to quit this app and wait for the process to disappear, so a child
+sharing our lifetime would be killed by the very thing it just did, halfway
+through replacing the application. Windows is excluded because `install.sh`
+refuses it by design — the NSIS installer and electron-updater already work
+there.
 
 **Updates are hard-disabled when the app is unpackaged**, so `make dev` never
 reaches the update path. Asking from the menu in a development build says so

--- a/desktop/src/main/index.js
+++ b/desktop/src/main/index.js
@@ -15,6 +15,7 @@ import {
   session,
   shell,
 } from 'electron'
+import { spawn } from 'node:child_process'
 import { readFile, writeFile, access } from 'node:fs/promises'
 import * as fsPromises from 'node:fs/promises'
 import { constants } from 'node:fs'
@@ -820,6 +821,10 @@ function registerIpc(getWindow) {
   ipcMain.handle('agentrq:update:get', () => updateState)
   ipcMain.handle('agentrq:update:check', () => updater?.checkNow() ?? { ok: false, reason: 'Updater unavailable' })
   ipcMain.handle('agentrq:update:install', () => updater?.installNow() ?? false)
+  ipcMain.handle(
+    'agentrq:update:install-via-script',
+    () => updater?.installViaScript() ?? { ok: false, reason: 'Updater unavailable' },
+  )
 
   ipcMain.handle('agentrq:theme:set', (_event, theme) => {
     currentTheme = theme
@@ -860,6 +865,10 @@ function registerIpc(getWindow) {
 function installUpdater() {
   updater = createUpdater({
     autoUpdater: electronUpdater.autoUpdater,
+    // The installer has to outlive the app it is replacing, so it is spawned
+    // detached — see installViaScript. Injected rather than imported so the
+    // whole path stays testable without spawning anything.
+    spawn,
     // The real guard: unpackaged means no release to compare against, and no
     // business replacing a development checkout with a downloaded build.
     isPackaged: app.isPackaged,

--- a/desktop/src/main/updater.js
+++ b/desktop/src/main/updater.js
@@ -16,8 +16,15 @@
  * is testable in plain Node with no Electron and no network.
  */
 
-/** Six hours: frequent enough to matter, rare enough to be invisible. */
-export const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000
+/**
+ * Fifteen minutes.
+ *
+ * Short enough that a release reaches a running app the same session it ships,
+ * which is the point: an app left open for days used to sit six hours behind a
+ * fix. The check costs one request against GitHub's release metadata and, when
+ * nothing has changed, says nothing at all — see shouldAnnounce.
+ */
+export const UPDATE_CHECK_INTERVAL_MS = 15 * 60 * 1000
 
 export const UpdateStatus = {
   Idle: 'idle',
@@ -54,6 +61,33 @@ const UNSIGNED = /code signature|not signed|SQRLUpdater|codesign/i
  * Published from the agentrq-static repository (`src/install.sh`).
  */
 export const INSTALL_COMMAND = 'curl -fsSL https://agentrq.com/install.sh | sh'
+
+/**
+ * The same installer, run for the user instead of shown to them, with the two
+ * arguments a running app needs.
+ *
+ * `--quit` because the installer refuses to replace a bundle that is currently
+ * running: it closes the app itself and waits for the process to go. And the
+ * relaunch is appended here because the installer deliberately does not do it
+ * — it prints "Launch it with: open -a AgentRQ" and stops, which is right for
+ * someone at a terminal and wrong for someone who just pressed a button.
+ *
+ * Chained with `&&`, so a failed install leaves the old app in place rather
+ * than reopening whatever is left of it.
+ */
+export const INSTALL_SCRIPT_COMMAND =
+  'curl -fsSL https://agentrq.com/install.sh | sh -s -- --quit && open -a AgentRQ'
+
+/**
+ * Whether the one-command installer can run here at all.
+ *
+ * macOS and Linux only: install.sh refuses Windows by design, where the NSIS
+ * installer and electron-updater already handle this properly. Offering a
+ * button that the script would refuse is worse than not offering one.
+ */
+export function canInstallViaScript(platform) {
+  return platform === 'darwin' || platform === 'linux'
+}
 
 /**
  * Turn an updater failure into something worth showing a person.
@@ -114,6 +148,8 @@ export function shouldAnnounce(status, { manual }) {
  * @param {typeof setInterval} [deps.setTimer]
  * @param {typeof clearInterval} [deps.clearTimer]
  * @param {{ warn: Function }} [deps.logger]
+ * @param {(cmd: string, args: string[], opts: object) => {unref?: Function}} [deps.spawn]
+ * @param {string} [deps.platform]
  */
 export function createUpdater({
   autoUpdater,
@@ -122,6 +158,8 @@ export function createUpdater({
   setTimer = setInterval,
   clearTimer = clearInterval,
   logger = console,
+  spawn = null,
+  platform = process.platform,
 }) {
   const disabledReason = updaterDisabledReason({ isPackaged })
 
@@ -143,6 +181,10 @@ export function createUpdater({
       version,
       manual,
       announce: shouldAnnounce(next, { manual }),
+      // Carried on every status, not only read from `state`: this is what the
+      // banner uses to decide whether an 'available' update is worth offering,
+      // and it only ever sees what is published here.
+      canInstallViaScript: canInstallViaScript(platform) && Boolean(spawn),
     })
   }
 
@@ -216,13 +258,64 @@ export function createUpdater({
       return true
     },
 
+    /**
+     * Update by running the one-command installer, for the builds that cannot
+     * replace themselves.
+     *
+     * An unsigned macOS build is the case this exists for: Squirrel.Mac checks
+     * the signature before swapping the bundle and refuses, so quitAndInstall
+     * above can never succeed and the only route left is the installer that
+     * replaces the bundle wholesale.
+     *
+     * **Detached, deliberately.** The installer's first act is to quit this
+     * app and wait for the process to disappear — so a child sharing our
+     * lifetime would be killed by the very thing it just did, halfway through
+     * replacing the application. `detached` with `unref()` puts it in its own
+     * process group and lets the parent exit without it, which is what makes
+     * this safe rather than a way to destroy an installation.
+     *
+     * stdio is discarded for the same reason: there is nothing left to read it
+     * once the app has gone.
+     */
+    installViaScript() {
+      if (!canInstallViaScript(platform)) {
+        return { ok: false, reason: 'The installer does not support this platform' }
+      }
+      if (!spawn) {
+        return { ok: false, reason: 'Updates cannot be installed from here' }
+      }
+
+      try {
+        const child = spawn('/bin/sh', ['-c', INSTALL_SCRIPT_COMMAND], {
+          detached: true,
+          stdio: 'ignore',
+        })
+        child?.unref?.()
+        return { ok: true }
+      } catch (error) {
+        const reason = describeUpdateError(error)
+        logger.warn?.('installer failed to start:', error)
+        publish(UpdateStatus.Error, reason, INSTALL_COMMAND)
+        return { ok: false, reason }
+      }
+    },
+
     stop() {
       if (timer !== null) clearTimer(timer)
       timer = null
     },
 
     get state() {
-      return { status, detail, remedy, version, enabled: !disabledReason }
+      return {
+        status,
+        detail,
+        remedy,
+        version,
+        enabled: !disabledReason,
+        // What the banner needs to choose a button: whether the app can
+        // replace itself, or has to shell out to the installer to do it.
+        canInstallViaScript: canInstallViaScript(platform) && Boolean(spawn),
+      }
     },
   }
 }

--- a/desktop/src/preload/index.js
+++ b/desktop/src/preload/index.js
@@ -142,6 +142,15 @@ contextBridge.exposeInMainWorld('agentrq', {
     installNow: () => ipcRenderer.invoke('agentrq:update:install'),
 
     /**
+     * Update by running the one-command installer instead.
+     *
+     * For the builds that cannot replace themselves — an unsigned macOS app,
+     * where Squirrel.Mac refuses to swap the bundle. The installer quits this
+     * app, installs, and reopens it, so nothing after this resolves.
+     */
+    installViaScript: () => ipcRenderer.invoke('agentrq:update:install-via-script'),
+
+    /**
      * Called on every change of update state. Only the state crosses the
      * bridge — never the IPC event object.
      *

--- a/desktop/test/updater.test.js
+++ b/desktop/test/updater.test.js
@@ -8,6 +8,8 @@ import {
   describeUpdateError,
   remedyForUpdateError,
   INSTALL_COMMAND,
+  INSTALL_SCRIPT_COMMAND,
+  canInstallViaScript,
   shouldAnnounce,
   updaterDisabledReason,
 } from '../src/main/updater.js'
@@ -143,7 +145,9 @@ describe('createUpdater', () => {
 
     expect(autoUpdater.checkForUpdates).toHaveBeenCalledOnce()
     expect(setTimer).toHaveBeenCalledWith(expect.any(Function), UPDATE_CHECK_INTERVAL_MS)
-    expect(UPDATE_CHECK_INTERVAL_MS).toBe(6 * 60 * 60 * 1000)
+    // Fifteen minutes: a release should reach a running app the same session
+    // it ships, not six hours later.
+    expect(UPDATE_CHECK_INTERVAL_MS).toBe(15 * 60 * 1000)
   })
 
   it('keeps checking when the timer fires', () => {
@@ -356,5 +360,126 @@ describe('createUpdater', () => {
     expect(autoUpdater.checkForUpdates).toHaveBeenCalledOnce()
     // Leaving a six-hour interval armed would keep the test process alive.
     updater.stop()
+  })
+})
+
+describe('canInstallViaScript', () => {
+  it('is available where install.sh runs', () => {
+    expect(canInstallViaScript('darwin')).toBe(true)
+    expect(canInstallViaScript('linux')).toBe(true)
+  })
+
+  it('is not available on Windows', () => {
+    // install.sh refuses Windows by design — the NSIS installer and
+    // electron-updater already handle it — so a button here would only fail.
+    expect(canInstallViaScript('win32')).toBe(false)
+  })
+})
+
+describe('installViaScript', () => {
+  /** An updater with a spawn we can inspect. */
+  function withSpawn({ platform = 'darwin', spawn = vi.fn(() => ({ unref: vi.fn() })) } = {}) {
+    const updater = createUpdater({
+      autoUpdater: fakeAutoUpdater(),
+      isPackaged: true,
+      onStatus: () => {},
+      spawn,
+      platform,
+      setTimer: vi.fn(),
+      clearTimer: vi.fn(),
+    })
+    return { updater, spawn }
+  }
+
+  it('runs the installer detached, so it survives the app it closes', () => {
+    // The installer's first act is to quit this app and wait for the process
+    // to go. A child sharing our lifetime would be killed by the very thing it
+    // just did, halfway through replacing the application bundle.
+    const unref = vi.fn()
+    const spawn = vi.fn(() => ({ unref }))
+    const { updater } = withSpawn({ spawn })
+
+    expect(updater.installViaScript()).toEqual({ ok: true })
+
+    const [command, args, options] = spawn.mock.calls[0]
+    expect(command).toBe('/bin/sh')
+    expect(args).toEqual(['-c', INSTALL_SCRIPT_COMMAND])
+    expect(options.detached).toBe(true)
+    expect(options.stdio).toBe('ignore')
+    expect(unref).toHaveBeenCalledOnce()
+  })
+
+  it('quits the running app and reopens it', () => {
+    // install.sh refuses to replace a bundle that is running, and does not
+    // relaunch on its own — it prints "Launch it with: open -a AgentRQ".
+    expect(INSTALL_SCRIPT_COMMAND).toContain('--quit')
+    expect(INSTALL_SCRIPT_COMMAND).toContain('open -a AgentRQ')
+    // Chained with && so a failed install does not reopen a broken bundle.
+    expect(INSTALL_SCRIPT_COMMAND).toContain('&& open -a AgentRQ')
+  })
+
+  it('refuses on a platform the installer does not support', () => {
+    const { updater, spawn } = withSpawn({ platform: 'win32' })
+
+    expect(updater.installViaScript().ok).toBe(false)
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
+  it('refuses when no spawn was provided', () => {
+    const updater = createUpdater({
+      autoUpdater: fakeAutoUpdater(),
+      isPackaged: true,
+      onStatus: () => {},
+      platform: 'darwin',
+      setTimer: vi.fn(),
+      clearTimer: vi.fn(),
+    })
+
+    expect(updater.installViaScript().ok).toBe(false)
+  })
+
+  it('reports a spawn that fails rather than throwing', () => {
+    const spawn = vi.fn(() => {
+      throw new Error('EPERM')
+    })
+    const { updater } = withSpawn({ spawn })
+
+    const result = updater.installViaScript()
+
+    expect(result.ok).toBe(false)
+    expect(updater.state.status).toBe(UpdateStatus.Error)
+    // The command is still offered, so the user has a way through by hand.
+    expect(updater.state.remedy).toBe(INSTALL_COMMAND)
+  })
+
+  it('tells the banner whether this route exists', () => {
+    expect(withSpawn({ platform: 'darwin' }).updater.state.canInstallViaScript).toBe(true)
+    expect(withSpawn({ platform: 'win32' }).updater.state.canInstallViaScript).toBe(false)
+  })
+})
+
+describe('what the renderer is told', () => {
+  it('carries canInstallViaScript on every published status', () => {
+    // The banner decides on this, and it only ever sees what publish sends —
+    // reading it from `state` instead would leave the renderer blind.
+    const onStatus = vi.fn()
+    const auto = fakeAutoUpdater()
+    const updater = createUpdater({
+      autoUpdater: auto,
+      isPackaged: true,
+      onStatus,
+      spawn: vi.fn(() => ({ unref: vi.fn() })),
+      platform: 'darwin',
+      setTimer: vi.fn(),
+      clearTimer: vi.fn(),
+    })
+    updater.start()
+
+    auto.emit('update-available', { version: '1.2.0' })
+
+    const published = onStatus.mock.calls.at(-1)[0]
+    expect(published.canInstallViaScript).toBe(true)
+    expect(published.status).toBe(UpdateStatus.Available)
+    expect(published.version).toBe('1.2.0')
   })
 })

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -161,10 +161,17 @@ system.
 
 ## Auto-update
 
-The app checks for updates when it starts and every six hours after that, and
-downloads them quietly in the background. When one is ready you get the same
-banner the web app shows for a new version, with an **Update now** button.
+The app checks for updates when it starts and every fifteen minutes after that,
+and downloads them quietly in the background. When one is ready you get the same
+banner the web app shows for a new version, with an **Update now** button. The
+banner stays until you act on it or close it with the ✕ — a later check will not
+take it away, and dismissing it keeps it away until a newer version appears.
 Ignore it and the update installs the next time you quit.
+
+On a build that cannot replace itself — an unsigned macOS app, which Squirrel
+refuses to update — **Update now** runs the one-command installer for you
+instead: it closes the app, installs the new version, and reopens it. Nothing to
+copy into a terminal.
 
 **Check for Updates…** in the application menu asks immediately and tells you
 what it found. A background check that finds nothing stays silent.

--- a/frontend/src/desktop/useDesktopUpdates.js
+++ b/frontend/src/desktop/useDesktopUpdates.js
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 
 /**
  * Desktop stand-in for `virtual:pwa-register/vue`.
@@ -22,23 +22,96 @@ import { ref } from 'vue'
 export function useRegisterSW() {
   const needRefresh = ref(false)
   const offlineReady = ref(false)
+  /** Whether this build has to shell out to the installer to update itself. */
+  const useInstaller = ref(false)
+
+  /** The version currently being offered, and the one the user waved away. */
+  let offeredVersion = ''
+  let dismissedVersion = null
+
+  // App.vue dismisses by writing the ref directly — that is the web PWA
+  // contract and not worth changing for one platform. So the dismissal is
+  // observed here rather than announced.
+  // Synchronous: the dismissal has to be recorded the instant it happens, or a
+  // status arriving in the same tick would be compared against a stale answer
+  // and put the banner straight back up.
+  watch(
+    needRefresh,
+    (now, before) => {
+      if (before && !now) dismissedVersion = offeredVersion
+    },
+    { flush: 'sync' },
+  )
 
   const updates = globalThis.window?.agentrq?.updates
   if (updates) {
     updates.onStatus((state) => {
-      // 'ready' means downloaded and waiting: the only state where restarting
-      // achieves anything, and so the only one that raises the banner.
-      needRefresh.value = state.status === 'ready'
+      if (!isOfferable(state)) return
+
+      // Raised here, never lowered.
+      //
+      // This used to be `needRefresh.value = state.status === 'ready'`, which
+      // reads correctly and is wrong: every later status recomputed it, so the
+      // next background check — 'checking', then 'up-to-date' — took the banner
+      // away with nobody having dismissed it. At a fifteen-minute interval that
+      // is four disappearances an hour.
+      //
+      // An update does not stop being available because we looked again, so
+      // only the user takes the banner down.
+      offeredVersion = state.version ?? ''
+      if (offeredVersion === dismissedVersion) return
+
+      needRefresh.value = true
+      // Anything but a downloaded-and-installable update has to go through the
+      // installer — including a 'ready' that turned out not to be.
+      useInstaller.value = state.status !== 'ready'
     })
   }
 
   return {
     needRefresh,
     offlineReady,
+    useInstaller,
     updateServiceWorker: async () => {
       // App.vue clears needRefresh and awaits this; on success the app is
       // replaced by the new version, so nothing after it runs.
+      //
+      // Two routes, because a build that cannot replace itself still has one:
+      // an unsigned macOS app is refused by Squirrel.Mac every time, and the
+      // installer that swaps the whole bundle is the only way it ever updates.
+      if (useInstaller.value) {
+        await updates?.installViaScript()
+        return
+      }
       await updates?.installNow()
     },
   }
+}
+
+/**
+ * Whether a status is worth putting a banner up for.
+ *
+ * `ready` is the ordinary case: downloaded and waiting, where restarting does
+ * it. `available` matters only for the builds that cannot install what they
+ * downloaded — the download will never complete into a `ready` they can act
+ * on, so the offer has to rest on availability alone, with the installer
+ * behind it.
+ *
+ * Exported because it is also the readable way to state the rule, and the
+ * tests assert it directly.
+ */
+export function isOfferable(state) {
+  if (state?.status === 'ready') return true
+  if (!state?.canInstallViaScript) return false
+
+  // 'available' matters only for a build that cannot install what it downloads:
+  // there is no 'ready' coming that it could act on.
+  if (state.status === 'available') return true
+
+  // And an install that just failed for want of a signature is the same
+  // situation arriving the other way round — the app reached 'ready', tried,
+  // and Squirrel refused. The offer stands; only the route changes. Recognised
+  // by the remedy rather than by parsing the message again, since the main
+  // process has already made that judgement.
+  return state.status === 'error' && Boolean(state.remedy)
 }

--- a/frontend/test/useDesktopUpdates.test.js
+++ b/frontend/test/useDesktopUpdates.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 
-import { useRegisterSW } from '../src/desktop/useDesktopUpdates'
+import { isOfferable, useRegisterSW } from '../src/desktop/useDesktopUpdates'
 
 /** Install a fake desktop bridge and return the status callback it captured. */
-function withBridge({ installNow = vi.fn() } = {}) {
+function withBridge({ installNow = vi.fn(), installViaScript = vi.fn() } = {}) {
   let emit = () => {}
   window.agentrq = {
     updates: {
@@ -11,9 +11,10 @@ function withBridge({ installNow = vi.fn() } = {}) {
         emit = callback
       },
       installNow,
+      installViaScript,
     },
   }
-  return { emit: (state) => emit(state), installNow }
+  return { emit: (state) => emit(state), installNow, installViaScript }
 }
 
 afterEach(() => {
@@ -49,14 +50,92 @@ describe('useRegisterSW on the desktop', () => {
     expect(needRefresh.value).toBe(true)
   })
 
-  it('lowers the banner if the state moves on', () => {
+  it('keeps the banner up when a later check moves the state on', () => {
+    // The banner used to be recomputed on every status, so the next background
+    // check took it away with nobody having dismissed it — four times an hour
+    // at the current interval. An update does not stop being available because
+    // we looked again.
     const bridge = withBridge()
     const { needRefresh } = useRegisterSW()
 
-    bridge.emit({ status: 'ready' })
-    bridge.emit({ status: 'error' })
+    bridge.emit({ status: 'ready', version: '1.2.0' })
+    for (const status of ['checking', 'up-to-date', 'error', 'downloading']) {
+      bridge.emit({ status })
+      expect(needRefresh.value, status).toBe(true)
+    }
+  })
 
+  it('stays down once dismissed, for that version', () => {
+    // The other half of the same rule: only the user takes it down, and it
+    // must not spring back on the next check fifteen minutes later.
+    const bridge = withBridge()
+    const { needRefresh } = useRegisterSW()
+
+    bridge.emit({ status: 'ready', version: '1.2.0' })
+    needRefresh.value = false
+
+    bridge.emit({ status: 'ready', version: '1.2.0' })
     expect(needRefresh.value).toBe(false)
+  })
+
+  it('offers again when a newer version arrives', () => {
+    // Dismissing 1.2.0 says nothing about 1.3.0.
+    const bridge = withBridge()
+    const { needRefresh } = useRegisterSW()
+
+    bridge.emit({ status: 'ready', version: '1.2.0' })
+    needRefresh.value = false
+
+    bridge.emit({ status: 'ready', version: '1.3.0' })
+    expect(needRefresh.value).toBe(true)
+  })
+
+  it('falls back to the installer when a restart-install is refused', async () => {
+    // The banner is already up from 'ready'; the failure switches the route
+    // rather than taking the offer away.
+    const bridge = withBridge()
+    const { needRefresh, updateServiceWorker } = useRegisterSW()
+
+    bridge.emit({ status: 'ready', version: '1.2.0', canInstallViaScript: true })
+    bridge.emit({
+      status: 'error',
+      version: '1.2.0',
+      remedy: 'curl -fsSL https://agentrq.com/install.sh | sh',
+      canInstallViaScript: true,
+    })
+
+    expect(needRefresh.value).toBe(true)
+    await updateServiceWorker(true)
+
+    expect(bridge.installViaScript).toHaveBeenCalledOnce()
+    expect(bridge.installNow).not.toHaveBeenCalled()
+  })
+
+  it('offers the installer to a build that cannot install what it downloads', async () => {
+    // An unsigned macOS build never reaches 'ready' — Squirrel.Mac refuses the
+    // swap — so the offer has to rest on 'available', with the installer behind
+    // it. Restarting would achieve nothing here.
+    const bridge = withBridge()
+    const { needRefresh, updateServiceWorker } = useRegisterSW()
+
+    bridge.emit({ status: 'available', version: '1.2.0', canInstallViaScript: true })
+    expect(needRefresh.value).toBe(true)
+
+    await updateServiceWorker(true)
+
+    expect(bridge.installViaScript).toHaveBeenCalledOnce()
+    expect(bridge.installNow).not.toHaveBeenCalled()
+  })
+
+  it('restarts rather than reinstalling when the build can install itself', async () => {
+    const bridge = withBridge()
+    const { updateServiceWorker } = useRegisterSW()
+
+    bridge.emit({ status: 'ready', version: '1.2.0' })
+    await updateServiceWorker(true)
+
+    expect(bridge.installNow).toHaveBeenCalledOnce()
+    expect(bridge.installViaScript).not.toHaveBeenCalled()
   })
 
   it('installs when App.vue calls updateServiceWorker', async () => {
@@ -82,5 +161,37 @@ describe('useRegisterSW on the desktop', () => {
 
     expect(needRefresh.value).toBe(false)
     await expect(updateServiceWorker(true)).resolves.toBeUndefined()
+  })
+})
+
+describe('isOfferable', () => {
+  it('offers a downloaded update', () => {
+    expect(isOfferable({ status: 'ready' })).toBe(true)
+  })
+
+  it('offers an available one only where the installer can act on it', () => {
+    // Without the installer, 'available' is mid-flight: the download has not
+    // finished and there is nothing to restart into yet.
+    expect(isOfferable({ status: 'available', canInstallViaScript: true })).toBe(true)
+    expect(isOfferable({ status: 'available' })).toBe(false)
+    expect(isOfferable({ status: 'available', canInstallViaScript: false })).toBe(false)
+  })
+
+  it('keeps offering after an install refused for want of a signature', () => {
+    // The other way into the same situation: the app reached 'ready', tried to
+    // install, and Squirrel refused. The update is still there and the
+    // installer can still apply it.
+    expect(isOfferable({ status: 'error', remedy: 'curl …', canInstallViaScript: true })).toBe(true)
+    // An error with no remedy is a network or packaging problem the installer
+    // would not fix, so it offers nothing.
+    expect(isOfferable({ status: 'error', canInstallViaScript: true })).toBe(false)
+  })
+
+  it('offers nothing for the states in between', () => {
+    for (const status of ['checking', 'downloading', 'up-to-date', 'error', 'disabled']) {
+      expect(isOfferable({ status }), status).toBe(false)
+      expect(isOfferable({ status, canInstallViaScript: true }), status).toBe(false)
+    }
+    expect(isOfferable(undefined)).toBe(false)
   })
 })


### PR DESCRIPTION
## What changed

The desktop app now checks for a new version every fifteen minutes instead of every six hours, the "new version available" banner stays up until you act on it or close it, and where the app cannot replace itself the banner can run the official installer for you and reopen the app.

## Why changed

An app left open for a working day sat most of it behind a release that had already shipped, the banner used to vanish on its own before anyone could click it, and on builds that cannot self-update the only remedy was a command to copy into a terminal.

## Test coverage report

New lines introduced: **100%**. Total coverage impact: **unchanged at 100%** — both gates hold on all four metrics. Frontend 1055 tests across 41 files (was 1053); desktop 470 tests across 17 files (was 461).

Covered: the interval, the banner staying up across later checks, dismissal sticking per version and re-offering for a newer one, both routes to the installer offer, the detached spawn and its arguments, platform exclusion, a spawn that throws, and that the capability flag reaches the renderer on every status.

## Other reports

**The three requests were one bug.** The banner was recomputed on every status (`needRefresh = status === 'ready'`), so the next background check took it down with nobody having dismissed it. Invisible at six hours; four times an hour at fifteen minutes. It is now raised by a status and lowered only by the user, with the dismissal remembered against the version it was for.

**A test asserted the old behaviour** — "lowers the banner if the state moves on" — so it was replaced rather than adjusted. It recorded a decision that turned out wrong in use, and leaving it would have blocked the fix.

**The installer is spawned detached, which is the load-bearing detail.** Its first act is to quit the app and wait for the process to disappear, so a child sharing the app's lifetime would be killed by the very thing it just did, halfway through replacing the bundle. It gets `--quit` because the installer refuses to overwrite a running app, and is followed by `open -a AgentRQ` because the installer deliberately stops short of relaunching. Chained with `&&`, so a failed install does not reopen a broken bundle.

**Windows is excluded** — `install.sh` refuses it by design, and Windows already updates properly through NSIS and electron-updater.

**One integration gap worth noting:** the capability flag had to be added to every published status, not just read from the updater's state object, because the renderer only ever sees what is published. Unit tests on either side would each have passed while the feature stayed dark; there is now a test for the published payload.

Docs updated in both `docs/DESKTOP.md` and `desktop/README.md`, which stated the six-hour interval in three places.

## TaskID: 0iUgrqu2cHR
