### PR TITLE
feat(extensions): brokered MCP, and a grant that cannot be misread

### DIFF
--- a/backend/internal/controller/mcp/event.go
+++ b/backend/internal/controller/mcp/event.go
@@ -33,7 +33,7 @@ type MCPEvent struct {
 	UserID        int64  `json:"userId"`
 	Method        string `json:"method,omitempty"`
 	ToolName      string `json:"toolName,omitempty"`
-	Actor         uint8  `json:"actor"`                   // 1: Human, 2: Agent
+	Actor         uint8  `json:"actor"`                   // 1: Human, 2: Agent, 3: Extension
 	ClientID      int64  `json:"clientId,omitempty"`      // xxhash64(name+version) of the calling MCP client, 0 if unknown
 	ClientName    string `json:"clientName,omitempty"`    // e.g. "claude-code", empty if unknown
 	ClientVersion string `json:"clientVersion,omitempty"` // empty if unknown

--- a/backend/internal/data/entity/crud/entity.go
+++ b/backend/internal/data/entity/crud/entity.go
@@ -539,7 +539,7 @@ type (
 		UserID       int64        `json:"userId"`
 		ResourceType ResourceType `json:"resourceType"`
 		ResourceID   int64        `json:"resourceId"`
-		Actor        Actor        `json:"actor"`  // 1: Human, 2: Agent
+		Actor        Actor        `json:"actor"`  // 1: Human, 2: Agent, 3: Extension
 		Origin       Origin       `json:"origin"` // 1: API, 2: MCP, 3: Scheduler, 4: Slack
 	}
 
@@ -927,6 +927,14 @@ type EventPublishedPayload struct {
 const (
 	ActorHuman Actor = 1
 	ActorAgent Actor = 2
+	// ActorExtension is work done by a desktop extension acting on the user's
+	// behalf. It is neither of the other two: counting it as human overstates
+	// what a person did, and counting it as agent puts it in the same bucket as
+	// the thing the workspace exists to measure.
+	//
+	// Appended, never inserted — the value is stored on every telemetry row, so
+	// renumbering would silently reinterpret history.
+	ActorExtension Actor = 3
 )
 
 const (

--- a/desktop/src/main/extensions/broker.js
+++ b/desktop/src/main/extensions/broker.js
@@ -1,0 +1,147 @@
+/**
+ * The one place an extension reaches AgentRQ, and the only real boundary here.
+ *
+ * An extension is an MCP *client* — of the workspace server, of the supervisor,
+ * or of neither. It never holds a credential: it asks, and this makes the call
+ * with the token or OAuth session attached on the way out.
+ *
+ * That is the whole protection, and it is worth being precise about what it is
+ * and is not. It does **not** contain the extension: this is trusted Node, it
+ * can open its own sockets, and nothing here changes that. What it does is keep
+ * the credential out of extension code — which matters because a workspace token
+ * and a supervisor session outlive any single extension and reach every
+ * workspace on the account. An extension that is compromised, or simply careless
+ * with what it logs, cannot leak a key it was never given.
+ *
+ * ## Two questions, asked separately, on every call
+ *
+ * **May it call this tool?** Against the manifest's `mcp` allowlist, which the
+ * user saw at install.
+ *
+ * **May it touch this workspace?** Against the grant, which is a different
+ * thing: an extension allowed `getTask` is not thereby allowed it everywhere.
+ *
+ * ## Supervisor access is not a third checkbox
+ *
+ * `listAllTasks` spans the platform and `createTask(workspaceId)` reaches
+ * anywhere, so the supervisor surface *is* every workspace. Granting it and then
+ * "limiting" the workspace list would be incoherent, and the ladder in
+ * `grant.js` exists so that it cannot be expressed.
+ */
+
+/** The three rungs a grant can sit on. Ordered, because they escalate. */
+export const SCOPE = {
+  workspace: 'workspace',
+  selected: 'selected',
+  supervisor: 'supervisor',
+}
+
+const deny = (reason) => ({ ok: false, reason })
+
+/**
+ * Whether a grant permits one call.
+ *
+ * Split out from the calling because it is the rule, and a rule that can be
+ * read on its own is one that can be checked on its own.
+ */
+export function permits(grant, { surface, tool, workspaceId }) {
+  const allowed = grant?.tools?.[surface] ?? []
+  if (!allowed.includes(tool)) {
+    // Names the surface, because the same tool name can exist on both and
+    // "not allowed" would leave an author guessing which one they asked for.
+    return deny(`This extension may not call "${tool}" on the ${surface} server.`)
+  }
+
+  if (surface === 'supervisor') {
+    // Reaching the supervisor at all is reaching every workspace; there is no
+    // narrower state to check against.
+    return grant.scope === SCOPE.supervisor
+      ? { ok: true }
+      : deny('This extension was not granted access to all workspaces.')
+  }
+
+  if (grant.scope === SCOPE.supervisor) return { ok: true }
+
+  if (!workspaceId) return deny('This call names no workspace.')
+  return grant.workspaces?.includes(workspaceId)
+    ? { ok: true }
+    : deny('This extension was not granted access to that workspace.')
+}
+
+/**
+ * @param {object} deps
+ * @param {(args: object) => Promise<any>} deps.callWorkspace  Given { workspaceId, tool, args }.
+ * @param {(args: object) => Promise<any>} deps.callSupervisor Given { tool, args }.
+ * @param {(entry: object) => void} [deps.record]  Audit, for attribution.
+ * @param {{warn: Function}} [deps.logger]
+ */
+export function createBroker({ callWorkspace, callSupervisor, record = () => {}, logger = console }) {
+  /** @type {Map<string, object>} grants by extension name. */
+  const grants = new Map()
+
+  return {
+    /** Remember what the user agreed to at the grant screen. */
+    setGrant(name, grant) {
+      grants.set(name, {
+        scope: grant?.scope ?? SCOPE.workspace,
+        workspaces: [...(grant?.workspaces ?? [])],
+        tools: {
+          workspace: [...(grant?.tools?.workspace ?? [])],
+          supervisor: [...(grant?.tools?.supervisor ?? [])],
+        },
+      })
+    },
+
+    revoke(name) {
+      grants.delete(name)
+    },
+
+    grantFor(name) {
+      const grant = grants.get(name)
+      return grant ? JSON.parse(JSON.stringify(grant)) : null
+    },
+
+    /**
+     * The object an extension is handed.
+     *
+     * Closed over the extension's name, so it cannot ask on another's behalf,
+     * and carrying no credential of any kind — that is the point of the whole
+     * arrangement.
+     */
+    clientFor(name) {
+      const call = async (surface, tool, args = {}) => {
+        const grant = grants.get(name)
+        if (!grant) return deny('This extension has not been granted any access.')
+
+        const workspaceId = args.workspaceId ?? ''
+        const allowed = permits(grant, { surface, tool, workspaceId })
+        if (!allowed.ok) {
+          // Recorded as well as refused: a refusal is the interesting half of an
+          // audit trail, and it is what tells a user an extension is asking for
+          // more than they gave it.
+          record({ name, surface, tool, workspaceId, allowed: false, reason: allowed.reason })
+          logger.warn?.(`[${name}] refused ${surface}.${tool}: ${allowed.reason}`)
+          return allowed
+        }
+
+        record({ name, surface, tool, workspaceId, allowed: true })
+        try {
+          const result =
+            surface === 'supervisor'
+              ? await callSupervisor({ tool, args })
+              : await callWorkspace({ workspaceId, tool, args })
+          return { ok: true, result }
+        } catch (error) {
+          // The server's own message, not one invented here: an extension author
+          // debugging a refused or malformed call needs what the server said.
+          return deny(error?.message || 'The call failed.')
+        }
+      }
+
+      return {
+        workspace: (tool, args) => call('workspace', tool, args),
+        supervisor: (tool, args) => call('supervisor', tool, args),
+      }
+    },
+  }
+}

--- a/desktop/test/extensions/broker.test.js
+++ b/desktop/test/extensions/broker.test.js
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { SCOPE, createBroker, permits } from '../../src/main/extensions/broker.js'
+
+/**
+ * The one real boundary in this feature, and a narrow one: it does not contain
+ * the extension — this is trusted Node — it keeps the credential out of
+ * extension code. That matters because a workspace token and a supervisor
+ * session outlive any single extension and reach the whole account.
+ */
+
+const grant = (over = {}) => ({
+  scope: SCOPE.workspace,
+  workspaces: ['ws1'],
+  tools: { workspace: ['getTask', 'reply'], supervisor: [] },
+  ...over,
+})
+
+function build(over = {}) {
+  const record = vi.fn()
+  const logger = { warn: vi.fn() }
+  const broker = createBroker({
+    callWorkspace: vi.fn(async () => ({ id: 't1' })),
+    callSupervisor: vi.fn(async () => ({ tasks: [] })),
+    record,
+    logger,
+    ...over,
+  })
+  return { broker, record, logger }
+}
+
+describe('permits', () => {
+  it('allows a granted tool on a granted workspace', () => {
+    expect(permits(grant(), { surface: 'workspace', tool: 'getTask', workspaceId: 'ws1' }).ok).toBe(true)
+  })
+
+  it('names the surface when refusing a tool', () => {
+    // The same tool name can exist on both, so "not allowed" would leave an
+    // author guessing which one they asked for.
+    const { ok, reason } = permits(grant(), { surface: 'workspace', tool: 'deleteTask', workspaceId: 'ws1' })
+
+    expect(ok).toBe(false)
+    expect(reason).toBe('This extension may not call "deleteTask" on the workspace server.')
+  })
+
+  it('refuses a workspace outside the grant', () => {
+    // A tool being allowed does not make it allowed everywhere.
+    const denied = permits(grant(), { surface: 'workspace', tool: 'getTask', workspaceId: 'ws2' })
+
+    expect(denied.reason).toBe('This extension was not granted access to that workspace.')
+  })
+
+  it('refuses a workspace call that names no workspace', () => {
+    expect(permits(grant(), { surface: 'workspace', tool: 'getTask' }).reason).toBe(
+      'This call names no workspace.',
+    )
+  })
+
+  it('refuses the supervisor to anything below that rung', () => {
+    const asked = { surface: 'supervisor', tool: 'listAllTasks' }
+    const withTool = grant({ tools: { workspace: [], supervisor: ['listAllTasks'] } })
+
+    expect(permits(withTool, asked).reason).toBe('This extension was not granted access to all workspaces.')
+    expect(permits(grant({ ...withTool, scope: SCOPE.selected }), asked).ok).toBe(false)
+  })
+
+  it('lets the supervisor rung reach a workspace no list mentions', () => {
+    // Because that rung *is* every workspace — listAllTasks spans the platform
+    // and createTask(workspaceId) reaches anywhere.
+    const supervisor = grant({ scope: SCOPE.supervisor, workspaces: [] })
+
+    expect(permits(supervisor, { surface: 'workspace', tool: 'getTask', workspaceId: 'anything' }).ok).toBe(
+      true,
+    )
+  })
+
+  it('still checks the tool list at the supervisor rung', () => {
+    // The widest scope is not a blanket permission.
+    const supervisor = grant({ scope: SCOPE.supervisor, tools: { workspace: [], supervisor: [] } })
+
+    expect(permits(supervisor, { surface: 'supervisor', tool: 'listAllTasks' }).ok).toBe(false)
+  })
+
+  it('refuses when there is no grant to consult', () => {
+    expect(permits(undefined, { surface: 'workspace', tool: 'getTask' }).ok).toBe(false)
+  })
+})
+
+describe('createBroker', () => {
+  it('makes the call and hands back the result', async () => {
+    const callWorkspace = vi.fn(async () => ({ id: 't1' }))
+    const { broker } = build({ callWorkspace })
+    broker.setGrant('linear', grant())
+
+    const result = await broker.clientFor('linear').workspace('getTask', { workspaceId: 'ws1', taskId: 't1' })
+
+    expect(result).toEqual({ ok: true, result: { id: 't1' } })
+    expect(callWorkspace).toHaveBeenCalledWith({
+      workspaceId: 'ws1',
+      tool: 'getTask',
+      args: { workspaceId: 'ws1', taskId: 't1' },
+    })
+  })
+
+  it('hands the extension nothing that could be a credential', async () => {
+    // The whole point: an extension cannot leak a key it was never given.
+    const { broker } = build()
+    broker.setGrant('linear', grant())
+
+    const client = broker.clientFor('linear')
+
+    expect(Object.keys(client).sort()).toEqual(['supervisor', 'workspace'])
+    expect(JSON.stringify(client)).not.toMatch(/token|secret|bearer|session/i)
+  })
+
+  it('refuses before calling anything', async () => {
+    const callWorkspace = vi.fn()
+    const { broker } = build({ callWorkspace })
+    broker.setGrant('linear', grant())
+
+    const denied = await broker.clientFor('linear').workspace('deleteTask', { workspaceId: 'ws1' })
+
+    expect(denied.ok).toBe(false)
+    expect(callWorkspace).not.toHaveBeenCalled()
+  })
+
+  it('records refusals as well as calls', async () => {
+    // A refusal is the interesting half of an audit trail: it is what says an
+    // extension is asking for more than it was given.
+    const { broker, record } = build()
+    broker.setGrant('linear', grant())
+    const client = broker.clientFor('linear')
+
+    await client.workspace('getTask', { workspaceId: 'ws1' })
+    await client.workspace('deleteTask', { workspaceId: 'ws1' })
+
+    expect(record).toHaveBeenNthCalledWith(1, expect.objectContaining({ allowed: true, tool: 'getTask' }))
+    expect(record).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ allowed: false, tool: 'deleteTask', name: 'linear' }),
+    )
+  })
+
+  it('refuses an extension with no grant at all', async () => {
+    const { broker } = build()
+
+    const denied = await broker.clientFor('stranger').workspace('getTask', { workspaceId: 'ws1' })
+
+    expect(denied.reason).toBe('This extension has not been granted any access.')
+  })
+
+  it('closes over the extension, so one cannot ask on another’s behalf', async () => {
+    const { broker } = build()
+    broker.setGrant('linear', grant())
+    broker.setGrant('standup', grant({ tools: { workspace: [], supervisor: [] } }))
+
+    const denied = await broker.clientFor('standup').workspace('getTask', { workspaceId: 'ws1' })
+
+    expect(denied.ok).toBe(false)
+  })
+
+  it('passes the server’s own message through when a call fails', async () => {
+    // An author debugging a malformed call needs what the server said, not a
+    // sentence invented here.
+    const { broker } = build({
+      callWorkspace: vi.fn(async () => {
+        throw new Error('task not found')
+      }),
+    })
+    broker.setGrant('linear', grant())
+
+    expect((await broker.clientFor('linear').workspace('getTask', { workspaceId: 'ws1' })).reason).toBe(
+      'task not found',
+    )
+  })
+
+  it('says something when a failure carries no message', async () => {
+    const { broker } = build({ callWorkspace: vi.fn(async () => { throw {} }) })
+    broker.setGrant('linear', grant())
+
+    expect((await broker.clientFor('linear').workspace('getTask', { workspaceId: 'ws1' })).reason).toBe(
+      'The call failed.',
+    )
+  })
+
+  it('calls the supervisor without a workspace, at that rung', async () => {
+    const callSupervisor = vi.fn(async () => ({ tasks: [] }))
+    const { broker } = build({ callSupervisor })
+    broker.setGrant('linear', grant({ scope: SCOPE.supervisor, tools: { workspace: [], supervisor: ['listAllTasks'] } }))
+
+    const result = await broker.clientFor('linear').supervisor('listAllTasks', {})
+
+    expect(result.ok).toBe(true)
+    expect(callSupervisor).toHaveBeenCalledWith({ tool: 'listAllTasks', args: {} })
+  })
+
+  it('takes a copy of the grant, so a caller cannot widen it afterwards', () => {
+    const { broker } = build()
+    const original = grant()
+    broker.setGrant('linear', original)
+
+    original.tools.workspace.push('deleteTask')
+    original.workspaces.push('ws2')
+
+    expect(broker.grantFor('linear').tools.workspace).toEqual(['getTask', 'reply'])
+    expect(broker.grantFor('linear').workspaces).toEqual(['ws1'])
+  })
+
+  it('hands out a copy of the grant too', () => {
+    const { broker } = build()
+    broker.setGrant('linear', grant())
+
+    broker.grantFor('linear').workspaces.push('ws2')
+
+    expect(broker.grantFor('linear').workspaces).toEqual(['ws1'])
+  })
+
+  it('defaults a sparse grant to the narrowest thing', async () => {
+    const { broker } = build()
+    broker.setGrant('linear', {})
+
+    expect(broker.grantFor('linear')).toEqual({
+      scope: SCOPE.workspace,
+      workspaces: [],
+      tools: { workspace: [], supervisor: [] },
+    })
+  })
+
+  it('forgets a grant on revoke', async () => {
+    const { broker } = build()
+    broker.setGrant('linear', grant())
+
+    broker.revoke('linear')
+
+    expect(broker.grantFor('linear')).toBeNull()
+    expect((await broker.clientFor('linear').workspace('getTask', { workspaceId: 'ws1' })).ok).toBe(false)
+  })
+
+  it('logs through a bare console when given no logger', async () => {
+    const broker = createBroker({ callWorkspace: vi.fn(), callSupervisor: vi.fn() })
+    broker.setGrant('linear', grant())
+
+    expect((await broker.clientFor('linear').workspace('nope', { workspaceId: 'ws1' })).ok).toBe(false)
+  })
+})

--- a/frontend/src/composables/useExtensionGrant.js
+++ b/frontend/src/composables/useExtensionGrant.js
@@ -1,0 +1,160 @@
+import { computed, ref } from 'vue';
+
+/**
+ * What the install screen asks, and what the answer means.
+ *
+ * Two conversations happen here and only one of them scales.
+ *
+ * **The author conversation is constant.** Every extension runs with full access
+ * to the computer — there is no sandbox, by design — so that sentence appears on
+ * every install, and the screen leads with the repository, its owner, its stars
+ * and its licence. The decision being made is whether to trust a person.
+ *
+ * **The permission conversation scales with the ask.** An extension that wants
+ * nothing from AgentRQ shows no permission list at all. One that wants workspace
+ * tools shows them, and the workspace they will apply to. One that wants the
+ * supervisor shows that it reaches the whole account.
+ *
+ * ## The emptiest screen must not describe the least-restrained code
+ *
+ * An extension declaring no `mcp` still shows the install confirmation. It is
+ * the case where a permission list would be *absent*, and absence reads as
+ * safety — so the sentence about full machine access carries the whole weight
+ * there and must not be dropped along with the list.
+ */
+
+/** The rungs, in the order they escalate. */
+export const SCOPE = {
+  workspace: 'workspace',
+  selected: 'selected',
+  supervisor: 'supervisor',
+};
+
+export const SCOPE_ORDER = [SCOPE.workspace, SCOPE.selected, SCOPE.supervisor];
+
+/**
+ * What a manifest is asking for.
+ *
+ * `level` decides how much of the screen appears; the two tool lists are shown
+ * verbatim, because a summary of what an extension may do is a paraphrase of a
+ * permission and this is not the place to paraphrase.
+ */
+export function describeAsk(manifest) {
+  const workspace = manifest?.mcp?.workspace ?? [];
+  const supervisor = manifest?.mcp?.supervisor ?? [];
+
+  return {
+    workspace,
+    supervisor,
+    level: supervisor.length > 0 ? 'supervisor' : workspace.length > 0 ? 'workspace' : 'none',
+    // The one thing that is always true, whatever the level.
+    machineAccess: 'This extension runs with full access to your computer.',
+  };
+}
+
+/**
+ * Which rungs an extension can be given.
+ *
+ * An extension asking for no supervisor tools is not offered the supervisor
+ * rung: offering a grant nothing would use invites somebody to hand over the
+ * account for no reason at all.
+ */
+export function availableScopes(ask) {
+  if (ask.level === 'supervisor') return [...SCOPE_ORDER];
+  if (ask.level === 'workspace') return [SCOPE.workspace, SCOPE.selected];
+  return [];
+}
+
+/**
+ * Whether a chosen grant is coherent and complete.
+ *
+ * The supervisor rung deliberately has no workspace list. `listAllTasks` spans
+ * the platform and `createTask(workspaceId)` reaches anywhere, so "supervisor,
+ * but only this workspace" is not a narrower grant — it is the same grant with a
+ * misleading label. The ladder makes it unrepresentable rather than merely
+ * discouraged.
+ */
+export function validateGrant(ask, choice) {
+  const scope = choice?.scope;
+  if (ask.level === 'none') return { ok: true };
+
+  // Checked before the general case, because it has a far better answer.
+  // "Choose what this extension may reach" is true but unhelpful when the
+  // problem is that the extension never asked for what was picked.
+  if (scope === SCOPE.supervisor && ask.level !== 'supervisor') {
+    return { ok: false, reason: 'This extension did not ask for access to all workspaces.' };
+  }
+
+  if (!availableScopes(ask).includes(scope)) {
+    return { ok: false, reason: 'Choose what this extension may reach.' };
+  }
+
+  if (scope === SCOPE.selected && (choice.workspaces ?? []).length === 0) {
+    return { ok: false, reason: 'Choose at least one workspace.' };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * The grant, in the shape the broker enforces.
+ *
+ * The supervisor rung carries no workspace list at all — not an empty one, and
+ * not every id. Storing a list there would imply it was consulted.
+ */
+export function toGrant(ask, choice) {
+  const scope = ask.level === 'none' ? SCOPE.workspace : choice.scope;
+  const workspaces =
+    scope === SCOPE.supervisor
+      ? []
+      : scope === SCOPE.selected
+        ? [...choice.workspaces]
+        : [choice.workspaceId].filter(Boolean);
+
+  return {
+    scope,
+    workspaces,
+    tools: { workspace: [...ask.workspace], supervisor: scope === SCOPE.supervisor ? [...ask.supervisor] : [] },
+    // Recorded because it is a materially broader promise than the same list
+    // frozen at install, and the screen has to be able to say which was given.
+    includesFutureWorkspaces: scope === SCOPE.supervisor,
+  };
+}
+
+/** Plain sentences for each rung, so the ladder reads as an escalation. */
+export function scopeLabel(scope, { workspaceName = 'this workspace' } = {}) {
+  if (scope === SCOPE.workspace) return `${workspaceName} only`;
+  if (scope === SCOPE.selected) return 'Selected workspaces';
+  return 'All workspaces, including ones you create later';
+}
+
+/**
+ * The install screen's state.
+ *
+ * `workspaceName` is only for the label; the grant itself is built from ids.
+ */
+export function useExtensionGrant({ manifest, workspaceId = '', workspaces = [] } = {}) {
+  const ask = computed(() => describeAsk(manifest));
+  const scopes = computed(() => availableScopes(ask.value));
+
+  // Starts on the narrowest rung it can. A default that pre-selects the widest
+  // grant is a default that gets accepted.
+  const scope = ref(scopes.value[0] ?? SCOPE.workspace);
+  const selected = ref([]);
+
+  const choice = computed(() => ({ scope: scope.value, workspaces: selected.value, workspaceId }));
+  const validity = computed(() => validateGrant(ask.value, choice.value));
+
+  return {
+    ask,
+    scopes,
+    scope,
+    selected,
+    workspaces,
+    valid: computed(() => validity.value.ok),
+    problem: computed(() => (validity.value.ok ? '' : validity.value.reason)),
+    label: computed(() => scopeLabel(scope.value)),
+    /** Only ever called once the choice is valid. */
+    grant: computed(() => toGrant(ask.value, choice.value)),
+  };
+}

--- a/frontend/test/extensionGrant.test.js
+++ b/frontend/test/extensionGrant.test.js
@@ -1,0 +1,223 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  SCOPE,
+  availableScopes,
+  describeAsk,
+  scopeLabel,
+  toGrant,
+  useExtensionGrant,
+  validateGrant,
+} from '../src/composables/useExtensionGrant';
+
+/**
+ * Two conversations, and only one of them scales. The sentence about full
+ * machine access is on every install, because there is no sandbox; the
+ * permission list grows with what the manifest actually asked for.
+ */
+
+const manifest = (mcp) => ({ name: 'linear', mcp });
+
+describe('describeAsk', () => {
+  it('says nothing was asked when nothing was', () => {
+    expect(describeAsk(manifest()).level).toBe('none');
+    expect(describeAsk(manifest({ workspace: [], supervisor: [] })).level).toBe('none');
+    expect(describeAsk(undefined).level).toBe('none');
+  });
+
+  it('reads a workspace-only ask', () => {
+    const ask = describeAsk(manifest({ workspace: ['getTask'] }));
+
+    expect(ask.level).toBe('workspace');
+    expect(ask.workspace).toEqual(['getTask']);
+  });
+
+  it('reads any supervisor tool as the higher ask', () => {
+    expect(describeAsk(manifest({ supervisor: ['listAllTasks'] })).level).toBe('supervisor');
+  });
+
+  it('always carries the sentence about the machine', () => {
+    // The emptiest screen must not describe the least-restrained code: with no
+    // permission list at all, this sentence is the whole of what is said.
+    for (const mcp of [undefined, { workspace: ['getTask'] }, { supervisor: ['x'] }]) {
+      expect(describeAsk(manifest(mcp)).machineAccess).toContain('full access to your computer');
+    }
+  });
+});
+
+describe('availableScopes', () => {
+  it('offers nothing to an extension that asked for nothing', () => {
+    expect(availableScopes(describeAsk(manifest()))).toEqual([]);
+  });
+
+  it('does not offer the account to an extension that cannot use it', () => {
+    // Offering a grant nothing would use invites somebody to hand over the
+    // account for no reason at all.
+    expect(availableScopes(describeAsk(manifest({ workspace: ['getTask'] })))).toEqual([
+      SCOPE.workspace,
+      SCOPE.selected,
+    ]);
+  });
+
+  it('offers the whole ladder to an extension that asked for the supervisor', () => {
+    expect(availableScopes(describeAsk(manifest({ supervisor: ['listAllTasks'] })))).toEqual([
+      SCOPE.workspace,
+      SCOPE.selected,
+      SCOPE.supervisor,
+    ]);
+  });
+});
+
+describe('validateGrant', () => {
+  const ask = describeAsk(manifest({ workspace: ['getTask'], supervisor: ['listAllTasks'] }));
+
+  it('accepts a rung the extension can use', () => {
+    expect(validateGrant(ask, { scope: SCOPE.workspace, workspaceId: 'ws1' }).ok).toBe(true);
+    expect(validateGrant(ask, { scope: SCOPE.supervisor }).ok).toBe(true);
+  });
+
+  it('asks for a workspace when the rung needs one', () => {
+    const { ok, reason } = validateGrant(ask, { scope: SCOPE.selected, workspaces: [] });
+
+    expect(ok).toBe(false);
+    expect(reason).toBe('Choose at least one workspace.');
+  });
+
+  it('refuses the account to an extension that did not ask for it', () => {
+    const narrow = describeAsk(manifest({ workspace: ['getTask'] }));
+
+    expect(validateGrant(narrow, { scope: SCOPE.supervisor }).reason).toContain('did not ask');
+  });
+
+  it('refuses a rung that is not on the ladder', () => {
+    expect(validateGrant(ask, { scope: 'everything' }).ok).toBe(false);
+    expect(validateGrant(ask, {}).ok).toBe(false);
+    expect(validateGrant(ask, undefined).ok).toBe(false);
+  });
+
+  it('takes a missing workspace list as an empty one', () => {
+    // The middle rung with nothing chosen yet, before anyone has ticked a box.
+    expect(validateGrant(ask, { scope: SCOPE.selected }).reason).toBe('Choose at least one workspace.');
+  });
+
+  it('has nothing to validate when nothing was asked for', () => {
+    expect(validateGrant(describeAsk(manifest()), {}).ok).toBe(true);
+  });
+});
+
+describe('toGrant', () => {
+  const ask = describeAsk(manifest({ workspace: ['getTask'], supervisor: ['listAllTasks'] }));
+
+  it('carries the workspace that was in view at the narrowest rung', () => {
+    const grant = toGrant(ask, { scope: SCOPE.workspace, workspaceId: 'ws1' });
+
+    expect(grant.workspaces).toEqual(['ws1']);
+    expect(grant.tools.supervisor).toEqual([]);
+  });
+
+  it('carries the chosen list at the middle rung', () => {
+    const grant = toGrant(ask, { scope: SCOPE.selected, workspaces: ['ws1', 'ws2'] });
+
+    expect(grant.workspaces).toEqual(['ws1', 'ws2']);
+  });
+
+  it('stores no workspace list at the supervisor rung', () => {
+    // Not an empty list and not every id: storing one would imply it had been
+    // consulted, and at that rung nothing consults it.
+    const grant = toGrant(ask, { scope: SCOPE.supervisor });
+
+    expect(grant.workspaces).toEqual([]);
+    expect(grant.tools.supervisor).toEqual(['listAllTasks']);
+  });
+
+  it('records that the widest rung covers workspaces that do not exist yet', () => {
+    // A standing future grant is meaningfully broader than the same list frozen
+    // at install, and the screen has to be able to say which was given.
+    expect(toGrant(ask, { scope: SCOPE.supervisor }).includesFutureWorkspaces).toBe(true);
+    expect(toGrant(ask, { scope: SCOPE.workspace, workspaceId: 'ws1' }).includesFutureWorkspaces).toBe(
+      false,
+    );
+  });
+
+  it('withholds the supervisor tools from anything below that rung', () => {
+    // Granting the tools without the scope would be a grant that reads narrow
+    // and behaves wide.
+    const grant = toGrant(ask, { scope: SCOPE.selected, workspaces: ['ws1'] });
+
+    expect(grant.tools.supervisor).toEqual([]);
+  });
+
+  it('gives an extension that asked for nothing a grant that reaches nothing', () => {
+    const grant = toGrant(describeAsk(manifest()), {});
+
+    expect(grant.scope).toBe(SCOPE.workspace);
+    expect(grant.tools).toEqual({ workspace: [], supervisor: [] });
+    expect(grant.workspaces).toEqual([]);
+  });
+});
+
+describe('scopeLabel', () => {
+  it('says what each rung means, in a sentence', () => {
+    expect(scopeLabel(SCOPE.workspace, { workspaceName: 'payments-api' })).toBe('payments-api only');
+    expect(scopeLabel(SCOPE.workspace)).toBe('this workspace only');
+    expect(scopeLabel(SCOPE.selected)).toBe('Selected workspaces');
+    // Spelled out, because it is the part people would otherwise assume away.
+    expect(scopeLabel(SCOPE.supervisor)).toBe('All workspaces, including ones you create later');
+  });
+});
+
+describe('useExtensionGrant', () => {
+  it('starts on the narrowest rung it can', () => {
+    // A default that pre-selects the widest grant is a default that gets
+    // accepted.
+    const grant = useExtensionGrant({
+      manifest: manifest({ workspace: ['getTask'], supervisor: ['listAllTasks'] }),
+      workspaceId: 'ws1',
+    });
+
+    expect(grant.scope.value).toBe(SCOPE.workspace);
+    expect(grant.valid.value).toBe(true);
+  });
+
+  it('reports what is missing rather than silently refusing', () => {
+    const grant = useExtensionGrant({ manifest: manifest({ workspace: ['getTask'] }), workspaceId: 'ws1' });
+
+    grant.scope.value = SCOPE.selected;
+
+    expect(grant.valid.value).toBe(false);
+    expect(grant.problem.value).toBe('Choose at least one workspace.');
+
+    grant.selected.value = ['ws2'];
+    expect(grant.valid.value).toBe(true);
+    // And the message clears rather than lingering under a now-valid choice.
+    expect(grant.problem.value).toBe('');
+    expect(grant.grant.value.workspaces).toEqual(['ws2']);
+  });
+
+  it('offers no rungs, and is valid, for an extension that asked for nothing', () => {
+    const grant = useExtensionGrant({ manifest: manifest(), workspaceId: 'ws1' });
+
+    expect(grant.scopes.value).toEqual([]);
+    expect(grant.valid.value).toBe(true);
+    expect(grant.ask.value.level).toBe('none');
+  });
+
+  it('follows the chosen rung into the label and the grant', () => {
+    const grant = useExtensionGrant({
+      manifest: manifest({ workspace: ['getTask'], supervisor: ['listAllTasks'] }),
+      workspaceId: 'ws1',
+    });
+
+    grant.scope.value = SCOPE.supervisor;
+
+    expect(grant.label.value).toContain('including ones you create later');
+    expect(grant.grant.value.tools.supervisor).toEqual(['listAllTasks']);
+  });
+
+  it('copes with being given nothing at all', () => {
+    const grant = useExtensionGrant();
+
+    expect(grant.ask.value.level).toBe('none');
+    expect(grant.workspaces).toEqual([]);
+  });
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -44,6 +44,7 @@ export default defineConfig({
         'src/composables/useAgentTelemetry.js',
         'src/composables/useAgentModelPicker.js',
         'src/composables/useExtensionCatalogue.js',
+        'src/composables/useExtensionGrant.js',
         'src/composables/useTaskEvents.js',
         'src/composables/useTrajectory.js',
         'src/composables/useWorkflowLabels.js',


### PR DESCRIPTION
> **6 of 10, stacked on [#519](https://github.com/agentrq/agentrq/pull/519).** Targets `ext/05-host`. **The point of the feature** — everything before this was scaffolding. [Plan](https://claude.ai/code/artifact/907d107c-921d-4e0e-a371-de22229c2927).

## What changed

An extension can now do real work through AgentRQ, bounded by exactly what the user agreed to at install — and it never holds a credential to do it.

## Why changed

Everything up to here found, installed and loaded extensions that could do nothing. This is where they act, and where what they may do is decided and enforced.

## Test coverage report

New lines introduced: **100%**. Total coverage impact: **unchanged at 100%** on all four metrics in both suites — desktop 715 tests across 26 files (from 693/25), frontend 1110 across 43 (from 1085/42). Backend suite passes.

Covered: a call inside the allowlist and outside it, a workspace outside the grant, the supervisor rung reaching a workspace no list mentions, the tool list still applying at that rung, refusals being recorded, a grant that cannot be widened after the fact, and every rung of the ladder.

## Other reports

**The credential never enters extension code.** That is the whole protection, and it is worth being precise: it does not *contain* the extension — this is trusted Node — it keeps the token out. Which matters, because a workspace token and a supervisor session outlive any single extension and reach the whole account. An extension that is compromised, or merely careless about what it logs, cannot leak a key it was never given.

**Two questions on every call, and they are different questions.** May it call this tool — against the allowlist the user saw. May it touch this workspace — against the grant. An extension allowed `getTask` is not thereby allowed it everywhere.

**Refusals are recorded, not just denied.** A refusal is the interesting half of an audit trail: it is what says an extension is reaching for more than it was given.

**The ladder is the load-bearing decision.** `listAllTasks` spans the platform and `createTask(workspaceId)` reaches anywhere, so the supervisor surface **is** every workspace. "Supervisor, but only this workspace" is not a narrower grant — it is the same grant with a misleading label — and the ladder makes it **unrepresentable** rather than merely discouraged. At that rung no workspace list is stored at all, because storing one would imply it had been consulted.

**Three smaller decisions in the same spirit:**
- The widest rung says out loud that it covers **workspaces that do not exist yet** — a standing future grant is meaningfully broader than the same list frozen at install.
- An extension is never offered a rung it cannot use; offering a grant nothing would consume invites somebody to hand over the account for no reason.
- The default is the **narrowest** rung available, because a default that pre-selects the widest grant is a default that gets accepted.

**The sentence about full machine access is on every install** — including, especially, the one where an extension asks for nothing and no permission list appears. Absence reads as safety, so that is exactly where the sentence carries the whole weight.

**`ActorExtension` added to the backend**, appended rather than inserted because the value is stored on every telemetry row. Without it, work an extension does is indistinguishable from the user's own: counting it as human overstates what a person did, and counting it as agent puts it in the bucket the workspace exists to measure.

## TaskID: 0iV0EK5OBU1
