### PR TITLE
feat(extensions): load one, and take it away again completely

### DIFF
--- a/desktop/src/main/extensions/config.js
+++ b/desktop/src/main/extensions/config.js
@@ -1,0 +1,188 @@
+/**
+ * What an extension is configured with, and where its secrets live.
+ *
+ * The manifest declares the fields; this validates what a user typed against
+ * them and keeps the answers. The split matters: ordinary values are readable
+ * settings, and secrets are not — an API key belongs in the OS keychain and
+ * should never appear in a file somebody could back up, sync or paste.
+ *
+ * ## Secrets are write-only from the interface
+ *
+ * A saved secret can be replaced but never read back. There is no legitimate
+ * reason for the settings screen to display one, and every reason not to: it
+ * would put a credential on screen, in a screenshot, and in whatever the
+ * renderer's process memory ends up in. The screen shows whether a value is set,
+ * which is the only part a person needs.
+ */
+
+const fail = (reason) => ({ ok: false, reason })
+
+/** Coerces and checks one declared field. */
+function coerce(field, raw) {
+  const value = raw ?? ''
+
+  if (field.type === 'boolean') {
+    if (typeof value === 'boolean') return { ok: true, value }
+    if (value === 'true' || value === 'false') return { ok: true, value: value === 'true' }
+    return fail(`"${field.label}" must be true or false.`)
+  }
+
+  if (field.type === 'number') {
+    const n = typeof value === 'number' ? value : Number(String(value).trim())
+    if (!Number.isFinite(n)) return fail(`"${field.label}" must be a number.`)
+    return { ok: true, value: n }
+  }
+
+  if (typeof value !== 'string') return fail(`"${field.label}" must be text.`)
+  return { ok: true, value: value.trim() }
+}
+
+/**
+ * Validates a whole submission against the fields a manifest declares.
+ *
+ * Unknown keys are refused rather than dropped. A settings form that silently
+ * discards a value looks like it saved it, and the extension then behaves as
+ * though the user never typed anything — which is a much harder thing to
+ * diagnose than being told the field does not exist.
+ */
+export function validateConfig(fields = [], submitted = {}) {
+  const known = new Map(fields.map((field) => [field.key, field]))
+
+  const unknown = Object.keys(submitted).filter((key) => !known.has(key))
+  if (unknown.length > 0) {
+    return fail(`This extension has no setting called ${unknown.map((k) => `"${k}"`).join(', ')}.`)
+  }
+
+  const values = {}
+  const secrets = {}
+  for (const field of fields) {
+    if (!(field.key in submitted)) continue
+
+    const result = coerce(field, submitted[field.key])
+    if (!result.ok) return result
+
+    // Split at the boundary, so nothing downstream has to remember which is
+    // which — the two go to different places and never meet again.
+    if (field.type === 'secret') secrets[field.key] = String(result.value)
+    else values[field.key] = result.value
+  }
+
+  return { ok: true, values, secrets }
+}
+
+/**
+ * What the settings screen is allowed to know about a secret.
+ *
+ * Set or not set. Never the value, and never its length — which narrows a guess
+ * more than people expect.
+ */
+export function describeSecrets(fields = [], stored = {}) {
+  return fields
+    .filter((field) => field.type === 'secret')
+    .map((field) => ({ key: field.key, label: field.label, set: Boolean(stored[field.key]) }))
+}
+
+/**
+ * Config and secrets for every installation.
+ *
+ * @param {object} deps
+ * @param {object} deps.store   { read(), write(state) } for the non-secret half.
+ * @param {object} deps.vault   { encrypt(text), decrypt(blob), available() }
+ */
+export function createConfigStore({ store, vault }) {
+  let state = null
+
+  async function load() {
+    if (state) return state
+    try {
+      const raw = await store.read()
+      state = { config: raw?.config ?? {}, secrets: raw?.secrets ?? {} }
+    } catch {
+      state = { config: {}, secrets: {} }
+    }
+    return state
+  }
+
+  return {
+    /** The readable settings for one extension. */
+    async get(name) {
+      await load()
+      return { ...(state.config[name] ?? {}) }
+    },
+
+    /**
+     * Which secrets are set, without revealing any of them.
+     *
+     * This is what the settings screen renders.
+     */
+    async describe(name, fields) {
+      await load()
+      return describeSecrets(fields, state.secrets[name] ?? {})
+    },
+
+    /**
+     * Save a submission.
+     *
+     * A secret with no encryption available is **refused rather than written in
+     * the clear**. Storing it anyway would be the worst of both worlds: the user
+     * believes it is protected, and it is sitting in a JSON file.
+     */
+    async save(name, fields, submitted) {
+      await load()
+      const result = validateConfig(fields, submitted)
+      if (!result.ok) return result
+
+      const secretKeys = Object.keys(result.secrets)
+      if (secretKeys.length > 0 && !vault.available()) {
+        return fail(
+          'This system has no secure storage available, so the secret was not saved. ' +
+            'Nothing here will write a credential to a plain file.',
+        )
+      }
+
+      const secrets = { ...(state.secrets[name] ?? {}) }
+      for (const key of secretKeys) {
+        // An emptied field clears the secret rather than storing an empty one,
+        // which is how somebody removes a credential they no longer want here.
+        secrets[key] = result.secrets[key] ? vault.encrypt(result.secrets[key]) : ''
+      }
+
+      state.config[name] = { ...(state.config[name] ?? {}), ...result.values }
+      state.secrets[name] = secrets
+      await store.write(state)
+      return { ok: true }
+    },
+
+    /**
+     * Everything an extension needs to run, secrets included.
+     *
+     * Only the host calls this, and only to hand values to the extension it is
+     * loading. A secret that will not decrypt is omitted rather than passed
+     * through as ciphertext, which an extension would otherwise send somewhere
+     * as though it were the key.
+     */
+    async resolve(name) {
+      await load()
+      const secrets = {}
+      for (const [key, blob] of Object.entries(state.secrets[name] ?? {})) {
+        if (!blob) continue
+        try {
+          secrets[key] = vault.decrypt(blob)
+        } catch {
+          // Left out entirely. The extension sees a missing setting, which it
+          // can report, rather than a value that is wrong in a way it cannot.
+        }
+      }
+      return { ...(state.config[name] ?? {}), ...secrets }
+    },
+
+    /** Forget everything about an extension, on uninstall. */
+    async forget(name) {
+      await load()
+      delete state.config[name]
+      delete state.secrets[name]
+      await store.write(state)
+      return { ok: true }
+    },
+  }
+}

--- a/desktop/src/main/extensions/host.js
+++ b/desktop/src/main/extensions/host.js
@@ -1,0 +1,257 @@
+import { createRegistries } from './registry.js'
+
+/**
+ * Loading an extension, and taking it away again.
+ *
+ * An extension is a Node module exporting the Cordis-like contract:
+ *
+ *     export const name = 'linear'
+ *     export const inject = ['ui', 'shortcuts']
+ *     export function apply(ctx, config) { … }
+ *
+ * `apply` is called once with a context carrying exactly the registries it
+ * declared, and everything it registers is remembered against its name — so
+ * unloading is complete by construction rather than by an author remembering to
+ * tidy up.
+ *
+ * ## This is trusted code, and nothing here pretends otherwise
+ *
+ * An extension runs with the privileges of the process it is in. There is no
+ * sandbox: that was considered and deliberately not built, because the value of
+ * this design is the ordinary Node ecosystem and a sandbox costs exactly that.
+ *
+ * What *is* enforced is everything AgentRQ owns — which registries an extension
+ * can reach, which names it may claim, and which MCP tools it may call. That is
+ * a real boundary around this application's data. It is not a boundary around
+ * the machine, and the install screen says so in those words.
+ *
+ * The one thing this must never do is run in the renderer. That is where the
+ * `window.agentrq` bridge exposes files, the clipboard and the shell, and
+ * third-party code next to it would have the whole machine through an API built
+ * for the app's own UI.
+ *
+ * ## Failure is loud
+ *
+ * An extension that throws on load, or repeatedly at runtime, is disabled and
+ * the user is told. An app that keeps reloading something broken degrades for
+ * reasons nobody can see from the outside.
+ */
+
+/** How many failures before an extension is switched off. */
+export const FAILURE_LIMIT = 3
+
+const fail = (reason) => ({ ok: false, reason })
+
+/**
+ * Checks the module actually looks like an extension before calling into it.
+ *
+ * A clear refusal here is worth a great deal: the alternative is a TypeError
+ * from inside `apply` that names a line number in somebody else's code.
+ */
+export function validateModule(module, expectedName) {
+  if (!module || typeof module !== 'object') return fail('This extension exports nothing.')
+  if (typeof module.apply !== 'function') {
+    return fail('This extension exports no apply(ctx, config) function.')
+  }
+  const declared = String(module.name ?? '').trim()
+  if (declared && declared !== expectedName) {
+    // Worth catching: the manifest name is what everything else addresses it
+    // by, so a module disagreeing means half the wiring would point elsewhere.
+    return fail(`This extension calls itself "${declared}" but its manifest says "${expectedName}".`)
+  }
+  const inject = Array.isArray(module.inject) ? module.inject.map(String) : []
+  return { ok: true, inject }
+}
+
+/**
+ * The context an extension is given.
+ *
+ * Only the registries it declared in `inject`. Handing over everything would
+ * make `inject` decorative, and the declaration is what lets the install screen
+ * say what an extension touches before it is ever run.
+ */
+export function buildContext({ name, registries, inject, config, logger }) {
+  const missing = inject.filter((key) => !(key in registries))
+  if (missing.length > 0) {
+    return fail(`This extension asks for something that does not exist: ${missing.join(', ')}.`)
+  }
+
+  const ctx = {
+    name,
+    config,
+    logger: {
+      info: (...args) => logger.info?.(`[${name}]`, ...args),
+      warn: (...args) => logger.warn?.(`[${name}]`, ...args),
+    },
+  }
+
+  for (const key of inject) {
+    const registry = registries[key]
+    ctx[key] = {
+      /**
+       * Registering throws rather than returning a result.
+       *
+       * `apply` is a procedure, and an author writing one will not check a
+       * return value they did not know to expect. A throw is caught by the
+       * host, reported against the extension, and abandons a load that was
+       * going to be half-applied anyway.
+       */
+      add(entry) {
+        const result = registry.add(name, entry)
+        if (!result.ok) throw new Error(result.reason)
+        return ctx[key]
+      },
+    }
+  }
+  return { ok: true, ctx }
+}
+
+/**
+ * @param {object} deps
+ * @param {(installation: object) => Promise<object>} deps.load  Imports the module.
+ * @param {(name: string) => Promise<object>} deps.readConfig
+ * @param {(name: string) => Promise<void>} [deps.onDisabled]
+ * @param {{info: Function, warn: Function}} [deps.logger]
+ */
+export function createHost({ load, readConfig, onDisabled = async () => {}, logger = console }) {
+  const registries = createRegistries()
+  /** @type {Map<string, object>} what is loaded right now. */
+  const loaded = new Map()
+  /**
+   * How many times each extension has failed.
+   *
+   * Kept apart from `loaded` deliberately. A failed load retracts everything the
+   * extension registered, which includes forgetting it is loaded — and if the
+   * count lived there it would be forgotten with it, resetting to zero on every
+   * attempt so the limit could never be reached.
+   */
+  const failures = new Map()
+
+  /**
+   * Undo everything an extension did.
+   *
+   * Registry entries are keyed by owner precisely so this is complete without
+   * the extension participating — an author who forgot to clean up, or whose
+   * `apply` threw halfway through, still leaves nothing behind.
+   */
+  function retract(name) {
+    let removed = 0
+    for (const registry of Object.values(registries)) removed += registry.removeOwner(name)
+    loaded.delete(name)
+    return removed
+  }
+
+  return {
+    registries,
+
+    /** What is loaded right now. */
+    list() {
+      return [...loaded.values()].map((installation) => ({
+        name: installation.name,
+        version: installation.version,
+        failures: failures.get(installation.name) ?? 0,
+      }))
+    },
+
+    /**
+     * Load one installation.
+     *
+     * A failure at any point retracts whatever was registered before it. A
+     * partially applied extension is the worst outcome available: it looks
+     * loaded, half its contributions are missing, and nothing says why.
+     */
+    async start(installation) {
+      const { name } = installation
+      if (loaded.has(name)) return fail(`${name} is already loaded.`)
+      if (installation.enabled === false) return fail(`${name} is disabled.`)
+
+      let module
+      try {
+        module = await load(installation)
+      } catch (error) {
+        return this.recordFailure(name, error)
+      }
+
+      const shape = validateModule(module, name)
+      if (!shape.ok) return this.recordFailure(name, new Error(shape.reason))
+
+      let config = {}
+      try {
+        config = await readConfig(name)
+      } catch (error) {
+        logger.warn?.(`[${name}] could not read configuration:`, error)
+      }
+
+      const context = buildContext({
+        name,
+        registries,
+        inject: shape.inject,
+        config,
+        logger,
+      })
+      if (!context.ok) return this.recordFailure(name, new Error(context.reason))
+
+      loaded.set(name, installation)
+      try {
+        await module.apply(context.ctx, config)
+      } catch (error) {
+        retract(name)
+        return this.recordFailure(name, error)
+      }
+
+      // A load that worked clears the slate. Otherwise two failures months
+      // apart would eventually disable something that has been working fine.
+      failures.delete(name)
+      return { ok: true, registered: Object.values(registries).reduce(
+        (n, registry) => n + registry.listFor(name).length,
+        0,
+      ) }
+    },
+
+    /** Unload it, taking every entry it registered with it. */
+    stop(name) {
+      if (!loaded.has(name)) return fail(`${name} is not loaded.`)
+      const removed = retract(name)
+      return { ok: true, removed }
+    },
+
+    /**
+     * Count a failure, disabling the extension once it is clearly not working.
+     *
+     * Three strikes rather than one: a transient failure — a network blip in a
+     * `apply` that fetches something — should not permanently switch off an
+     * extension somebody relies on. Three of them is not transient.
+     */
+    async recordFailure(name, error) {
+      const reason = error?.message || String(error ?? 'Unknown error')
+      const count = (failures.get(name) ?? 0) + 1
+      failures.set(name, count)
+
+      logger.warn?.(`[${name}] failed:`, reason)
+
+      if (count >= FAILURE_LIMIT) {
+        retract(name)
+        await onDisabled(name, reason)
+        return { ok: false, reason, disabled: true }
+      }
+      return { ok: false, reason, disabled: false }
+    },
+
+    /** Everything contributed to one registry, with lazy entries resolved. */
+    resolve(registry, context) {
+      const target = registries[registry]
+      if (!target) return []
+      return target.resolve(context, {
+        onError: (owner, error) => {
+          logger.warn?.(`[${owner}] failed while building a ${target.name}:`, error?.message ?? error)
+        },
+      })
+    },
+
+    /** Unload everything, for shutdown. */
+    stopAll() {
+      for (const name of [...loaded.keys()]) retract(name)
+      failures.clear()
+    },
+  }
+}

--- a/desktop/src/main/extensions/registry.js
+++ b/desktop/src/main/extensions/registry.js
@@ -1,0 +1,160 @@
+/**
+ * Named registries, and the three rules that make them predictable.
+ *
+ * Every extension does the same thing: it contributes entries. A page in the
+ * sidebar, an action in a workspace header, an item on a task's context menu, a
+ * keyboard shortcut, a schedule — all of them are entries in a registry, so
+ * adding a surface later is an entry type rather than a subsystem.
+ *
+ * The shape is borrowed from Cordis, which the DeepSeek Harness is built on and
+ * which this project already ships a plugin for. What is deliberately *not*
+ * borrowed is its trust model: Cordis hands a plugin real capability with no
+ * boundary because its plugins are trusted in-process code. Ours are too, which
+ * is a decision made with eyes open — but it means the ergonomics are the part
+ * worth copying and nothing here should be mistaken for containment.
+ *
+ * ## Three rules
+ *
+ * **Unique names, rejected loudly.** A duplicate registration fails with a
+ * message naming both claimants. Silently letting the last one win is how two
+ * extensions end up fighting over a shortcut and neither author can tell why.
+ *
+ * **Explicit order.** Entries carry an `order`, and ties break on owner and id,
+ * so what the user sees never depends on which extension happened to load first.
+ *
+ * **Lazy values.** An entry's value may be a function of context, resolved when
+ * something asks. That is what lets a task menu item decide whether it applies
+ * to *this* task rather than being a permanent row on every one of them.
+ */
+
+/** Where a name has to be unique. */
+export const SCOPES = {
+  /** One claimant across every extension — shortcuts, tool names. */
+  global: 'global',
+  /** One claimant per extension — pages, which are addressed by owner and id. */
+  owner: 'owner',
+}
+
+const fail = (reason) => ({ ok: false, reason })
+
+/** Ordered, then stable. Never dependent on load sequence. */
+function byOrderThenName(a, b) {
+  return a.order - b.order || a.owner.localeCompare(b.owner) || a.id.localeCompare(b.id)
+}
+
+/**
+ * One registry.
+ *
+ * @param {object} options
+ * @param {string} options.name    What it holds, for the messages.
+ * @param {'global'|'owner'} [options.scope]
+ */
+export function createRegistry({ name, scope = SCOPES.global }) {
+  /** @type {Map<string, object>} keyed by whatever `scope` makes unique. */
+  const entries = new Map()
+
+  const keyFor = (owner, id) => (scope === SCOPES.owner ? `${owner}:${id}` : id)
+
+  return {
+    name,
+    scope,
+
+    /**
+     * Claim a name.
+     *
+     * The message names the extension already holding it, because "duplicate
+     * id" tells an author nothing they can act on — the useful fact is *who*
+     * they are colliding with.
+     */
+    add(owner, entry) {
+      const id = String(entry?.id ?? '').trim()
+      if (!owner) return fail(`Cannot register a ${name} without an extension.`)
+      if (!id) return fail(`A ${name} needs an id.`)
+
+      const key = keyFor(owner, id)
+      const existing = entries.get(key)
+      if (existing) {
+        return existing.owner === owner
+          ? fail(`${owner} registers the ${name} "${id}" twice.`)
+          : fail(`${owner} cannot register the ${name} "${id}": ${existing.owner} already has it.`)
+      }
+
+      entries.set(key, {
+        ...entry,
+        id,
+        owner,
+        // Defaulted rather than required: most entries have no opinion, and
+        // making every author pick a number would produce arbitrary ones.
+        order: Number.isFinite(entry?.order) ? entry.order : 100,
+      })
+      return { ok: true }
+    },
+
+    /** Everything registered, in the order it should appear. */
+    list() {
+      return [...entries.values()].sort(byOrderThenName)
+    },
+
+    /** Just this extension's, which is what an uninstall needs to know. */
+    listFor(owner) {
+      return this.list().filter((entry) => entry.owner === owner)
+    },
+
+    /**
+     * Everything registered, with each lazy value resolved against `context`.
+     *
+     * An entry whose value throws is **dropped, not propagated**. One extension
+     * deciding badly must not empty a menu that other extensions are also in,
+     * and the failure is reported so it can be counted against that extension
+     * rather than disappearing.
+     */
+    resolve(context, { onError = () => {} } = {}) {
+      return this.list().flatMap((entry) => {
+        if (typeof entry.value !== 'function') return [entry]
+        try {
+          const value = entry.value(context)
+          return value === undefined ? [] : [{ ...entry, value }]
+        } catch (error) {
+          onError(entry.owner, error)
+          return []
+        }
+      })
+    },
+
+    /** Give up every name this extension holds. */
+    removeOwner(owner) {
+      let removed = 0
+      for (const [key, entry] of entries) {
+        if (entry.owner === owner) {
+          entries.delete(key)
+          removed += 1
+        }
+      }
+      return removed
+    },
+
+    /** Whether a name is already taken, and by whom. */
+    claimedBy(owner, id) {
+      return entries.get(keyFor(owner, id))?.owner ?? ''
+    },
+  }
+}
+
+/**
+ * The set of registries the host offers.
+ *
+ * Named here rather than created ad hoc so that `inject` can be checked against
+ * something: an extension asking for a registry that does not exist should be
+ * told at load, not discover it when a call returns undefined.
+ */
+export function createRegistries() {
+  return {
+    // Addressed as /extensions/:name/:pageId, so a page only has to be unique
+    // within the extension that owns it.
+    ui: createRegistry({ name: 'view', scope: SCOPES.owner }),
+    // A key sequence has one meaning, whoever asked for it.
+    shortcuts: createRegistry({ name: 'shortcut', scope: SCOPES.global }),
+    // A schedule is reconciled by id against what already exists on the server.
+    schedules: createRegistry({ name: 'schedule', scope: SCOPES.owner }),
+  }
+}

--- a/desktop/test/extensions/config.test.js
+++ b/desktop/test/extensions/config.test.js
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import {
+  createConfigStore,
+  describeSecrets,
+  validateConfig,
+} from '../../src/main/extensions/config.js'
+
+/**
+ * The split that matters: ordinary settings are readable, and secrets are not.
+ * A saved secret can be replaced but never read back — there is no reason for a
+ * settings screen to show a credential, and every reason not to.
+ */
+
+const fields = [
+  { key: 'teamId', type: 'string', label: 'Team' },
+  { key: 'apiKey', type: 'secret', label: 'API key' },
+  { key: 'verbose', type: 'boolean', label: 'Verbose' },
+  { key: 'limit', type: 'number', label: 'Limit' },
+]
+
+/**
+ * A vault that round-trips but does not leave the plaintext lying in the output.
+ *
+ * Deliberately not `enc(${text})`: a fake that keeps the value visible makes
+ * "the secret is never stored in the clear" pass against the fake rather than
+ * against the code.
+ */
+const fakeVault = (available = true) => ({
+  available: () => available,
+  encrypt: (text) => Buffer.from(text, 'utf8').toString('base64'),
+  decrypt: (blob) => {
+    if (!/^[A-Za-z0-9+/]*={0,2}$/.test(blob)) throw new Error('cannot decrypt')
+    return Buffer.from(blob, 'base64').toString('utf8')
+  },
+})
+
+const fakeStore = (initial = { config: {}, secrets: {} }) => {
+  let saved = initial
+  return {
+    read: vi.fn(async () => saved),
+    write: vi.fn(async (state) => {
+      saved = JSON.parse(JSON.stringify(state))
+    }),
+    get saved() {
+      return saved
+    },
+  }
+}
+
+describe('validateConfig', () => {
+  it('separates secrets from everything else', () => {
+    const { values, secrets } = validateConfig(fields, { teamId: 'ENG', apiKey: 'sk-1' })
+
+    expect(values).toEqual({ teamId: 'ENG' })
+    expect(secrets).toEqual({ apiKey: 'sk-1' })
+  })
+
+  it('refuses a setting the extension never declared', () => {
+    // A form that silently discards a value looks like it saved it, and the
+    // extension then behaves as though nothing was typed.
+    const { ok, reason } = validateConfig(fields, { nope: 'x' })
+
+    expect(ok).toBe(false)
+    expect(reason).toBe('This extension has no setting called "nope".')
+  })
+
+  it('coerces the types it declares, and refuses what it cannot', () => {
+    expect(validateConfig(fields, { verbose: 'true' }).values.verbose).toBe(true)
+    expect(validateConfig(fields, { verbose: false }).values.verbose).toBe(false)
+    expect(validateConfig(fields, { limit: '20' }).values.limit).toBe(20)
+    expect(validateConfig(fields, { limit: 7 }).values.limit).toBe(7)
+
+    expect(validateConfig(fields, { verbose: 'maybe' }).reason).toBe('"Verbose" must be true or false.')
+    expect(validateConfig(fields, { limit: 'lots' }).reason).toBe('"Limit" must be a number.')
+    expect(validateConfig(fields, { teamId: { a: 1 } }).reason).toBe('"Team" must be text.')
+  })
+
+  it('trims text, so a pasted value with a stray space still works', () => {
+    expect(validateConfig(fields, { teamId: '  ENG  ' }).values.teamId).toBe('ENG')
+  })
+
+  it('treats a field submitted as empty as empty, not as a crash', () => {
+    // A form posts a cleared field as null rather than omitting it.
+    expect(validateConfig(fields, { teamId: null }).values.teamId).toBe('')
+    expect(validateConfig(fields, { teamId: undefined }).values.teamId).toBe('')
+  })
+
+  it('leaves out what was not submitted', () => {
+    const { values, secrets } = validateConfig(fields, {})
+
+    expect(values).toEqual({})
+    expect(secrets).toEqual({})
+  })
+
+  it('copes with an extension that declares nothing', () => {
+    expect(validateConfig(undefined, {}).ok).toBe(true)
+  })
+})
+
+describe('describeSecrets', () => {
+  it('says whether each is set, and nothing else about it', () => {
+    // Not the value, and not its length — which narrows a guess more than
+    // people expect.
+    const described = describeSecrets(fields, { apiKey: 'c2stMQ==' })
+
+    expect(described).toEqual([{ key: 'apiKey', label: 'API key', set: true }])
+  })
+
+  it('reports an unset secret as unset', () => {
+    expect(describeSecrets(fields, {})[0].set).toBe(false)
+    expect(describeSecrets(fields, { apiKey: '' })[0].set).toBe(false)
+  })
+
+  it('copes with nothing declared', () => {
+    expect(describeSecrets()).toEqual([])
+  })
+})
+
+describe('createConfigStore', () => {
+  const build = (vault = fakeVault(), store = fakeStore()) => ({
+    config: createConfigStore({ store, vault }),
+    store,
+  })
+
+  it('saves settings and hands them back', async () => {
+    const { config } = build()
+
+    await config.save('linear', fields, { teamId: 'ENG', limit: 5 })
+
+    expect(await config.get('linear')).toEqual({ teamId: 'ENG', limit: 5 })
+  })
+
+  it('encrypts a secret and never stores it in the clear', async () => {
+    const { config, store } = build()
+
+    await config.save('linear', fields, { apiKey: 'sk-live-1' })
+
+    expect(JSON.stringify(store.saved)).not.toContain('sk-live-1')
+    expect(store.saved.secrets.linear.apiKey).toBe(Buffer.from('sk-live-1').toString('base64'))
+  })
+
+  it('gives the extension the decrypted value, and only the extension', async () => {
+    const { config } = build()
+    await config.save('linear', fields, { teamId: 'ENG', apiKey: 'sk-1' })
+
+    expect(await config.resolve('linear')).toEqual({ teamId: 'ENG', apiKey: 'sk-1' })
+    // The settings screen sees only whether it is set.
+    expect(await config.describe('linear', fields)).toEqual([
+      { key: 'apiKey', label: 'API key', set: true },
+    ])
+  })
+
+  it('refuses to save a secret with nowhere safe to put it', async () => {
+    // Writing it anyway is the worst of both worlds: the user believes it is
+    // protected and it is sitting in a JSON file.
+    const { config, store } = build(fakeVault(false))
+
+    const { ok, reason } = await config.save('linear', fields, { apiKey: 'sk-1' })
+
+    expect(ok).toBe(false)
+    expect(reason).toContain('no secure storage available')
+    expect(store.write).not.toHaveBeenCalled()
+  })
+
+  it('still saves ordinary settings on a system with no secure storage', async () => {
+    const { config } = build(fakeVault(false))
+
+    expect((await config.save('linear', fields, { teamId: 'ENG' })).ok).toBe(true)
+  })
+
+  it('clears a secret when the field is emptied', async () => {
+    // How somebody removes a credential they no longer want stored here.
+    const { config } = build()
+    await config.save('linear', fields, { apiKey: 'sk-1' })
+
+    await config.save('linear', fields, { apiKey: '' })
+
+    expect(await config.resolve('linear')).toEqual({})
+    expect((await config.describe('linear', fields))[0].set).toBe(false)
+  })
+
+  it('omits a secret that will not decrypt rather than passing the ciphertext on', async () => {
+    // An extension handed ciphertext would send it somewhere as though it were
+    // the key. A missing setting is something it can report; a wrong one is not.
+    const store = fakeStore({ config: {}, secrets: { linear: { apiKey: 'not base64!!' } } })
+    const { config } = build(fakeVault(), store)
+
+    expect(await config.resolve('linear')).toEqual({})
+  })
+
+  it('merges an update rather than replacing everything', async () => {
+    const { config } = build()
+    await config.save('linear', fields, { teamId: 'ENG', limit: 5 })
+
+    await config.save('linear', fields, { limit: 9 })
+
+    expect(await config.get('linear')).toEqual({ teamId: 'ENG', limit: 9 })
+  })
+
+  it('refuses an invalid submission without writing anything', async () => {
+    const { config, store } = build()
+
+    expect((await config.save('linear', fields, { limit: 'lots' })).ok).toBe(false)
+    expect(store.write).not.toHaveBeenCalled()
+  })
+
+  it('forgets everything on uninstall', async () => {
+    const { config, store } = build()
+    await config.save('linear', fields, { teamId: 'ENG', apiKey: 'sk-1' })
+
+    await config.forget('linear')
+
+    expect(await config.get('linear')).toEqual({})
+    expect(await config.resolve('linear')).toEqual({})
+    expect(store.saved.secrets.linear).toBeUndefined()
+  })
+
+  it('starts empty when there is nothing saved yet', async () => {
+    const store = { read: vi.fn(async () => { throw new Error('ENOENT') }), write: vi.fn() }
+    const { config } = build(fakeVault(), store)
+
+    expect(await config.get('linear')).toEqual({})
+  })
+
+  it('copes with a stored shape it does not recognise', async () => {
+    const store = fakeStore({})
+    const { config } = build(fakeVault(), store)
+
+    expect(await config.get('linear')).toEqual({})
+    expect(await config.describe('linear', fields)).toEqual([
+      { key: 'apiKey', label: 'API key', set: false },
+    ])
+  })
+})

--- a/desktop/test/extensions/host.test.js
+++ b/desktop/test/extensions/host.test.js
@@ -1,0 +1,404 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { FAILURE_LIMIT, buildContext, createHost, validateModule } from '../../src/main/extensions/host.js'
+import { createRegistries } from '../../src/main/extensions/registry.js'
+
+/**
+ * Loading is only half of it. The half worth testing is what happens when an
+ * extension misbehaves: a partially applied extension — loaded, half its
+ * contributions missing, nothing saying why — is the worst outcome available
+ * here, so every failure path retracts everything before it.
+ */
+
+const installation = (over = {}) => ({ name: 'linear', version: '1.0.0', enabled: true, ...over })
+
+/** An extension module, with whatever apply the test needs. */
+const moduleWith = (apply, over = {}) => ({ name: 'linear', inject: ['ui'], apply, ...over })
+
+function build({ module = moduleWith(() => {}), config = {}, ...over } = {}) {
+  const onDisabled = vi.fn(async () => {})
+  const logger = { info: vi.fn(), warn: vi.fn() }
+  const host = createHost({
+    load: vi.fn(async () => module),
+    readConfig: vi.fn(async () => config),
+    onDisabled,
+    logger,
+    ...over,
+  })
+  return { host, onDisabled, logger }
+}
+
+describe('validateModule', () => {
+  it('accepts a module with an apply and reads what it injects', () => {
+    const { ok, inject } = validateModule(moduleWith(() => {}), 'linear')
+
+    expect(ok).toBe(true)
+    expect(inject).toEqual(['ui'])
+  })
+
+  it('refuses a module with no apply, plainly', () => {
+    // The alternative is a TypeError naming a line in somebody else's code.
+    expect(validateModule({}, 'linear').reason).toBe('This extension exports no apply(ctx, config) function.')
+    expect(validateModule(undefined, 'linear').reason).toBe('This extension exports nothing.')
+    expect(validateModule('not a module', 'linear').ok).toBe(false)
+  })
+
+  it('catches a module that disagrees with its manifest about its own name', () => {
+    // The manifest name is what everything else addresses it by, so half the
+    // wiring would point somewhere else.
+    const { ok, reason } = validateModule(moduleWith(() => {}, { name: 'linear-issues' }), 'linear')
+
+    expect(ok).toBe(false)
+    expect(reason).toBe('This extension calls itself "linear-issues" but its manifest says "linear".')
+  })
+
+  it('lets a module leave its name out', () => {
+    expect(validateModule({ apply: () => {} }, 'linear').ok).toBe(true)
+  })
+
+  it('treats a missing or malformed inject as asking for nothing', () => {
+    expect(validateModule({ apply: () => {} }, 'x').inject).toEqual([])
+    expect(validateModule({ apply: () => {}, inject: 'ui' }, 'x').inject).toEqual([])
+  })
+})
+
+describe('buildContext', () => {
+  const registries = () => createRegistries()
+
+  it('gives an extension only what it asked for', () => {
+    // Handing over everything would make `inject` decorative, and the
+    // declaration is what lets the install screen say what it touches.
+    const { ctx } = buildContext({
+      name: 'linear',
+      registries: registries(),
+      inject: ['ui'],
+      config: {},
+      logger: console,
+    })
+
+    expect(typeof ctx.ui.add).toBe('function')
+    expect(ctx.shortcuts).toBeUndefined()
+  })
+
+  it('refuses an extension asking for something that does not exist', () => {
+    const { ok, reason } = buildContext({
+      name: 'linear',
+      registries: registries(),
+      inject: ['ui', 'telepathy'],
+      config: {},
+      logger: console,
+    })
+
+    expect(ok).toBe(false)
+    expect(reason).toContain('telepathy')
+  })
+
+  it('throws on a rejected registration rather than returning a result', () => {
+    // apply() is a procedure, and an author will not check a return value they
+    // did not know to expect.
+    const shared = registries()
+    shared.ui.add('standup', { id: 'index' })
+
+    const { ctx } = buildContext({
+      name: 'standup',
+      registries: shared,
+      inject: ['ui'],
+      config: {},
+      logger: console,
+    })
+
+    expect(() => ctx.ui.add({ id: 'index' })).toThrow('registers the view "index" twice')
+  })
+
+  it('chains, so a run of registrations reads as one', () => {
+    const { ctx } = buildContext({
+      name: 'linear',
+      registries: registries(),
+      inject: ['ui'],
+      config: {},
+      logger: console,
+    })
+
+    expect(ctx.ui.add({ id: 'a' }).add({ id: 'b' })).toBe(ctx.ui)
+  })
+
+  it('prefixes what an extension logs with its name', () => {
+    const logger = { info: vi.fn(), warn: vi.fn() }
+    const { ctx } = buildContext({ name: 'linear', registries: registries(), inject: [], config: {}, logger })
+
+    ctx.logger.info('hello')
+    ctx.logger.warn('careful')
+
+    expect(logger.info).toHaveBeenCalledWith('[linear]', 'hello')
+    expect(logger.warn).toHaveBeenCalledWith('[linear]', 'careful')
+  })
+
+  it('survives a logger that offers nothing', () => {
+    const { ctx } = buildContext({ name: 'x', registries: registries(), inject: [], config: {}, logger: {} })
+
+    expect(() => ctx.logger.info('hi')).not.toThrow()
+    expect(() => ctx.logger.warn('hi')).not.toThrow()
+  })
+})
+
+describe('createHost', () => {
+  it('loads an extension and keeps what it registered', async () => {
+    const { host } = build({
+      module: moduleWith((ctx) => {
+        ctx.ui.add({ id: 'index' })
+      }),
+    })
+
+    const { ok, registered } = await host.start(installation())
+
+    expect(ok).toBe(true)
+    expect(registered).toBe(1)
+    expect(host.registries.ui.list()).toHaveLength(1)
+    expect(host.list()).toEqual([{ name: 'linear', version: '1.0.0', failures: 0 }])
+  })
+
+  it('hands the extension its configuration', async () => {
+    const apply = vi.fn()
+    const { host } = build({ module: moduleWith(apply), config: { teamId: 'ENG' } })
+
+    await host.start(installation())
+
+    expect(apply).toHaveBeenCalledWith(expect.objectContaining({ config: { teamId: 'ENG' } }), {
+      teamId: 'ENG',
+    })
+  })
+
+  it('refuses to load one twice, or one that is disabled', async () => {
+    const { host } = build()
+    await host.start(installation())
+
+    expect((await host.start(installation())).reason).toBe('linear is already loaded.')
+    expect((await host.start(installation({ name: 'other', enabled: false }))).reason).toBe(
+      'other is disabled.',
+    )
+  })
+
+  it('retracts everything when apply throws halfway through', async () => {
+    // A partially applied extension looks loaded, is missing half its
+    // contributions, and says nothing about why.
+    const { host } = build({
+      module: moduleWith((ctx) => {
+        ctx.ui.add({ id: 'index' })
+        throw new Error('boom')
+      }),
+    })
+
+    const { ok, reason } = await host.start(installation())
+
+    expect(ok).toBe(false)
+    expect(reason).toBe('boom')
+    expect(host.registries.ui.list()).toEqual([])
+  })
+
+  it('reports a module that will not import', async () => {
+    const { host } = build({
+      load: vi.fn(async () => {
+        throw new Error('Cannot find module')
+      }),
+    })
+
+    expect((await host.start(installation())).reason).toBe('Cannot find module')
+  })
+
+  it('reports a module of the wrong shape', async () => {
+    const { host } = build({ module: { name: 'linear' } })
+
+    expect((await host.start(installation())).reason).toContain('exports no apply')
+  })
+
+  it('loads anyway when the configuration cannot be read', async () => {
+    // Missing settings are the extension's problem to report; refusing to load
+    // it entirely takes away its chance to say so.
+    const { host, logger } = build({
+      readConfig: vi.fn(async () => {
+        throw new Error('EACCES')
+      }),
+    })
+
+    expect((await host.start(installation())).ok).toBe(true)
+    expect(logger.warn).toHaveBeenCalled()
+  })
+
+  it('unloads, taking every entry with it', async () => {
+    // Keyed by owner precisely so this is complete without the author helping.
+    const { host } = build({
+      module: moduleWith((ctx) => {
+        ctx.ui.add({ id: 'a' }).add({ id: 'b' })
+      }),
+    })
+    await host.start(installation())
+
+    const { ok, removed } = host.stop('linear')
+
+    expect(ok).toBe(true)
+    expect(removed).toBe(2)
+    expect(host.registries.ui.list()).toEqual([])
+    expect(host.list()).toEqual([])
+  })
+
+  it('refuses to unload what is not loaded', () => {
+    expect(build().host.stop('ghost').reason).toBe('ghost is not loaded.')
+  })
+
+  it('disables an extension that keeps failing, and says so', async () => {
+    // An app that keeps reloading something broken degrades for reasons nobody
+    // can see from outside.
+    const { host, onDisabled } = build({
+      module: moduleWith(() => {
+        throw new Error('always')
+      }),
+    })
+
+    // A failed load retracts itself, so each attempt starts clean — the count
+    // is what has to survive, and it is kept apart from the loaded state for
+    // exactly that reason.
+    for (let i = 1; i < FAILURE_LIMIT; i += 1) {
+      expect((await host.start(installation())).disabled).toBe(false)
+    }
+    const last = await host.start(installation())
+
+    expect(last.disabled).toBe(true)
+    expect(onDisabled).toHaveBeenCalledWith('linear', 'always')
+  })
+
+  it('tolerates a transient failure rather than switching off on the first one', async () => {
+    // A network blip inside apply should not permanently disable something
+    // somebody relies on.
+    const { host, onDisabled } = build({
+      module: moduleWith(() => {
+        throw new Error('blip')
+      }),
+    })
+
+    await host.start(installation())
+
+    expect(onDisabled).not.toHaveBeenCalled()
+  })
+
+  it('clears the count when a load finally works', async () => {
+    // Otherwise two failures months apart would eventually disable something
+    // that has been working perfectly well in between.
+    let broken = true
+    const { host, onDisabled } = build({
+      module: moduleWith(() => {
+        if (broken) throw new Error('blip')
+      }),
+    })
+
+    await host.start(installation())
+    broken = false
+    await host.start(installation())
+    expect(host.list()[0].failures).toBe(0)
+
+    host.stop('linear')
+    broken = true
+    await host.start(installation())
+    await host.start(installation())
+
+    expect(onDisabled).not.toHaveBeenCalled()
+  })
+
+  it('refuses at load an extension asking for a registry that does not exist', async () => {
+    // Told at load, not discovered when a call returns undefined.
+    const { host } = build({ module: moduleWith(() => {}, { inject: ['telepathy'] }) })
+
+    expect((await host.start(installation())).reason).toContain('telepathy')
+  })
+
+  it('describes a failure that carries nothing at all', async () => {
+    const { host } = build({
+      module: moduleWith(() => {
+        throw null
+      }),
+    })
+
+    expect((await host.start(installation())).reason).toBe('Unknown error')
+  })
+
+  it('disables without an onDisabled being supplied', async () => {
+    // Production may not care to be told; the disabling still has to happen.
+    const host = createHost({
+      load: async () => moduleWith(() => {
+        throw new Error('always')
+      }),
+      readConfig: async () => ({}),
+      logger: { info: vi.fn(), warn: vi.fn() },
+    })
+
+    for (let i = 1; i < FAILURE_LIMIT; i += 1) await host.start(installation())
+
+    expect((await host.start(installation())).disabled).toBe(true)
+  })
+
+  it('resolves a registry against a context', async () => {
+    const { host } = build({
+      module: moduleWith((ctx) => {
+        ctx.ui.add({ id: 'a', value: (t) => (t.done ? 'shown' : undefined) })
+      }),
+    })
+    await host.start(installation())
+
+    expect(host.resolve('ui', { done: true })[0].value).toBe('shown')
+    expect(host.resolve('ui', { done: false })).toEqual([])
+  })
+
+  it('reports an entry that throws while being resolved, without losing the rest', async () => {
+    const { host, logger } = build({
+      module: moduleWith((ctx) => {
+        ctx.ui.add({ id: 'bad', value: () => { throw new Error('nope') } })
+      }),
+    })
+    await host.start(installation())
+
+    expect(host.resolve('ui', {})).toEqual([])
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('[linear]'), 'nope')
+  })
+
+  it('reports a resolve failure that is not an Error', async () => {
+    const { host, logger } = build({
+      module: moduleWith((ctx) => {
+        ctx.ui.add({ id: 'bad', value: () => { throw 'a string' } })
+      }),
+    })
+    await host.start(installation())
+
+    host.resolve('ui', {})
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('[linear]'), 'a string')
+  })
+
+  it('answers with nothing for a registry that does not exist', () => {
+    expect(build().host.resolve('telepathy', {})).toEqual([])
+  })
+
+  it('unloads everything for shutdown', async () => {
+    const { host } = build({ module: moduleWith((ctx) => ctx.ui.add({ id: 'a' })) })
+    await host.start(installation())
+
+    host.stopAll()
+
+    expect(host.list()).toEqual([])
+    expect(host.registries.ui.list()).toEqual([])
+  })
+
+  it('describes a failure that is not an Error', async () => {
+    const { host } = build({
+      module: moduleWith(() => {
+        throw 'just a string'
+      }),
+    })
+
+    expect((await host.start(installation())).reason).toBe('just a string')
+  })
+
+  it('logs through a bare console when given no logger', async () => {
+    const host = createHost({ load: async () => moduleWith(() => {}), readConfig: async () => ({}) })
+
+    expect((await host.start(installation())).ok).toBe(true)
+  })
+})

--- a/desktop/test/extensions/registry.test.js
+++ b/desktop/test/extensions/registry.test.js
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { SCOPES, createRegistries, createRegistry } from '../../src/main/extensions/registry.js'
+
+/**
+ * Three rules carry this: names are unique and a duplicate is rejected loudly,
+ * order never depends on load sequence, and a value may be a function so an
+ * entry can decide whether it applies at all.
+ */
+
+describe('createRegistry', () => {
+  const build = (scope) => createRegistry({ name: 'shortcut', scope })
+
+  it('accepts an entry and hands it back with its owner', () => {
+    const registry = build()
+
+    expect(registry.add('linear', { id: 'l' }).ok).toBe(true)
+    expect(registry.list()).toEqual([{ id: 'l', owner: 'linear', order: 100 }])
+  })
+
+  it('names who already holds a colliding id', () => {
+    // "Duplicate id" tells an author nothing they can act on; the useful fact
+    // is who they are colliding with.
+    const registry = build()
+    registry.add('standup', { id: 's' })
+
+    const { ok, reason } = registry.add('linear', { id: 's' })
+
+    expect(ok).toBe(false)
+    expect(reason).toBe('linear cannot register the shortcut "s": standup already has it.')
+  })
+
+  it('catches an extension colliding with itself', () => {
+    const registry = build()
+    registry.add('linear', { id: 'l' })
+
+    expect(registry.add('linear', { id: 'l' }).reason).toBe('linear registers the shortcut "l" twice.')
+  })
+
+  it('lets two extensions use the same id where the scope is per-extension', () => {
+    // A page is addressed by owner and id, so there is nothing to collide.
+    const registry = build(SCOPES.owner)
+
+    expect(registry.add('linear', { id: 'index' }).ok).toBe(true)
+    expect(registry.add('standup', { id: 'index' }).ok).toBe(true)
+    expect(registry.list()).toHaveLength(2)
+  })
+
+  it('refuses an entry with nothing to call it', () => {
+    const registry = build()
+
+    expect(registry.add('linear', {}).reason).toBe('A shortcut needs an id.')
+    expect(registry.add('linear', { id: '  ' }).ok).toBe(false)
+    expect(registry.add('', { id: 'l' }).reason).toContain('without an extension')
+  })
+
+  it('orders by order, then stably, whatever the load sequence', () => {
+    // What a user sees must not depend on which extension loaded first.
+    const registry = build()
+    registry.add('zeta', { id: 'b', order: 10 })
+    registry.add('alpha', { id: 'a', order: 10 })
+    registry.add('mid', { id: 'c', order: 1 })
+
+    expect(registry.list().map((e) => e.id)).toEqual(['c', 'a', 'b'])
+  })
+
+  it('defaults the order rather than making every author pick a number', () => {
+    const registry = build()
+    registry.add('a', { id: 'x' })
+    registry.add('b', { id: 'y', order: 5 })
+
+    expect(registry.list().map((e) => e.id)).toEqual(['y', 'x'])
+  })
+
+  it('ignores an order that is not a number', () => {
+    const registry = build()
+    registry.add('a', { id: 'x', order: 'first' })
+
+    expect(registry.list()[0].order).toBe(100)
+  })
+
+  it('resolves a lazy value against the context it is given', () => {
+    const registry = build()
+    registry.add('linear', { id: 'l', value: (task) => `issue for ${task.title}` })
+
+    expect(registry.resolve({ title: 'Ship it' })[0].value).toBe('issue for Ship it')
+  })
+
+  it('drops a lazy entry that opts out', () => {
+    // This is what stops ten installed extensions meaning ten permanent rows on
+    // every task.
+    const registry = build()
+    registry.add('linear', { id: 'l', value: (task) => (task.done ? 'x' : undefined) })
+
+    expect(registry.resolve({ done: false })).toEqual([])
+    expect(registry.resolve({ done: true })).toHaveLength(1)
+  })
+
+  it('drops an entry that throws, and reports it, without emptying the menu', () => {
+    // One extension deciding badly must not take out the ones beside it.
+    const onError = vi.fn()
+    const registry = build()
+    registry.add('good', { id: 'g', value: () => 'fine' })
+    registry.add('bad', {
+      id: 'b',
+      value: () => {
+        throw new Error('nope')
+      },
+    })
+
+    const resolved = registry.resolve({}, { onError })
+
+    expect(resolved.map((e) => e.id)).toEqual(['g'])
+    expect(onError).toHaveBeenCalledWith('bad', expect.any(Error))
+  })
+
+  it('leaves a static value alone', () => {
+    const registry = build()
+    registry.add('linear', { id: 'l', value: 'plain' })
+
+    expect(registry.resolve({})[0].value).toBe('plain')
+  })
+
+  it('resolves with no error handler given', () => {
+    const registry = build()
+    registry.add('bad', { id: 'b', value: () => { throw new Error('nope') } })
+
+    expect(registry.resolve({})).toEqual([])
+  })
+
+  it('gives up every name an extension held', () => {
+    const registry = build()
+    registry.add('linear', { id: 'a' })
+    registry.add('linear', { id: 'b' })
+    registry.add('standup', { id: 'c' })
+
+    expect(registry.removeOwner('linear')).toBe(2)
+    expect(registry.list().map((e) => e.id)).toEqual(['c'])
+    // And the name is free again.
+    expect(registry.add('other', { id: 'a' }).ok).toBe(true)
+  })
+
+  it('lists just one extension’s entries, which is what an uninstall needs', () => {
+    const registry = build()
+    registry.add('linear', { id: 'a' })
+    registry.add('standup', { id: 'b' })
+
+    expect(registry.listFor('linear').map((e) => e.id)).toEqual(['a'])
+  })
+
+  it('says who holds a name, or nobody', () => {
+    const registry = build()
+    registry.add('linear', { id: 'l' })
+
+    expect(registry.claimedBy('anyone', 'l')).toBe('linear')
+    expect(registry.claimedBy('anyone', 'free')).toBe('')
+  })
+})
+
+describe('createRegistries', () => {
+  it('offers the surfaces an extension can contribute to', () => {
+    const registries = createRegistries()
+
+    expect(Object.keys(registries).sort()).toEqual(['schedules', 'shortcuts', 'ui'])
+  })
+
+  it('scopes each one the way that surface is addressed', () => {
+    const registries = createRegistries()
+
+    // A key sequence has one meaning whoever asked for it; a page is reached at
+    // /extensions/:name/:pageId and only has to be unique within its extension.
+    expect(registries.shortcuts.scope).toBe(SCOPES.global)
+    expect(registries.ui.scope).toBe(SCOPES.owner)
+  })
+})


### PR DESCRIPTION
> **5 of 10, stacked on [#518](https://github.com/agentrq/agentrq/pull/518).** Targets `ext/04-install`. [Plan](https://claude.ai/code/artifact/907d107c-921d-4e0e-a371-de22229c2927).

## What changed

Extensions can now be loaded and unloaded: an extension's `apply` is called with the registries it declared, everything it contributes is remembered against its name, and unloading takes all of it away.

## Why changed

Installing something is only useful if it can then run. This is the runtime — the contract, what an extension may reach through it, and what happens when it misbehaves.

## Test coverage report

New lines introduced: **100%**. Total coverage impact: **unchanged at 100%** on all four metrics — desktop is now 693 tests across 25 files, up from 620 across 22.

The module loader, the config store and the keychain are injected, so a load, a throw, a duplicate registration and a failed decrypt are all exercised without a real extension or a real keychain.

## Other reports

**Unloading is complete by construction.** Registry entries are keyed by owner, so an author who forgets to clean up — or whose `apply` throws halfway through — still leaves nothing behind. Every failure path retracts what came before it, because a partially applied extension looks loaded, is missing half its contributions, and says nothing about why.

**The context carries only what was declared.** Handing over every registry would make `inject` decorative, and that declaration is what lets the install screen say what an extension touches before it has run once.

**Three registry rules, each load-bearing:** a duplicate is rejected loudly and *names who already holds it* ("duplicate id" tells an author nothing they can act on); order is explicit with ties broken on owner and id, so nothing depends on load sequence; and a value may be a function of context, which is what stops ten installed extensions meaning ten permanent rows on every task.

**Secrets are write-only.** A saved secret can be replaced but never read back, and the settings screen learns only whether one is *set* — not its value, and not its length, which narrows a guess more than people expect. A secret with no secure storage available is **refused rather than written in the clear**, and one that will not decrypt is omitted rather than handed to an extension as ciphertext it would send somewhere as though it were the key.

**A real bug the tests found rather than confirmed.** The failure count lived in the same map as the loaded state — and since a failed load *retracts* that state, the count reset to zero on every attempt, so an extension could fail forever without ever reaching the limit. It is kept separately now, and a successful load clears it so two failures months apart don't accumulate into a disable.

**Nothing here is a sandbox, and the code says so.** What is enforced is what AgentRQ owns — which registries an extension reaches, which names it may claim. That is a real boundary around this application's data and explicitly not one around the machine.

Nothing consumes these registries yet: the surfaces arrive in 7/10 and 8/10, and brokered MCP in 6/10.

## TaskID: 0iV0Bl3TlGz
