### PR TITLE
chore: bump patch version to v0.5.21

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.5.20"
+	_appVersion   = "v0.5.21"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.5.20" {
-			t.Errorf("Expected version v0.5.20, got %s", s.Version())
+		if s.Version() != "v0.5.21" {
+			t.Errorf("Expected version v0.5.21, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.5.20",
+      "version": "0.5.21",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "AgentRQ desktop app — AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.5.20",
+      "version": "0.5.21",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.5.20",
+  "version": "0.5.21",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
## What changed

The application version moves from 0.5.20 to 0.5.21 everywhere it is declared — the desktop and web packages and their lockfiles, the backend constant, and the test that asserts it.

## Why changed

Six changes have landed since the last release and none of them ships until the version is bumped: the tag build refuses to package a tree whose version sources disagree, and the desktop updater compares this number against the published release.

Shipping in this version, since v0.5.20 — one feature arriving in pieces, plus the desktop update prompt it leans on:

**feat**
- a model can be chosen from the interface, on the workspace card and on the task-creation form, wherever the connected agent offers a choice and will act on it (#507, #508, #509)
- the desktop app checks for updates every fifteen minutes rather than every six hours, keeps its banner up until the user acts on it, and can run the installer for builds that cannot replace themselves (#512)

**fix**
- six defects in the model-selection feature, found by review and none of them caught by its own tests — chief among them a picker that could appear and then refuse to work, and one that stayed hidden from the agents most able to use it (#510)
- the model list is no longer cut off by the scrolling container the workspace cards sit in (#511)

## Test coverage report

No new lines of logic — the change is nine literal version strings, one of which *is* a test assertion, so the new lines are 100% covered by construction. Total coverage is unchanged.

## Other reports

Version sync verified in both the forms CI runs:

```
$ node desktop/scripts/check-versions.mjs
✓ desktop, frontend and backend are all at 0.5.21

$ GITHUB_REF=refs/tags/v0.5.21 node desktop/scripts/check-versions.mjs
✓ desktop, frontend and backend are all at 0.5.21
✓ tag v0.5.21 matches version 0.5.21
```

`go test ./internal/service/config/...` passes, and `npm ci` still resolves in both `desktop/` and `frontend/` — the lockfile version fields were edited by hand, so no dependency resolution shifted underneath the release.

The unrelated `"source-map-support": "~0.5.20"` dependency range, and the version numbers used as fixtures and comment examples in the desktop tests and release workflow, were deliberately left alone.

**Worth noting for this release:** #511 fixes a bug that is visible the moment a capable gateway connects, and #510 fixes six more in the same feature. Releasing the model picker without them would put known-broken behaviour in front of users.

## TaskID: 0iUgrqu2cHR
