### PR TITLE
fix(tasks): query ongoing tasks directly

### DIFF
--- a/backend/internal/controller/crud/task.go
+++ b/backend/internal/controller/crud/task.go
@@ -185,6 +185,25 @@ func (c *controller) ListTasks(ctx context.Context, req entity.ListTasksRequest)
 	return &entity.ListTasksResponse{Tasks: tasks}, nil
 }
 
+func (c *controller) otherTaskOngoing(ctx context.Context, workspaceID, taskID, userID int64) (bool, error) {
+	// Limit 2, not 1: the task being transitioned may itself already be ongoing
+	// and occupy the first row, which would hide any other ongoing task.
+	tasks, err := c.repository.ListTasks(ctx, entity.ListTasksRequest{
+		WorkspaceID: workspaceID,
+		Status:      []string{"ongoing"},
+		Limit:       2,
+	}, userID)
+	if err != nil {
+		return false, err
+	}
+	for _, t := range tasks {
+		if t.ID != taskID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (c *controller) RespondToTask(ctx context.Context, req entity.RespondToTaskRequest) (*entity.RespondToTaskResponse, error) {
 	uid := monoflake.IDFromBase62(req.UserID).Int64()
 	if c.limiter != nil && !c.limiter.AllowMessage(uid) {
@@ -206,14 +225,12 @@ func (c *controller) RespondToTask(ctx context.Context, req entity.RespondToTask
 	switch req.Action {
 	case "allow", "allow_all":
 		// Enforce single ongoing task per workspace
-		uid := monoflake.IDFromBase62(req.UserID).Int64()
-		tasks, err := c.repository.ListTasks(ctx, entity.ListTasksRequest{WorkspaceID: req.WorkspaceID}, uid)
-		if err == nil {
-			for _, t := range tasks {
-				if t.Status == "ongoing" && t.ID != req.TaskID {
-					return nil, fmt.Errorf("another task is already ongoing in this workspace")
-				}
-			}
+		ongoing, err := c.otherTaskOngoing(ctx, req.WorkspaceID, req.TaskID, uid)
+		if err != nil {
+			return nil, err
+		}
+		if ongoing {
+			return nil, fmt.Errorf("another task is already ongoing in this workspace")
 		}
 		m.Status = "ongoing"
 		createMsg = true
@@ -322,14 +339,12 @@ func (c *controller) UpdateTaskStatus(ctx context.Context, req entity.UpdateTask
 
 	if req.Status == "ongoing" {
 		// Enforce single ongoing task per workspace
-		uid := monoflake.IDFromBase62(req.UserID).Int64()
-		tasks, err := c.repository.ListTasks(ctx, entity.ListTasksRequest{WorkspaceID: req.WorkspaceID}, uid)
-		if err == nil {
-			for _, t := range tasks {
-				if t.Status == "ongoing" && t.ID != req.TaskID {
-					return nil, fmt.Errorf("another task is already ongoing in this workspace")
-				}
-			}
+		ongoing, err := c.otherTaskOngoing(ctx, req.WorkspaceID, req.TaskID, uid)
+		if err != nil {
+			return nil, err
+		}
+		if ongoing {
+			return nil, fmt.Errorf("another task is already ongoing in this workspace")
 		}
 	}
 

--- a/backend/internal/controller/crud/task_test.go
+++ b/backend/internal/controller/crud/task_test.go
@@ -395,6 +395,25 @@ func TestListTasks_Empty(t *testing.T) {
 	}
 }
 
+func expectOngoingQuery(t *testing.T, e *testEnv, workspaceID int64, ret []model.Task, retErr error) {
+	t.Helper()
+	e.repo.EXPECT().ListTasks(gomock.Any(), gomock.Any(), testUserID).DoAndReturn(
+		func(_ context.Context, req entity.ListTasksRequest, _ int64) ([]model.Task, error) {
+			if len(req.Status) != 1 || req.Status[0] != "ongoing" {
+				t.Errorf("expected the guard to query status=[ongoing], got %v", req.Status)
+			}
+			if req.WorkspaceID != workspaceID {
+				t.Errorf("expected workspace %d, got %d", workspaceID, req.WorkspaceID)
+			}
+			// The task being transitioned may itself already be ongoing and take
+			// the first row, so a limit of 1 could hide a second ongoing task.
+			if req.Limit < 2 {
+				t.Errorf("expected a limit of at least 2, got %d", req.Limit)
+			}
+			return ret, retErr
+		})
+}
+
 // ── RespondToTask ─────────────────────────────────────────────────────────────
 
 func TestRespondToTask_Allow(t *testing.T) {
@@ -405,7 +424,9 @@ func TestRespondToTask_Allow(t *testing.T) {
 
 	e.repo.EXPECT().GetWorkspace(gomock.Any(), int64(1), testUserID).Return(activeWorkspace(), nil)
 	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(10), testUserID).Return(task, nil)
-	e.repo.EXPECT().ListTasks(gomock.Any(), gomock.Any(), testUserID).Return([]model.Task{task}, nil)
+	// The only ongoing row is this task itself, which the guard must exclude by
+	// ID rather than treat as a conflict.
+	expectOngoingQuery(t, e, 1, []model.Task{{ID: 10, WorkspaceID: 1, Status: "ongoing"}}, nil)
 	e.idgen.EXPECT().NextID().Return(int64(100)) // attachment ID (always server-generated)
 	e.idgen.EXPECT().NextID().Return(int64(101)) // message ID
 	e.storage.EXPECT().Save(gomock.Any(), "data1").Return(nil)
@@ -433,7 +454,8 @@ func TestRespondToTask_AllowAll(t *testing.T) {
 
 	e.repo.EXPECT().GetWorkspace(gomock.Any(), int64(1), testUserID).Return(activeWorkspace(), nil)
 	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(10), testUserID).Return(task, nil)
-	e.repo.EXPECT().ListTasks(gomock.Any(), gomock.Any(), testUserID).Return([]model.Task{task}, nil)
+	// Same self-exclusion check on the allow_all branch.
+	expectOngoingQuery(t, e, 1, []model.Task{{ID: 10, WorkspaceID: 1, Status: "ongoing"}}, nil)
 	e.idgen.EXPECT().NextID().Return(int64(100))
 	e.repo.EXPECT().CreateMessage(gomock.Any(), gomock.Any()).Return(nil)
 	e.repo.EXPECT().UpdateTask(gomock.Any(), gomock.Any()).Return(updated, nil)
@@ -447,6 +469,43 @@ func TestRespondToTask_AllowAll(t *testing.T) {
 	}
 	if resp.Task.Status != "ongoing" {
 		t.Errorf("expected status ongoing")
+	}
+}
+
+func TestRespondToTask_AllowOngoingConflict(t *testing.T) {
+	e := newTestController(t)
+
+	// Approving a task while another is ongoing must be refused, and must not
+	// write anything: no CreateMessage and no UpdateTask are expected.
+	task := model.Task{ID: 10, WorkspaceID: 1, Status: "notstarted"}
+	other := model.Task{ID: 11, WorkspaceID: 1, Status: "ongoing"}
+
+	e.repo.EXPECT().GetWorkspace(gomock.Any(), int64(1), testUserID).Return(activeWorkspace(), nil)
+	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(10), testUserID).Return(task, nil)
+	expectOngoingQuery(t, e, 1, []model.Task{other}, nil)
+
+	_, err := e.controller.RespondToTask(context.Background(), entity.RespondToTaskRequest{
+		WorkspaceID: 1, TaskID: 10, Action: "allow", UserID: testUserIDStr,
+	})
+	if err == nil || !strings.Contains(err.Error(), "another task is already ongoing") {
+		t.Fatalf("expected ongoing conflict error, got %v", err)
+	}
+}
+
+func TestRespondToTask_AllowAllOngoingLookupFailsClosed(t *testing.T) {
+	e := newTestController(t)
+
+	task := model.Task{ID: 10, WorkspaceID: 1, Status: "notstarted"}
+
+	e.repo.EXPECT().GetWorkspace(gomock.Any(), int64(1), testUserID).Return(activeWorkspace(), nil)
+	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(10), testUserID).Return(task, nil)
+	expectOngoingQuery(t, e, 1, nil, fmt.Errorf("db unavailable"))
+
+	_, err := e.controller.RespondToTask(context.Background(), entity.RespondToTaskRequest{
+		WorkspaceID: 1, TaskID: 10, Action: "allow_all", UserID: testUserIDStr,
+	})
+	if err == nil || !strings.Contains(err.Error(), "db unavailable") {
+		t.Fatalf("expected the lookup error to surface, got %v", err)
 	}
 }
 
@@ -520,7 +579,7 @@ func TestUpdateTaskStatus_OngoingConflict(t *testing.T) {
 
 	e.repo.EXPECT().GetWorkspace(gomock.Any(), int64(1), testUserID).Return(activeWorkspace(), nil)
 	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(10), testUserID).Return(task, nil)
-	e.repo.EXPECT().ListTasks(gomock.Any(), gomock.Any(), testUserID).Return([]model.Task{ongoing}, nil)
+	expectOngoingQuery(t, e, 1, []model.Task{ongoing}, nil)
 
 	_, err := e.controller.UpdateTaskStatus(context.Background(), entity.UpdateTaskStatusRequest{
 		WorkspaceID: 1, TaskID: 10, Status: "ongoing", UserID: testUserIDStr,
@@ -564,6 +623,70 @@ func TestUpdateTaskStatus_InvalidStatus(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "invalid task status") {
 		t.Fatalf("expected invalid status error, got %v", err)
+	}
+}
+
+func TestUpdateTaskStatus_OngoingAllowsSelf(t *testing.T) {
+	e := newTestController(t)
+
+	// The only ongoing task is this one, so re-asserting "ongoing" is not a
+	// conflict with itself.
+	task := model.Task{ID: 10, WorkspaceID: 1, Status: "ongoing"}
+	updated := model.Task{ID: 10, WorkspaceID: 1, Status: "ongoing"}
+
+	e.repo.EXPECT().GetWorkspace(gomock.Any(), int64(1), testUserID).Return(activeWorkspace(), nil)
+	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(10), testUserID).Return(task, nil)
+	expectOngoingQuery(t, e, 1, []model.Task{task}, nil)
+	e.repo.EXPECT().UpdateTask(gomock.Any(), gomock.Any()).Return(updated, nil)
+
+	resp, err := e.controller.UpdateTaskStatus(context.Background(), entity.UpdateTaskStatusRequest{
+		WorkspaceID: 1, TaskID: 10, Status: "ongoing", UserID: testUserIDStr,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Task.Status != "ongoing" {
+		t.Errorf("expected status ongoing, got %s", resp.Task.Status)
+	}
+}
+
+func TestUpdateTaskStatus_OngoingConflictBehindSelf(t *testing.T) {
+	e := newTestController(t)
+
+	// The task under transition is already ongoing and comes back first; the
+	// conflicting task is behind it. Asking for a single row would have missed
+	// it entirely.
+	task := model.Task{ID: 10, WorkspaceID: 1, Status: "ongoing"}
+	other := model.Task{ID: 11, WorkspaceID: 1, Status: "ongoing"}
+
+	e.repo.EXPECT().GetWorkspace(gomock.Any(), int64(1), testUserID).Return(activeWorkspace(), nil)
+	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(10), testUserID).Return(task, nil)
+	expectOngoingQuery(t, e, 1, []model.Task{task, other}, nil)
+
+	_, err := e.controller.UpdateTaskStatus(context.Background(), entity.UpdateTaskStatusRequest{
+		WorkspaceID: 1, TaskID: 10, Status: "ongoing", UserID: testUserIDStr,
+	})
+	if err == nil || !strings.Contains(err.Error(), "another task is already ongoing") {
+		t.Fatalf("expected ongoing conflict error, got %v", err)
+	}
+}
+
+func TestUpdateTaskStatus_OngoingLookupFailsClosed(t *testing.T) {
+	e := newTestController(t)
+
+	// A guard that cannot verify must not let the task through: no UpdateTask
+	// is expected here, and gomock fails the test if one happens.
+	task := model.Task{ID: 10, WorkspaceID: 1, Status: "notstarted"}
+
+	e.repo.EXPECT().GetWorkspace(gomock.Any(), int64(1), testUserID).Return(activeWorkspace(), nil)
+	e.repo.EXPECT().GetTask(gomock.Any(), int64(1), int64(10), testUserID).Return(task, nil)
+	expectOngoingQuery(t, e, 1, nil, fmt.Errorf("db unavailable"))
+
+	_, err := e.controller.UpdateTaskStatus(context.Background(), entity.UpdateTaskStatusRequest{
+		WorkspaceID: 1, TaskID: 10, Status: "ongoing", UserID: testUserIDStr,
+	})
+	if err == nil || !strings.Contains(err.Error(), "db unavailable") {
+		t.Fatalf("expected the lookup error to surface, got %v", err)
 	}
 }
 


### PR DESCRIPTION
**What changed**

Both places that enforce "one ongoing task per workspace" now ask the repository for ongoing tasks directly, instead of fetching a page of every task in the workspace and filtering it in Go. The check moves into one otherTaskOngoing helper that RespondToTask (the allow / allow_all branch) and UpdateTaskStatus both call.

Two smaller things came with it. The helper asks for two rows rather than one, because the task being transitioned may itself already be ongoing and take the only row, which would hide a genuine conflict behind it. And a failed lookup now returns its error instead of being swallowed by if err == nil, so the guard no longer silently disengages when it cannot verify.

**Why changed**

repository.ListTasks caps an unfiltered request at 100 rows ordered created_at desc — a deliberate safety limit against OOM. Both guards called it with no status filter and no limit, so they only ever saw the 100 most recently created tasks and scanned those for status == "ongoing".

In a workspace past that mark, an older task still sitting in ongoing falls outside the page. The guard finds nothing, and a second task goes ongoing. That is a normal state for a long-lived workspace: tasks accumulate, and a long-running one ages out of the newest hundred.

Worth being precise about what this is, because the old code reads like a concurrency guard and is not one. It is a check-then-act across two round-trips with no transaction and no row lock, so two genuinely concurrent approvals would still both pass it. What was actually broken is simpler and more common: a deterministic wrong answer on a sequential path. One person, one click, one stale page of results. That is the failure this fixes.

The filtered query is also the pattern already used elsewhere for the same question — mcp/server.go:1863 and :2037 both ask Status: ["ongoing", "blocked"], Limit: 1.

**Test coverage report**

otherTaskOngoing is at 100% of statements. UpdateTaskStatus rises to 90.3% and RespondToTask to 88.5%; the crud package total is 71.8%. Full backend suite passes.

AI-Assisted: Opus 5