### PR TITLE
feat(extensions): keyboard shortcuts under a prefix of their own

### DIFF
--- a/desktop/src/main/extensions/install.js
+++ b/desktop/src/main/extensions/install.js
@@ -1,4 +1,5 @@
 import { parseManifest } from './manifest.js'
+import { checkShortcuts } from './shortcuts.js'
 import { describeSource, pinFor, verifyDigest } from './source.js'
 
 /**
@@ -111,6 +112,9 @@ export function createInstaller({
   dirFor,
   store,
   now = () => Date.now(),
+  // What every other extension already holds. A getter rather than a value so
+  // it reflects what is installed at the moment of the check.
+  claimedKeys = () => [],
 }) {
   let state = null
 
@@ -155,6 +159,13 @@ export function createInstaller({
 
       const parsed = parseManifest(manifestSource)
       if (!parsed.ok) return { ok: false, reason: parsed.reason, temp }
+
+      // Checked here, before anything is written, so a keyboard conflict is a
+      // sentence in front of somebody who can still decide not to install —
+      // rather than a key that silently does nothing afterwards, with both
+      // extensions looking correct in isolation.
+      const keys = checkShortcuts(parsed.manifest, claimedKeys())
+      if (!keys.ok) return { ok: false, reason: keys.problems.join(' '), temp }
 
       return { ok: true, temp, dir: fetched.dir, manifest: parsed.manifest, commit: fetched.commit }
     } catch (error) {

--- a/desktop/src/main/extensions/shortcuts.js
+++ b/desktop/src/main/extensions/shortcuts.js
@@ -1,0 +1,95 @@
+/**
+ * Whether an extension's shortcuts can be given to it.
+ *
+ * Asked at **install**, from the manifest, and that timing is the whole point.
+ * A conflict discovered at runtime is a key that silently does nothing: nothing
+ * on screen explains it, and the two extensions involved each look correct in
+ * isolation. Asked here, it is a sentence naming the one already using it, in
+ * front of somebody who can still decide not to install.
+ *
+ * The renderer has its own copy of the prefix rules for dispatching. This is the
+ * gate, and it deliberately answers the narrower question — may these be
+ * claimed — rather than trying to be a second dispatcher.
+ */
+
+/** The one key reserved for extensions. Mirrors the renderer's constant. */
+export const PREFIX = 'x'
+
+/** A single letter or digit, and never the prefix itself. */
+export function isBindableKey(key) {
+  const value = String(key ?? '').toLowerCase()
+  return value.length === 1 && value !== PREFIX && /^[a-z0-9]$/.test(value)
+}
+
+/**
+ * What an extension is asking to bind, from its manifest.
+ *
+ * Malformed entries are dropped here rather than refused: `conflicts` reports
+ * them, and reading the list twice with two different ideas of what counts
+ * would be a way for the two to disagree.
+ */
+export function requestedKeys(manifest) {
+  return (manifest?.shortcuts ?? [])
+    .map((shortcut) => ({
+      key: String(shortcut?.key ?? '').toLowerCase(),
+      action: String(shortcut?.action ?? ''),
+      title: String(shortcut?.title ?? ''),
+    }))
+    .filter((shortcut) => shortcut.key !== '')
+}
+
+/**
+ * Whether this extension's shortcuts can all be claimed.
+ *
+ * `taken` is what every *other* installed extension already holds — an
+ * extension updating in place must not conflict with the version of itself
+ * being replaced, which would make every update after the first impossible.
+ */
+export function checkShortcuts(manifest, taken = []) {
+  const owner = manifest?.name ?? ''
+  const held = new Map(
+    taken
+      .filter((entry) => entry.owner !== owner)
+      .map((entry) => [String(entry.key).toLowerCase(), entry.owner]),
+  )
+
+  const problems = []
+  const seen = new Set()
+
+  for (const { key } of requestedKeys(manifest)) {
+    if (!isBindableKey(key)) {
+      problems.push(
+        key === PREFIX
+          ? `"${PREFIX}" is the prefix itself and cannot also be a shortcut.`
+          : `"${key}" is not a key an extension can bind. Use a single letter or digit.`,
+      )
+      continue
+    }
+    if (seen.has(key)) {
+      problems.push(`This extension asks for "${PREFIX} ${key}" twice.`)
+      continue
+    }
+    seen.add(key)
+
+    const other = held.get(key)
+    if (other) problems.push(`"${PREFIX} ${key}" is already used by ${other}.`)
+  }
+
+  return { ok: problems.length === 0, problems }
+}
+
+/** Everything currently claimed, for the check above and for the help sheet. */
+export function claimedShortcuts(installations = []) {
+  return installations
+    .filter((installation) => installation.enabled !== false)
+    .flatMap((installation) =>
+      requestedKeys(installation.manifest)
+        .filter(({ key }) => isBindableKey(key))
+        .map(({ key, action, title }) => ({
+          key,
+          owner: installation.name,
+          id: action,
+          label: title || action,
+        })),
+    )
+}

--- a/desktop/test/extensions/install.test.js
+++ b/desktop/test/extensions/install.test.js
@@ -267,6 +267,40 @@ describe('install', () => {
     expect((await installer.install({ kind: 'local', path: '/x' }, { linked: true })).ok).toBe(false)
   })
 
+  it('refuses a shortcut another extension already holds, before writing anything', async () => {
+    // A conflict found at runtime is a key that silently does nothing, and
+    // nothing on screen explains it. Found here, it is a sentence.
+    const withShortcut = JSON.stringify({
+      ...JSON.parse(manifestFor('thing')),
+      shortcuts: [{ key: 'l', action: 'create' }],
+    })
+    const { installer, moved } = build({
+      manifest: withShortcut,
+      claimedKeys: () => [{ key: 'l', owner: 'standup' }],
+    })
+
+    const { ok, reason } = await installer.install(releaseSource())
+
+    expect(ok).toBe(false)
+    expect(reason).toBe('"x l" is already used by standup.')
+    expect(moved).toEqual([])
+  })
+
+  it('lets an extension keep its own shortcut through an update', async () => {
+    // Otherwise every update after the first conflicts with the version it is
+    // replacing, which makes updating impossible.
+    const withShortcut = JSON.stringify({
+      ...JSON.parse(manifestFor('thing')),
+      shortcuts: [{ key: 'l', action: 'create' }],
+    })
+    const { installer } = build({
+      manifest: withShortcut,
+      claimedKeys: () => [{ key: 'l', owner: 'thing' }],
+    })
+
+    expect((await installer.install(releaseSource())).ok).toBe(true)
+  })
+
   it('replaces an earlier installation of the same name rather than doubling it', async () => {
     const { installer, saved } = build()
 

--- a/desktop/test/extensions/shortcuts.test.js
+++ b/desktop/test/extensions/shortcuts.test.js
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  PREFIX,
+  checkShortcuts,
+  claimedShortcuts,
+  isBindableKey,
+  requestedKeys,
+} from '../../src/main/extensions/shortcuts.js'
+
+/**
+ * Asked at install, from the manifest. A conflict found at runtime is a key that
+ * silently does nothing, with both extensions looking correct in isolation and
+ * nothing on screen to explain it.
+ */
+
+const manifest = (shortcuts, name = 'linear') => ({ name, shortcuts })
+
+describe('isBindableKey', () => {
+  it('takes one letter or digit, and not the prefix', () => {
+    expect(isBindableKey('l')).toBe(true)
+    expect(isBindableKey('4')).toBe(true)
+    expect(isBindableKey(PREFIX)).toBe(false)
+    expect(isBindableKey('Enter')).toBe(false)
+    expect(isBindableKey('')).toBe(false)
+    expect(isBindableKey(undefined)).toBe(false)
+    expect(isBindableKey(null)).toBe(false)
+  })
+})
+
+describe('requestedKeys', () => {
+  it('reads what a manifest asks for', () => {
+    const keys = requestedKeys(manifest([{ key: 'L', action: 'create', title: 'Create issue' }]))
+
+    expect(keys).toEqual([{ key: 'l', action: 'create', title: 'Create issue' }])
+  })
+
+  it('drops an entry with no key, leaving the rest', () => {
+    expect(requestedKeys(manifest([{ action: 'x' }, { key: 'l' }]))).toHaveLength(1)
+  })
+
+  it('copes with a manifest asking for none', () => {
+    expect(requestedKeys(manifest())).toEqual([])
+    expect(requestedKeys(undefined)).toEqual([])
+  })
+})
+
+describe('checkShortcuts', () => {
+  it('accepts keys nobody holds', () => {
+    expect(checkShortcuts(manifest([{ key: 'l' }]), []).ok).toBe(true)
+  })
+
+  it('names who already holds one', () => {
+    const { ok, problems } = checkShortcuts(manifest([{ key: 'l' }]), [{ key: 'l', owner: 'standup' }])
+
+    expect(ok).toBe(false)
+    expect(problems[0]).toBe('"x l" is already used by standup.')
+  })
+
+  it('lets an extension keep its own keys through an update', () => {
+    // Otherwise every update after the first would conflict with the version
+    // it is replacing, which makes updating impossible.
+    const taken = [{ key: 'l', owner: 'linear' }]
+
+    expect(checkShortcuts(manifest([{ key: 'l' }], 'linear'), taken).ok).toBe(true)
+  })
+
+  it('refuses the prefix, and says why', () => {
+    expect(checkShortcuts(manifest([{ key: PREFIX }]), []).problems[0]).toContain('is the prefix itself')
+  })
+
+  it('refuses a key that could never be pressed as one', () => {
+    expect(checkShortcuts(manifest([{ key: 'Enter' }]), []).problems[0]).toContain('single letter or digit')
+  })
+
+  it('catches an extension asking twice for the same key', () => {
+    expect(checkShortcuts(manifest([{ key: 'l' }, { key: 'L' }]), []).problems[0]).toContain('twice')
+  })
+
+  it('reports every problem, so a manifest can be fixed in one pass', () => {
+    const { problems } = checkShortcuts(manifest([{ key: 'l' }, { key: 'Enter' }]), [
+      { key: 'l', owner: 'standup' },
+    ])
+
+    expect(problems).toHaveLength(2)
+  })
+
+  it('has nothing to check when nothing is asked for', () => {
+    expect(checkShortcuts(manifest(), []).ok).toBe(true)
+    expect(checkShortcuts(undefined).ok).toBe(true)
+  })
+})
+
+describe('claimedShortcuts', () => {
+  const installation = (name, keys, over = {}) => ({
+    name,
+    manifest: manifest(keys.map((key) => ({ key, action: `${key}-action`, title: `${name} ${key}` })), name),
+    ...over,
+  })
+
+  it('lists what every installed extension holds', () => {
+    const claimed = claimedShortcuts([installation('linear', ['l']), installation('standup', ['s'])])
+
+    expect(claimed.map((c) => `${c.owner}:${c.key}`)).toEqual(['linear:l', 'standup:s'])
+    expect(claimed[0].label).toBe('linear l')
+  })
+
+  it('leaves out a disabled extension, whose keys are free again', () => {
+    const claimed = claimedShortcuts([installation('linear', ['l'], { enabled: false })])
+
+    expect(claimed).toEqual([])
+  })
+
+  it('leaves out a key that could never be pressed', () => {
+    expect(claimedShortcuts([installation('linear', ['Enter'])])).toEqual([])
+  })
+
+  it('falls back to the action when a shortcut has no title', () => {
+    const bare = { name: 'linear', manifest: manifest([{ key: 'l', action: 'create' }], 'linear') }
+
+    expect(claimedShortcuts([bare])[0].label).toBe('create')
+  })
+
+  it('copes with nothing installed', () => {
+    expect(claimedShortcuts()).toEqual([])
+  })
+})

--- a/frontend/src/composables/useExtensionShortcuts.js
+++ b/frontend/src/composables/useExtensionShortcuts.js
@@ -1,0 +1,191 @@
+import { computed, ref } from 'vue';
+
+import { isTypingTarget } from './useKeyboardShortcuts';
+
+/**
+ * Keyboard shortcuts for extensions, under a prefix of their own.
+ *
+ *     x then l   →  Linear: create issue
+ *     x then s   →  Standup: today's notes
+ *
+ * ## Why a prefix rather than a list of forbidden letters
+ *
+ * The application's scheme is bare letters, and `useKeyboardShortcuts.js`
+ * explains at length why: most modifier combinations never reach the page at
+ * all — Cmd+N opens a window, Cmd+H hides the app — so a shortcut bound to one
+ * "would simply never fire, which is worse than having no shortcut."
+ *
+ * That leaves single letters, of which `k n w m t ?` are already spoken for. A
+ * blocklist of those fails three ways at once. It is a **tiny namespace**. It
+ * **freezes the application**, because every letter an extension takes is one we
+ * can never add without breaking somebody. And **extensions collide with each
+ * other**, resolved by whoever installed first, which is no answer at all.
+ *
+ * One reserved prefix fixes all three. `x` belongs to extensions and to nothing
+ * else, so the single-letter space stays entirely ours and the second key is a
+ * namespace nobody else is competing for. It is also a scheme people already
+ * know from `g`-then-key in Gmail and GitHub.
+ *
+ * ## In-app only
+ *
+ * The application registers Cmd+Shift+N in the *main* process, so it fires
+ * whether or not the window has focus. That is a system-wide key grab, and
+ * handing one to third-party code is a different order of capability from a key
+ * that works while the app is in front of you. Extensions get the second kind.
+ */
+
+/** The one key reserved for extensions. */
+export const PREFIX = 'x';
+
+/**
+ * How long a half-typed sequence waits for its second key.
+ *
+ * Long enough not to punish a deliberate pause, short enough that a stray `x`
+ * does not leave the next letter typed into a menu doing something unexpected
+ * several seconds later.
+ */
+export const SEQUENCE_TIMEOUT_MS = 2000;
+
+/** Letters an extension may not claim, because the prefix would never reach them. */
+export const RESERVED_SECOND_KEYS = Object.freeze([PREFIX]);
+
+/**
+ * Whether a second key is one an extension may have.
+ *
+ * A single character, and not the prefix itself — `x x` would mean "start a
+ * sequence, then start another", which is not a thing a person can press.
+ */
+export function isBindableKey(key) {
+  const value = String(key ?? '').toLowerCase();
+  if (value.length !== 1) return false;
+  if (RESERVED_SECOND_KEYS.includes(value)) return false;
+  return /^[a-z0-9]$/.test(value)
+}
+
+/**
+ * What is wrong with an extension's requested shortcuts, if anything.
+ *
+ * Answered from the manifest at **install**, not at runtime. A conflict
+ * discovered when somebody presses a key is a key that silently does nothing,
+ * and no amount of looking at the screen explains it; told at install, it is a
+ * sentence naming the extension already using it.
+ */
+export function conflicts(requested = [], existing = []) {
+  const taken = new Map(existing.map((entry) => [String(entry.key).toLowerCase(), entry.owner]));
+  const problems = [];
+  const seen = new Set();
+
+  for (const shortcut of requested) {
+    const key = String(shortcut?.key ?? '').toLowerCase();
+
+    if (!isBindableKey(key)) {
+      problems.push(
+        key === PREFIX
+          ? `"${PREFIX}" is the prefix itself and cannot also be a shortcut.`
+          : `"${shortcut?.key ?? ''}" is not a key an extension can bind. Use a single letter or digit.`,
+      )
+      continue
+    }
+    if (seen.has(key)) {
+      problems.push(`This extension asks for "${PREFIX} ${key}" twice.`)
+      continue
+    }
+    seen.add(key)
+
+    const owner = taken.get(key)
+    if (owner) problems.push(`"${PREFIX} ${key}" is already used by ${owner}.`)
+  }
+
+  return { ok: problems.length === 0, problems }
+}
+
+/** How a sequence is written on screen. */
+export function formatSequence(key) {
+  return `${PREFIX} then ${String(key ?? '').toLowerCase()}`
+}
+
+/**
+ * The keyboard state for extension shortcuts.
+ *
+ * `entries` is a getter so newly installed extensions are bindable without a
+ * reload, and `now`/`clearAfter` are injected so the timeout is testable without
+ * waiting two seconds.
+ */
+export function useExtensionShortcuts({
+  entries = () => [],
+  onInvoke = () => {},
+  onPrefix = () => {},
+  now = () => Date.now(),
+} = {}) {
+  /** When the prefix was pressed, or 0 when no sequence is in flight. */
+  const startedAt = ref(0)
+  const armed = computed(() => startedAt.value !== 0)
+
+  /** Everything bindable right now, for the help sheet and the dispatcher. */
+  const bindings = computed(() =>
+    entries()
+      .filter((entry) => isBindableKey(entry.key))
+      .map((entry) => ({
+        key: String(entry.key).toLowerCase(),
+        owner: entry.owner,
+        id: entry.id,
+        label: entry.label ?? entry.id,
+        sequence: formatSequence(entry.key),
+      })),
+  )
+
+  function reset() {
+    startedAt.value = 0
+  }
+
+  /**
+   * Offers a key event to the sequence.
+   *
+   * Returns whether it was consumed, so a caller can leave everything else
+   * alone — the application's own bare letters must keep working, and a
+   * half-typed extension sequence must not swallow them.
+   */
+  function handle(event) {
+    if (!event?.key) return false
+
+    // Modifiers mean the keystroke belongs to the browser or the system, and
+    // typing means the letters are text. Both are the same rules the
+    // application's own bare letters follow.
+    const bare = !event.metaKey && !event.ctrlKey && !event.altKey
+    if (!bare || isTypingTarget(event.target)) {
+      reset()
+      return false
+    }
+
+    const key = event.key.toLowerCase()
+
+    if (!armed.value) {
+      if (key !== PREFIX) return false
+      startedAt.value = now()
+      // Announced so the interface can show what is available, the way `?`
+      // shows the sheet — a prefix nobody can see the options for is a prefix
+      // nobody uses twice.
+      onPrefix(bindings.value)
+      return true
+    }
+
+    // A sequence left half-typed goes stale rather than waiting forever: a
+    // stray `x` must not turn the next letter, minutes later, into a command.
+    if (now() - startedAt.value > SEQUENCE_TIMEOUT_MS) {
+      reset()
+      return key === PREFIX ? handle(event) : false
+    }
+
+    reset()
+    // Escape abandons it, which is what everybody tries first.
+    if (key === 'escape') return true
+
+    const binding = bindings.value.find((entry) => entry.key === key)
+    if (!binding) return false
+
+    onInvoke(binding)
+    return true
+  }
+
+  return { armed, bindings, handle, reset }
+}

--- a/frontend/test/extensionShortcuts.test.js
+++ b/frontend/test/extensionShortcuts.test.js
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ref } from 'vue';
+
+import {
+  PREFIX,
+  RESERVED_SECOND_KEYS,
+  SEQUENCE_TIMEOUT_MS,
+  conflicts,
+  formatSequence,
+  isBindableKey,
+  useExtensionShortcuts,
+} from '../src/composables/useExtensionShortcuts';
+
+/**
+ * One reserved prefix instead of a list of forbidden letters. A blocklist would
+ * be a tiny namespace, would freeze the application out of every letter an
+ * extension claimed, and would still let two extensions collide with each other.
+ */
+
+const entry = (over = {}) => ({ key: 'l', owner: 'linear', id: 'create', label: 'Create issue', ...over });
+
+/** A bare keypress, as the dispatcher sees it. */
+const press = (key, over = {}) => ({ key, metaKey: false, ctrlKey: false, altKey: false, target: null, ...over });
+
+describe('isBindableKey', () => {
+  it('takes a single letter or digit', () => {
+    expect(isBindableKey('l')).toBe(true);
+    expect(isBindableKey('L')).toBe(true);
+    expect(isBindableKey('7')).toBe(true);
+  });
+
+  it('refuses the prefix itself', () => {
+    // "x x" would mean start a sequence and then start another, which is not a
+    // thing a person can press.
+    expect(isBindableKey(PREFIX)).toBe(false);
+    expect(RESERVED_SECOND_KEYS).toContain(PREFIX);
+  });
+
+  it('refuses anything that is not one ordinary key', () => {
+    for (const key of ['', 'ab', 'Enter', '?', '-', undefined]) {
+      expect(isBindableKey(key), String(key)).toBe(false);
+    }
+  });
+});
+
+describe('conflicts', () => {
+  it('accepts a key nobody has taken', () => {
+    expect(conflicts([{ key: 'l' }], [])).toEqual({ ok: true, problems: [] });
+  });
+
+  it('names the extension already using a key', () => {
+    // Told at install, this is a sentence. Discovered at runtime, it is a key
+    // that silently does nothing and no amount of looking explains it.
+    const { ok, problems } = conflicts([{ key: 'l' }], [{ key: 'l', owner: 'standup' }]);
+
+    expect(ok).toBe(false);
+    expect(problems[0]).toBe('"x l" is already used by standup.');
+  });
+
+  it('is case-insensitive about a collision', () => {
+    expect(conflicts([{ key: 'L' }], [{ key: 'l', owner: 'standup' }]).ok).toBe(false);
+  });
+
+  it('refuses the prefix with an explanation rather than a shrug', () => {
+    expect(conflicts([{ key: PREFIX }], []).problems[0]).toContain('is the prefix itself');
+  });
+
+  it('refuses a key that could never be pressed as one', () => {
+    expect(conflicts([{ key: 'Enter' }], []).problems[0]).toContain('not a key an extension can bind');
+  });
+
+  it('catches an extension asking for the same key twice', () => {
+    expect(conflicts([{ key: 'l' }, { key: 'l' }], []).problems[0]).toContain('twice');
+  });
+
+  it('reports every problem, not just the first', () => {
+    // An author fixing a manifest wants the whole list.
+    const { problems } = conflicts([{ key: 'l' }, { key: 'Enter' }], [{ key: 'l', owner: 'standup' }]);
+
+    expect(problems).toHaveLength(2);
+  });
+
+  it('has nothing to say about an extension asking for none', () => {
+    expect(conflicts().ok).toBe(true);
+  });
+
+  it('copes with an entry that is not a shortcut at all', () => {
+    // A manifest is written by hand, so a null in the list is a thing that
+    // happens, and it should be a message rather than a crash.
+    const { ok, problems } = conflicts([null, {}], []);
+
+    expect(ok).toBe(false);
+    expect(problems).toHaveLength(2);
+  });
+});
+
+describe('formatSequence', () => {
+  it('writes a sequence the way it is pressed', () => {
+    expect(formatSequence('L')).toBe('x then l');
+    expect(formatSequence()).toBe('x then ');
+  });
+});
+
+describe('useExtensionShortcuts', () => {
+  function build({ bindings = [entry()], clock = { t: 1000 } } = {}) {
+    const onInvoke = vi.fn();
+    const onPrefix = vi.fn();
+    const installed = ref(bindings);
+    const shortcuts = useExtensionShortcuts({
+      entries: () => installed.value,
+      onInvoke,
+      onPrefix,
+      now: () => clock.t,
+    });
+    return { shortcuts, onInvoke, onPrefix, clock, installed };
+  }
+
+  it('invokes on the second key of the sequence', () => {
+    const { shortcuts, onInvoke } = build();
+
+    expect(shortcuts.handle(press('x'))).toBe(true);
+    expect(shortcuts.armed.value).toBe(true);
+    expect(shortcuts.handle(press('l'))).toBe(true);
+
+    expect(onInvoke).toHaveBeenCalledWith(expect.objectContaining({ owner: 'linear', id: 'create' }));
+    expect(shortcuts.armed.value).toBe(false);
+  });
+
+  it('announces the prefix, so the options can be shown', () => {
+    // A prefix nobody can see the options for is a prefix nobody uses twice.
+    const { shortcuts, onPrefix } = build();
+
+    shortcuts.handle(press('x'));
+
+    expect(onPrefix).toHaveBeenCalledWith([expect.objectContaining({ sequence: 'x then l' })]);
+  });
+
+  it('leaves every other key alone', () => {
+    // The application's own bare letters have to keep working.
+    const { shortcuts, onInvoke } = build();
+
+    expect(shortcuts.handle(press('n'))).toBe(false);
+    expect(onInvoke).not.toHaveBeenCalled();
+  });
+
+  it('consumes a second key nobody claimed without inventing a meaning for it', () => {
+    const { shortcuts, onInvoke } = build();
+    shortcuts.handle(press('x'));
+
+    expect(shortcuts.handle(press('q'))).toBe(false);
+    expect(onInvoke).not.toHaveBeenCalled();
+    expect(shortcuts.armed.value).toBe(false);
+  });
+
+  it('abandons a sequence on escape, which is what everybody tries', () => {
+    const { shortcuts, onInvoke } = build();
+    shortcuts.handle(press('x'));
+
+    expect(shortcuts.handle(press('Escape'))).toBe(true);
+    expect(shortcuts.armed.value).toBe(false);
+    expect(onInvoke).not.toHaveBeenCalled();
+  });
+
+  it('lets a half-typed sequence go stale', () => {
+    // A stray x must not turn the next letter, minutes later, into a command.
+    const clock = { t: 1000 };
+    const { shortcuts, onInvoke } = build({ clock });
+    shortcuts.handle(press('x'));
+
+    clock.t += SEQUENCE_TIMEOUT_MS + 1;
+
+    expect(shortcuts.handle(press('l'))).toBe(false);
+    expect(onInvoke).not.toHaveBeenCalled();
+  });
+
+  it('starts a fresh sequence when the stale key is the prefix again', () => {
+    const clock = { t: 1000 };
+    const { shortcuts, onInvoke } = build({ clock });
+    shortcuts.handle(press('x'));
+    clock.t += SEQUENCE_TIMEOUT_MS + 1;
+
+    expect(shortcuts.handle(press('x'))).toBe(true);
+    expect(shortcuts.handle(press('l'))).toBe(true);
+    expect(onInvoke).toHaveBeenCalledOnce();
+  });
+
+  it('still fires within the timeout', () => {
+    const clock = { t: 1000 };
+    const { shortcuts, onInvoke } = build({ clock });
+    shortcuts.handle(press('x'));
+
+    clock.t += SEQUENCE_TIMEOUT_MS;
+    shortcuts.handle(press('l'));
+
+    expect(onInvoke).toHaveBeenCalledOnce();
+  });
+
+  it('stays out of the way while somebody is typing', () => {
+    // The same rule the application's own bare letters follow.
+    const { shortcuts, onInvoke } = build();
+    const textarea = { tagName: 'TEXTAREA', closest: () => null };
+
+    expect(shortcuts.handle(press('x', { target: textarea }))).toBe(false);
+    expect(shortcuts.armed.value).toBe(false);
+    expect(onInvoke).not.toHaveBeenCalled();
+  });
+
+  it('drops a sequence the moment focus moves into a text field', () => {
+    const { shortcuts, onInvoke } = build();
+    shortcuts.handle(press('x'));
+
+    shortcuts.handle(press('l', { target: { tagName: 'INPUT', closest: () => null } }));
+
+    expect(onInvoke).not.toHaveBeenCalled();
+    expect(shortcuts.armed.value).toBe(false);
+  });
+
+  it('ignores a keystroke held with a modifier', () => {
+    // A held modifier means the keystroke belongs to the browser or the system.
+    const { shortcuts } = build();
+
+    expect(shortcuts.handle(press('x', { metaKey: true }))).toBe(false);
+    expect(shortcuts.handle(press('x', { ctrlKey: true }))).toBe(false);
+    expect(shortcuts.handle(press('x', { altKey: true }))).toBe(false);
+    expect(shortcuts.armed.value).toBe(false);
+  });
+
+  it('follows what is installed, without a reload', () => {
+    const { shortcuts, installed, onInvoke } = build({ bindings: [] });
+
+    shortcuts.handle(press('x'));
+    expect(shortcuts.handle(press('l'))).toBe(false);
+
+    installed.value = [entry()];
+    shortcuts.handle(press('x'));
+    shortcuts.handle(press('l'));
+
+    expect(onInvoke).toHaveBeenCalledOnce();
+  });
+
+  it('leaves out a binding whose key could never be pressed', () => {
+    const { shortcuts } = build({ bindings: [entry({ key: 'Enter' }), entry()] });
+
+    expect(shortcuts.bindings.value.map((b) => b.key)).toEqual(['l']);
+  });
+
+  it('falls back to the id when a binding has no label', () => {
+    const { shortcuts } = build({ bindings: [entry({ label: undefined })] });
+
+    expect(shortcuts.bindings.value[0].label).toBe('create');
+  });
+
+  it('ignores an event with no key at all', () => {
+    expect(build().shortcuts.handle({})).toBe(false);
+    expect(build().shortcuts.handle(undefined)).toBe(false);
+  });
+
+  it('can be reset from outside, for a view that is going away', () => {
+    const { shortcuts } = build();
+    shortcuts.handle(press('x'));
+
+    shortcuts.reset();
+
+    expect(shortcuts.armed.value).toBe(false);
+  });
+
+  it('works with nothing supplied at all', () => {
+    const shortcuts = useExtensionShortcuts();
+
+    expect(shortcuts.bindings.value).toEqual([]);
+    expect(shortcuts.handle(press('x'))).toBe(true);
+    expect(shortcuts.handle(press('l'))).toBe(false);
+  });
+
+  it('invokes through the default handler without a caller supplying one', () => {
+    // Nothing listening is not a reason to throw on the way past.
+    const shortcuts = useExtensionShortcuts({ entries: () => [entry()] });
+
+    shortcuts.handle(press('x'));
+
+    expect(() => shortcuts.handle(press('l'))).not.toThrow();
+  });
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -45,6 +45,7 @@ export default defineConfig({
         'src/composables/useAgentModelPicker.js',
         'src/composables/useExtensionCatalogue.js',
         'src/composables/useExtensionGrant.js',
+        'src/composables/useExtensionShortcuts.js',
         'src/composables/useExtensionView.js',
         'src/composables/useTaskContextMenu.js',
         'src/composables/useTaskEvents.js',


### PR DESCRIPTION
> **8 of 10, stacked on [#521](https://github.com/agentrq/agentrq/pull/521).** Targets `ext/07-ui`. [Plan](https://claude.ai/code/artifact/907d107c-921d-4e0e-a371-de22229c2927).

## What changed

Extensions can bind keyboard shortcuts — `x` then a letter — and a clash with another extension is refused before installing rather than discovered when a key does nothing.

## Why changed

An extension's action is only as reachable as the ways to invoke it. The prefix is what lets extensions have shortcuts at all without taking letters the application will want later.

## Test coverage report

New lines introduced: **100%**. Total coverage impact: **unchanged at 100%** on all four metrics — frontend 1180 tests across 46 files (from 1149/45), desktop 734 across 27 (from 715/26).

Covered: the sequence firing, going stale, being abandoned with Escape, releasing an unclaimed second key, suppression while typing and under a modifier, the install-time conflict check with its message, an extension keeping its own keys through an update, and a manifest asking for the prefix itself.

## Other reports

**Why a prefix and not a blocklist.** The app's scheme is bare letters — `useKeyboardShortcuts.js` explains at length that most modifier combinations never reach the page, so a shortcut bound to one *"would simply never fire, which is worse than having no shortcut."* That leaves single letters, of which `k n w m t ?` are taken. A blocklist of those fails three ways at once: it is a **tiny namespace**, it **freezes the application** out of every letter an extension claims, and **extensions still collide with each other**, resolved by whoever installed first. One reserved prefix fixes all three.

**Conflicts are caught at install, and the timing is the point.** Found at runtime, a conflict is a key that silently does nothing — nothing on screen explains it and both extensions look correct in isolation. Found at install, it is *"x l is already used by standup"*, in front of somebody who can still decide not to install.

**An extension keeps its own keys through an update.** Otherwise every update after the first would conflict with the version it is replacing, and updating would be impossible — a check that is technically correct and makes the feature unusable.

**Three behaviours the sequence needed:**
- A half-typed sequence **goes stale**, so a stray `x` cannot turn the next letter, minutes later, into a command.
- **Escape abandons it**, which is what everybody tries first.
- A second key nobody claimed is **released, not swallowed**, so the app's own bare letters keep working underneath.

**No global shortcuts.** Cmd+Shift+N is registered in the *main* process and fires whether or not the window has focus. That is a system-wide key grab and a different order of capability from a key that works while the app is in front of you.

## TaskID: 0iV0JOmIGAb
