### PR TITLE
feat(extensions): the three UI surfaces, and one context menu instead of two

### DIFF
--- a/frontend/src/components/ContextMenu.vue
+++ b/frontend/src/components/ContextMenu.vue
@@ -5,7 +5,7 @@ const props = defineProps({
   show: Boolean,
   x: { type: Number, default: 0 },
   y: { type: Number, default: 0 },
-  items: { type: Array, default: () => [] } // [{ key, label }]
+  items: { type: Array, default: () => [] } // [{ key, label }] or { key, divider: true }
 });
 
 const emit = defineEmits(['close', 'select']);
@@ -39,10 +39,16 @@ onUnmounted(() => {
          :style="{ top: y + 'px', left: x + 'px' }"
          @click.stop
          @contextmenu.prevent.stop>
-      <button v-for="item in items" :key="item.key" @click="onSelect(item)"
-              class="w-full text-left px-3 py-2 text-[11px] font-semibold text-gray-700 dark:text-zinc-300 hover:bg-gray-50 dark:hover:bg-zinc-800 hover:text-black dark:hover:text-white transition-colors">
-        {{ item.label }}
-      </button>
+      <template v-for="item in items" :key="item.key">
+        <!-- Extension entries sit below this, so the app's own items never move
+             when something is installed and it stays visible where a row came
+             from. -->
+        <div v-if="item.divider" class="my-1 border-t border-gray-100 dark:border-zinc-800"></div>
+        <button v-else @click="onSelect(item)"
+                class="w-full text-left px-3 py-2 text-[11px] font-semibold text-gray-700 dark:text-zinc-300 hover:bg-gray-50 dark:hover:bg-zinc-800 hover:text-black dark:hover:text-white transition-colors">
+          {{ item.label }}
+        </button>
+      </template>
     </div>
   </Teleport>
 </template>

--- a/frontend/src/components/TaskFeed.vue
+++ b/frontend/src/components/TaskFeed.vue
@@ -29,7 +29,7 @@
       :show="contextMenu.show"
       :x="contextMenu.x"
       :y="contextMenu.y"
-      :items="[{ key: 'move', label: 'Move Task' }]"
+      :items="contextMenuItems"
       @close="closeContextMenu"
       @select="onContextMenuSelect"
     />
@@ -137,6 +137,7 @@ import cronParser from 'cron-parser';
 import { deleteTask, respondToTask, updateTaskOrder, updateTaskStatus, sendPermissionVerdict, updateTaskAssignee, moveTask, fetchTasks, fetchTaskCounts } from '../api';
 import { useCron } from '../composables/useCron';
 import { taskDotClass } from '../composables/useTaskStatusStyle';
+import { menuItemsFor } from '../composables/useTaskContextMenu';
 import DeleteModal from './DeleteModal.vue';
 import MoveTaskModal from './MoveTaskModal.vue';
 import ContextMenu from './ContextMenu.vue';
@@ -192,6 +193,11 @@ const taskToMoveId = ref(null);
 const taskToMoveTitle = ref('');
 
 const contextMenu = ref({ show: false, x: 0, y: 0, task: null });
+
+// One list, shared with the board. It used to be written inline here and again
+// in KanbanBoardView, which meant an item added to one and not the other made
+// right-click do different things on two views of the same task.
+const contextMenuItems = computed(() => menuItemsFor(contextMenu.value.task));
 
 const ongoingTasks = ref([]);
 const notStartedTasks = ref([]);

--- a/frontend/src/composables/useExtensionView.js
+++ b/frontend/src/composables/useExtensionView.js
@@ -1,0 +1,148 @@
+/**
+ * What an extension is allowed to draw, and what happens to what it sends.
+ *
+ * Extensions describe; AgentRQ renders. A page or panel is a JSON spec in a
+ * closed vocabulary, drawn with this application's own components — there is no
+ * third-party markup in the renderer and no iframe, which is what keeps
+ * extension UI looking like the rest of the product instead of approximating it,
+ * and keeps the renderer's privileged origin free of anybody else's code.
+ *
+ * ## The vocabulary is closed, and unknown nodes are refused
+ *
+ * A node type nobody recognises is **rejected, not skipped**. Skipping it would
+ * render a page that is quietly missing whatever the author thought they had
+ * written — worse for them than being told, and worse for the user than seeing
+ * nothing at all.
+ *
+ * ## Everything an extension sends is untrusted text
+ *
+ * Not because extensions are assumed hostile — they run as trusted code and
+ * could do far worse than inject markup — but because text arriving from an
+ * extension often did not originate there. It came from an issue title, a commit
+ * message, a webhook payload. Treating it as untrusted at the boundary is what
+ * stops that being anybody's problem to remember.
+ */
+
+/** Every node an extension may use. Anything else is a mistake worth reporting. */
+export const NODE_TYPES = Object.freeze({
+  text: ['value', 'tone'],
+  heading: ['value'],
+  rows: ['items'],
+  row: ['label', 'value', 'href'],
+  badge: ['value', 'tone'],
+  button: ['label', 'action', 'tone'],
+  link: ['label', 'href'],
+  empty: ['value'],
+  group: ['label', 'children'],
+});
+
+/** Tones map to our own palette; an unknown one falls back rather than leaking a colour. */
+export const TONES = Object.freeze(['default', 'muted', 'positive', 'warning', 'critical']);
+
+/** Bounded so one extension cannot render a page nobody can scroll past. */
+export const MAX_NODES = 200;
+export const MAX_DEPTH = 5;
+export const MAX_TEXT = 2000;
+
+const fail = (reason) => ({ ok: false, reason });
+
+/**
+ * Whether a link is one we will make clickable.
+ *
+ * The same instinct `markdown.js` applies to agent-written message bodies, for
+ * the same reason: a `file:` URL is how a link reaches the machine, and
+ * `javascript:` needs no explanation. Anything not plainly http(s) keeps its
+ * text and loses its href.
+ */
+export function safeHref(href) {
+  const value = String(href ?? '').trim();
+  if (!value) return '';
+  return /^https?:\/\//i.test(value) ? value : '';
+}
+
+/** Clamps text, so a runaway value truncates rather than filling the screen. */
+function text(value) {
+  const string = typeof value === 'string' ? value : String(value ?? '');
+  return string.length > MAX_TEXT ? `${string.slice(0, MAX_TEXT)}…` : string;
+}
+
+function tone(value) {
+  return TONES.includes(value) ? value : 'default';
+}
+
+/**
+ * Validates and normalises one node, recursively.
+ *
+ * Returns the node the renderer will draw — with every string clamped, every
+ * tone known, and every href either safe or absent — or a reason it will draw
+ * nothing at all.
+ */
+function normaliseNode(node, depth, budget) {
+  if (depth > MAX_DEPTH) return fail(`This view nests deeper than ${MAX_DEPTH} levels.`);
+  if (budget.count >= MAX_NODES) return fail(`This view has more than ${MAX_NODES} elements.`);
+  if (!node || typeof node !== 'object' || Array.isArray(node)) {
+    return fail('Every element of a view must be an object.');
+  }
+
+  const type = String(node.type ?? '');
+  if (!(type in NODE_TYPES)) {
+    // Named, and the alternatives listed: an author who mistyped "headding" is
+    // one line from working, and a bare "unknown type" leaves them guessing.
+    return fail(`"${type || '(none)'}" is not something a view can contain. Use one of: ${Object.keys(NODE_TYPES).join(', ')}.`);
+  }
+
+  budget.count += 1;
+  const out = { type };
+
+  if (type === 'group' || type === 'rows') {
+    const children = node[type === 'group' ? 'children' : 'items'];
+    if (!Array.isArray(children)) return fail(`A "${type}" needs a list of elements.`);
+
+    const normalised = [];
+    for (const child of children) {
+      const result = normaliseNode(child, depth + 1, budget);
+      if (!result.ok) return result;
+      normalised.push(result.node);
+    }
+    if (type === 'group') out.label = text(node.label);
+    out[type === 'group' ? 'children' : 'items'] = normalised;
+    return { ok: true, node: out };
+  }
+
+  if ('value' in node) out.value = text(node.value);
+  if ('label' in node) out.label = text(node.label);
+  if ('tone' in node) out.tone = tone(node.tone);
+  if ('href' in node) out.href = safeHref(node.href);
+  // An action names something the extension registered; it is passed back
+  // verbatim on click and is never interpreted here.
+  if ('action' in node) out.action = String(node.action ?? '');
+
+  return { ok: true, node: out };
+}
+
+/**
+ * Turns what an extension returned into what the renderer will draw.
+ *
+ * One reason rather than a list, deliberately: a spec is generated by code, so
+ * the first thing wrong with it is the thing to fix, and the rest are usually
+ * the same mistake repeated.
+ */
+export function normaliseView(spec) {
+  if (!spec || typeof spec !== 'object') return fail('This view returned nothing to draw.');
+
+  const nodes = Array.isArray(spec) ? spec : spec.nodes;
+  if (!Array.isArray(nodes)) return fail('A view must be a list of elements.');
+
+  // An empty view is a legitimate answer — "nothing to show" is a state, not a
+  // failure — and it keeps its title, because a heading over an empty panel is
+  // how a person can tell which panel is empty.
+  const budget = { count: 0 };
+  const out = [];
+  for (const node of nodes) {
+    const result = normaliseNode(node, 1, budget);
+    if (!result.ok) return result;
+    out.push(result.node);
+  }
+
+  return { ok: true, view: { title: text(spec.title ?? ''), nodes: out } };
+}

--- a/frontend/src/composables/useTaskContextMenu.js
+++ b/frontend/src/composables/useTaskContextMenu.js
@@ -1,0 +1,128 @@
+import { computed, reactive } from 'vue';
+
+/**
+ * What a right-click on a task offers.
+ *
+ * There is one list, and both views that show tasks read it. Until now the items
+ * were written inline in two places — `KanbanBoardView.vue` and `TaskFeed.vue`,
+ * each with its own literal `[{ key: 'move', label: 'Move Task' }]` — which was
+ * survivable while the list was a single hard-coded row and stops being
+ * survivable the moment anything is added to it: an entry added to one and not
+ * the other means right-click does different things on two views of the same
+ * task, and nothing about that failure announces itself.
+ *
+ * ## Built-ins never move
+ *
+ * Our own items come first, extension items after a divider. So installing
+ * something does not shuffle the entry somebody's hand already knows, and it
+ * stays visible which rows came from where.
+ *
+ * ## An extension item has to earn its place on each task
+ *
+ * Every entry may carry a `when(task)` predicate. Without one, ten installed
+ * extensions mean ten permanent rows on every task, and a menu that long is one
+ * nobody reads. An entry that says nothing about when it applies is assumed to
+ * always apply, which is right for the built-ins and rare for the rest.
+ */
+
+/** The items AgentRQ itself offers. First, always, and in this order. */
+export const BUILT_IN_ITEMS = [{ key: 'move', label: 'Move Task' }];
+
+/** What a divider looks like to `ContextMenu.vue`. */
+export const DIVIDER = { key: '__divider', divider: true };
+
+/**
+ * Whether an extension's entry applies to this task.
+ *
+ * A predicate that throws is treated as "no". One extension deciding badly must
+ * not empty a menu that other extensions are also in, and a thrown error is not
+ * a reason to show a row whose own author could not say whether it belonged.
+ */
+export function appliesTo(entry, task) {
+  if (typeof entry?.when !== 'function') return true;
+  try {
+    return Boolean(entry.when(task));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The full item list for one task.
+ *
+ * Extension entries are namespaced on the way in. Two extensions may both want
+ * a key called `create`, and the menu has to be able to tell them apart when one
+ * is chosen — the owner is what makes that possible without asking authors to
+ * invent globally unique names.
+ */
+export function menuItemsFor(task, extensionEntries = []) {
+  const applicable = extensionEntries
+    .filter((entry) => appliesTo(entry, task))
+    .map((entry) => ({
+      key: `ext:${entry.owner}:${entry.id}`,
+      label: entry.label ?? entry.id,
+      owner: entry.owner,
+      id: entry.id,
+    }));
+
+  if (applicable.length === 0) return [...BUILT_IN_ITEMS];
+  return [...BUILT_IN_ITEMS, DIVIDER, ...applicable];
+}
+
+/**
+ * Reads a chosen key back into who should handle it.
+ *
+ * The prefix is what keeps a built-in and an extension entry from ever being
+ * confused for one another, however an author names theirs.
+ */
+export function parseSelection(key) {
+  const parts = String(key ?? '').split(':');
+  if (parts[0] !== 'ext' || parts.length < 3) return { kind: 'builtin', key };
+  return { kind: 'extension', owner: parts[1], id: parts.slice(2).join(':') };
+}
+
+/**
+ * The menu's state, shared by every view that shows tasks.
+ *
+ * `entries` is a getter rather than a value so the menu follows what is
+ * installed: an extension enabled while the board is open should appear on the
+ * next right-click, not on the next reload. For that to hold, the getter has to
+ * read something reactive — a store or a ref — which is what every real caller
+ * does, and what a test has to do too if it means to prove it.
+ */
+export function useTaskContextMenu({ entries = () => [], onExtensionSelect = () => {} } = {}) {
+  const state = reactive({ show: false, x: 0, y: 0, task: null });
+  const menu = computed(() => state);
+
+  return {
+    menu,
+    items: computed(() => menuItemsFor(state.task, entries())),
+
+    open(event, task) {
+      Object.assign(state, { show: true, x: event.clientX, y: event.clientY, task });
+    },
+
+    close() {
+      state.show = false;
+    },
+
+    /**
+     * Routes a chosen key, returning the built-in key when it is one of ours.
+     *
+     * The caller keeps its own switch for built-ins — those do things only the
+     * view knows how to do — and extension entries are handed off here so no
+     * view has to learn what an extension is.
+     */
+    select(key) {
+      const task = state.task;
+      state.show = false;
+      if (!task) return null;
+
+      const parsed = parseSelection(key);
+      if (parsed.kind === 'builtin') return parsed.key;
+
+      onExtensionSelect({ owner: parsed.owner, id: parsed.id, task });
+      return null;
+    },
+  };
+}

--- a/frontend/src/views/KanbanBoardView.vue
+++ b/frontend/src/views/KanbanBoardView.vue
@@ -115,7 +115,7 @@
       :show="contextMenu.show"
       :x="contextMenu.x"
       :y="contextMenu.y"
-      :items="[{ key: 'move', label: 'Move Task' }]"
+      :items="contextMenuItems"
       @close="closeContextMenu"
       @select="onContextMenuSelect"
     />
@@ -129,6 +129,7 @@ import { fetchTasks, updateTaskStatus, updateTaskOrder, moveTask, updateTaskAssi
 import { useEventBus } from '../useEventBus';
 import { useToasts } from '../composables/useToasts';
 import { useWorkspaceStore } from '../stores/workspaceStore';
+import { menuItemsFor } from '../composables/useTaskContextMenu';
 import LoadingState from '../components/LoadingState.vue';
 import MoveTaskModal from '../components/MoveTaskModal.vue';
 import ContextMenu from '../components/ContextMenu.vue';
@@ -414,6 +415,9 @@ function openTask(t) {
 
 // ---- Context menu / move task ----
 const contextMenu = ref({ show: false, x: 0, y: 0, task: null });
+
+// The same list TaskFeed reads. See useTaskContextMenu for why it is shared.
+const contextMenuItems = computed(() => menuItemsFor(contextMenu.value.task));
 const showMoveModal = ref(false);
 const taskToMoveId = ref(null);
 const taskToMoveTitle = ref('');

--- a/frontend/test/extensionView.test.js
+++ b/frontend/test/extensionView.test.js
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  MAX_DEPTH,
+  MAX_NODES,
+  MAX_TEXT,
+  NODE_TYPES,
+  TONES,
+  normaliseView,
+  safeHref,
+} from '../src/composables/useExtensionView';
+
+/**
+ * Extensions describe; AgentRQ renders. The vocabulary is closed, so a page
+ * looks like the rest of the product rather than approximating it, and the
+ * renderer's privileged origin never carries anybody else's markup.
+ */
+
+const view = (nodes, title = 'Issues') => ({ title, nodes });
+
+describe('safeHref', () => {
+  it('keeps an ordinary web link', () => {
+    expect(safeHref('https://linear.app/x')).toBe('https://linear.app/x');
+    expect(safeHref('http://internal/x')).toBe('http://internal/x');
+  });
+
+  it('drops anything that is not plainly the web', () => {
+    // The same instinct markdown.js applies to agent-written bodies: a file:
+    // URL is how a link reaches the machine, and javascript: needs no
+    // explanation.
+    for (const href of ['file:///etc/passwd', 'javascript:alert(1)', 'data:text/html,x', 'mailto:a@b']) {
+      expect(safeHref(href), href).toBe('');
+    }
+    expect(safeHref(undefined)).toBe('');
+  });
+});
+
+describe('normaliseView', () => {
+  it('accepts every node type it offers', () => {
+    const nodes = Object.keys(NODE_TYPES).map((type) => {
+      if (type === 'group') return { type, label: 'g', children: [{ type: 'text', value: 'x' }] };
+      if (type === 'rows') return { type, items: [{ type: 'row', label: 'a', value: 'b' }] };
+      return { type, value: 'x', label: 'x' };
+    });
+
+    expect(normaliseView(view(nodes)).ok).toBe(true);
+  });
+
+  it('takes a bare list as well as a titled view', () => {
+    expect(normaliseView([{ type: 'text', value: 'x' }]).view.nodes).toHaveLength(1);
+    expect(normaliseView(view([{ type: 'text', value: 'x' }])).view.title).toBe('Issues');
+  });
+
+  it('names an unknown node type and lists what it could have been', () => {
+    // An author who mistyped "headding" is one line from working; a bare
+    // "unknown type" leaves them guessing.
+    const { ok, reason } = normaliseView(view([{ type: 'headding', value: 'x' }]));
+
+    expect(ok).toBe(false);
+    expect(reason).toContain('"headding" is not something a view can contain');
+    expect(reason).toContain('heading');
+  });
+
+  it('rejects rather than skips, so nothing renders half a page', () => {
+    const { ok } = normaliseView(view([{ type: 'text', value: 'fine' }, { type: 'iframe' }]));
+
+    expect(ok).toBe(false);
+  });
+
+  it('refuses an element that is not an object', () => {
+    expect(normaliseView(view(['just text'])).reason).toContain('must be an object');
+    expect(normaliseView(view([null])).ok).toBe(false);
+    expect(normaliseView(view([['nested']])).ok).toBe(false);
+  });
+
+  it('refuses a node with no type at all', () => {
+    expect(normaliseView(view([{ value: 'x' }])).reason).toContain('"(none)"');
+  });
+
+  it('refuses anything that is not a view', () => {
+    expect(normaliseView(undefined).reason).toBe('This view returned nothing to draw.');
+    expect(normaliseView('a string').ok).toBe(false);
+    expect(normaliseView({ title: 'x' }).reason).toBe('A view must be a list of elements.');
+  });
+
+  it('accepts an empty view, which is a legitimate answer', () => {
+    // "Nothing to show" is a state, not a failure.
+    const { ok, view: out } = normaliseView(view([]));
+
+    expect(ok).toBe(true);
+    expect(out.nodes).toEqual([]);
+  });
+
+  it('nests groups, and refuses nesting past the limit', () => {
+    const nest = (depth) =>
+      depth === 0 ? { type: 'text', value: 'deep' } : { type: 'group', children: [nest(depth - 1)] };
+
+    expect(normaliseView(view([nest(MAX_DEPTH - 1)])).ok).toBe(true);
+    expect(normaliseView(view([nest(MAX_DEPTH + 1)])).reason).toContain('nests deeper');
+  });
+
+  it('refuses a group or rows with no list in it', () => {
+    expect(normaliseView(view([{ type: 'group', label: 'g' }])).reason).toContain('needs a list');
+    expect(normaliseView(view([{ type: 'rows' }])).reason).toContain('needs a list');
+  });
+
+  it('caps how much one extension can put on a page', () => {
+    const many = Array.from({ length: MAX_NODES + 1 }, () => ({ type: 'text', value: 'x' }));
+
+    expect(normaliseView(view(many)).reason).toContain(`more than ${MAX_NODES} elements`);
+  });
+
+  it('counts nested nodes against the same budget', () => {
+    const children = Array.from({ length: MAX_NODES }, () => ({ type: 'text', value: 'x' }));
+
+    expect(normaliseView(view([{ type: 'group', children }])).ok).toBe(false);
+  });
+
+  it('truncates a runaway string rather than rendering it', () => {
+    const { view: out } = normaliseView(view([{ type: 'text', value: 'x'.repeat(MAX_TEXT + 100) }]));
+
+    expect(out.nodes[0].value).toHaveLength(MAX_TEXT + 1);
+    expect(out.nodes[0].value.endsWith('…')).toBe(true);
+  });
+
+  it('coerces a value that is not a string at all', () => {
+    expect(normaliseView(view([{ type: 'text', value: 42 }])).view.nodes[0].value).toBe('42');
+    expect(normaliseView(view([{ type: 'text', value: null }])).view.nodes[0].value).toBe('');
+  });
+
+  it('falls back on an unknown tone rather than letting a colour through', () => {
+    expect(normaliseView(view([{ type: 'badge', value: 'x', tone: 'neon' }])).view.nodes[0].tone).toBe(
+      'default',
+    );
+    for (const tone of TONES) {
+      expect(normaliseView(view([{ type: 'badge', value: 'x', tone }])).view.nodes[0].tone).toBe(tone);
+    }
+  });
+
+  it('strips an href it will not follow, keeping the text', () => {
+    const { view: out } = normaliseView(view([{ type: 'link', label: 'Home', href: 'file:///' }]));
+
+    expect(out.nodes[0].label).toBe('Home');
+    expect(out.nodes[0].href).toBe('');
+  });
+
+  it('passes an action back verbatim without interpreting it', () => {
+    // It names something the extension registered; this is not the place to
+    // decide what it means.
+    const { view: out } = normaliseView(view([{ type: 'button', label: 'Go', action: 'create-issue' }]));
+
+    expect(out.nodes[0].action).toBe('create-issue');
+    expect(normaliseView(view([{ type: 'button', action: null }])).view.nodes[0].action).toBe('');
+  });
+
+  it('drops a title that is not a string', () => {
+    expect(normaliseView({ title: 7, nodes: [] }).view.title).toBe('7');
+    expect(normaliseView({ nodes: [] }).view.title).toBe('');
+  });
+});

--- a/frontend/test/taskContextMenu.test.js
+++ b/frontend/test/taskContextMenu.test.js
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ref } from 'vue';
+
+import {
+  BUILT_IN_ITEMS,
+  DIVIDER,
+  appliesTo,
+  menuItemsFor,
+  parseSelection,
+  useTaskContextMenu,
+} from '../src/composables/useTaskContextMenu';
+
+/**
+ * There is one list now, and both views that show tasks read it. The item list
+ * used to be written inline in KanbanBoardView and TaskFeed separately, which
+ * was survivable for a single hard-coded row and stops being survivable the
+ * moment anything is added: an entry in one and not the other means right-click
+ * does different things on two views of the same task.
+ */
+
+const entry = (over = {}) => ({ owner: 'linear', id: 'create', label: 'Create Linear issue', ...over });
+const task = { id: 't1', status: 'completed' };
+
+describe('appliesTo', () => {
+  it('shows an entry that says nothing about when it applies', () => {
+    expect(appliesTo(entry(), task)).toBe(true);
+  });
+
+  it('asks the predicate when there is one', () => {
+    expect(appliesTo(entry({ when: (t) => t.status === 'completed' }), task)).toBe(true);
+    expect(appliesTo(entry({ when: (t) => t.status === 'ongoing' }), task)).toBe(false);
+  });
+
+  it('treats a predicate that throws as a no', () => {
+    // One extension deciding badly must not empty a menu other extensions are
+    // in, and a thrown error is not a reason to show a row whose own author
+    // could not say whether it belonged.
+    const thrower = entry({ when: () => { throw new Error('nope'); } });
+
+    expect(appliesTo(thrower, task)).toBe(false);
+  });
+});
+
+describe('menuItemsFor', () => {
+  it('is just the built-ins when nothing is installed', () => {
+    expect(menuItemsFor(task, [])).toEqual(BUILT_IN_ITEMS);
+    expect(menuItemsFor(task)).toEqual(BUILT_IN_ITEMS);
+  });
+
+  it('puts extensions after a divider, with the built-ins unmoved', () => {
+    // Installing something must not shuffle the entry somebody's hand knows.
+    const items = menuItemsFor(task, [entry()]);
+
+    expect(items[0]).toEqual(BUILT_IN_ITEMS[0]);
+    expect(items[1]).toEqual(DIVIDER);
+    expect(items[2].label).toBe('Create Linear issue');
+  });
+
+  it('adds no divider when every extension entry opted out', () => {
+    // A trailing divider under nothing is a menu that looks broken.
+    const items = menuItemsFor(task, [entry({ when: () => false })]);
+
+    expect(items).toEqual(BUILT_IN_ITEMS);
+  });
+
+  it('namespaces keys, so two extensions may both call theirs "create"', () => {
+    const items = menuItemsFor(task, [entry(), entry({ owner: 'standup' })]);
+
+    expect(items[2].key).toBe('ext:linear:create');
+    expect(items[3].key).toBe('ext:standup:create');
+  });
+
+  it('falls back to the id when an entry has no label', () => {
+    expect(menuItemsFor(task, [entry({ label: undefined })])[2].label).toBe('create');
+  });
+});
+
+describe('parseSelection', () => {
+  it('reads a built-in as a built-in', () => {
+    expect(parseSelection('move')).toEqual({ kind: 'builtin', key: 'move' });
+  });
+
+  it('reads an extension key back into who should handle it', () => {
+    expect(parseSelection('ext:linear:create')).toEqual({
+      kind: 'extension',
+      owner: 'linear',
+      id: 'create',
+    });
+  });
+
+  it('keeps an id that contains a colon intact', () => {
+    expect(parseSelection('ext:linear:issue:new').id).toBe('issue:new');
+  });
+
+  it('treats anything malformed as a built-in rather than guessing', () => {
+    expect(parseSelection('ext:linear').kind).toBe('builtin');
+    expect(parseSelection(undefined).kind).toBe('builtin');
+  });
+});
+
+describe('useTaskContextMenu', () => {
+  it('opens where the click was, on the task that was clicked', () => {
+    const menu = useTaskContextMenu();
+
+    menu.open({ clientX: 10, clientY: 20 }, task);
+
+    expect(menu.menu.value).toMatchObject({ show: true, x: 10, y: 20, task });
+  });
+
+  it('follows what is installed rather than what was installed at mount', () => {
+    // An extension enabled while the board is open should appear on the next
+    // right-click, not the next reload.
+    // Reading something reactive, which is what every real caller does.
+    const installed = ref([]);
+    const menu = useTaskContextMenu({ entries: () => installed.value });
+    menu.open({ clientX: 0, clientY: 0 }, task);
+
+    expect(menu.items.value).toHaveLength(1);
+
+    installed.value = [entry()];
+    expect(menu.items.value).toHaveLength(3);
+  });
+
+  it('hands a built-in back to the view that knows what to do with it', () => {
+    const onExtensionSelect = vi.fn();
+    const menu = useTaskContextMenu({ onExtensionSelect });
+    menu.open({ clientX: 0, clientY: 0 }, task);
+
+    expect(menu.select('move')).toBe('move');
+    expect(onExtensionSelect).not.toHaveBeenCalled();
+    expect(menu.menu.value.show).toBe(false);
+  });
+
+  it('routes an extension entry away, so no view learns what an extension is', () => {
+    const onExtensionSelect = vi.fn();
+    const menu = useTaskContextMenu({ entries: () => [entry()], onExtensionSelect });
+    menu.open({ clientX: 0, clientY: 0 }, task);
+
+    expect(menu.select('ext:linear:create')).toBeNull();
+    expect(onExtensionSelect).toHaveBeenCalledWith({ owner: 'linear', id: 'create', task });
+  });
+
+  it('does nothing when nothing was open', () => {
+    const menu = useTaskContextMenu();
+
+    expect(menu.select('move')).toBeNull();
+  });
+
+  it('closes without choosing', () => {
+    const menu = useTaskContextMenu();
+    menu.open({ clientX: 0, clientY: 0 }, task);
+
+    menu.close();
+
+    expect(menu.menu.value.show).toBe(false);
+  });
+
+  it('works with nothing supplied at all', () => {
+    // The state a view is in before any extension is installed.
+    const menu = useTaskContextMenu();
+    menu.open({ clientX: 0, clientY: 0 }, task);
+
+    expect(menu.items.value).toEqual(BUILT_IN_ITEMS);
+    expect(menu.select('ext:linear:create')).toBeNull();
+  });
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -45,6 +45,8 @@ export default defineConfig({
         'src/composables/useAgentModelPicker.js',
         'src/composables/useExtensionCatalogue.js',
         'src/composables/useExtensionGrant.js',
+        'src/composables/useExtensionView.js',
+        'src/composables/useTaskContextMenu.js',
         'src/composables/useTaskEvents.js',
         'src/composables/useTrajectory.js',
         'src/composables/useWorkflowLabels.js',


### PR DESCRIPTION
> **7 of 10, stacked on [#520](https://github.com/agentrq/agentrq/pull/520).** Targets `ext/06-broker`. [Plan](https://claude.ai/code/artifact/907d107c-921d-4e0e-a371-de22229c2927).

## What changed

Extensions can now contribute to three places in the interface — a page, an action on a workspace, and an item on a task's right-click menu — described as a spec that AgentRQ draws with its own components.

## Why changed

An extension that can act but cannot be seen or reached is only half a feature. These are the three places where "do something with this" belongs.

## Test coverage report

New lines introduced: **100%**. Total coverage impact: **unchanged at 100%** on all four metrics — frontend 1149 tests across 45 files, up from 1110 across 43. Desktop suite unchanged at 715.

Covered: every node type, unknown types, oversized and over-nested specs, unsafe links, the `when` predicate including one that throws, the divider appearing and disappearing, key namespacing, and both views reading the same list.

## Other reports

**The context menu had to be unified before anything could be added to it.** The item list was written inline in `KanbanBoardView` and `TaskFeed` separately — the same literal in both. That was survivable while it held one hard-coded row and stops being survivable immediately after: an entry added to one and not the other means right-click does different things on two views of the same task, and nothing about that announces itself. There is one list now, and both views read it.

**Built-ins first, extensions below a divider.** Installing something never shuffles the entry somebody's hand already knows, and it stays visible where a row came from. When every extension entry opts out, the divider goes too — a divider under nothing looks like a broken menu.

**`when(task)` decides per task, and one that throws is a no.** Ten installed extensions must not mean ten permanent rows on every task, and a thrown error is not a reason to show a row whose own author could not say whether it belonged.

**Entry keys are namespaced by owner**, so two extensions may both call theirs `create` without either inventing a globally unique name.

**Unknown node types are rejected, not skipped.** Skipping renders a page quietly missing whatever the author thought they wrote — worse for them than being told, worse for the user than seeing nothing. The message names the type and lists the alternatives, because somebody who typed `headding` is one line from working.

**Links are classified exactly as `markdown.js` already classifies agent-written message bodies**, for the same reason: a `file:` URL is how a link reaches the machine. Text is clamped, tones fall back rather than leaking a colour, and node count and nesting depth are bounded.

**One small bug the tests found:** an empty view discarded its title, so a panel reading *"Issues — nothing to show"* lost the heading that said which panel was empty. An empty view is a legitimate answer and keeps it now.

## TaskID: 0iV0GuefpOj
