### PR TITLE
feat(extensions): find them by topic, and remember what was found

### DIFF
--- a/desktop/src/main/extensions/discovery.js
+++ b/desktop/src/main/extensions/discovery.js
@@ -1,0 +1,305 @@
+import { parseManifest } from './manifest.js'
+
+/**
+ * Finding extensions, and remembering what was found.
+ *
+ * Discovery is a GitHub repository topic. Anyone may publish by adding
+ * `agentrq-extension` to a repository and committing a manifest — there is no
+ * registry to run, no submission flow, and nobody to arbitrate a namespace. The
+ * cost of that openness is that the topic is *discovery, not endorsement*, which
+ * is why the catalogue shows an owner and a star count rather than a badge.
+ *
+ * ## This runs in the main process, and could not run anywhere else
+ *
+ * The renderer is served from the privileged `app://` scheme, whose entire
+ * purpose is that it only ever sees same-origin traffic — that is why `/api`,
+ * `/mcp` and `/.well-known` are forwarded from here rather than fetched there.
+ * A request to api.github.com from the renderer is exactly the cross-origin call
+ * that architecture exists to prevent, and the CSP would refuse it anyway.
+ *
+ * `fetchJson` and the two file operations are injected, so the whole path is
+ * testable without a network or a disk.
+ *
+ * ## What the live API actually does
+ *
+ * Measured rather than assumed, because both limits shape the design:
+ *
+ * - **10 requests a minute** unauthenticated, **30** with a user token.
+ * - **1000 results maximum** for any one search, however many exist.
+ *
+ * The first is why nothing here runs on a page load: the UI reads the cache, and
+ * a refresh is a deliberate act or a long timer. The second is why the search is
+ * partitioned — the ceiling is not hypothetical, `topic:mcp-server` already
+ * returns over 28,000 repositories, of which only the first 1000 are reachable.
+ */
+
+/** The topic that makes a repository findable as an extension. */
+export const TOPIC = 'agentrq-extension'
+
+/** GitHub's maximum, and its hard ceiling on any single search. */
+export const SEARCH_PAGE_SIZE = 100
+export const SEARCH_RESULT_CAP = 1000
+
+/** Long enough that a background refresh is never the reason a limit is hit. */
+export const REFRESH_INTERVAL_MS = 6 * 60 * 60 * 1000
+
+/**
+ * Star ranges the search is split across when one query cannot reach everything.
+ *
+ * Split by stars rather than by date because the distribution is extreme — the
+ * overwhelming majority of repositories have none — so the buckets get finer at
+ * the bottom, where the crowd is. Each is a disjoint range, so a repository
+ * appears in exactly one and no result is counted twice.
+ */
+export const STAR_BUCKETS = [
+  '>=1000',
+  '200..999',
+  '50..199',
+  '10..49',
+  '3..9',
+  '1..2',
+  '0',
+]
+
+/** The search query for the whole topic, or for one slice of it. */
+export function buildQuery(starRange = '') {
+  return starRange ? `topic:${TOPIC} stars:${starRange}` : `topic:${TOPIC}`
+}
+
+/** Where a repository's manifest lives, on whichever branch is its default. */
+export function manifestUrl({ fullName, defaultBranch }) {
+  return `https://raw.githubusercontent.com/${fullName}/${defaultBranch}/agentrq-extension.json`
+}
+
+/** The fields of a search result the catalogue actually shows or needs. */
+function toRepo(item) {
+  return {
+    fullName: item.full_name,
+    owner: item.owner?.login ?? item.full_name?.split('/')[0] ?? '',
+    name: item.name,
+    description: item.description ?? '',
+    stars: item.stargazers_count ?? 0,
+    pushedAt: item.pushed_at ?? '',
+    defaultBranch: item.default_branch || 'main',
+    url: item.html_url ?? `https://github.com/${item.full_name}`,
+  }
+}
+
+/**
+ * Every repository carrying the topic, across as many searches as it takes.
+ *
+ * Returns `truncated` when the ceiling genuinely could not be worked around —
+ * a single star bucket holding more than a thousand repositories. Reported
+ * rather than hidden: a catalogue quietly missing entries is worse than one that
+ * says it is incomplete, because nobody can tell the difference from inside.
+ */
+export async function searchRepos(fetchJson, { token = '' } = {}) {
+  const first = await fetchJson(searchUrl(buildQuery(), 1), token)
+  const total = first?.total_count ?? 0
+
+  if (total <= SEARCH_RESULT_CAP) {
+    const repos = await drainPages(fetchJson, buildQuery(), total, token, first)
+    return { repos, truncated: false }
+  }
+
+  const seen = new Map()
+  let truncated = false
+  for (const bucket of STAR_BUCKETS) {
+    const query = buildQuery(bucket)
+    const head = await fetchJson(searchUrl(query, 1), token)
+    const count = head?.total_count ?? 0
+    if (count > SEARCH_RESULT_CAP) truncated = true
+
+    for (const repo of await drainPages(fetchJson, query, count, token, head)) {
+      // Buckets are disjoint, so this only guards against a repository gaining
+      // or losing a star between two requests — cheap insurance against a
+      // duplicate or a gap that would otherwise be invisible.
+      seen.set(repo.fullName, repo)
+    }
+  }
+  return { repos: [...seen.values()], truncated }
+}
+
+function searchUrl(query, page) {
+  const params = new URLSearchParams({
+    q: query,
+    per_page: String(SEARCH_PAGE_SIZE),
+    page: String(page),
+    sort: 'stars',
+    order: 'desc',
+  })
+  return `https://api.github.com/search/repositories?${params}`
+}
+
+/** Pages through one query, reusing the response that told us how many there are. */
+async function drainPages(fetchJson, query, total, token, first) {
+  const reachable = Math.min(total, SEARCH_RESULT_CAP)
+  const pages = Math.ceil(reachable / SEARCH_PAGE_SIZE)
+  const repos = (first?.items ?? []).map(toRepo)
+
+  for (let page = 2; page <= pages; page += 1) {
+    const body = await fetchJson(searchUrl(query, page), token)
+    repos.push(...(body?.items ?? []).map(toRepo))
+  }
+  return repos.slice(0, reachable)
+}
+
+/**
+ * One catalogue row: a repository, and either its extension or why it has none.
+ *
+ * A repository carrying the topic with a manifest that does not parse is kept
+ * here as **broken, with its reason**, rather than dropped. The author needs to
+ * see why — a silently missing extension is undebuggable for them — and anyone
+ * following a link to it needs the catalogue to explain itself rather than
+ * appear empty.
+ */
+export function toEntry(repo, manifestSource) {
+  if (manifestSource === null) {
+    return { ...repo, ok: false, reason: 'No agentrq-extension.json in this repository.' }
+  }
+  const parsed = parseManifest(manifestSource)
+  return parsed.ok
+    ? { ...repo, ok: true, manifest: parsed.manifest }
+    : { ...repo, ok: false, reason: parsed.reason }
+}
+
+/** Runs `worker` over `items`, a few at a time. */
+async function pooled(items, limit, worker) {
+  const out = []
+  for (let i = 0; i < items.length; i += limit) {
+    out.push(...(await Promise.all(items.slice(i, i + limit).map(worker))))
+  }
+  return out
+}
+
+/**
+ * The catalogue: what is known, and how to go and find out again.
+ *
+ * @param {object} deps
+ * @param {(url: string, token: string) => Promise<any>} deps.fetchJson  Resolves null on 404.
+ * @param {(url: string, token: string) => Promise<string|null>} deps.fetchText
+ * @param {() => Promise<string>} deps.readFile   Rejects when the cache is absent.
+ * @param {(contents: string) => Promise<void>} deps.writeFile
+ * @param {() => number} [deps.now]
+ * @param {number} [deps.concurrency]
+ */
+export function createDiscovery({
+  fetchJson,
+  fetchText,
+  readFile,
+  writeFile,
+  now = () => Date.now(),
+  concurrency = 6,
+}) {
+  // `fetchedAt` is null for "never looked", not 0 — an epoch timestamp is a
+  // legitimate value, and a sentinel that collides with one is a bug waiting for
+  // whoever writes the test that happens to start its clock there.
+  let index = { entries: [], fetchedAt: null, truncated: false }
+  let loaded = false
+
+  async function load() {
+    if (loaded) return index
+    loaded = true
+    try {
+      const parsed = JSON.parse(await readFile())
+      if (Array.isArray(parsed?.entries)) index = { truncated: false, fetchedAt: null, ...parsed }
+    } catch {
+      // No cache yet, or one we cannot read. Either way the catalogue is empty
+      // until a refresh, which is a state the UI already has to render.
+    }
+    return index
+  }
+
+  return {
+    /**
+     * What is known right now, without going anywhere.
+     *
+     * This is what the UI calls. At ten requests a minute, a catalogue that
+     * searched on every page load would spend its budget on people who opened a
+     * panel and closed it again.
+     */
+    async list() {
+      const current = await load()
+      // The entries array is copied too. A shallow spread hands the caller the
+      // very array this holds, so anything that sorted or filtered it in place
+      // would quietly edit the catalogue for everyone who asks next.
+      return { ...current, entries: [...current.entries] }
+    },
+
+    /**
+     * Whether enough time has passed that a background refresh is due.
+     *
+     * A catalogue that has never been fetched is stale by definition, however
+     * recently the app started. Treating "never" as an age would leave a first
+     * run reporting itself fresh and empty.
+     */
+    async isStale() {
+      const { fetchedAt } = await load()
+      return fetchedAt === null || now() - fetchedAt >= REFRESH_INTERVAL_MS
+    },
+
+    /**
+     * Go and look again.
+     *
+     * Manifests are only re-fetched for repositories that have actually been
+     * pushed to since the last look. A catalogue of any size is mostly unchanged
+     * between refreshes, and re-reading every manifest to discover that would
+     * turn a routine refresh into hundreds of requests.
+     *
+     * A failure leaves the cache exactly as it was. Replacing a working
+     * catalogue with an empty one because a request timed out would be a worse
+     * answer than the slightly stale one already in hand.
+     */
+    async refresh({ token = '' } = {}) {
+      const previous = await load()
+      const known = new Map(previous.entries.map((entry) => [entry.fullName, entry]))
+
+      let found
+      try {
+        found = await searchRepos(fetchJson, { token })
+      } catch (error) {
+        return {
+          ok: false,
+          reason: describeFailure(error),
+          index: { ...previous, entries: [...previous.entries] },
+        }
+      }
+
+      const entries = await pooled(found.repos, concurrency, async (repo) => {
+        const cached = known.get(repo.fullName)
+        if (cached && cached.pushedAt && cached.pushedAt === repo.pushedAt) {
+          // Unchanged since we last read it: keep the verdict, refresh the
+          // things that move on their own, like the star count.
+          return { ...cached, ...repo }
+        }
+        try {
+          return toEntry(repo, await fetchText(manifestUrl(repo), token))
+        } catch (error) {
+          return { ...repo, ok: false, reason: describeFailure(error) }
+        }
+      })
+
+      index = { entries, fetchedAt: now(), truncated: found.truncated }
+      try {
+        await writeFile(JSON.stringify(index))
+      } catch {
+        // An unwritable cache costs the next launch a refresh; it does not make
+        // this one wrong, and failing here would throw away results we have.
+      }
+      return { ok: true, index: { ...index, entries: [...entries] } }
+    },
+  }
+}
+
+/** Turns a failure into something worth putting in front of a person. */
+export function describeFailure(error) {
+  const message = String(error?.message ?? error ?? 'Unknown error')
+
+  if (/rate limit|\b403\b/i.test(message)) {
+    return 'GitHub rate limit reached. Add a personal access token in settings, or try again shortly.'
+  }
+  if (/ENOTFOUND|ETIMEDOUT|ECONNREFUSED|EAI_AGAIN|network|fetch failed/i.test(message)) {
+    return 'Could not reach GitHub.'
+  }
+  return message
+}

--- a/desktop/test/extensions/discovery.test.js
+++ b/desktop/test/extensions/discovery.test.js
@@ -1,0 +1,465 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import {
+  REFRESH_INTERVAL_MS,
+  SEARCH_RESULT_CAP,
+  STAR_BUCKETS,
+  buildQuery,
+  createDiscovery,
+  describeFailure,
+  manifestUrl,
+  searchRepos,
+  toEntry,
+} from '../../src/main/extensions/discovery.js'
+
+/**
+ * Two measured facts drive almost everything here: GitHub answers 10 searches a
+ * minute unauthenticated, and returns at most 1000 results for any one query
+ * however many exist. The first is why nothing searches on a page load; the
+ * second is why the search is partitioned. `topic:mcp-server` already holds over
+ * 28,000 repositories, so the ceiling is not hypothetical.
+ */
+
+/** A search result item in the shape GitHub actually returns. */
+const item = (n, over = {}) => ({
+  full_name: `owner${n}/ext${n}`,
+  name: `ext${n}`,
+  owner: { login: `owner${n}` },
+  description: `Extension ${n}`,
+  stargazers_count: n,
+  pushed_at: `2026-09-0${(n % 9) + 1}T00:00:00Z`,
+  default_branch: 'main',
+  html_url: `https://github.com/owner${n}/ext${n}`,
+  ...over,
+})
+
+const manifestFor = (name) =>
+  JSON.stringify({
+    name,
+    version: '1.0.0',
+    license: 'MIT',
+    engines: { agentrq: '^1.4' },
+    artifact: { release: 'v1.0.0', asset: `${name}.tgz`, sha256: 'a'.repeat(64) },
+  })
+
+/** A fake GitHub: a page of results per query, and a manifest per repository. */
+function fakeGitHub({ totals = {}, manifests = {}, defaultTotal = 2 } = {}) {
+  const calls = { search: [], manifest: [] }
+
+  const fetchJson = vi.fn(async (url, token) => {
+    const parsed = new URL(url)
+    const query = parsed.searchParams.get('q')
+    const page = Number(parsed.searchParams.get('page'))
+    calls.search.push({ query, page, token })
+
+    const total = totals[query] ?? defaultTotal
+    const reachable = Math.min(total, SEARCH_RESULT_CAP)
+    const start = (page - 1) * 100
+    const count = Math.max(0, Math.min(100, reachable - start))
+    // Number the items by query so buckets return distinct repositories.
+    const offset = Object.keys(totals).indexOf(query) * 1000
+    return {
+      total_count: total,
+      items: Array.from({ length: count }, (_, i) => item(offset + start + i + 1)),
+    }
+  })
+
+  const fetchText = vi.fn(async (url, token) => {
+    calls.manifest.push({ url, token })
+    const name = url.split('/')[4]
+    return name in manifests ? manifests[name] : manifestFor(name)
+  })
+
+  return { fetchJson, fetchText, calls }
+}
+
+/** An in-memory cache file. */
+function fakeStore(initial = null) {
+  let contents = initial
+  return {
+    readFile: vi.fn(async () => {
+      if (contents === null) throw new Error('ENOENT')
+      return contents
+    }),
+    writeFile: vi.fn(async (next) => {
+      contents = next
+    }),
+    get contents() {
+      return contents
+    },
+  }
+}
+
+describe('buildQuery and manifestUrl', () => {
+  it('searches the topic, and one slice of it', () => {
+    expect(buildQuery()).toBe('topic:agentrq-extension')
+    expect(buildQuery('10..49')).toBe('topic:agentrq-extension stars:10..49')
+  })
+
+  it('reads the manifest from whichever branch is the default', () => {
+    // Not every repository is on main, and guessing costs a 404 per repo.
+    expect(manifestUrl({ fullName: 'a/b', defaultBranch: 'trunk' })).toBe(
+      'https://raw.githubusercontent.com/a/b/trunk/agentrq-extension.json',
+    )
+  })
+})
+
+describe('searchRepos', () => {
+  it('pages through a result set that fits under the ceiling', async () => {
+    const { fetchJson, calls } = fakeGitHub({ totals: { 'topic:agentrq-extension': 250 } })
+
+    const { repos, truncated } = await searchRepos(fetchJson)
+
+    expect(repos).toHaveLength(250)
+    expect(truncated).toBe(false)
+    expect(calls.search.map((c) => c.page)).toEqual([1, 2, 3])
+  })
+
+  it('does not partition when it does not have to', async () => {
+    const { fetchJson, calls } = fakeGitHub({ totals: { 'topic:agentrq-extension': 40 } })
+
+    await searchRepos(fetchJson)
+
+    // One query, one page: the budget is ten searches a minute.
+    expect(calls.search).toHaveLength(1)
+  })
+
+  it('partitions by stars once the topic outgrows a single search', async () => {
+    // The case that is already real for a popular topic: more repositories exist
+    // than any one query can reach, so the search is split into disjoint slices.
+    const totals = { 'topic:agentrq-extension': 4000 }
+    for (const bucket of STAR_BUCKETS) totals[buildQuery(bucket)] = 100
+    const { fetchJson, calls } = fakeGitHub({ totals })
+
+    const { repos, truncated } = await searchRepos(fetchJson)
+
+    expect(truncated).toBe(false)
+    expect(repos).toHaveLength(STAR_BUCKETS.length * 100)
+    const queried = calls.search.map((c) => c.query)
+    for (const bucket of STAR_BUCKETS) expect(queried).toContain(buildQuery(bucket))
+  })
+
+  it('says so when even a slice cannot be reached in full', async () => {
+    // Honest rather than quietly short: a catalogue missing entries with no way
+    // to tell is worse than one that reports itself incomplete.
+    const totals = { 'topic:agentrq-extension': 40000 }
+    for (const bucket of STAR_BUCKETS) totals[buildQuery(bucket)] = 50
+    totals[buildQuery('0')] = 5000
+    const { fetchJson } = fakeGitHub({ totals })
+
+    const { truncated } = await searchRepos(fetchJson)
+
+    expect(truncated).toBe(true)
+  })
+
+  it('never returns more than the ceiling from one query', async () => {
+    const { fetchJson } = fakeGitHub({ totals: { 'topic:agentrq-extension': 1000 } })
+
+    const { repos } = await searchRepos(fetchJson)
+
+    expect(repos).toHaveLength(SEARCH_RESULT_CAP)
+  })
+
+  it('sends the token when there is one, and nothing when there is not', async () => {
+    const { fetchJson, calls } = fakeGitHub()
+
+    await searchRepos(fetchJson, { token: 'ghp_x' })
+    await searchRepos(fetchJson)
+
+    expect(calls.search[0].token).toBe('ghp_x')
+    expect(calls.search.at(-1).token).toBe('')
+  })
+
+  it('copes with a response carrying no items at all', async () => {
+    const fetchJson = vi.fn(async () => ({}))
+    const { repos } = await searchRepos(fetchJson)
+    expect(repos).toEqual([])
+  })
+
+  it('copes with a later page that comes back empty', async () => {
+    // The count and the pages are two separate requests; a repository deleted
+    // between them leaves a short page rather than an error.
+    const fetchJson = vi.fn(async (url) => {
+      const page = Number(new URL(url).searchParams.get('page'))
+      return page === 1 ? { total_count: 150, items: [item(1)] } : {}
+    })
+
+    const { repos } = await searchRepos(fetchJson)
+
+    expect(repos).toHaveLength(1)
+  })
+
+  it('copes with a bucket whose head response says nothing', async () => {
+    const fetchJson = vi.fn(async (url) => {
+      const query = new URL(url).searchParams.get('q')
+      return query === 'topic:agentrq-extension' ? { total_count: 4000, items: [] } : null
+    })
+
+    const { repos, truncated } = await searchRepos(fetchJson)
+
+    expect(repos).toEqual([])
+    expect(truncated).toBe(false)
+  })
+
+  it('fills in what a sparse search result leaves out', async () => {
+    // GitHub omits a description that is null, and a repository can be missing
+    // fields the catalogue still has to render something for.
+    const fetchJson = vi.fn(async () => ({
+      total_count: 1,
+      items: [{ full_name: 'solo/ext' }],
+    }))
+
+    const { repos } = await searchRepos(fetchJson)
+
+    expect(repos[0]).toEqual({
+      fullName: 'solo/ext',
+      owner: 'solo',
+      name: undefined,
+      description: '',
+      stars: 0,
+      pushedAt: '',
+      defaultBranch: 'main',
+      url: 'https://github.com/solo/ext',
+    })
+  })
+
+  it('has an owner even when the result carries neither owner nor full name', async () => {
+    const fetchJson = vi.fn(async () => ({ total_count: 1, items: [{ name: 'ext' }] }))
+
+    const { repos } = await searchRepos(fetchJson)
+
+    expect(repos[0].owner).toBe('')
+  })
+})
+
+describe('toEntry', () => {
+  const repo = { fullName: 'a/b', owner: 'a', stars: 3 }
+
+  it('keeps a valid manifest', () => {
+    const entry = toEntry(repo, manifestFor('linear'))
+
+    expect(entry.ok).toBe(true)
+    expect(entry.manifest.name).toBe('linear')
+    expect(entry.stars).toBe(3)
+  })
+
+  it('keeps a repository with no manifest, and says that is what is wrong', () => {
+    const entry = toEntry(repo, null)
+
+    expect(entry.ok).toBe(false)
+    expect(entry.reason).toBe('No agentrq-extension.json in this repository.')
+  })
+
+  it('keeps a broken manifest, and carries the reason through', () => {
+    // The author needs to see why. A silently missing extension is
+    // undebuggable for them, and looks like a broken catalogue to everyone else.
+    const entry = toEntry(repo, JSON.stringify({ name: 'x', version: '1.0.0' }))
+
+    expect(entry.ok).toBe(false)
+    expect(entry.reason).toContain('"license" is required')
+  })
+
+  it('keeps a repository whose manifest is not JSON', () => {
+    expect(toEntry(repo, '<!doctype html>').reason).toBe('This is not valid JSON.')
+  })
+})
+
+describe('createDiscovery', () => {
+  const build = (github = fakeGitHub(), store = fakeStore(), extra = {}) =>
+    createDiscovery({ ...github, ...store, ...extra })
+
+  it('starts empty and goes nowhere until asked', async () => {
+    // Ten searches a minute is not a budget to spend on people who opened a
+    // panel and closed it again.
+    const github = fakeGitHub()
+    const discovery = build(github)
+
+    const index = await discovery.list()
+
+    expect(index.entries).toEqual([])
+    expect(github.fetchJson).not.toHaveBeenCalled()
+  })
+
+  it('reads a cache written by an earlier run', async () => {
+    const cached = JSON.stringify({
+      entries: [{ fullName: 'a/b', ok: true, manifest: { name: 'b' } }],
+      fetchedAt: 1000,
+    })
+    const discovery = build(fakeGitHub(), fakeStore(cached))
+
+    const index = await discovery.list()
+
+    expect(index.entries).toHaveLength(1)
+    expect(index.fetchedAt).toBe(1000)
+  })
+
+  it('ignores a cache it cannot make sense of', async () => {
+    const discovery = build(fakeGitHub(), fakeStore('{ not json'))
+    expect((await discovery.list()).entries).toEqual([])
+  })
+
+  it('ignores a cache of the wrong shape', async () => {
+    const discovery = build(fakeGitHub(), fakeStore('{"entries":"lots"}'))
+    expect((await discovery.list()).entries).toEqual([])
+  })
+
+  it('searches, reads every manifest, and writes what it found', async () => {
+    const github = fakeGitHub({ totals: { 'topic:agentrq-extension': 2 } })
+    const store = fakeStore()
+    const discovery = build(github, store, { now: () => 5000 })
+
+    const { ok, index } = await discovery.refresh()
+
+    expect(ok).toBe(true)
+    expect(index.entries).toHaveLength(2)
+    expect(index.entries.every((e) => e.ok)).toBe(true)
+    expect(index.fetchedAt).toBe(5000)
+    expect(JSON.parse(store.contents).entries).toHaveLength(2)
+  })
+
+  it('re-reads only the repositories that have actually changed', async () => {
+    // A catalogue is mostly unchanged between refreshes. Re-reading every
+    // manifest to discover that would turn a routine refresh into hundreds of
+    // requests against a limit measured in tens per minute.
+    const github = fakeGitHub({ totals: { 'topic:agentrq-extension': 2 } })
+    const store = fakeStore()
+    const discovery = build(github, store)
+
+    await discovery.refresh()
+    const afterFirst = github.fetchText.mock.calls.length
+    await discovery.refresh()
+
+    expect(afterFirst).toBe(2)
+    expect(github.fetchText.mock.calls.length).toBe(2)
+  })
+
+  it('re-reads a repository that has been pushed to since', async () => {
+    const github = fakeGitHub({ totals: { 'topic:agentrq-extension': 1 } })
+    const store = fakeStore()
+    const discovery = build(github, store)
+    await discovery.refresh()
+
+    github.fetchJson.mockImplementationOnce(async () => ({
+      total_count: 1,
+      items: [item(1, { pushed_at: '2026-10-01T00:00:00Z' })],
+    }))
+    await discovery.refresh()
+
+    expect(github.fetchText.mock.calls.length).toBe(2)
+  })
+
+  it('keeps the star count current even for an unchanged repository', async () => {
+    // Stars move on their own; the manifest does not.
+    const github = fakeGitHub({ totals: { 'topic:agentrq-extension': 1 } })
+    const discovery = build(github, fakeStore())
+    await discovery.refresh()
+
+    github.fetchJson.mockImplementationOnce(async () => ({
+      total_count: 1,
+      items: [item(1, { stargazers_count: 99 })],
+    }))
+    const { index } = await discovery.refresh()
+
+    expect(index.entries[0].stars).toBe(99)
+    expect(index.entries[0].ok).toBe(true)
+  })
+
+  it('keeps the previous catalogue when the search fails', async () => {
+    // Replacing a working catalogue with an empty one because a request timed
+    // out is a worse answer than the slightly stale one already in hand.
+    const github = fakeGitHub({ totals: { 'topic:agentrq-extension': 2 } })
+    const discovery = build(github, fakeStore())
+    await discovery.refresh()
+
+    github.fetchJson.mockRejectedValueOnce(new Error('fetch failed'))
+    const { ok, reason, index } = await discovery.refresh()
+
+    expect(ok).toBe(false)
+    expect(reason).toBe('Could not reach GitHub.')
+    expect(index.entries).toHaveLength(2)
+  })
+
+  it('records a manifest that could not be fetched as that repository’s reason', async () => {
+    const github = fakeGitHub({ totals: { 'topic:agentrq-extension': 1 } })
+    github.fetchText.mockRejectedValueOnce(new Error('ETIMEDOUT'))
+    const discovery = build(github, fakeStore())
+
+    const { index } = await discovery.refresh()
+
+    expect(index.entries[0].ok).toBe(false)
+    expect(index.entries[0].reason).toBe('Could not reach GitHub.')
+  })
+
+  it('keeps the results when the cache cannot be written', async () => {
+    const store = fakeStore()
+    store.writeFile.mockRejectedValueOnce(new Error('EACCES'))
+    const discovery = build(fakeGitHub({ totals: { 'topic:agentrq-extension': 1 } }), store)
+
+    const { ok, index } = await discovery.refresh()
+
+    expect(ok).toBe(true)
+    expect(index.entries).toHaveLength(1)
+  })
+
+  it('passes the token to both the search and the manifest reads', async () => {
+    const github = fakeGitHub({ totals: { 'topic:agentrq-extension': 1 } })
+    const discovery = build(github, fakeStore())
+
+    await discovery.refresh({ token: 'ghp_x' })
+
+    expect(github.calls.search[0].token).toBe('ghp_x')
+    expect(github.calls.manifest[0].token).toBe('ghp_x')
+  })
+
+  it('carries truncation through to the catalogue', async () => {
+    const totals = { 'topic:agentrq-extension': 40000 }
+    for (const bucket of STAR_BUCKETS) totals[buildQuery(bucket)] = 10
+    totals[buildQuery('0')] = 5000
+    const discovery = build(fakeGitHub({ totals }), fakeStore())
+
+    expect((await discovery.refresh()).index.truncated).toBe(true)
+  })
+
+  it('knows when a refresh is due', async () => {
+    let clock = 0
+    const discovery = build(fakeGitHub({ totals: { 'topic:agentrq-extension': 1 } }), fakeStore(), {
+      now: () => clock,
+    })
+
+    expect(await discovery.isStale()).toBe(true)
+    await discovery.refresh()
+    expect(await discovery.isStale()).toBe(false)
+
+    clock = REFRESH_INTERVAL_MS
+    expect(await discovery.isStale()).toBe(true)
+  })
+
+  it('hands out a copy, so a caller cannot edit the catalogue', async () => {
+    const discovery = build(fakeGitHub({ totals: { 'topic:agentrq-extension': 1 } }), fakeStore())
+    await discovery.refresh()
+
+    const first = await discovery.list()
+    first.entries.length = 0
+
+    expect((await discovery.list()).entries).toHaveLength(1)
+  })
+})
+
+describe('describeFailure', () => {
+  it('names the rate limit and what to do about it', () => {
+    // The one failure a person can actually act on.
+    expect(describeFailure(new Error('API rate limit exceeded'))).toContain('personal access token')
+    expect(describeFailure(new Error('HTTP 403'))).toContain('rate limit')
+  })
+
+  it('reports an unreachable network plainly', () => {
+    for (const message of ['ENOTFOUND', 'ETIMEDOUT', 'ECONNREFUSED', 'fetch failed']) {
+      expect(describeFailure(new Error(message)), message).toBe('Could not reach GitHub.')
+    }
+  })
+
+  it('passes anything else through rather than inventing a diagnosis', () => {
+    expect(describeFailure(new Error('Unexpected token <'))).toBe('Unexpected token <')
+    expect(describeFailure(undefined)).toBe('Unknown error')
+  })
+})


### PR DESCRIPTION
> **2 of 10, stacked on [#515](https://github.com/agentrq/agentrq/pull/515).** Targets `ext/01-manifest`. [Plan](https://claude.ai/code/artifact/907d107c-921d-4e0e-a371-de22229c2927).

## What changed

The desktop app can now find extensions — searching GitHub for the topic, reading each manifest, and keeping a local catalogue of what it found.

## Why changed

Discovery is a GitHub topic rather than a registry, so there is nothing to run and nobody to arbitrate a namespace. What that costs is the work of searching within limits that are much tighter than they look.

## Test coverage report

New lines introduced: **100%**. Total coverage impact: **unchanged at 100%** on all four metrics — 550 tests across 19 files, up from 515 across 18.

`fetchJson`, `fetchText`, `readFile` and `writeFile` are all injected, so pagination, partitioning, rate limits, network failure and cache corruption are all exercised without a network or a disk.

## Other reports

**Two measured limits shape the design**, both checked against the live API rather than assumed:

| | |
|---|---|
| Search, unauthenticated | 10 req/min |
| Search, with a token | 30 req/min |
| Max results per search | **1000**, hard cap |

So **nothing searches on a page load** — the UI reads the cache, and a refresh is a deliberate act or a long timer. And the search is **partitioned across disjoint star ranges** when one query cannot reach everything. That ceiling is not hypothetical: `topic:mcp-server` already holds over 28,000 repositories, of which only the first 1000 are reachable.

**Where even a slice cannot be reached, the catalogue reports itself truncated** rather than being quietly short. From the inside, a catalogue missing entries is indistinguishable from a complete one.

**Refreshes are incremental.** Manifests are re-read only for repositories pushed to since the last look, because a catalogue is mostly unchanged between refreshes and re-reading everything to discover that would turn a routine refresh into hundreds of requests. Star counts refresh regardless — they move on their own.

**A failed refresh keeps the previous catalogue.** Replacing something that works with an empty list because a request timed out is a worse answer than a slightly stale one.

**Two bugs the tests caught rather than confirmed:**

- `list()` spread the index shallowly, handing callers the very array it holds — anything sorting or filtering in place would have edited the catalogue for everyone who asked next.
- A never-fetched catalogue reported itself **fresh**, because the "never" sentinel was `0` and `0` is also a legitimate timestamp. It is `null` now, which cannot collide with one.

Still no UI and nothing executes: that is 3/10 onward.

## TaskID: 0iV06ITQlrl
