### PR TITLE
feat(extensions): browse the catalogue, and see why anything is unusable

### DIFF
--- a/desktop/src/main/extensions/catalogue.js
+++ b/desktop/src/main/extensions/catalogue.js
@@ -1,0 +1,32 @@
+import { checkCompatibility } from './manifest.js'
+
+/**
+ * The catalogue as the interface receives it.
+ *
+ * Discovery finds repositories and validates their manifests; this decides
+ * whether *this* install can run them, and it belongs here rather than in the
+ * renderer for the same reason the search does — the app version and the live
+ * tool lists are main-process facts, and the manifest rules are already here.
+ *
+ * The renderer is left with grouping and ordering, and never has to learn what
+ * an SPDX identifier or a semver range is.
+ */
+
+/**
+ * Marks every entry with whether it can be used, and why not.
+ *
+ * A broken entry passes through untouched: there is no manifest to judge, and
+ * its parse failure is already the reason it cannot be used.
+ */
+export function decorate(index, { appVersion = '', workspaceTools = [], supervisorTools = [] } = {}) {
+  const entries = (index?.entries ?? []).map((entry) => {
+    if (!entry.ok) return entry
+    const { compatible, reasons } = checkCompatibility(entry.manifest, {
+      appVersion,
+      workspaceTools,
+      supervisorTools,
+    })
+    return { ...entry, compatible, reasons }
+  })
+  return { ...index, entries }
+}

--- a/desktop/src/main/index.js
+++ b/desktop/src/main/index.js
@@ -46,6 +46,8 @@ import { createEventStreamClient } from './sse.js'
 import { LinkTarget, classifyLink, linkWindowBounds } from './links.js'
 import { FileOpenAction, fileOpenAction, localPathFromFileUrl } from './files.js'
 import { UpdateStatus, createUpdater } from './updater.js'
+import { createDiscovery } from './extensions/discovery.js'
+import { decorate } from './extensions/catalogue.js'
 // Externalised by the build, so this resolves from node_modules at runtime.
 // Importing it is inert; the dev guard is about never *using* it against a
 // development checkout.
@@ -130,6 +132,7 @@ let currentTheme = 'system'
 /** Set when a deep link arrives before the window is ready to receive it. */
 let pendingRoute = null
 let updater = null
+let discovery = null
 /**
  * The signed-in profile in use, and the Electron session that carries its
  * cookies. Everything that talks to the server goes through this session rather
@@ -820,6 +823,18 @@ function registerIpc(getWindow) {
 
   ipcMain.handle('agentrq:update:get', () => updateState)
   ipcMain.handle('agentrq:update:check', () => updater?.checkNow() ?? { ok: false, reason: 'Updater unavailable' })
+  ipcMain.handle('agentrq:extensions:state', async () => {
+    const index = (await discovery?.list()) ?? { entries: [] }
+    // Compatibility is decided here, where the running version and the tool
+    // lists are — the renderer never has to learn what a semver range is.
+    return { index: decorate(index, { appVersion: app.getVersion() }), installed: [] }
+  })
+
+  ipcMain.handle('agentrq:extensions:refresh', async () => {
+    const result = (await discovery?.refresh()) ?? { ok: false, reason: 'Extensions are unavailable.' }
+    return { ...result, index: decorate(result.index ?? { entries: [] }, { appVersion: app.getVersion() }) }
+  })
+
   ipcMain.handle('agentrq:update:install', () => updater?.installNow() ?? false)
   ipcMain.handle(
     'agentrq:update:install-via-script',
@@ -862,6 +877,45 @@ function registerIpc(getWindow) {
   })
 }
 
+/**
+ * The extension catalogue.
+ *
+ * Every request goes out from here rather than from the renderer, which is on
+ * the privileged `app://` scheme and only ever sees same-origin traffic — a call
+ * to api.github.com from there is the cross-origin request that architecture
+ * exists to prevent, and the CSP would refuse it in any case.
+ */
+function installExtensions() {
+  const cachePath = join(app.getPath('userData'), 'extensions-catalogue.json')
+
+  discovery = createDiscovery({
+    fetchJson: async (url, token) => {
+      const response = await fetch(url, { headers: githubHeaders(token) })
+      if (response.status === 404) return null
+      if (!response.ok) throw new Error(`GitHub responded ${response.status}`)
+      return response.json()
+    },
+    fetchText: async (url, token) => {
+      const response = await fetch(url, { headers: githubHeaders(token) })
+      // A repository with the topic and no manifest is an ordinary state, not a
+      // failure: it is listed as broken with that as its reason.
+      if (response.status === 404) return null
+      if (!response.ok) throw new Error(`GitHub responded ${response.status}`)
+      return response.text()
+    },
+    readFile: () => readFile(cachePath, 'utf8'),
+    writeFile: (contents) => writeFile(cachePath, contents, 'utf8'),
+  })
+}
+
+function githubHeaders(token) {
+  return {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'AgentRQ',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  }
+}
+
 function installUpdater() {
   updater = createUpdater({
     autoUpdater: electronUpdater.autoUpdater,
@@ -880,6 +934,8 @@ function installUpdater() {
   })
   updater.start()
 }
+
+
 
 function installTray() {
   // An empty image is a deliberate placeholder: a tray icon is an art asset,
@@ -963,6 +1019,7 @@ if (!app.requestSingleInstanceLock()) {
     installTray()
     installGlobalShortcut()
     installUpdater()
+    installExtensions()
 
     const launchLink = deepLinkFromArgv(process.argv)
     if (launchLink) openDeepLink(launchLink)

--- a/desktop/src/preload/index.js
+++ b/desktop/src/preload/index.js
@@ -133,6 +133,22 @@ contextBridge.exposeInMainWorld('agentrq', {
     },
   },
 
+  extensions: {
+    /**
+     * What is already known — the cached catalogue, and what is installed.
+     *
+     * Never searches. GitHub answers ten searches a minute unauthenticated, and
+     * spending that on somebody opening a screen would leave nothing for the
+     * person who actually asked.
+     *
+     * @returns {Promise<{index: object, installed: string[]}>}
+     */
+    state: () => ipcRenderer.invoke('agentrq:extensions:state'),
+
+    /** Go and look again. A deliberate act, from a button. */
+    refresh: () => ipcRenderer.invoke('agentrq:extensions:refresh'),
+  },
+
   updates: {
     /** @returns {Promise<{status: string, detail: string, version: string, enabled: boolean}>} */
     get: () => ipcRenderer.invoke('agentrq:update:get'),

--- a/desktop/test/extensions/catalogue.test.js
+++ b/desktop/test/extensions/catalogue.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+
+import { decorate } from '../../src/main/extensions/catalogue.js'
+
+/**
+ * Compatibility is decided here rather than in the renderer, because the app
+ * version and the live tool lists are main-process facts. The renderer is left
+ * with grouping and ordering, and never learns what a semver range is.
+ */
+
+const entry = (over = {}) => ({
+  fullName: 'owner/ext',
+  ok: true,
+  manifest: {
+    name: 'ext',
+    engines: { agentrq: '^1.4' },
+    mcp: { workspace: ['getTask'], supervisor: [] },
+  },
+  ...over,
+})
+
+describe('decorate', () => {
+  it('marks an entry this build can run', () => {
+    const { entries } = decorate({ entries: [entry()] }, {
+      appVersion: '1.4.0',
+      workspaceTools: ['getTask'],
+    })
+
+    expect(entries[0].compatible).toBe(true)
+    expect(entries[0].reasons).toEqual([])
+  })
+
+  it('says which version is needed and which is running', () => {
+    const { entries } = decorate({ entries: [entry()] }, {
+      appVersion: '1.3.0',
+      workspaceTools: ['getTask'],
+    })
+
+    expect(entries[0].compatible).toBe(false)
+    expect(entries[0].reasons[0]).toBe('Needs AgentRQ ^1.4; this is 1.3.0.')
+  })
+
+  it('names a tool the connected server does not offer', () => {
+    // The real check for a self-hosted backend, which may be older than the
+    // extension expects even when the app itself is new enough.
+    const { entries } = decorate({ entries: [entry()] }, { appVersion: '1.4.0' })
+
+    expect(entries[0].reasons).toContain('The workspace server does not offer "getTask".')
+  })
+
+  it('leaves a broken entry exactly as it was', () => {
+    // There is no manifest to judge, and its parse failure is already the reason.
+    const broken = entry({ ok: false, reason: '"license" is required.', manifest: undefined })
+
+    const { entries } = decorate({ entries: [broken] }, { appVersion: '1.4.0' })
+
+    expect(entries[0]).toEqual(broken)
+  })
+
+  it('carries the rest of the index through untouched', () => {
+    const { truncated, fetchedAt } = decorate(
+      { entries: [], truncated: true, fetchedAt: 42 },
+      { appVersion: '1.4.0' },
+    )
+
+    expect(truncated).toBe(true)
+    expect(fetchedAt).toBe(42)
+  })
+
+  it('copes with nothing at all', () => {
+    expect(decorate(undefined).entries).toEqual([])
+    expect(decorate({}).entries).toEqual([])
+  })
+})

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -229,6 +229,22 @@
             </svg>
             <span v-if="!isCollapsed || isMobileMenuOpen">Workflows</span>
           </router-link>
+
+          <!-- Desktop only: extensions run in the app, so the browser has
+               nothing to show. Absent rather than disabled, and branched on the
+               platform store rather than by sniffing for the bridge. -->
+          <router-link v-if="platformStore.isDesktop" to="/extensions"
+              @mouseenter="showTooltip($event, 'Extensions')" @mouseleave="hideTooltip"
+              class="flex items-center gap-2.5 px-2 py-1.5 text-xs transition-all duration-150 rounded-md"
+              :class="[
+                (isCollapsed && !isMobileMenuOpen) ? 'justify-center' : '',
+                $route.path.startsWith('/extensions') ? 'bg-gray-200 dark:bg-zinc-800 text-black dark:text-white' : 'text-gray-500 dark:text-zinc-400 hover:bg-gray-200 dark:hover:bg-zinc-700 hover:text-gray-900 dark:hover:text-zinc-50'
+              ]">
+            <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M14.25 6.087c0-.355.186-.676.401-.959.221-.29.349-.634.349-1.003 0-1.036-1.007-1.875-2.25-1.875s-2.25.84-2.25 1.875c0 .369.128.713.349 1.003.215.283.401.604.401.959v0a.64.64 0 01-.657.643 48.39 48.39 0 01-4.163-.3c.186 1.613.293 3.25.315 4.907a.656.656 0 01-.658.663v0c-.355 0-.676-.186-.959-.401a1.647 1.647 0 00-1.003-.349c-1.036 0-1.875 1.007-1.875 2.25s.84 2.25 1.875 2.25c.369 0 .713-.128 1.003-.349.283-.215.604-.401.959-.401v0c.31 0 .555.26.532.57a48.039 48.039 0 01-.642 5.056c1.518.19 3.058.309 4.616.354a.64.64 0 00.657-.643v0c0-.355-.186-.676-.401-.959a1.647 1.647 0 01-.349-1.003c0-1.035 1.007-1.875 2.25-1.875s2.25.84 2.25 1.875c0 .369-.128.713-.349 1.003-.215.283-.4.604-.4.959v0c0 .333.277.599.61.58a48.1 48.1 0 005.427-.63 48.05 48.05 0 00.582-4.717.532.532 0 00-.533-.57v0c-.355 0-.676.186-.959.401-.29.221-.634.349-1.003.349-1.035 0-1.875-1.007-1.875-2.25s.84-2.25 1.875-2.25c.37 0 .713.128 1.003.349.283.215.604.401.96.401v0a.656.656 0 00.658-.663 48.422 48.422 0 00-.37-5.36c-1.886.342-3.81.542-5.766.59a.658.658 0 01-.663-.658v0z" />
+            </svg>
+            <span v-if="!isCollapsed || isMobileMenuOpen">Extensions</span>
+          </router-link>
         </div>
 
         <!-- Sidebar Footer -->

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -45,6 +45,11 @@ export const routes = [
   { path: '/events', component: () => import('./views/EventsView.vue') },
   { path: '/events/:id', component: () => import('./views/EventDetailView.vue') },
 
+  // Desktop-only in practice — the view renders nothing without the bridge, and
+  // the sidebar entry is hidden in the browser. The route lives here all the
+  // same, because this is the only route table and the desktop build mounts it.
+  { path: '/extensions', component: () => import('./desktop/ExtensionsView.vue') },
+
   { path: '/workflows', component: () => import('./views/WorkflowsView.vue') },
   { path: '/workflows/:id', component: () => import('./views/WorkflowDetailView.vue') },
 

--- a/frontend/src/composables/useExtensionCatalogue.js
+++ b/frontend/src/composables/useExtensionCatalogue.js
@@ -1,0 +1,167 @@
+import { computed, ref } from 'vue';
+
+/**
+ * What the Extensions screen shows, and in what order.
+ *
+ * The catalogue comes from the desktop bridge, already searched, validated *and
+ * judged compatible* in the main process — which is where the manifest rules,
+ * the running version and the live tool list all are. This is only concerned
+ * with turning that into rows a person can act on, so it is a plain composable
+ * that never learns what SPDX or a semver range is.
+ *
+ * ## Nothing usable is hidden
+ *
+ * A repository carrying the topic whose manifest does not parse is **listed as
+ * broken with its reason**, and one that needs a newer AgentRQ is **listed but
+ * not installable**, with the version stated. Both are deliberate. A silently
+ * missing extension is undebuggable for the author who published it, and to
+ * anyone following a link to it the catalogue simply looks broken — which is a
+ * worse failure than an honest row explaining itself.
+ */
+
+/**
+ * The order rows appear in.
+ *
+ * Installed first, because those are the ones a person came to manage. Then what
+ * they could install, most-starred first — stars being the only signal an
+ * uncurated catalogue has. Then what they cannot use, which is reference rather
+ * than choice, so it sits at the bottom rather than interrupting the list.
+ */
+export const GROUPS = ['installed', 'available', 'unavailable'];
+
+/**
+ * Which group a row belongs in.
+ *
+ * Installed wins over everything: an extension that stopped being compatible
+ * after an app downgrade is still installed, and hiding it among the
+ * unavailable is how somebody fails to find the thing they need to remove.
+ */
+export function groupFor(entry, { installed = false } = {}) {
+  if (installed) return 'installed';
+  if (!entry.ok || !entry.compatible) return 'unavailable';
+  return 'available';
+}
+
+/**
+ * Why a row cannot be used, or '' when it can.
+ *
+ * A broken manifest reports the parse failure, which is the author's problem to
+ * fix; an incompatible one reports every reason rather than the first, because
+ * somebody fixing a manifest wants the whole list.
+ */
+export function blockedReason(entry) {
+  if (!entry.ok) return entry.reason ?? 'This manifest could not be read.';
+  if (!entry.compatible) return (entry.reasons ?? []).join(' ');
+  return '';
+}
+
+/**
+ * The rows for the screen, grouped and ordered.
+ *
+ * `installedNames` comes from what is actually installed rather than from the
+ * catalogue, so an extension that has been removed from GitHub still appears
+ * while it is on this machine — the row someone needs in order to uninstall it
+ * is exactly the one a catalogue-driven list would drop.
+ */
+export function toRows(index, { installedNames = [] } = {}) {
+  const installed = new Set(installedNames);
+  const rows = (index?.entries ?? []).map((entry) => {
+    // `compatible` and `reasons` arrive already decided from the main process;
+    // an entry that never parsed has no manifest to judge, so it is simply not.
+    const row = {
+      ...entry,
+      compatible: entry.ok === true && entry.compatible !== false,
+      reasons: entry.reasons ?? [],
+      installed: installed.has(entry.manifest?.name ?? ''),
+    };
+    return { ...row, group: groupFor(row, { installed: row.installed }), blocked: blockedReason(row) };
+  });
+
+  return GROUPS.map((group) => ({
+    group,
+    rows: rows.filter((row) => row.group === group).sort(byStarsThenName),
+  })).filter((section) => section.rows.length > 0);
+}
+
+/**
+ * Most-starred first, then alphabetical.
+ *
+ * Stars are the only signal an uncurated catalogue carries, and the name breaks
+ * the tie so the order is stable rather than dependent on whatever order the
+ * search happened to return.
+ */
+function byStarsThenName(a, b) {
+  return (b.stars ?? 0) - (a.stars ?? 0) || String(a.fullName).localeCompare(String(b.fullName));
+}
+
+/** A one-line summary of the catalogue's state, for the screen's header. */
+export function summarise(index, sections) {
+  const total = sections.reduce((n, section) => n + section.rows.length, 0);
+  if (total === 0) return 'No extensions found yet.';
+
+  const unavailable = sections.find((s) => s.group === 'unavailable')?.rows.length ?? 0;
+  const parts = [`${total} extension${total === 1 ? '' : 's'}`];
+  if (unavailable > 0) parts.push(`${unavailable} unavailable`);
+  // Said out loud, because a truncated catalogue is indistinguishable from a
+  // complete one unless it says so.
+  if (index?.truncated) parts.push('list is incomplete');
+  return parts.join(' · ');
+}
+
+/**
+ * The screen's state, over the desktop bridge.
+ *
+ * With no bridge — the web build, or the frontend's own test run — everything
+ * stays inert and empty rather than throwing, which is what lets the section be
+ * *absent* in the browser rather than broken in it.
+ */
+export function useExtensionCatalogue({ bridge = globalThis.window?.agentrq?.extensions } = {}) {
+  const index = ref({ entries: [], fetchedAt: null, truncated: false });
+  const installedNames = ref([]);
+  const loading = ref(false);
+  const error = ref('');
+
+  const sections = computed(() => toRows(index.value, { installedNames: installedNames.value }));
+
+  const summary = computed(() => summarise(index.value, sections.value));
+
+  /** Read what is already known. Never searches — see the refresh below. */
+  async function load() {
+    if (!bridge) return;
+    loading.value = true;
+    error.value = '';
+    try {
+      const state = await bridge.state();
+      index.value = state?.index ?? index.value;
+      installedNames.value = state?.installed ?? [];
+    } catch (err) {
+      error.value = err?.message || 'Could not read the extension catalogue.';
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  /**
+   * Go and look again — a deliberate act, never something a page load triggers.
+   *
+   * GitHub answers ten searches a minute unauthenticated, and a catalogue that
+   * refreshed itself on every visit would spend that budget on people who opened
+   * the screen and closed it again.
+   */
+  async function refresh() {
+    if (!bridge) return;
+    loading.value = true;
+    error.value = '';
+    try {
+      const result = await bridge.refresh();
+      if (result?.index) index.value = result.index;
+      if (result && result.ok === false) error.value = result.reason ?? 'Could not refresh.';
+    } catch (err) {
+      error.value = err?.message || 'Could not refresh the extension catalogue.';
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  return { index, sections, summary, loading, error, load, refresh, available: Boolean(bridge) };
+}

--- a/frontend/src/desktop/ExtensionsView.vue
+++ b/frontend/src/desktop/ExtensionsView.vue
@@ -1,0 +1,123 @@
+<template>
+  <div class="flex-1 overflow-y-auto px-4 pb-10 custom-scrollbar">
+    <div class="max-w-4xl mx-auto pt-8">
+
+      <div class="flex items-start justify-between gap-4 mb-1">
+        <h1 class="text-2xl font-black text-gray-900 dark:text-white">Extensions</h1>
+        <button type="button" @click="refresh()" :disabled="loading"
+                class="shrink-0 px-4 py-2 rounded-sm bg-black dark:bg-white text-white dark:text-black text-[10px] font-black uppercase tracking-widest hover:opacity-80 disabled:opacity-40 transition-all">
+          {{ loading ? 'Checking…' : 'Check GitHub' }}
+        </button>
+      </div>
+
+      <p class="text-[11px] text-gray-500 dark:text-zinc-400 mb-6">
+        {{ summary }} ·
+        <span class="text-gray-400 dark:text-zinc-500">
+          Published by anyone on GitHub under the <code class="font-mono">agentrq-extension</code> topic.
+        </span>
+      </p>
+
+      <div v-if="error"
+           class="mb-6 px-3 py-2 rounded-sm border border-amber-200 dark:border-amber-900/60 bg-amber-50 dark:bg-amber-950/30 text-[11px] text-amber-800 dark:text-amber-300">
+        {{ error }}
+      </div>
+
+      <div v-if="sections.length === 0 && !loading"
+           class="border border-dashed border-gray-200 dark:border-zinc-800 rounded-sm px-6 py-10 text-center">
+        <p class="text-[11px] text-gray-500 dark:text-zinc-400">
+          Nothing found yet. <strong class="font-semibold text-gray-700 dark:text-zinc-300">Check GitHub</strong>
+          to search for extensions.
+        </p>
+      </div>
+
+      <section v-for="section in sections" :key="section.group" class="mb-8">
+        <h2 class="text-[10px] font-black uppercase tracking-widest text-gray-400 dark:text-zinc-500 mb-3">
+          {{ GROUP_LABELS[section.group] }}
+        </h2>
+
+        <div class="flex flex-col gap-2">
+          <article v-for="row in section.rows" :key="row.fullName"
+                   class="border border-gray-200 dark:border-zinc-800 rounded-sm px-4 py-3 bg-white dark:bg-zinc-900">
+
+            <div class="flex items-baseline justify-between gap-3 min-w-0">
+              <div class="min-w-0">
+                <h3 class="text-sm font-black text-gray-900 dark:text-white truncate">
+                  {{ row.manifest?.displayName || row.manifest?.name || row.name }}
+                </h3>
+                <!-- The owner leads. Installing is a decision about whether to
+                     trust a person, not a comparison of feature lists. -->
+                <p class="text-[10px] font-bold uppercase tracking-wider text-gray-500 dark:text-zinc-400 mt-0.5">
+                  {{ row.owner }}
+                </p>
+              </div>
+              <div class="flex items-center gap-2 shrink-0 text-[10px] text-gray-400 dark:text-zinc-500 font-mono">
+                <span v-if="row.manifest?.license">{{ row.manifest.license }}</span>
+                <span>★ {{ row.stars ?? 0 }}</span>
+              </div>
+            </div>
+
+            <p v-if="row.description" class="text-[11px] text-gray-600 dark:text-zinc-400 mt-2 leading-snug">
+              {{ row.description }}
+            </p>
+
+            <!-- Why it cannot be used, stated rather than implied by its absence. -->
+            <p v-if="row.blocked"
+               class="text-[11px] text-amber-700 dark:text-amber-400 mt-2 leading-snug">
+              {{ row.blocked }}
+            </p>
+
+            <div class="flex items-center gap-3 mt-3">
+              <a :href="row.url" target="_blank" rel="noopener noreferrer"
+                 class="text-[10px] font-bold uppercase tracking-wider text-gray-500 dark:text-zinc-400 hover:text-black dark:hover:text-white transition-colors">
+                View on GitHub
+              </a>
+              <span v-if="row.pushedAt" class="text-[10px] text-gray-400 dark:text-zinc-600 font-mono">
+                updated {{ shortDate(row.pushedAt) }}
+              </span>
+            </div>
+          </article>
+        </div>
+      </section>
+
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Browsing what exists.
+ *
+ * Desktop only, and it lives here in `frontend/src/desktop/` rather than under
+ * `desktop/` because Tailwind scans from the build root: a class used only in a
+ * file outside this tree is silently dropped from the stylesheet, and the page
+ * renders unstyled with no error to explain it.
+ *
+ * Nothing installs yet — that is 4/10. What this has to get right is that every
+ * row explains itself: a broken manifest shows its parse failure, and an
+ * incompatible one shows the version it wants against the version running.
+ */
+import { onMounted } from 'vue';
+
+import { useExtensionCatalogue } from '../composables/useExtensionCatalogue';
+
+const GROUP_LABELS = {
+  installed: 'Installed',
+  available: 'Available',
+  unavailable: 'Unavailable',
+};
+
+const { sections, summary, loading, error, load, refresh } = useExtensionCatalogue();
+
+// Reads the cache. Deliberately not a search: GitHub answers ten of those a
+// minute, and spending that on somebody opening a screen would leave nothing
+// for the person who actually pressed the button.
+onMounted(load);
+
+/** `2026-09-10T…` → `10 Sep`, which is all a row has room for. */
+function shortDate(iso) {
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime())
+    ? ''
+    : date.toLocaleDateString(undefined, { day: 'numeric', month: 'short' });
+}
+</script>

--- a/frontend/test/app.test.js
+++ b/frontend/test/app.test.js
@@ -34,6 +34,9 @@ describe('routes', () => {
       '/workspaces/:id/tasks/:taskId/edit',
       '/events',
       '/events/:id',
+      // Desktop-only in practice, but it lives in the one route table like
+      // everything else — the desktop build mounts exactly this list.
+      '/extensions',
       '/workflows',
       '/workflows/:id',
       '/login',

--- a/frontend/test/extensionCatalogue.test.js
+++ b/frontend/test/extensionCatalogue.test.js
@@ -1,0 +1,322 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import {
+  GROUPS,
+  blockedReason,
+  groupFor,
+  summarise,
+  toRows,
+  useExtensionCatalogue,
+} from '../src/composables/useExtensionCatalogue';
+
+/**
+ * The catalogue is uncurated: anyone may publish by adding a topic to a
+ * repository. So the screen's job is less "present a list" than "explain
+ * itself" — every row that cannot be used says why, and nothing is hidden.
+ */
+
+const entry = (over = {}) => ({
+  fullName: 'owner/thing',
+  owner: 'owner',
+  stars: 10,
+  ok: true,
+  compatible: true,
+  reasons: [],
+  manifest: { name: 'thing', displayName: 'Thing', license: 'MIT' },
+  ...over,
+});
+
+afterEach(() => {
+  delete window.agentrq;
+});
+
+describe('groupFor', () => {
+  it('puts what is usable where it can be chosen', () => {
+    expect(groupFor(entry())).toBe('available');
+  });
+
+  it('puts what is installed first, whatever else is true of it', () => {
+    // An extension that stopped being compatible after an app downgrade is
+    // still installed, and burying it among the unavailable is how somebody
+    // fails to find the thing they need to remove.
+    expect(groupFor(entry({ compatible: false }), { installed: true })).toBe('installed');
+    expect(groupFor(entry({ ok: false }), { installed: true })).toBe('installed');
+  });
+
+  it('puts a broken or incompatible entry out of the way, not out of sight', () => {
+    expect(groupFor(entry({ ok: false }))).toBe('unavailable');
+    expect(groupFor(entry({ compatible: false }))).toBe('unavailable');
+  });
+});
+
+describe('blockedReason', () => {
+  it('is empty for something that works', () => {
+    expect(blockedReason(entry())).toBe('');
+  });
+
+  it('reports a manifest that could not be read', () => {
+    expect(blockedReason(entry({ ok: false, reason: '"license" is required.' }))).toBe(
+      '"license" is required.',
+    );
+  });
+
+  it('still says something when a broken entry carries no reason', () => {
+    expect(blockedReason({ ok: false })).toBe('This manifest could not be read.');
+  });
+
+  it('gives every incompatibility, not just the first', () => {
+    // Somebody fixing a manifest wants the whole list.
+    const row = entry({
+      compatible: false,
+      reasons: ['Needs AgentRQ ^1.5; this is 1.4.0.', 'The workspace server does not offer "x".'],
+    });
+
+    expect(blockedReason(row)).toContain('Needs AgentRQ ^1.5');
+    expect(blockedReason(row)).toContain('does not offer "x"');
+  });
+
+  it('copes with an incompatible entry that lists no reasons', () => {
+    expect(blockedReason(entry({ compatible: false, reasons: undefined }))).toBe('');
+  });
+});
+
+describe('toRows', () => {
+  it('groups, and drops the groups that would be empty', () => {
+    const index = { entries: [entry()] };
+
+    const sections = toRows(index);
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0].group).toBe('available');
+  });
+
+  it('orders the groups the way the screen reads', () => {
+    const index = {
+      entries: [
+        entry({ fullName: 'a/broken', ok: false, reason: 'bad', manifest: undefined }),
+        entry({ fullName: 'b/installed', manifest: { name: 'installed' } }),
+        entry({ fullName: 'c/available' }),
+      ],
+    };
+
+    const sections = toRows(index, { installedNames: ['installed'] });
+
+    expect(sections.map((s) => s.group)).toEqual(GROUPS);
+  });
+
+  it('sorts by stars, then by name so the order is stable', () => {
+    // Stars are the only signal an uncurated catalogue carries; the name breaks
+    // the tie rather than leaving it to whatever the search returned.
+    const index = {
+      entries: [
+        entry({ fullName: 'z/one', stars: 5 }),
+        entry({ fullName: 'a/two', stars: 5 }),
+        entry({ fullName: 'm/three', stars: 99 }),
+      ],
+    };
+
+    const [{ rows }] = toRows(index);
+
+    expect(rows.map((r) => r.fullName)).toEqual(['m/three', 'a/two', 'z/one']);
+  });
+
+  it('marks what is installed from the machine, not from the catalogue', () => {
+    // An extension pulled from GitHub is still on this machine, and the row
+    // needed to uninstall it is exactly the one a catalogue-driven list drops.
+    const index = { entries: [entry({ manifest: { name: 'thing' } })] };
+
+    const [{ group, rows }] = toRows(index, { installedNames: ['thing'] });
+
+    expect(group).toBe('installed');
+    expect(rows[0].installed).toBe(true);
+  });
+
+  it('treats an unparsed entry as incompatible without a manifest to judge', () => {
+    const index = { entries: [entry({ ok: false, reason: 'bad', manifest: undefined })] };
+
+    const [{ rows }] = toRows(index);
+
+    expect(rows[0].compatible).toBe(false);
+    expect(rows[0].blocked).toBe('bad');
+  });
+
+  it('copes with an empty or missing catalogue', () => {
+    expect(toRows(undefined)).toEqual([]);
+    expect(toRows({ entries: [] })).toEqual([]);
+  });
+
+  it('defaults stars when an entry carries none, on either side of a comparison', () => {
+    // A brand-new repository has no stars at all, and it must not sort
+    // unpredictably depending on which side of the comparison it lands.
+    const index = {
+      entries: [
+        entry({ fullName: 'a/none', stars: undefined }),
+        entry({ fullName: 'b/one', stars: 1 }),
+        entry({ fullName: 'c/none', stars: undefined }),
+      ],
+    };
+
+    const [{ rows }] = toRows(index);
+
+    expect(rows.map((r) => r.fullName)).toEqual(['b/one', 'a/none', 'c/none']);
+  });
+
+  it('copes with a compatible entry that lists no reasons at all', () => {
+    // The ordinary case once the main process has judged it: compatible, with
+    // the reasons field simply absent rather than an empty array.
+    const index = { entries: [entry({ reasons: undefined })] };
+
+    const [{ rows }] = toRows(index);
+
+    expect(rows[0].reasons).toEqual([]);
+    expect(rows[0].blocked).toBe('');
+  });
+});
+
+describe('summarise', () => {
+  const sectionsFor = (index) => toRows(index);
+
+  it('says so when there is nothing yet', () => {
+    expect(summarise({ entries: [] }, [])).toBe('No extensions found yet.');
+  });
+
+  it('counts what there is, in the singular where it should', () => {
+    const index = { entries: [entry()] };
+    expect(summarise(index, sectionsFor(index))).toBe('1 extension');
+
+    const two = { entries: [entry(), entry({ fullName: 'b/x' })] };
+    expect(summarise(two, sectionsFor(two))).toBe('2 extensions');
+  });
+
+  it('calls out how many cannot be used', () => {
+    const index = { entries: [entry(), entry({ fullName: 'b/x', ok: false, reason: 'bad' })] };
+    expect(summarise(index, sectionsFor(index))).toBe('2 extensions · 1 unavailable');
+  });
+
+  it('says out loud when the list is incomplete', () => {
+    // A truncated catalogue is indistinguishable from a complete one unless it
+    // says so, and this one can be: GitHub returns at most 1000 results.
+    const index = { entries: [entry()], truncated: true };
+    expect(summarise(index, sectionsFor(index))).toBe('1 extension · list is incomplete');
+  });
+
+  it('copes with no index at all', () => {
+    expect(summarise(undefined, [])).toBe('No extensions found yet.');
+  });
+});
+
+describe('useExtensionCatalogue', () => {
+  const fakeBridge = (over = {}) => ({
+    state: vi.fn(async () => ({ index: { entries: [entry()] }, installed: [] })),
+    refresh: vi.fn(async () => ({ ok: true, index: { entries: [entry(), entry({ fullName: 'b/x' })] } })),
+    ...over,
+  });
+
+  it('stays inert with no bridge, so the web build is absent rather than broken', async () => {
+    const catalogue = useExtensionCatalogue({ bridge: undefined });
+
+    expect(catalogue.available).toBe(false);
+    await catalogue.load();
+    await catalogue.refresh();
+
+    expect(catalogue.sections.value).toEqual([]);
+    expect(catalogue.error.value).toBe('');
+  });
+
+  it('reads what is already known without going anywhere', async () => {
+    // Ten searches a minute is not a budget to spend on somebody opening a
+    // screen and closing it again.
+    const bridge = fakeBridge();
+    const catalogue = useExtensionCatalogue({ bridge });
+
+    await catalogue.load();
+
+    expect(bridge.state).toHaveBeenCalledOnce();
+    expect(bridge.refresh).not.toHaveBeenCalled();
+    expect(catalogue.sections.value[0].rows).toHaveLength(1);
+  });
+
+  it('searches only when asked', async () => {
+    const bridge = fakeBridge();
+    const catalogue = useExtensionCatalogue({ bridge });
+
+    await catalogue.refresh();
+
+    expect(bridge.refresh).toHaveBeenCalledOnce();
+    expect(catalogue.sections.value[0].rows).toHaveLength(2);
+  });
+
+  it('shows why a refresh failed, and keeps what it had', async () => {
+    const bridge = fakeBridge();
+    const catalogue = useExtensionCatalogue({ bridge });
+    await catalogue.load();
+
+    bridge.refresh.mockResolvedValueOnce({ ok: false, reason: 'GitHub rate limit reached.' });
+    await catalogue.refresh();
+
+    expect(catalogue.error.value).toBe('GitHub rate limit reached.');
+    expect(catalogue.sections.value[0].rows).toHaveLength(1);
+  });
+
+  it('reports a refusal that carries no reason', async () => {
+    const bridge = fakeBridge({ refresh: vi.fn(async () => ({ ok: false })) });
+    const catalogue = useExtensionCatalogue({ bridge });
+
+    await catalogue.refresh();
+
+    expect(catalogue.error.value).toBe('Could not refresh.');
+  });
+
+  it('survives a bridge that throws', async () => {
+    const bridge = fakeBridge({
+      state: vi.fn(async () => {
+        throw new Error('bridge gone');
+      }),
+      refresh: vi.fn(async () => {
+        throw new Error('bridge gone');
+      }),
+    });
+    const catalogue = useExtensionCatalogue({ bridge });
+
+    await catalogue.load();
+    expect(catalogue.error.value).toBe('bridge gone');
+
+    await catalogue.refresh();
+    expect(catalogue.error.value).toBe('bridge gone');
+    expect(catalogue.loading.value).toBe(false);
+  });
+
+  it('says something even when the failure carries no message', async () => {
+    const bridge = fakeBridge({
+      state: vi.fn(async () => {
+        throw {};
+      }),
+      refresh: vi.fn(async () => {
+        throw {};
+      }),
+    });
+    const catalogue = useExtensionCatalogue({ bridge });
+
+    await catalogue.load();
+    expect(catalogue.error.value).toBe('Could not read the extension catalogue.');
+
+    await catalogue.refresh();
+    expect(catalogue.error.value).toBe('Could not refresh the extension catalogue.');
+  });
+
+  it('keeps what it had when the bridge answers with nothing', async () => {
+    const bridge = fakeBridge({ state: vi.fn(async () => undefined), refresh: vi.fn(async () => undefined) });
+    const catalogue = useExtensionCatalogue({ bridge });
+
+    await catalogue.load();
+    await catalogue.refresh();
+
+    expect(catalogue.sections.value).toEqual([]);
+    expect(catalogue.error.value).toBe('');
+  });
+
+  it('finds the bridge on the window when none is passed', () => {
+    window.agentrq = { extensions: fakeBridge() };
+    expect(useExtensionCatalogue().available).toBe(true);
+  });
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -43,6 +43,7 @@ export default defineConfig({
         'src/composables/useTaskStatusStyle.js',
         'src/composables/useAgentTelemetry.js',
         'src/composables/useAgentModelPicker.js',
+        'src/composables/useExtensionCatalogue.js',
         'src/composables/useTaskEvents.js',
         'src/composables/useTrajectory.js',
         'src/composables/useWorkflowLabels.js',


### PR DESCRIPTION
> **3 of 10, stacked on [#516](https://github.com/agentrq/agentrq/pull/516).** Targets `ext/02-discovery`. [Plan](https://claude.ai/code/artifact/907d107c-921d-4e0e-a371-de22229c2927).

## What changed

The desktop app now has an Extensions section in the sidebar and a screen listing what was found on GitHub — including the ones that cannot be used, each saying why.

## Why changed

The first piece anybody can look at. Discovery already found and validated extensions in the main process; this is where that becomes something a person can read.

## Test coverage report

New lines introduced: **100%**. Total coverage impact: **unchanged at 100%** on all four metrics in both suites — frontend 1085 tests across 42 files (from 1055/41), desktop 556 across 20 (from 550/19).

The list logic is a composable added to `test.coverage.include`, so it is gated: grouping and ordering, a broken entry, an incompatible one, one already installed, an empty catalogue, a truncated one, a bridge that throws, and no bridge at all.

## Other reports

**Nothing usable is hidden.** A repository whose manifest does not parse is listed as **broken with its parse failure**; one needing a newer AgentRQ is listed with the version it wants against the version running. Filtering either out would leave the author unable to debug their own extension, and anyone following a link seeing a catalogue that looks broken.

**The owner leads each card**, above the description. Installing is a decision about whether to trust a person, so the person is what the card is about.

**Compatibility is decided in the main process.** That is where the running version and the live tool lists are, and where the manifest rules already live. The renderer groups and orders, and never learns what an SPDX identifier or a semver range is. My first draft imported the manifest module straight into a composable — which could not have worked across the process boundary, and was the wrong seam regardless.

**Installed rows come from the machine, not the catalogue.** An extension pulled from GitHub is still installed here, and the row needed to remove it is exactly the one a catalogue-driven list would drop. Installed also outranks broken and incompatible, so one that stopped working after a downgrade stays where its owner would look.

**Nothing searches on mount** — the screen reads the cache and offers a button. Ten searches a minute is not a budget to spend on somebody opening a screen and closing it again.

**Three project rules this touches**, all of which have teeth:
- The route goes in the **one route table**, which a parity test enforces — desktop and web mount the same list.
- The view lives in `frontend/src/desktop/` because Tailwind scans from the build root; a class used only under `desktop/` is silently dropped and the page renders unstyled with no error.
- The sidebar entry branches on the **platform store**, so it is absent in the browser rather than broken there.

## TaskID: 0iV08BT0LkP
