### PR TITLE
feat(extensions): the manifest, and whether one is worth offering

### DIFF
--- a/desktop/src/main/extensions/manifest.js
+++ b/desktop/src/main/extensions/manifest.js
@@ -1,0 +1,362 @@
+/**
+ * The extension manifest, and whether one is worth offering.
+ *
+ * An extension is a GitHub repository carrying the `agentrq-extension` topic and
+ * an `agentrq-extension.json` at its root. The topic makes it findable; this
+ * file is what makes it an extension. Everything downstream — the catalogue, the
+ * installer, the grant screen — trusts what comes out of here, so this is
+ * deliberately the most testable thing in the feature: pure functions, no
+ * Electron, no network, no filesystem.
+ *
+ * ## Every rejection carries a reason, and the reason is copy
+ *
+ * A repository with the topic and a bad manifest is *listed as broken with its
+ * reason* rather than quietly dropped — the author needs to see why, and a
+ * silently-missing extension is undebuggable for them and looks like a broken
+ * catalogue to anyone following a link. So the strings below are user-facing
+ * text, addressed to the person who wrote the manifest, and are worth the same
+ * care as anything else a person reads.
+ *
+ * ## Why validation is split in two
+ *
+ * `parseManifest` answers "is this a well-formed manifest", which depends on
+ * nothing but the document. `checkCompatibility` answers "can *this* install
+ * run it", which depends on the running app and on the tools the connected
+ * server actually offers.
+ *
+ * They are separate because the answers have different lifetimes. A manifest is
+ * parsed once at discovery, when no workspace is in view and no tool list is
+ * known; compatibility is re-asked at install and again on update, against a
+ * self-hosted backend that may be older than the extension expects. Folding them
+ * together would mean either caching an answer that goes stale or refusing to
+ * index anything until a server is reachable.
+ */
+
+/** Keys a manifest may carry. Anything else is a typo worth reporting. */
+const KNOWN_KEYS = new Set([
+  'name',
+  'displayName',
+  'version',
+  'description',
+  'license',
+  'engines',
+  'mcp',
+  'config',
+  'provides',
+  'shortcuts',
+  'artifact',
+])
+
+/**
+ * The name, which is an address rather than a label.
+ *
+ * It appears in a route (`/extensions/:name/:pageId`), in registry keys and in
+ * the install directory, so the same discipline the workspace memory keys use
+ * applies for the same reason: a name with a space in it is not one.
+ */
+const NAME_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/
+
+/** Lowercase hex, 64 characters. Anything else could not be a SHA-256. */
+const SHA256_RE = /^[a-f0-9]{64}$/
+
+/**
+ * SPDX identifiers we recognise, plus the honest refusal.
+ *
+ * An extension runs with full access to the machine, so the terms it is offered
+ * under are part of the decision to install it rather than metadata — which is
+ * why this is required rather than optional.
+ *
+ * It is a fixed list and case-sensitive on purpose. Accepting free text would
+ * make `MIT`, `mit` and `MIT License` three different licenses and none of them
+ * comparable; accepting any SPDX-shaped string would take `MITT` without
+ * comment. The list is short enough to read and long enough to cover what people
+ * actually publish under; an identifier missing from it is a one-line addition,
+ * and the rejection says so rather than pretending the license is invalid.
+ *
+ * `UNLICENSED` is deliberately here. "All rights reserved, no permission
+ * granted" is an answer a user can act on. Silence is not an answer; it just
+ * leaves the question unasked.
+ */
+const SPDX = new Set([
+  'AGPL-3.0-only',
+  'AGPL-3.0-or-later',
+  'Apache-2.0',
+  'BSD-2-Clause',
+  'BSD-3-Clause',
+  'BSL-1.0',
+  'CC0-1.0',
+  'CC-BY-4.0',
+  'CC-BY-SA-4.0',
+  'EPL-2.0',
+  'GPL-2.0-only',
+  'GPL-2.0-or-later',
+  'GPL-3.0-only',
+  'GPL-3.0-or-later',
+  'ISC',
+  'LGPL-2.1-only',
+  'LGPL-3.0-only',
+  'LGPL-3.0-or-later',
+  'MIT',
+  'MPL-2.0',
+  'Unlicense',
+  'Zlib',
+  'UNLICENSED',
+])
+
+const fail = (reason) => ({ ok: false, reason })
+
+/** A trimmed string, or '' for anything that is not one. */
+function str(value) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+/**
+ * Validates the license, suggesting the right spelling where it can.
+ *
+ * The case-insensitive near-match is the whole reason this is worth a function:
+ * `mit` is not a slip to reject flatly, it is somebody who meant `MIT`, and
+ * saying so costs nothing and saves a round trip through a maintainer.
+ */
+export function validateLicense(value) {
+  const license = str(value)
+  if (!license) {
+    return fail('"license" is required. Use an SPDX identifier such as "MIT", or "UNLICENSED".')
+  }
+  if (SPDX.has(license)) return { ok: true, license }
+
+  const near = [...SPDX].find((id) => id.toLowerCase() === license.toLowerCase())
+  if (near) {
+    return fail(`"license" must be spelled exactly as the SPDX identifier: "${near}", not "${license}".`)
+  }
+  return fail(
+    `"license" is not a recognised SPDX identifier: "${license}". ` +
+      'Use one of the standard identifiers, or "UNLICENSED" if no permission is granted.',
+  )
+}
+
+/**
+ * Whether an app version satisfies a range.
+ *
+ * A deliberately narrow subset of semver — exact, `^`, `~` and `>=` — because
+ * this project carries exactly one runtime dependency and re-implementing the
+ * whole grammar to avoid a second one would trade a dependency for a class of
+ * subtle bugs. (`semver` is present transitively today, which is not the same as
+ * being available.)
+ *
+ * Anything outside the subset is **refused as unsupported rather than guessed
+ * at**. A range nobody parsed correctly is how an extension ends up installed on
+ * a version it cannot run on, and the failure then surfaces somewhere far away
+ * from the manifest that caused it.
+ */
+export function satisfiesRange(version, range) {
+  const v = parseVersion(version)
+  const spec = str(range)
+  if (!v) return fail(`"${version}" is not a version this can compare.`)
+  if (!spec) return fail('"engines.agentrq" is required, for example "^1.4".')
+
+  const operator = spec.startsWith('>=') ? '>=' : spec[0] === '^' || spec[0] === '~' ? spec[0] : ''
+  const bound = parseVersion(spec.slice(operator.length))
+  if (!bound) {
+    return fail(
+      `"engines.agentrq" is not a range this understands: "${spec}". ` +
+        'Supported forms are "1.4.0", "^1.4", "~1.4" and ">=1.4".',
+    )
+  }
+
+  if (compare(v, bound) < 0) return { ok: true, satisfied: false }
+
+  // ^ allows anything up to the next major; ~ up to the next minor; >= has no
+  // ceiling; an exact version means exactly itself.
+  if (operator === '>=') return { ok: true, satisfied: true }
+  if (operator === '^') return { ok: true, satisfied: v.major === bound.major }
+  if (operator === '~') return { ok: true, satisfied: v.major === bound.major && v.minor === bound.minor }
+  return { ok: true, satisfied: compare(v, bound) === 0 }
+}
+
+/** `1.4` and `1.4.2` both parse; a missing part is zero. */
+function parseVersion(value) {
+  const match = /^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?$/.exec(str(value))
+  if (!match) return null
+  return { major: +match[1], minor: +(match[2] ?? 0), patch: +(match[3] ?? 0) }
+}
+
+function compare(a, b) {
+  return a.major - b.major || a.minor - b.minor || a.patch - b.patch
+}
+
+/** The tools an extension asks for, on one of the two MCP surfaces. */
+function validateToolList(value, surface) {
+  if (value === undefined) return { ok: true, tools: [] }
+  if (!Array.isArray(value)) {
+    return fail(`"mcp.${surface}" must be a list of tool names.`)
+  }
+  const tools = []
+  for (const entry of value) {
+    const tool = str(entry)
+    if (!tool) return fail(`"mcp.${surface}" contains an entry that is not a tool name.`)
+    if (tools.includes(tool)) return fail(`"mcp.${surface}" lists "${tool}" twice.`)
+    tools.push(tool)
+  }
+  return { ok: true, tools }
+}
+
+/** The release asset an install downloads, and the digest that pins it. */
+function validateArtifact(value) {
+  if (!value || typeof value !== 'object') {
+    return fail('"artifact" is required, naming the release, the asset and its sha256.')
+  }
+  const release = str(value.release)
+  const asset = str(value.asset)
+  const sha256 = str(value.sha256).toLowerCase()
+
+  if (!release) return fail('"artifact.release" is required, for example "v1.2.0".')
+  if (!asset) return fail('"artifact.asset" is required — the file name of the release asset.')
+  if (!SHA256_RE.test(sha256)) {
+    // Worth its own message: this is the field that makes an install honest, and
+    // a git tag can be moved under one that is already in place.
+    return fail('"artifact.sha256" must be a 64-character hex SHA-256 of the asset.')
+  }
+  return { ok: true, artifact: { release, asset, sha256 } }
+}
+
+/** Config fields an extension asks the user to fill in. */
+function validateConfig(value) {
+  if (value === undefined) return { ok: true, config: [] }
+  if (!Array.isArray(value)) return fail('"config" must be a list of fields.')
+
+  const config = []
+  const seen = new Set()
+  for (const field of value) {
+    if (!field || typeof field !== 'object') return fail('"config" contains an entry that is not a field.')
+    const key = str(field.key)
+    const type = str(field.type) || 'string'
+    if (!key) return fail('Every "config" field needs a "key".')
+    if (seen.has(key)) return fail(`"config" declares "${key}" twice.`)
+    if (!['string', 'secret', 'boolean', 'number'].includes(type)) {
+      return fail(`"config.${key}" has an unknown type "${type}". Use string, secret, boolean or number.`)
+    }
+    seen.add(key)
+    config.push({ key, type, label: str(field.label) || key })
+  }
+  return { ok: true, config }
+}
+
+/**
+ * Reads a manifest and says whether it is one.
+ *
+ * Structure only — nothing here depends on the running app or on any server. See
+ * `checkCompatibility` for the half that does.
+ */
+export function parseManifest(source) {
+  let raw = source
+  if (typeof source === 'string') {
+    try {
+      raw = JSON.parse(source)
+    } catch {
+      return fail('This is not valid JSON.')
+    }
+  }
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return fail('A manifest must be a JSON object.')
+  }
+
+  // Reported rather than ignored: a mistyped key is an author expecting
+  // behaviour they will not get, and silence is the one response that guarantees
+  // they never find out.
+  const unknown = Object.keys(raw).filter((key) => !KNOWN_KEYS.has(key))
+  if (unknown.length > 0) {
+    return fail(`Unknown field${unknown.length > 1 ? 's' : ''}: ${unknown.map((k) => `"${k}"`).join(', ')}.`)
+  }
+
+  const name = str(raw.name)
+  if (!name) return fail('"name" is required.')
+  if (!NAME_RE.test(name)) {
+    return fail(
+      `"name" must be lowercase words joined by single hyphens, like "linear-issues". Got "${name}".`,
+    )
+  }
+
+  const version = str(raw.version)
+  if (!parseVersion(version)) {
+    return fail(`"version" must be a version like "1.2.0". Got "${version || '(missing)'}".`)
+  }
+
+  const license = validateLicense(raw.license)
+  if (!license.ok) return license
+
+  const engines = raw.engines && typeof raw.engines === 'object' ? raw.engines : {}
+  const agentrq = str(engines.agentrq)
+  if (!agentrq) {
+    return fail('"engines.agentrq" is required, so an incompatible build can say so before installing.')
+  }
+  // Parsed now, against a version known to be valid, purely to reject an
+  // unsupported range at discovery rather than at install.
+  const rangeCheck = satisfiesRange('0.0.0', agentrq)
+  if (!rangeCheck.ok) return rangeCheck
+
+  const mcp = raw.mcp && typeof raw.mcp === 'object' ? raw.mcp : {}
+  const workspace = validateToolList(mcp.workspace, 'workspace')
+  if (!workspace.ok) return workspace
+  const supervisor = validateToolList(mcp.supervisor, 'supervisor')
+  if (!supervisor.ok) return supervisor
+
+  const config = validateConfig(raw.config)
+  if (!config.ok) return config
+
+  const artifact = validateArtifact(raw.artifact)
+  if (!artifact.ok) return artifact
+
+  return {
+    ok: true,
+    manifest: {
+      name,
+      displayName: str(raw.displayName) || name,
+      version,
+      description: str(raw.description),
+      license: license.license,
+      engines: { agentrq },
+      mcp: { workspace: workspace.tools, supervisor: supervisor.tools },
+      config: config.config,
+      provides: raw.provides && typeof raw.provides === 'object' ? raw.provides : {},
+      shortcuts: Array.isArray(raw.shortcuts) ? raw.shortcuts : [],
+      artifact: artifact.artifact,
+    },
+  }
+}
+
+/**
+ * Whether this install can actually run a parsed manifest.
+ *
+ * Answered against the app that is running and the tools the connected servers
+ * actually advertise — which is the real check, because a self-hosted backend
+ * may be older than the extension expects and a tool an extension asks for may
+ * simply not exist there.
+ *
+ * Returns every reason rather than the first. An author fixing a manifest wants
+ * the whole list, and a user being told why something is unavailable is better
+ * served by "needs AgentRQ 1.5, you have 1.4" plus the missing tool than by
+ * whichever happened to be checked first.
+ */
+export function checkCompatibility(manifest, { appVersion, workspaceTools = [], supervisorTools = [] } = {}) {
+  const reasons = []
+
+  const range = satisfiesRange(appVersion, manifest.engines.agentrq)
+  if (!range.ok) {
+    reasons.push(range.reason)
+  } else if (!range.satisfied) {
+    reasons.push(`Needs AgentRQ ${manifest.engines.agentrq}; this is ${appVersion}.`)
+  }
+
+  const missing = (asked, offered, surface) =>
+    asked
+      .filter((tool) => !offered.includes(tool))
+      .forEach((tool) => reasons.push(`The ${surface} server does not offer "${tool}".`))
+
+  missing(manifest.mcp.workspace, workspaceTools, 'workspace')
+  missing(manifest.mcp.supervisor, supervisorTools, 'supervisor')
+
+  return { compatible: reasons.length === 0, reasons }
+}
+
+/** Exported for the tests, and as the readable statement of what is accepted. */
+export const SPDX_IDENTIFIERS = SPDX

--- a/desktop/test/extensions/manifest.test.js
+++ b/desktop/test/extensions/manifest.test.js
@@ -1,0 +1,375 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  SPDX_IDENTIFIERS,
+  checkCompatibility,
+  parseManifest,
+  satisfiesRange,
+  validateLicense,
+} from '../../src/main/extensions/manifest.js'
+
+/**
+ * The manifest is what turns a repository carrying the topic into an extension,
+ * and everything downstream trusts what comes out of it. So these tests assert
+ * the *reasons* as well as the verdicts: a rejected manifest is listed in the
+ * catalogue with its reason showing, which makes those strings user-facing copy
+ * rather than diagnostics.
+ */
+
+/** A manifest with nothing wrong with it, to vary one field at a time. */
+const valid = () => ({
+  name: 'linear',
+  displayName: 'Linear',
+  version: '1.2.0',
+  description: 'Create and search Linear issues from tasks.',
+  license: 'MIT',
+  engines: { agentrq: '^1.4' },
+  mcp: { workspace: ['getTask', 'reply'], supervisor: ['listAllTasks'] },
+  config: [{ key: 'apiKey', type: 'secret', label: 'Linear API key' }],
+  provides: { ui: ['workspacePanel'] },
+  artifact: { release: 'v1.2.0', asset: 'linear-1.2.0.tgz', sha256: 'a'.repeat(64) },
+})
+
+describe('parseManifest', () => {
+  it('accepts a well-formed manifest and normalises it', () => {
+    const { ok, manifest } = parseManifest(valid())
+
+    expect(ok).toBe(true)
+    expect(manifest.name).toBe('linear')
+    expect(manifest.license).toBe('MIT')
+    expect(manifest.mcp.workspace).toEqual(['getTask', 'reply'])
+    expect(manifest.artifact.sha256).toBe('a'.repeat(64))
+  })
+
+  it('reads a manifest that arrives as text', () => {
+    // It arrives from GitHub as a string, not an object.
+    expect(parseManifest(JSON.stringify(valid())).ok).toBe(true)
+  })
+
+  it('says so plainly when the file is not JSON at all', () => {
+    const { ok, reason } = parseManifest('<!doctype html>')
+    expect(ok).toBe(false)
+    expect(reason).toBe('This is not valid JSON.')
+  })
+
+  it('refuses anything that is not a JSON object', () => {
+    for (const input of ['[]', '"a string"', 'null', '7']) {
+      expect(parseManifest(input).ok, input).toBe(false)
+    }
+  })
+
+  it('defaults the display name and description rather than demanding them', () => {
+    const { displayName, ...rest } = valid()
+    delete rest.description
+    const { manifest } = parseManifest(rest)
+
+    expect(manifest.displayName).toBe('linear')
+    expect(manifest.description).toBe('')
+  })
+
+  describe('name', () => {
+    it('requires one', () => {
+      const m = valid()
+      delete m.name
+      expect(parseManifest(m).reason).toBe('"name" is required.')
+    })
+
+    it('accepts lowercase words joined by single hyphens', () => {
+      for (const name of ['linear', 'linear-issues', 'a1', 'one-two-three']) {
+        expect(parseManifest({ ...valid(), name }).ok, name).toBe(true)
+      }
+    })
+
+    it('refuses a name that could not be addressed', () => {
+      // The name goes in a route, in registry keys and in a directory path — a
+      // name with a space in it is not one.
+      for (const name of ['Linear', 'linear issues', 'linear_issues', '-linear', 'linear-', 'linear--x']) {
+        const { ok, reason } = parseManifest({ ...valid(), name })
+        expect(ok, name).toBe(false)
+        expect(reason, name).toContain('lowercase words joined by single hyphens')
+      }
+    })
+  })
+
+  describe('license', () => {
+    it('is required, because it is part of the decision to install', () => {
+      const m = valid()
+      delete m.license
+      const { ok, reason } = parseManifest(m)
+
+      expect(ok).toBe(false)
+      expect(reason).toContain('"license" is required')
+      expect(reason).toContain('UNLICENSED')
+    })
+
+    it('accepts UNLICENSED as an honest answer', () => {
+      expect(parseManifest({ ...valid(), license: 'UNLICENSED' }).ok).toBe(true)
+    })
+
+    it('corrects the spelling rather than just refusing it', () => {
+      // "mit" is not a slip to reject flatly — it is somebody who meant MIT.
+      const { ok, reason } = validateLicense('mit')
+
+      expect(ok).toBe(false)
+      expect(reason).toContain('"MIT"')
+      expect(reason).toContain('exactly')
+    })
+
+    it('refuses free text, so licenses stay comparable', () => {
+      const { ok, reason } = validateLicense('MIT License')
+      expect(ok).toBe(false)
+      expect(reason).toContain('not a recognised SPDX identifier')
+    })
+
+    it('refuses an identifier that merely looks like one', () => {
+      expect(validateLicense('MITT').ok).toBe(false)
+    })
+
+    it('refuses a blank string as firmly as a missing field', () => {
+      expect(validateLicense('   ').reason).toContain('"license" is required')
+    })
+
+    it('recognises the identifiers people actually publish under', () => {
+      for (const id of ['MIT', 'Apache-2.0', 'AGPL-3.0-only', 'BSD-3-Clause', 'ISC', 'MPL-2.0']) {
+        expect(SPDX_IDENTIFIERS.has(id), id).toBe(true)
+      }
+    })
+  })
+
+  describe('version and engines', () => {
+    it('requires a version it can compare', () => {
+      expect(parseManifest({ ...valid(), version: 'latest' }).reason).toContain('"version" must be a version')
+      const m = valid()
+      delete m.version
+      expect(parseManifest(m).reason).toContain('(missing)')
+    })
+
+    it('requires an engines range, so an incompatible build can say so', () => {
+      const m = valid()
+      delete m.engines
+      expect(parseManifest(m).reason).toContain('"engines.agentrq" is required')
+    })
+
+    it('refuses a range it does not understand rather than guessing', () => {
+      // A range nobody parsed correctly is how an extension gets installed on a
+      // version it cannot run on, failing far from the manifest that caused it.
+      const { ok, reason } = parseManifest({ ...valid(), engines: { agentrq: '1.x || >=2 <3' } })
+
+      expect(ok).toBe(false)
+      expect(reason).toContain('not a range this understands')
+      expect(reason).toContain('"^1.4"')
+    })
+  })
+
+  describe('mcp', () => {
+    it('treats both surfaces as optional', () => {
+      const m = valid()
+      delete m.mcp
+      const { ok, manifest } = parseManifest(m)
+
+      expect(ok).toBe(true)
+      expect(manifest.mcp).toEqual({ workspace: [], supervisor: [] })
+    })
+
+    it('refuses anything that is not a list of names', () => {
+      expect(parseManifest({ ...valid(), mcp: { workspace: 'getTask' } }).reason).toContain(
+        '"mcp.workspace" must be a list',
+      )
+      expect(parseManifest({ ...valid(), mcp: { supervisor: [7] } }).reason).toContain(
+        'not a tool name',
+      )
+    })
+
+    it('refuses a tool listed twice', () => {
+      const mcp = { workspace: ['getTask', 'getTask'] }
+      expect(parseManifest({ ...valid(), mcp }).reason).toContain('lists "getTask" twice')
+    })
+  })
+
+  describe('config', () => {
+    it('is optional and defaults its labels to the key', () => {
+      const { manifest } = parseManifest({ ...valid(), config: [{ key: 'teamId' }] })
+      expect(manifest.config).toEqual([{ key: 'teamId', type: 'string', label: 'teamId' }])
+    })
+
+    it('refuses a field with no key, a duplicate, or an unknown type', () => {
+      expect(parseManifest({ ...valid(), config: [{ type: 'string' }] }).reason).toContain('needs a "key"')
+      expect(
+        parseManifest({ ...valid(), config: [{ key: 'a' }, { key: 'a' }] }).reason,
+      ).toContain('declares "a" twice')
+      expect(
+        parseManifest({ ...valid(), config: [{ key: 'a', type: 'file' }] }).reason,
+      ).toContain('unknown type "file"')
+    })
+
+    it('refuses a config that is not a list', () => {
+      expect(parseManifest({ ...valid(), config: {} }).reason).toContain('"config" must be a list')
+      expect(parseManifest({ ...valid(), config: ['a'] }).reason).toContain('not a field')
+    })
+  })
+
+  describe('artifact', () => {
+    it('is required, since there is nothing to install without one', () => {
+      const m = valid()
+      delete m.artifact
+      expect(parseManifest(m).reason).toContain('"artifact" is required')
+    })
+
+    it('needs the release and the asset named', () => {
+      const artifact = { asset: 'x.tgz', sha256: 'a'.repeat(64) }
+      expect(parseManifest({ ...valid(), artifact }).reason).toContain('"artifact.release" is required')
+      expect(
+        parseManifest({ ...valid(), artifact: { release: 'v1', sha256: 'a'.repeat(64) } }).reason,
+      ).toContain('"artifact.asset" is required')
+    })
+
+    it('demands a real digest, because a git tag can be moved under an install', () => {
+      for (const sha256 of ['', 'abc', 'g'.repeat(64), 'a'.repeat(63)]) {
+        const { ok, reason } = parseManifest({ ...valid(), artifact: { release: 'v1', asset: 'x', sha256 } })
+        expect(ok, sha256).toBe(false)
+        expect(reason).toContain('64-character hex SHA-256')
+      }
+    })
+
+    it('accepts an uppercase digest, lowercased', () => {
+      const artifact = { release: 'v1', asset: 'x', sha256: 'A'.repeat(64) }
+      expect(parseManifest({ ...valid(), artifact }).manifest.artifact.sha256).toBe('a'.repeat(64))
+    })
+  })
+
+  it('fills in the optional fields when they are simply absent', () => {
+    // A minimal manifest is a legitimate manifest: an extension that provides
+    // nothing but a task menu item declares no config, no provides and no
+    // shortcuts, and must not have to write empty containers to say so.
+    const m = valid()
+    delete m.config
+    delete m.provides
+    delete m.shortcuts
+    const { ok, manifest } = parseManifest(m)
+
+    expect(ok).toBe(true)
+    expect(manifest.config).toEqual([])
+    expect(manifest.provides).toEqual({})
+    expect(manifest.shortcuts).toEqual([])
+  })
+
+  it('carries declared shortcuts through, for the install-time conflict check', () => {
+    // Conflicts are caught at install from the manifest, not at runtime, so the
+    // declaration has to survive parsing to be checked against what is bound.
+    const shortcuts = [{ key: 'l', action: 'create-issue', title: 'Create Linear issue' }]
+    const { manifest } = parseManifest({ ...valid(), shortcuts })
+
+    expect(manifest.shortcuts).toEqual(shortcuts)
+  })
+
+  it('ignores optional fields of the wrong shape rather than adopting them', () => {
+    const { manifest } = parseManifest({ ...valid(), provides: 'everything', shortcuts: 'x' })
+
+    expect(manifest.provides).toEqual({})
+    expect(manifest.shortcuts).toEqual([])
+  })
+
+  it('reports an unknown field rather than ignoring it', () => {
+    // A mistyped key is an author expecting behaviour they will not get, and
+    // silence is the one response that guarantees they never find out.
+    const { ok, reason } = parseManifest({ ...valid(), licence: 'MIT' })
+
+    expect(ok).toBe(false)
+    expect(reason).toBe('Unknown field: "licence".')
+  })
+
+  it('lists every unknown field, not just the first', () => {
+    const { reason } = parseManifest({ ...valid(), licence: 'MIT', autor: 'me' })
+    expect(reason).toBe('Unknown fields: "licence", "autor".')
+  })
+})
+
+describe('satisfiesRange', () => {
+  it('reads a caret range as anything up to the next major', () => {
+    expect(satisfiesRange('1.4.0', '^1.4').satisfied).toBe(true)
+    expect(satisfiesRange('1.9.9', '^1.4').satisfied).toBe(true)
+    expect(satisfiesRange('2.0.0', '^1.4').satisfied).toBe(false)
+    expect(satisfiesRange('1.3.9', '^1.4').satisfied).toBe(false)
+  })
+
+  it('reads a tilde range as anything up to the next minor', () => {
+    expect(satisfiesRange('1.4.7', '~1.4').satisfied).toBe(true)
+    expect(satisfiesRange('1.5.0', '~1.4').satisfied).toBe(false)
+  })
+
+  it('reads >= as having no ceiling', () => {
+    expect(satisfiesRange('9.0.0', '>=1.4').satisfied).toBe(true)
+    expect(satisfiesRange('1.3.0', '>=1.4').satisfied).toBe(false)
+  })
+
+  it('reads a bare version as exactly itself', () => {
+    expect(satisfiesRange('1.4.0', '1.4.0').satisfied).toBe(true)
+    expect(satisfiesRange('1.4.1', '1.4.0').satisfied).toBe(false)
+  })
+
+  it('treats a missing part as zero, and tolerates a v prefix', () => {
+    expect(satisfiesRange('1.4', '^1.4').satisfied).toBe(true)
+    expect(satisfiesRange('v1.4.0', '^1.4').satisfied).toBe(true)
+    // A bare major on both sides: "2" is 2.0.0, and satisfies ">=1".
+    expect(satisfiesRange('2', '>=1').satisfied).toBe(true)
+    expect(satisfiesRange('1', '^2').satisfied).toBe(false)
+  })
+
+  it('refuses a version or a range it cannot compare', () => {
+    expect(satisfiesRange('nightly', '^1.4').ok).toBe(false)
+    expect(satisfiesRange('1.4.0', '').reason).toContain('"engines.agentrq" is required')
+    expect(satisfiesRange('1.4.0', '^banana').ok).toBe(false)
+  })
+})
+
+describe('checkCompatibility', () => {
+  const manifest = () => parseManifest(valid()).manifest
+  const tools = { workspaceTools: ['getTask', 'reply'], supervisorTools: ['listAllTasks'] }
+
+  it('passes when the app is new enough and every tool exists', () => {
+    const { compatible, reasons } = checkCompatibility(manifest(), { appVersion: '1.4.2', ...tools })
+
+    expect(compatible).toBe(true)
+    expect(reasons).toEqual([])
+  })
+
+  it('says which version is needed and which is running', () => {
+    const { compatible, reasons } = checkCompatibility(manifest(), { appVersion: '1.3.0', ...tools })
+
+    expect(compatible).toBe(false)
+    expect(reasons[0]).toBe('Needs AgentRQ ^1.4; this is 1.3.0.')
+  })
+
+  it('names a tool the connected server does not offer', () => {
+    // The real check: a self-hosted backend may be older than the extension.
+    const { compatible, reasons } = checkCompatibility(manifest(), {
+      appVersion: '1.4.0',
+      workspaceTools: ['getTask'],
+      supervisorTools: [],
+    })
+
+    expect(compatible).toBe(false)
+    expect(reasons).toContain('The workspace server does not offer "reply".')
+    expect(reasons).toContain('The supervisor server does not offer "listAllTasks".')
+  })
+
+  it('reports every reason, not just the first', () => {
+    // An author fixing a manifest wants the whole list.
+    const { reasons } = checkCompatibility(manifest(), { appVersion: '1.0.0' })
+
+    expect(reasons.length).toBe(4)
+  })
+
+  it('carries an unparseable range through as its own reason', () => {
+    const broken = { ...manifest(), engines: { agentrq: 'whenever' } }
+    const { compatible, reasons } = checkCompatibility(broken, { appVersion: '1.4.0', ...tools })
+
+    expect(compatible).toBe(false)
+    expect(reasons[0]).toContain('not a range this understands')
+  })
+
+  it('assumes nothing is offered when told nothing', () => {
+    const { compatible } = checkCompatibility(manifest(), { appVersion: '1.4.0' })
+    expect(compatible).toBe(false)
+  })
+})


### PR DESCRIPTION
> **1 of 10, stacked.** Targets `feat/extensions`, the integration branch. Nothing reaches `main` until the final PR. [Plan](https://claude.ai/code/artifact/907d107c-921d-4e0e-a371-de22229c2927).

## What changed

The desktop app can now read an extension's manifest and say whether it is a valid one — and if not, exactly what is wrong with it, in words its author can act on.

## Why changed

A repository carrying the `agentrq-extension` topic is only an extension if its manifest says so. Everything that follows — the catalogue, the installer, the grant screen — trusts what comes out of this, so it is the foundation and is built to be checked directly rather than discovered later inside an installer.

## Test coverage report

New lines introduced: **100%**. Total coverage impact: **unchanged at 100%** on all four metrics — the desktop suite is now 515 tests across 18 files, up from 470 across 17.

Pure functions, no Electron, no network, no filesystem, so every rule is tested at the point it is stated. Tests assert the **reasons**, not just the verdicts: a broken manifest is listed in the catalogue with its reason showing, which makes those strings user-facing copy.

## Other reports

**License is required, and must be an SPDX identifier.** An extension runs with full access to the machine, so its terms are part of the decision to install rather than metadata. Free text would make `MIT`, `mit` and `MIT License` three incomparable licenses; accepting any SPDX-*shaped* string would take `MITT` without comment. So it is a fixed case-sensitive list — and a case-insensitive near-miss is **corrected** rather than refused, because `mit` is not a slip to reject flatly, it is somebody who meant `MIT`. `UNLICENSED` is deliberately valid.

**Validation is split in two, where the task described one function.** `parseManifest` answers "is this well-formed", which depends only on the document and is settled once at discovery. `checkCompatibility` answers "can *this* install run it", which depends on the running app and on the tools the connected server actually advertises — and must be re-asked at install and on update, against a self-hosted backend that may be older than the extension expects. Folding them together would mean either caching an answer that goes stale or refusing to index anything until a server is reachable.

**The semver subset is deliberately narrow** — exact, `^`, `~`, `>=` — and anything outside it is refused as unsupported rather than guessed at. This project carries exactly one runtime dependency; re-implementing the whole grammar to avoid a second would trade a dependency for a class of subtle bugs. (`semver` is present transitively today, which is not the same as being available.)

**Unknown fields are reported, not ignored.** A mistyped key is an author expecting behaviour they will not get.

Nothing is wired up yet: no discovery, no UI, nothing executes. That is 2/10 onward.

## TaskID: 0iV04SNosS1
