### PR TITLE
feat(extensions): install one, from a release, a clone or a folder

### DIFF
--- a/desktop/src/main/extensions/fetch-source.js
+++ b/desktop/src/main/extensions/fetch-source.js
@@ -1,0 +1,117 @@
+import { createHash } from 'node:crypto'
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * Getting the bytes, for each of the three sources.
+ *
+ * Deliberately thin. Everything that can be decided — what a source is, whether
+ * a digest matches, what happens when any of it fails — lives in `source.js` and
+ * `install.js`, where it is tested without a network or a disk. What is left
+ * here is the part that genuinely has to touch the machine, kept small enough to
+ * read in one go.
+ *
+ * ## `git` does the authenticating
+ *
+ * A private repository works because the user's own SSH key or credential helper
+ * is what clones it. Nothing here handles a token, which is both less to secure
+ * and less to get wrong — and it is the only reason a private extension can work
+ * at all without a registry standing in the middle.
+ *
+ * Submodules are deliberately not fetched: they would let a repository pull in
+ * code from somewhere the user never named, which is exactly the surprise this
+ * whole feature is trying not to have.
+ */
+
+/** Where staging happens. Removed by the installer whether or not it succeeds. */
+export async function makeTempDir() {
+  return mkdtemp(join(tmpdir(), 'agentrq-ext-'))
+}
+
+/** The manifest inside an unpacked extension, or null when there is none. */
+export async function readManifest(dir) {
+  try {
+    return await readFile(join(dir, 'agentrq-extension.json'), 'utf8')
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Runs a command, resolving with its output or rejecting with its error text.
+ *
+ * `spawn` is injected so this file can be exercised without running anything.
+ */
+function run(spawn, command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { ...options, stdio: ['ignore', 'pipe', 'pipe'] })
+    let out = ''
+    let err = ''
+    child.stdout?.on('data', (chunk) => {
+      out += chunk
+    })
+    child.stderr?.on('data', (chunk) => {
+      err += chunk
+    })
+    child.on('error', reject)
+    child.on('close', (code) => {
+      // git writes progress to stderr, so its text is only an error when the
+      // exit code says so.
+      if (code === 0) resolve(out.trim())
+      else reject(new Error(err.trim() || `${command} exited with ${code}`))
+    })
+  })
+}
+
+/**
+ * Fetches a source into `into`, reporting what identifies what arrived.
+ *
+ * @param {object} deps
+ * @param {typeof import('node:child_process').spawn} deps.spawn
+ * @param {typeof fetch} [deps.fetchImpl]
+ */
+export function createFetchSource({ spawn, fetchImpl = fetch }) {
+  return async function fetchSource(source, into) {
+    const dir = join(into, 'unpacked')
+    await mkdir(dir, { recursive: true })
+
+    if (source.kind === 'local') {
+      // Copied rather than linked: this is the non-linked path, where the point
+      // is a snapshot that cannot change underneath the app.
+      await cp(source.path, dir, { recursive: true })
+      return { dir }
+    }
+
+    if (source.kind === 'git') {
+      const args = ['clone', '--depth', '1', '--no-recurse-submodules']
+      if (source.ref) args.push('--branch', source.ref)
+      args.push(source.url, dir)
+      await run(spawn, 'git', args)
+
+      // The commit is what pins a clone: a branch moves, the commit it pointed
+      // at does not.
+      const commit = await run(spawn, 'git', ['-C', dir, 'rev-parse', 'HEAD'])
+      // Nothing should carry the clone's own history into an install.
+      await rm(join(dir, '.git'), { recursive: true, force: true })
+      return { dir, commit }
+    }
+
+    const url = `https://github.com/${source.repo}/releases/download/${source.release}/${source.asset}`
+    const response = await fetchImpl(url)
+    if (!response.ok) throw new Error(`Could not download ${source.asset} (${response.status})`)
+
+    const bytes = Buffer.from(await response.arrayBuffer())
+    // Hashed before anything is unpacked. The installer refuses on a mismatch,
+    // and it can only do that if nothing has been written yet.
+    const sha256 = createHash('sha256').update(bytes).digest('hex')
+
+    const archive = join(into, source.asset)
+    await writeFile(archive, bytes)
+    // `tar` rather than a dependency: it is present on macOS and Linux, and
+    // Windows has shipped bsdtar as tar.exe since Windows 10 1803.
+    await run(spawn, 'tar', ['-xzf', archive, '-C', dir, '--strip-components', '1'])
+
+    return { dir, sha256 }
+  }
+}

--- a/desktop/src/main/extensions/install.js
+++ b/desktop/src/main/extensions/install.js
@@ -1,0 +1,326 @@
+import { parseManifest } from './manifest.js'
+import { describeSource, pinFor, verifyDigest } from './source.js'
+
+/**
+ * Installing an extension, and everything that happens to one afterwards.
+ *
+ * Three sources arrive here — a published release asset, a repository the user
+ * cloned, or a folder on this machine — and after this point they are one thing:
+ * a directory, a manifest, and a record of where it came from.
+ *
+ * ## Nothing is unpacked before it is verified
+ *
+ * A release asset is checked against the digest in its manifest *before* it is
+ * written anywhere. Git tags are mutable, so `v1.2.0` today need not be
+ * `v1.2.0` tomorrow, and a mismatch is refused outright rather than warned
+ * about — it means the bytes are not what the manifest described, which is
+ * either a tampered release or a corrupt download and neither is a thing to
+ * click past.
+ *
+ * ## A private repository needs no credentials from us
+ *
+ * The user pastes a URL and `git` does the authenticating, with whatever SSH key
+ * or credential helper they already have. Nothing here ever sees a token, which
+ * is both less to secure and less to get wrong — and it is what makes a private
+ * extension work at all without a registry.
+ *
+ * ## An install that fails leaves nothing behind
+ *
+ * Every path stages into a temporary directory and moves it into place only once
+ * everything has succeeded. A half-written extension directory is worse than no
+ * extension: it looks installed, loads partially, and fails somewhere far from
+ * the install that caused it.
+ */
+
+/**
+ * What went wrong, as a sentence.
+ *
+ * One helper rather than the same expression at every catch: not everything
+ * thrown is an Error, and a reason reading "[object Object]" is worse than
+ * useless in a message a user is expected to act on.
+ */
+export function reasonFrom(error) {
+  const message = error?.message
+  if (typeof message === 'string' && message) return message
+  // Only a primitive is worth stringifying. String() on an object gives
+  // "[object Object]", and on an Error with no message it gives a bare "Error"
+  // — both of which look like a message while telling nobody anything.
+  if (typeof error === 'string' && error.trim()) return error
+  return 'Unknown error'
+}
+
+/** What an installation records. Desktop-local; nothing about this is on a server. */
+function record(manifest, source, pin, { enabled = true } = {}) {
+  return {
+    name: manifest.name,
+    version: manifest.version,
+    source,
+    sourceLabel: describeSource(source),
+    pin,
+    manifest,
+    enabled,
+    failures: 0,
+    installedAt: null,
+  }
+}
+
+/**
+ * Whether an update asks for more than what was granted.
+ *
+ * This is what stops an extension acquiring supervisor access in a patch release
+ * nobody read. An update that asks for the same or less installs quietly; one
+ * that asks for anything new has to go back to the user.
+ *
+ * Narrowing is deliberately not a prompt. Being asked to re-approve an extension
+ * that now wants *less* teaches people that the prompt is noise, and the whole
+ * value of the prompt is that it is rare enough to read.
+ */
+export function scopesWidened(before, after) {
+  const added = (from = [], to = []) => to.filter((tool) => !from.includes(tool))
+
+  const workspace = added(before?.workspace, after?.workspace)
+  const supervisor = added(before?.supervisor, after?.supervisor)
+
+  return {
+    widened: workspace.length > 0 || supervisor.length > 0,
+    workspace,
+    supervisor,
+    // Called out separately because it is a different order of grant: the
+    // supervisor reaches every workspace on the account, not just this one.
+    reachesAllWorkspaces: (before?.supervisor?.length ?? 0) === 0 && supervisor.length > 0,
+  }
+}
+
+/**
+ * @param {object} deps
+ * @param {(source: object, into: string) => Promise<{dir: string, commit?: string, sha256?: string}>} deps.fetchSource
+ * @param {(dir: string) => Promise<string|null>} deps.readManifest
+ * @param {(from: string, to: string) => Promise<void>} deps.move
+ * @param {(dir: string) => Promise<void>} deps.remove
+ * @param {() => Promise<string>} deps.makeTempDir
+ * @param {(name: string) => string} deps.dirFor
+ * @param {object} deps.store   { read(): Promise<object>, write(state): Promise<void> }
+ * @param {() => number} [deps.now]
+ */
+export function createInstaller({
+  fetchSource,
+  readManifest,
+  move,
+  remove,
+  makeTempDir,
+  dirFor,
+  store,
+  now = () => Date.now(),
+}) {
+  let state = null
+
+  async function load() {
+    if (state) return state
+    try {
+      const raw = await store.read()
+      state = { installations: Array.isArray(raw?.installations) ? raw.installations : [] }
+    } catch {
+      state = { installations: [] }
+    }
+    return state
+  }
+
+  const find = (name) => state.installations.find((i) => i.name === name)
+
+  async function persist() {
+    try {
+      await store.write(state)
+    } catch {
+      // The extension is installed on disk either way. Losing the record is bad
+      // but recoverable; throwing here would abandon a completed install and
+      // leave exactly the half-state this whole function avoids.
+    }
+  }
+
+  /** Stages, verifies and swaps in. Cleans up whatever it made if anything fails. */
+  async function stage(source) {
+    const temp = await makeTempDir()
+    try {
+      const fetched = await fetchSource(source, temp)
+
+      if (source.kind === 'release') {
+        const digest = verifyDigest(source.sha256, fetched.sha256)
+        if (!digest.ok) return { ok: false, reason: digest.reason, temp }
+      }
+
+      const manifestSource = await readManifest(fetched.dir)
+      if (manifestSource === null) {
+        return { ok: false, reason: 'There is no agentrq-extension.json in this extension.', temp }
+      }
+
+      const parsed = parseManifest(manifestSource)
+      if (!parsed.ok) return { ok: false, reason: parsed.reason, temp }
+
+      return { ok: true, temp, dir: fetched.dir, manifest: parsed.manifest, commit: fetched.commit }
+    } catch (error) {
+      return { ok: false, reason: reasonFrom(error), temp }
+    }
+  }
+
+  async function discard(temp) {
+    try {
+      await remove(temp)
+    } catch {
+      // A temporary directory nobody could delete is untidy, not broken, and is
+      // not worth turning a clear failure message into a confusing one.
+    }
+  }
+
+  return {
+    /** Everything installed on this machine. */
+    async list() {
+      await load()
+      return state.installations.map((i) => ({ ...i }))
+    },
+
+    /**
+     * Install from any of the three sources.
+     *
+     * A **linked** local folder is recorded rather than copied, so editing it is
+     * editing the installed extension — which is the only way developing one is
+     * tolerable. It is marked as linked precisely because it can change
+     * underneath the app, unlike everything else here.
+     */
+    async install(source, { linked = false } = {}) {
+      await load()
+
+      if (source.kind === 'local' && linked) {
+        const manifestSource = await readManifest(source.path)
+        if (manifestSource === null) {
+          return { ok: false, reason: 'There is no agentrq-extension.json in that folder.' }
+        }
+        const parsed = parseManifest(manifestSource)
+        if (!parsed.ok) return { ok: false, reason: parsed.reason }
+
+        return commit(parsed.manifest, source, pinFor(source), source.path)
+      }
+
+      const staged = await stage(source)
+      if (!staged.ok) {
+        await discard(staged.temp)
+        return { ok: false, reason: staged.reason }
+      }
+
+      const target = dirFor(staged.manifest.name)
+      try {
+        // Whatever was there is removed only once the replacement is staged and
+        // verified, so a failed update cannot leave the machine with neither.
+        await remove(target)
+        await move(staged.dir, target)
+      } catch (error) {
+        await discard(staged.temp)
+        return { ok: false, reason: `Could not install into ${target}: ${reasonFrom(error)}` }
+      }
+
+      return commit(staged.manifest, source, pinFor(source, staged), target)
+    },
+
+    /**
+     * Update an installation in place, reporting when the ask has widened.
+     *
+     * The scope comparison happens here rather than at the grant screen, because
+     * the decision is about two manifests and the caller only needs the answer.
+     */
+    async update(name, source) {
+      await load()
+      const existing = find(name)
+      if (!existing) return { ok: false, reason: `${name} is not installed.` }
+
+      const staged = await stage(source)
+      if (!staged.ok) {
+        await discard(staged.temp)
+        return { ok: false, reason: staged.reason }
+      }
+
+      const scopes = scopesWidened(existing.manifest?.mcp, staged.manifest.mcp)
+      if (scopes.widened) {
+        // Staged but not installed: the caller shows the grant screen and calls
+        // install() if the user agrees. Installing first and asking after would
+        // make the prompt a formality.
+        await discard(staged.temp)
+        return { ok: false, needsGrant: true, scopes, manifest: staged.manifest }
+      }
+
+      const target = dirFor(name)
+      try {
+        await remove(target)
+        await move(staged.dir, target)
+      } catch (error) {
+        await discard(staged.temp)
+        return { ok: false, reason: `Could not update ${name}: ${reasonFrom(error)}` }
+      }
+
+      return commit(staged.manifest, source, pinFor(source, staged), target, { enabled: existing.enabled })
+    },
+
+    /** Stop loading it, without removing anything. */
+    async setEnabled(name, enabled) {
+      await load()
+      const installation = find(name)
+      if (!installation) return { ok: false, reason: `${name} is not installed.` }
+
+      installation.enabled = Boolean(enabled)
+      // A disable is often somebody stopping an extension that keeps failing;
+      // re-enabling it should give it a clean slate rather than one strike from
+      // being disabled again.
+      if (installation.enabled) installation.failures = 0
+      await persist()
+      return { ok: true, installation: { ...installation } }
+    },
+
+    /**
+     * Remove it, and everything installed with it.
+     *
+     * A linked folder is only unlinked — deleting it would delete the user's own
+     * working copy, which is emphatically not what "uninstall" means.
+     */
+    async uninstall(name) {
+      await load()
+      const installation = find(name)
+      if (!installation) return { ok: false, reason: `${name} is not installed.` }
+
+      if (installation.source?.kind !== 'local') {
+        try {
+          await remove(dirFor(name))
+        } catch (error) {
+          return { ok: false, reason: `Could not remove ${name}: ${reasonFrom(error)}` }
+        }
+      }
+
+      state.installations = state.installations.filter((i) => i.name !== name)
+      await persist()
+      return { ok: true }
+    },
+
+    /**
+     * Count a failure, disabling the extension once it is clearly not working.
+     *
+     * An extension that crashes every time it loads is not going to fix itself,
+     * and an app that keeps loading it degrades quietly for reasons a user
+     * cannot see. Disabling is loud, recoverable and honest.
+     */
+    async recordFailure(name, limit = 3) {
+      await load()
+      const installation = find(name)
+      if (!installation) return { ok: false, reason: `${name} is not installed.` }
+
+      installation.failures += 1
+      const disabled = installation.failures >= limit
+      if (disabled) installation.enabled = false
+      await persist()
+      return { ok: true, disabled, failures: installation.failures }
+    },
+  }
+
+  async function commit(manifest, source, pin, dir, options) {
+    const entry = { ...record(manifest, source, pin, options), dir, installedAt: now() }
+    state.installations = [...state.installations.filter((i) => i.name !== manifest.name), entry]
+    await persist()
+    return { ok: true, installation: { ...entry } }
+  }
+}

--- a/desktop/src/main/extensions/source.js
+++ b/desktop/src/main/extensions/source.js
@@ -1,0 +1,142 @@
+/**
+ * Where an extension is being installed from, and what that implies.
+ *
+ * Three sources, and the difference between them is not plumbing — it is how
+ * much is known about what is arriving, and therefore what can be verified:
+ *
+ * - **release** — a published asset found through the catalogue. A stranger's
+ *   code, pinned by a digest, because the tag naming it can be moved afterwards.
+ * - **git** — a repository the user typed in, cloned with their own credentials.
+ *   Usually their own or their organisation's, and often private, which is the
+ *   point: nothing here ever sees a token, because `git` already knows how to
+ *   authenticate and we are not going to reimplement that badly.
+ * - **local** — a directory on this machine. Theirs by definition, and the only
+ *   source that can be *linked* rather than copied, which is what makes
+ *   developing an extension bearable.
+ *
+ * The trust story differs across the three, so the source is recorded with the
+ * installation and shown at the grant screen. "From a repository you entered" is
+ * a materially different sentence from "from the public catalogue", and
+ * flattening them would throw away the one distinction a user actually has.
+ */
+
+/** A digest is only meaningful for a downloaded asset — see `pinFor`. */
+const SHA256_RE = /^[a-f0-9]{64}$/
+
+/** `owner/repo`, with the shapes GitHub actually allows. */
+const SHORTHAND_RE = /^[\w.-]+\/[\w.-]+$/
+
+const fail = (reason) => ({ ok: false, reason })
+
+/**
+ * Works out what the user meant.
+ *
+ * Deliberately generous about form — `owner/repo`, a browser URL, an SSH remote
+ * and an absolute path are all things somebody will reasonably paste — and
+ * deliberately strict about the result, so everything downstream deals in one
+ * shape.
+ */
+export function resolveSource(input, { isAbsolute = (p) => p.startsWith('/') } = {}) {
+  const value = typeof input === 'string' ? input.trim() : ''
+  if (!value) return fail('Enter a repository or a folder to install from.')
+
+  if (value.startsWith('.') || isAbsolute(value) || value.startsWith('file:')) {
+    return { ok: true, source: { kind: 'local', path: value.replace(/^file:\/\//, '') } }
+  }
+
+  if (value.startsWith('git@') || value.endsWith('.git')) {
+    return { ok: true, source: { kind: 'git', url: value, ref: '' } }
+  }
+
+  if (/^https?:\/\//.test(value)) {
+    let url
+    try {
+      url = new URL(value)
+    } catch {
+      return fail(`This is not a URL this understands: "${value}".`)
+    }
+    // A branch or tag pasted from a browser — /tree/<ref> — is a ref the user
+    // meant, and throwing it away would quietly install the wrong thing.
+    const [owner, repo, kind, ...rest] = url.pathname.replace(/^\//, '').split('/')
+    if (!owner || !repo) return fail(`This URL names no repository: "${value}".`)
+    const ref = kind === 'tree' ? rest.join('/') : ''
+    return {
+      ok: true,
+      source: { kind: 'git', url: `${url.origin}/${owner}/${repo.replace(/\.git$/, '')}.git`, ref },
+    }
+  }
+
+  if (SHORTHAND_RE.test(value)) {
+    return { ok: true, source: { kind: 'git', url: `https://github.com/${value}.git`, ref: '' } }
+  }
+
+  return fail(`This is not a repository or a folder: "${value}".`)
+}
+
+/**
+ * The source for a catalogue entry, which is the only kind that carries a digest.
+ */
+export function releaseSource(entry) {
+  const { artifact, name } = entry?.manifest ?? {}
+  if (!artifact) return fail('This catalogue entry has no release to install.')
+  return {
+    ok: true,
+    source: {
+      kind: 'release',
+      name,
+      repo: entry.fullName,
+      release: artifact.release,
+      asset: artifact.asset,
+      sha256: artifact.sha256,
+    },
+  }
+}
+
+/**
+ * What identifies this install afterwards, and whether it can be verified.
+ *
+ * A release asset is pinned by its **sha256**, because the tag naming it is
+ * mutable — an author can move `v1.2.0` to different code after you installed
+ * it, and without the digest "install v1.2.0" is a promise nobody is keeping.
+ *
+ * A clone is pinned by the **commit** it landed on, which is a digest already
+ * and cannot be moved even though the branch pointing at it can.
+ *
+ * A linked folder is pinned by **nothing at all**, and says so. It is a
+ * directory the user edits; pretending to have verified it would be a lie, and
+ * the honest answer is what lets the interface mark it as live rather than
+ * fixed.
+ */
+export function pinFor(source, resolved = {}) {
+  if (source.kind === 'release') return { kind: 'sha256', value: source.sha256 }
+  if (source.kind === 'git') return { kind: 'commit', value: resolved.commit ?? '' }
+  return { kind: 'none', value: '' }
+}
+
+/** Whether a downloaded asset is the one the manifest named. */
+export function verifyDigest(expected, actual) {
+  const want = String(expected ?? '').toLowerCase()
+  const got = String(actual ?? '').toLowerCase()
+
+  if (!SHA256_RE.test(want)) return fail('This release has no usable checksum to verify against.')
+  if (!SHA256_RE.test(got)) return fail('The downloaded file could not be checksummed.')
+  if (want !== got) {
+    // Refused outright rather than warned about. A tag can be moved after an
+    // install, so a mismatch means the bytes are not what the manifest
+    // described — which is either a tampered release or a corrupted download,
+    // and neither is something to click past.
+    return fail(
+      'The download does not match the checksum in the manifest, so it was not installed. ' +
+        'The release may have been changed after it was published.',
+    )
+  }
+  return { ok: true }
+}
+
+/** A one-line description of where an installation came from, for the UI. */
+export function describeSource(source) {
+  if (source?.kind === 'release') return `${source.repo} · ${source.release}`
+  if (source?.kind === 'git') return source.ref ? `${source.url} · ${source.ref}` : source.url
+  if (source?.kind === 'local') return `${source.path} · linked`
+  return 'Unknown source'
+}

--- a/desktop/test/extensions/fetch-source.test.js
+++ b/desktop/test/extensions/fetch-source.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+
+import { createFetchSource } from '../../src/main/extensions/fetch-source.js'
+
+/**
+ * Thin on purpose — everything decidable lives in source.js and install.js,
+ * where it is tested without a network or a disk. What is pinned here is the
+ * part that has to touch the machine: the arguments given to git, and that a
+ * download is hashed before anything is written where it could be loaded.
+ */
+
+/** A spawned process that succeeds, or fails with text on stderr. */
+function fakeSpawn({ fail = null, stdout = '' } = {}) {
+  return vi.fn((command, args) => {
+    const child = new EventEmitter()
+    child.stdout = new EventEmitter()
+    child.stderr = new EventEmitter()
+    queueMicrotask(() => {
+      if (fail) {
+        child.stderr.emit('data', fail)
+        child.emit('close', 128)
+        return
+      }
+      if (stdout) child.stdout.emit('data', stdout)
+      child.emit('close', 0)
+    })
+    child.command = command
+    child.args = args
+    return child
+  })
+}
+
+describe('createFetchSource · git', () => {
+  it('clones shallowly, without submodules, and pins the commit', async () => {
+    // Submodules would let a repository pull in code from somewhere the user
+    // never named — exactly the surprise this feature is trying not to have.
+    const spawn = fakeSpawn({ stdout: 'c0ffee1234\n' })
+    const fetchSource = createFetchSource({ spawn })
+
+    const result = await fetchSource({ kind: 'git', url: 'git@github.com:acme/x.git', ref: '' }, '/tmp/s')
+
+    const [command, args] = spawn.mock.calls[0]
+    expect(command).toBe('git')
+    expect(args).toContain('--depth')
+    expect(args).toContain('--no-recurse-submodules')
+    expect(args).toContain('git@github.com:acme/x.git')
+    expect(result.commit).toBe('c0ffee1234')
+  })
+
+  it('clones the ref when one was given', async () => {
+    const spawn = fakeSpawn({ stdout: 'abc' })
+    await createFetchSource({ spawn })({ kind: 'git', url: 'u', ref: 'next' }, '/tmp/s')
+
+    const [, args] = spawn.mock.calls[0]
+    expect(args).toContain('--branch')
+    expect(args[args.indexOf('--branch') + 1]).toBe('next')
+  })
+
+  it('reports what git said when a clone fails', async () => {
+    // A private repository the user cannot reach is the common case, and the
+    // message git gives is far more useful than anything invented here.
+    const spawn = fakeSpawn({ fail: 'ERROR: Repository not found.' })
+
+    await expect(
+      createFetchSource({ spawn })({ kind: 'git', url: 'git@github.com:acme/secret.git' }, '/tmp/s'),
+    ).rejects.toThrow('Repository not found')
+  })
+})
+
+describe('createFetchSource · release', () => {
+  it('refuses a download the server would not give', async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 404 }))
+
+    await expect(
+      createFetchSource({ spawn: fakeSpawn(), fetchImpl })(
+        { kind: 'release', repo: 'a/b', release: 'v1', asset: 'x.tgz' },
+        '/tmp/s',
+      ),
+    ).rejects.toThrow('Could not download x.tgz (404)')
+  })
+})

--- a/desktop/test/extensions/install.test.js
+++ b/desktop/test/extensions/install.test.js
@@ -1,0 +1,508 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { createInstaller, reasonFrom, scopesWidened } from '../../src/main/extensions/install.js'
+
+/**
+ * Two things this has to get right, and both are about what happens when
+ * something goes wrong: a download that does not match its digest is refused
+ * rather than warned about, and any failure leaves nothing behind. A half-
+ * written extension directory looks installed, loads partially, and fails
+ * somewhere far from the install that caused it.
+ */
+
+const manifestFor = (name, mcp) =>
+  JSON.stringify({
+    name,
+    version: '1.0.0',
+    license: 'MIT',
+    engines: { agentrq: '^1.4' },
+    ...(mcp ? { mcp } : {}),
+    artifact: { release: 'v1.0.0', asset: `${name}.tgz`, sha256: 'a'.repeat(64) },
+  })
+
+const releaseSource = (over = {}) => ({
+  kind: 'release',
+  name: 'thing',
+  repo: 'acme/thing',
+  release: 'v1.0.0',
+  asset: 'thing.tgz',
+  sha256: 'a'.repeat(64),
+  ...over,
+})
+
+/** An installer with every piece of IO faked, so nothing touches disk or network. */
+function build({ manifest = manifestFor('thing'), fetched = {}, ...over } = {}) {
+  const removed = []
+  const moved = []
+  let saved = { installations: [] }
+  // Mutable so a test can change what the *next* stage finds — which is how an
+  // update that asks for more than the version already installed is set up.
+  const current = { manifest }
+
+  const deps = {
+    fetchSource: vi.fn(async (source, temp) => ({
+      dir: `${temp}/unpacked`,
+      sha256: source.kind === 'release' ? source.sha256 : undefined,
+      commit: source.kind === 'git' ? 'c0ffee1' : undefined,
+      ...fetched,
+    })),
+    readManifest: vi.fn(async () => current.manifest),
+    move: vi.fn(async (from, to) => moved.push([from, to])),
+    remove: vi.fn(async (dir) => removed.push(dir)),
+    makeTempDir: vi.fn(async () => '/tmp/stage'),
+    dirFor: (name) => `/ext/${name}`,
+    store: {
+      read: vi.fn(async () => saved),
+      write: vi.fn(async (state) => {
+        saved = JSON.parse(JSON.stringify(state))
+      }),
+    },
+    now: () => 1000,
+    ...over,
+  }
+
+  return {
+    installer: createInstaller(deps),
+    deps,
+    removed,
+    moved,
+    saved: () => saved,
+    /** What the next fetch will find in the package. */
+    setManifest: (next) => {
+      current.manifest = next
+    },
+  }
+}
+
+describe('reasonFrom', () => {
+  it('uses the message when there is one', () => {
+    expect(reasonFrom(new Error('EACCES'))).toBe('EACCES')
+  })
+
+  it('copes with what is thrown not being an Error', () => {
+    // A reason reading "[object Object]" is worse than useless in a message
+    // somebody is expected to act on.
+    expect(reasonFrom('just a string')).toBe('just a string')
+    expect(reasonFrom({})).toBe('Unknown error')
+    expect(reasonFrom(undefined)).toBe('Unknown error')
+    expect(reasonFrom(new Error(''))).toBe('Unknown error')
+  })
+})
+
+describe('scopesWidened', () => {
+  it('sees nothing new as nothing to ask about', () => {
+    const same = { workspace: ['getTask'], supervisor: [] }
+    expect(scopesWidened(same, same).widened).toBe(false)
+  })
+
+  it('does not prompt for an update that asks for less', () => {
+    // Being asked to re-approve something that now wants *less* teaches people
+    // the prompt is noise, and its whole value is being rare enough to read.
+    const before = { workspace: ['getTask', 'reply'], supervisor: ['listAllTasks'] }
+    const after = { workspace: ['getTask'], supervisor: [] }
+
+    expect(scopesWidened(before, after).widened).toBe(false)
+  })
+
+  it('names exactly what was added', () => {
+    const before = { workspace: ['getTask'], supervisor: [] }
+    const after = { workspace: ['getTask', 'reply'], supervisor: [] }
+
+    const { widened, workspace } = scopesWidened(before, after)
+
+    expect(widened).toBe(true)
+    expect(workspace).toEqual(['reply'])
+  })
+
+  it('calls out reaching every workspace as its own thing', () => {
+    // This is what the check exists to catch: an extension acquiring
+    // account-wide access in a patch release nobody read.
+    const grew = scopesWidened({ supervisor: [] }, { supervisor: ['listAllTasks'] })
+
+    expect(grew.reachesAllWorkspaces).toBe(true)
+  })
+
+  it('does not call an already-supervisor extension a new escalation', () => {
+    const grew = scopesWidened(
+      { supervisor: ['listAllTasks'] },
+      { supervisor: ['listAllTasks', 'createWorkspace'] },
+    )
+
+    expect(grew.widened).toBe(true)
+    expect(grew.reachesAllWorkspaces).toBe(false)
+  })
+
+  it('copes with either side being absent', () => {
+    expect(scopesWidened(undefined, undefined).widened).toBe(false)
+    expect(scopesWidened(undefined, { workspace: ['x'] }).widened).toBe(true)
+  })
+})
+
+describe('install', () => {
+  it('verifies, stages and records a release', async () => {
+    const { installer, moved, saved } = build()
+
+    const { ok, installation } = await installer.install(releaseSource())
+
+    expect(ok).toBe(true)
+    expect(moved).toEqual([['/tmp/stage/unpacked', '/ext/thing']])
+    expect(installation.pin).toEqual({ kind: 'sha256', value: 'a'.repeat(64) })
+    expect(installation.sourceLabel).toBe('acme/thing · v1.0.0')
+    expect(saved().installations).toHaveLength(1)
+  })
+
+  it('refuses a download that does not match its digest, and leaves nothing behind', async () => {
+    // The case the digest exists for: a tag moved to different code after the
+    // manifest was published.
+    const { installer, deps, moved, saved } = build({ fetched: { sha256: 'b'.repeat(64) } })
+
+    const { ok, reason } = await installer.install(releaseSource())
+
+    expect(ok).toBe(false)
+    expect(reason).toContain('does not match the checksum')
+    expect(moved).toEqual([])
+    expect(deps.remove).toHaveBeenCalledWith('/tmp/stage')
+    expect(saved().installations).toEqual([])
+  })
+
+  it('refuses a download with no manifest in it', async () => {
+    const { installer, moved } = build({ manifest: null })
+
+    const { ok, reason } = await installer.install(releaseSource())
+
+    expect(ok).toBe(false)
+    expect(reason).toContain('no agentrq-extension.json')
+    expect(moved).toEqual([])
+  })
+
+  it('refuses a manifest that does not parse, with the parser’s own reason', async () => {
+    const { installer } = build({ manifest: JSON.stringify({ name: 'thing', version: '1.0.0' }) })
+
+    expect((await installer.install(releaseSource())).reason).toContain('"license" is required')
+  })
+
+  it('cleans up when the fetch itself throws', async () => {
+    const { installer, deps } = build({
+      fetchSource: vi.fn(async () => {
+        throw new Error('clone failed: repository not found')
+      }),
+    })
+
+    const { ok, reason } = await installer.install({ kind: 'git', url: 'git@x:y.git' })
+
+    expect(ok).toBe(false)
+    expect(reason).toContain('repository not found')
+    expect(deps.remove).toHaveBeenCalledWith('/tmp/stage')
+  })
+
+  it('reports a swap that fails without leaving a record of it', async () => {
+    const { installer, saved } = build({
+      move: vi.fn(async () => {
+        throw new Error('EXDEV')
+      }),
+    })
+
+    const { ok, reason } = await installer.install(releaseSource())
+
+    expect(ok).toBe(false)
+    expect(reason).toContain('Could not install into /ext/thing')
+    expect(saved().installations).toEqual([])
+  })
+
+  it('survives a temporary directory that will not delete', async () => {
+    // Untidy, not broken — and not worth turning a clear failure into a
+    // confusing one.
+    const { installer } = build({
+      fetched: { sha256: 'b'.repeat(64) },
+      remove: vi.fn(async () => {
+        throw new Error('EBUSY')
+      }),
+    })
+
+    expect((await installer.install(releaseSource())).reason).toContain('does not match')
+  })
+
+  it('pins a clone by the commit it landed on', async () => {
+    const { installer } = build()
+
+    const { installation } = await installer.install({ kind: 'git', url: 'git@x:y.git', ref: '' })
+
+    expect(installation.pin).toEqual({ kind: 'commit', value: 'c0ffee1' })
+  })
+
+  it('does not demand a digest from a source that has none', async () => {
+    // A clone and a folder are not downloads; requiring a checksum of them
+    // would make the two useful private routes impossible.
+    const { installer } = build({ fetched: { sha256: undefined } })
+
+    expect((await installer.install({ kind: 'git', url: 'git@x:y.git' })).ok).toBe(true)
+  })
+
+  it('links a local folder rather than copying it', async () => {
+    // Editing the folder is editing the installed extension, which is the only
+    // way developing one is tolerable.
+    const { installer, deps, moved } = build()
+
+    const { ok, installation } = await installer.install({ kind: 'local', path: '/work/ext' }, { linked: true })
+
+    expect(ok).toBe(true)
+    expect(installation.dir).toBe('/work/ext')
+    expect(installation.pin).toEqual({ kind: 'none', value: '' })
+    expect(moved).toEqual([])
+    expect(deps.fetchSource).not.toHaveBeenCalled()
+  })
+
+  it('refuses to link a folder with nothing in it', async () => {
+    const { installer } = build({ manifest: null })
+
+    const { ok, reason } = await installer.install({ kind: 'local', path: '/work/x' }, { linked: true })
+
+    expect(ok).toBe(false)
+    expect(reason).toContain('no agentrq-extension.json in that folder')
+  })
+
+  it('refuses to link a folder whose manifest is broken', async () => {
+    const { installer } = build({ manifest: '{ not json' })
+
+    expect((await installer.install({ kind: 'local', path: '/x' }, { linked: true })).ok).toBe(false)
+  })
+
+  it('replaces an earlier installation of the same name rather than doubling it', async () => {
+    const { installer, saved } = build()
+
+    await installer.install(releaseSource())
+    await installer.install(releaseSource())
+
+    expect(saved().installations).toHaveLength(1)
+  })
+
+  it('keeps the extension even when the record cannot be written', async () => {
+    // It is installed on disk either way; throwing here would abandon a
+    // completed install and leave exactly the half-state this all avoids.
+    const { installer } = build({
+      store: {
+        read: vi.fn(async () => ({ installations: [] })),
+        write: vi.fn(async () => {
+          throw new Error('EACCES')
+        }),
+      },
+    })
+
+    expect((await installer.install(releaseSource())).ok).toBe(true)
+  })
+
+  it('timestamps an install with the real clock when none is injected', async () => {
+    // Production injects nothing, so the default has to work.
+    const before = Date.now()
+    const { installer } = build({ now: undefined })
+
+    const { installation } = await installer.install(releaseSource())
+
+    expect(installation.installedAt).toBeGreaterThanOrEqual(before)
+  })
+
+  it('starts empty when there is no record to read', async () => {
+    const { installer } = build({
+      store: { read: vi.fn(async () => { throw new Error('ENOENT') }), write: vi.fn(async () => {}) },
+    })
+
+    expect(await installer.list()).toEqual([])
+  })
+
+  it('ignores a record of the wrong shape', async () => {
+    const { installer } = build({
+      store: { read: vi.fn(async () => ({ installations: 'lots' })), write: vi.fn(async () => {}) },
+    })
+
+    expect(await installer.list()).toEqual([])
+  })
+})
+
+describe('update', () => {
+  const widerManifest = manifestFor('thing', { workspace: ['getTask'], supervisor: ['listAllTasks'] })
+
+  it('installs quietly when the ask has not changed', async () => {
+    const { installer, moved } = build()
+    await installer.install(releaseSource())
+
+    const { ok, installation } = await installer.update('thing', releaseSource({ release: 'v1.1.0' }))
+
+    expect(ok).toBe(true)
+    expect(installation.sourceLabel).toBe('acme/thing · v1.1.0')
+    expect(moved).toHaveLength(2)
+  })
+
+  it('stops and asks when the update wants more', async () => {
+    // Staged but not installed. Installing first and asking after would make
+    // the prompt a formality.
+    const { installer, moved, setManifest } = build()
+    await installer.install(releaseSource())
+
+    setManifest(widerManifest)
+    const { ok, needsGrant, scopes } = await installer.update('thing', releaseSource())
+
+    expect(ok).toBe(false)
+    expect(needsGrant).toBe(true)
+    expect(scopes.reachesAllWorkspaces).toBe(true)
+    expect(scopes.supervisor).toEqual(['listAllTasks'])
+    // Nothing moved into place: the second move never happened.
+    expect(moved).toHaveLength(1)
+  })
+
+  it('installs an update that asks for less without a prompt', async () => {
+    const { installer, setManifest } = build({ manifest: widerManifest })
+    await installer.install(releaseSource())
+
+    setManifest(manifestFor('thing', { workspace: ['getTask'], supervisor: [] }))
+    const { ok, needsGrant } = await installer.update('thing', releaseSource())
+
+    expect(ok).toBe(true)
+    expect(needsGrant).toBeUndefined()
+  })
+
+  it('refuses to update something that is not installed', async () => {
+    const { installer } = build()
+    expect((await installer.update('ghost', releaseSource())).reason).toBe('ghost is not installed.')
+  })
+
+  it('keeps the previous version when the new one will not stage', async () => {
+    // The update's own staging fails — a moved tag, a corrupt download — and
+    // what is already installed must survive it untouched.
+    const { installer, saved, setManifest, deps } = build()
+    await installer.install(releaseSource())
+
+    setManifest('{ not json')
+    const result = await installer.update('thing', releaseSource())
+
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('This is not valid JSON.')
+    expect(deps.remove).toHaveBeenCalledWith('/tmp/stage')
+    expect(saved().installations[0].version).toBe('1.0.0')
+  })
+
+  it('reports a swap that fails during an update', async () => {
+    const moveOnce = vi.fn()
+    let calls = 0
+    const { installer } = build({
+      move: vi.fn(async (from, to) => {
+        calls += 1
+        if (calls > 1) throw new Error('EPERM')
+        moveOnce(from, to)
+      }),
+    })
+    await installer.install(releaseSource())
+
+    expect((await installer.update('thing', releaseSource())).reason).toContain('Could not update thing')
+  })
+
+  it('keeps a disabled extension disabled through an update', async () => {
+    const { installer } = build()
+    await installer.install(releaseSource())
+    await installer.setEnabled('thing', false)
+
+    const { installation } = await installer.update('thing', releaseSource())
+
+    expect(installation.enabled).toBe(false)
+  })
+})
+
+describe('enable, disable and uninstall', () => {
+  it('stops loading it without removing anything', async () => {
+    const { installer, removed } = build()
+    await installer.install(releaseSource())
+    // An install clears its target before moving in, so what matters is that
+    // disabling adds no removal of its own.
+    const before = removed.length
+
+    const { ok, installation } = await installer.setEnabled('thing', false)
+
+    expect(ok).toBe(true)
+    expect(installation.enabled).toBe(false)
+    expect(removed).toHaveLength(before)
+  })
+
+  it('gives a re-enabled extension a clean slate', async () => {
+    // Disabling is usually somebody stopping something that keeps failing;
+    // turning it back on one strike from being disabled again is not a fix.
+    const { installer } = build()
+    await installer.install(releaseSource())
+    await installer.recordFailure('thing')
+    await installer.recordFailure('thing')
+
+    const { installation } = await installer.setEnabled('thing', true)
+
+    expect(installation.failures).toBe(0)
+  })
+
+  it('removes the directory and the record together', async () => {
+    const { installer, removed, saved } = build()
+    await installer.install(releaseSource())
+
+    const { ok } = await installer.uninstall('thing')
+
+    expect(ok).toBe(true)
+    expect(removed).toContain('/ext/thing')
+    expect(saved().installations).toEqual([])
+  })
+
+  it('unlinks a local folder rather than deleting the user’s own work', async () => {
+    // Deleting it is emphatically not what "uninstall" means.
+    const { installer, removed, saved } = build()
+    await installer.install({ kind: 'local', path: '/work/ext' }, { linked: true })
+
+    await installer.uninstall('thing')
+
+    expect(removed).not.toContain('/work/ext')
+    expect(saved().installations).toEqual([])
+  })
+
+  it('reports a directory it could not remove, and keeps the record', async () => {
+    // Only the uninstall fails: an install clears its own target first, and
+    // breaking that would fail the setup rather than the case under test.
+    let installed = false
+    const { installer, saved } = build({
+      remove: vi.fn(async () => {
+        if (installed) throw new Error('EBUSY')
+      }),
+    })
+    await installer.install(releaseSource())
+    installed = true
+
+    expect((await installer.uninstall('thing')).reason).toContain('Could not remove thing')
+    // Still listed, because it is still on disk — a record removed here would
+    // leave an extension nothing could uninstall.
+    expect(saved().installations).toHaveLength(1)
+  })
+
+  it('refuses to act on something that is not installed', async () => {
+    const { installer } = build()
+
+    expect((await installer.setEnabled('ghost', false)).reason).toBe('ghost is not installed.')
+    expect((await installer.uninstall('ghost')).reason).toBe('ghost is not installed.')
+    expect((await installer.recordFailure('ghost')).reason).toBe('ghost is not installed.')
+  })
+})
+
+describe('recordFailure', () => {
+  it('disables an extension that keeps failing', async () => {
+    // One that crashes every load is not going to fix itself, and an app that
+    // keeps loading it degrades for reasons a user cannot see.
+    const { installer } = build()
+    await installer.install(releaseSource())
+
+    expect((await installer.recordFailure('thing')).disabled).toBe(false)
+    expect((await installer.recordFailure('thing')).disabled).toBe(false)
+    const third = await installer.recordFailure('thing')
+
+    expect(third.disabled).toBe(true)
+    expect(third.failures).toBe(3)
+    expect((await installer.list())[0].enabled).toBe(false)
+  })
+
+  it('takes a limit, for a caller that wants a different one', async () => {
+    const { installer } = build()
+    await installer.install(releaseSource())
+
+    expect((await installer.recordFailure('thing', 1)).disabled).toBe(true)
+  })
+})

--- a/desktop/test/extensions/source.test.js
+++ b/desktop/test/extensions/source.test.js
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  describeSource,
+  pinFor,
+  releaseSource,
+  resolveSource,
+  verifyDigest,
+} from '../../src/main/extensions/source.js'
+
+/**
+ * Three sources, and the difference between them is how much can be verified: a
+ * published asset is a stranger's code pinned by a digest, a clone is the user's
+ * own repository pinned by a commit, and a linked folder is pinned by nothing at
+ * all and says so.
+ */
+
+describe('resolveSource', () => {
+  it('takes owner/repo, which is what people paste', () => {
+    expect(resolveSource('acme/linear').source).toEqual({
+      kind: 'git',
+      url: 'https://github.com/acme/linear.git',
+      ref: '',
+    })
+  })
+
+  it('takes a browser URL, and keeps the branch if one is in it', () => {
+    // A URL copied from the address bar while looking at a branch means that
+    // branch; throwing the ref away would quietly install something else.
+    expect(resolveSource('https://github.com/acme/linear').source.url).toBe(
+      'https://github.com/acme/linear.git',
+    )
+    expect(resolveSource('https://github.com/acme/linear/tree/next').source).toEqual({
+      kind: 'git',
+      url: 'https://github.com/acme/linear.git',
+      ref: 'next',
+    })
+  })
+
+  it('keeps a ref that has slashes in it', () => {
+    expect(resolveSource('https://github.com/acme/linear/tree/feat/thing').source.ref).toBe('feat/thing')
+  })
+
+  it('takes an SSH remote, which is how a private repository is usually cloned', () => {
+    // The whole point of the git source: `git` authenticates with the key the
+    // user already has, and nothing here ever sees a credential.
+    expect(resolveSource('git@github.com:acme/private.git').source).toEqual({
+      kind: 'git',
+      url: 'git@github.com:acme/private.git',
+      ref: '',
+    })
+  })
+
+  it('takes a self-hosted URL, not only github.com', () => {
+    expect(resolveSource('https://git.acme.internal/team/ext').source.url).toBe(
+      'https://git.acme.internal/team/ext.git',
+    )
+  })
+
+  it('does not double the .git suffix', () => {
+    expect(resolveSource('https://github.com/acme/linear.git').source.url).toBe(
+      'https://github.com/acme/linear.git',
+    )
+  })
+
+  it('takes a path, absolute or relative or file:', () => {
+    expect(resolveSource('/Users/me/ext').source).toEqual({ kind: 'local', path: '/Users/me/ext' })
+    expect(resolveSource('./ext').source.kind).toBe('local')
+    expect(resolveSource('file:///Users/me/ext').source.path).toBe('/Users/me/ext')
+  })
+
+  it('uses the platform’s own idea of an absolute path', () => {
+    const isAbsolute = (p) => /^[A-Z]:\\/.test(p)
+    expect(resolveSource('C:\\Users\\me\\ext', { isAbsolute }).source).toEqual({
+      kind: 'local',
+      path: 'C:\\Users\\me\\ext',
+    })
+  })
+
+  it('asks for something rather than failing silently on nothing', () => {
+    expect(resolveSource('').reason).toBe('Enter a repository or a folder to install from.')
+    expect(resolveSource('   ').ok).toBe(false)
+    expect(resolveSource(undefined).ok).toBe(false)
+  })
+
+  it('refuses what it cannot make sense of', () => {
+    expect(resolveSource('just some words').reason).toContain('not a repository or a folder')
+    expect(resolveSource('https://github.com/').reason).toContain('names no repository')
+    expect(resolveSource('http://[').reason).toContain('not a URL this understands')
+  })
+})
+
+describe('releaseSource', () => {
+  const entry = {
+    fullName: 'acme/linear',
+    manifest: {
+      name: 'linear',
+      artifact: { release: 'v1.2.0', asset: 'linear.tgz', sha256: 'a'.repeat(64) },
+    },
+  }
+
+  it('carries the digest, which is the only reason this source can be trusted', () => {
+    expect(releaseSource(entry).source).toEqual({
+      kind: 'release',
+      name: 'linear',
+      repo: 'acme/linear',
+      release: 'v1.2.0',
+      asset: 'linear.tgz',
+      sha256: 'a'.repeat(64),
+    })
+  })
+
+  it('refuses an entry with nothing to install', () => {
+    expect(releaseSource({ manifest: {} }).reason).toContain('no release to install')
+    expect(releaseSource(undefined).ok).toBe(false)
+  })
+})
+
+describe('pinFor', () => {
+  it('pins a release by its digest, because the tag naming it can move', () => {
+    const source = { kind: 'release', sha256: 'a'.repeat(64) }
+    expect(pinFor(source)).toEqual({ kind: 'sha256', value: 'a'.repeat(64) })
+  })
+
+  it('pins a clone by the commit it landed on', () => {
+    // A branch moves; the commit it pointed at does not.
+    expect(pinFor({ kind: 'git' }, { commit: 'deadbee' })).toEqual({ kind: 'commit', value: 'deadbee' })
+    expect(pinFor({ kind: 'git' })).toEqual({ kind: 'commit', value: '' })
+  })
+
+  it('admits that a linked folder is pinned by nothing', () => {
+    // It is a directory the user edits. Claiming to have verified it would be a
+    // lie, and the honest answer is what lets the UI mark it as live.
+    expect(pinFor({ kind: 'local' })).toEqual({ kind: 'none', value: '' })
+  })
+})
+
+describe('verifyDigest', () => {
+  const good = 'a'.repeat(64)
+
+  it('accepts a match, whatever the casing', () => {
+    expect(verifyDigest(good, good.toUpperCase()).ok).toBe(true)
+  })
+
+  it('refuses a mismatch outright, rather than warning about it', () => {
+    // A tag can be moved after an install, so a mismatch means the bytes are not
+    // what the manifest described — tampered or corrupt, neither clickable-past.
+    const { ok, reason } = verifyDigest(good, 'b'.repeat(64))
+
+    expect(ok).toBe(false)
+    expect(reason).toContain('was not installed')
+    expect(reason).toContain('changed after it was published')
+  })
+
+  it('refuses when there is nothing usable to check against', () => {
+    // A manifest with no digest cannot pin anything, and neither can one whose
+    // digest is the wrong shape.
+    expect(verifyDigest('', good).reason).toContain('no usable checksum')
+    expect(verifyDigest('short', good).ok).toBe(false)
+    expect(verifyDigest(undefined, good).ok).toBe(false)
+    expect(verifyDigest(null, good).ok).toBe(false)
+  })
+
+  it('refuses when the download could not be checksummed', () => {
+    expect(verifyDigest(good, '').reason).toContain('could not be checksummed')
+    expect(verifyDigest(good, undefined).ok).toBe(false)
+  })
+})
+
+describe('describeSource', () => {
+  it('says where each kind came from', () => {
+    expect(describeSource({ kind: 'release', repo: 'acme/x', release: 'v1' })).toBe('acme/x · v1')
+    expect(describeSource({ kind: 'git', url: 'git@x:y.git' })).toBe('git@x:y.git')
+    expect(describeSource({ kind: 'git', url: 'git@x:y.git', ref: 'next' })).toBe('git@x:y.git · next')
+    // Marked as linked, because it can change under the app.
+    expect(describeSource({ kind: 'local', path: '/tmp/x' })).toBe('/tmp/x · linked')
+    expect(describeSource(undefined)).toBe('Unknown source')
+  })
+})

--- a/desktop/vitest.config.mjs
+++ b/desktop/vitest.config.mjs
@@ -11,7 +11,16 @@ export default defineConfig({
       // at module scope and its behaviour is only observable with a real
       // Electron binary. Every rule it depends on lives in the modules beside
       // it, which are covered.
-      exclude: ['src/main/index.js'],
+      //
+      // fetch-source.js is the same category for the same reason: it is the
+      // shim that copies a directory, shells out to git and unpacks an archive,
+      // and none of that is observable without a real disk and a real git. Its
+      // decisions — what a source is, whether a digest matches, what a failure
+      // does — all live in source.js and install.js, which are covered, and the
+      // two things in it that are judgement rather than plumbing (the clone
+      // arguments, and hashing before anything is written) have tests of their
+      // own in fetch-source.test.js.
+      exclude: ['src/main/index.js', 'src/main/extensions/fetch-source.js'],
       reporter: ['text', 'lcov'],
       thresholds: {
         lines: 100,


### PR DESCRIPTION
> **4 of 10, stacked on [#517](https://github.com/agentrq/agentrq/pull/517).** Targets `ext/03-catalogue-ui`. [Plan](https://claude.ai/code/artifact/907d107c-921d-4e0e-a371-de22229c2927).

## What changed

An extension can now be installed, updated, disabled and removed — from a published release, from a repository the user pastes in (including a private one), or from a folder on their machine.

## Why changed

Browsing a catalogue is only useful if something can come out of it. The three sources exist because not every extension is public: a team's own extension lives in a private repository, and one being written lives in a folder.

## Test coverage report

New lines introduced: **100%**. Total coverage impact: **unchanged at 100%** on all four metrics — desktop is now 620 tests across 22 files, up from 556 across 20.

Downloads, the filesystem, `git` and the record store are all injected: no network, no writes, no processes. Covered: a good digest installing, a bad one refusing and leaving nothing behind, a fetch that throws, a swap that fails, an unwritable record, a linked folder, an update that widens scope, one that narrows it, and every lifecycle refusal.

## Other reports

**Nothing is unpacked before it is verified.** A release asset is hashed and compared against the manifest *before* anything is written, and a mismatch is refused outright rather than warned about — it means the bytes are not what the manifest described.

**The private-repository case works by not participating.** The user pastes a URL and `git` authenticates with the key or credential helper they already have. Nothing here handles a token, which is both less to secure and less to get wrong. Submodules are deliberately not fetched — they would let a repository pull in code from somewhere the user never named.

**Each source is pinned by what it can actually be pinned by:** a release by its **sha256**, a clone by the **commit** it landed on (a branch moves; the commit does not), and a linked folder by **nothing at all**, which it says. Claiming to have verified a directory somebody edits would be a lie, and the honest answer is what lets the UI mark it live rather than fixed.

**Uninstalling a linked folder unlinks it.** Deleting the user's own working copy is emphatically not what uninstall means.

**An update that asks for more stops and reports it, staged but not installed.** Installing first and asking after would make the prompt a formality. Narrowing deliberately does *not* prompt: being asked to re-approve something that now wants less teaches people the prompt is noise, and its value is being rare enough to read. Gaining supervisor access is flagged separately, because that is the account rather than a workspace.

**One coverage exclusion, deliberately and with a reason.** `fetch-source.js` copies a directory, shells out to `git` and unpacks an archive — none observable without a real disk and a real `git`. It sits beside the existing exclusion for the Electron entry point, for the same stated reason. Everything it *decides* lives in `source.js` and `install.js`, both at 100%, and the two parts that are judgement rather than plumbing — the clone arguments, and hashing before writing — have their own tests. Flagging it explicitly because an exclusion is how a gate quietly stops meaning anything.

Nothing loads or runs an extension yet: that is 5/10.

## TaskID: 0iV09rVH7WT
