### PR TITLE
feat(extensions): install one from the catalogue, and say when you cannot

### DIFF
--- a/desktop/src/main/extensions/runtime.js
+++ b/desktop/src/main/extensions/runtime.js
@@ -1,5 +1,6 @@
 import { checkCompatibility, parseManifest } from './manifest.js'
 import { checkShortcuts, requestedKeys } from './shortcuts.js'
+import { releaseSource } from './source.js'
 import { entriesFor, invokeEntry, registryFor } from './surfaces.js'
 
 /**
@@ -158,6 +159,38 @@ export function createRuntime({
    * afterwards would refuse exactly those calls, and the extension author would
    * see a permission error for a permission the user had granted.
    */
+  /**
+   * The half of an install that is the same whichever source it came from:
+   * store the settings, record the grant, and start it.
+   *
+   * Shared rather than written twice, because the order matters — settings are
+   * written before the extension runs, and a refused write undoes the install
+   * rather than leaving one configured with half its values.
+   */
+  async function settle(installed, manifest, { grant = null, config = null } = {}) {
+    const name = manifest.name
+
+    if (config) {
+      // Always an array: `parseManifest` normalises it, and this manifest came
+      // from there.
+      const saved = await configStore.save(name, manifest.config, config)
+      // Refused rather than written in the clear — a machine with no secure
+      // storage does not get a plaintext credential — and refusing the whole
+      // install is right, because an extension configured with half its
+      // settings is one that fails somewhere less obvious.
+      if (!saved.ok) {
+        await installer.uninstall(name)
+        return saved
+      }
+    }
+
+    if (grant) grants.set(name, grant)
+    const started = await start({ ...installed.installation, grant: grants.get(name) ?? null })
+    if (!started.ok) return { ok: true, installation: installed.installation, loadFailure: started.reason }
+
+    return { ok: true, installation: installed.installation, ...started }
+  }
+
   async function start(installation) {
     const grant = clampToManifest(installation.grant ?? grants.get(installation.name), installation.manifest)
     if (grant) {
@@ -291,25 +324,47 @@ export function createRuntime({
       const installed = await installer.install({ kind: 'local', path }, { linked: true })
       if (!installed.ok) return installed
 
-      if (config) {
-        // Always an array: `parseManifest` normalises it, and this manifest came
-        // from there.
-        const saved = await configStore.save(name, inspected.manifest.config, config)
-        // Refused rather than written in the clear — a machine with no secure
-        // storage does not get a plaintext credential — and refusing the whole
-        // install is right, because an extension configured with half its
-        // settings is one that fails somewhere less obvious.
-        if (!saved.ok) {
-          await installer.uninstall(name)
-          return saved
-        }
-      }
+      return settle(installed, inspected.manifest, { grant, config })
+    },
 
-      if (grant) grants.set(name, grant)
-      const started = await start({ ...installed.installation, grant: grants.get(name) ?? null })
-      if (!started.ok) return { ok: true, installation: installed.installation, loadFailure: started.reason }
+    /**
+     * Install a catalogue entry from the release its manifest names.
+     *
+     * The counterpart to `installLocal`, and deliberately **not** linked: a
+     * downloaded release is a copy this app owns, so removing the extension
+     * removes it. A folder is the author's own working copy and is only
+     * recorded.
+     *
+     * The entry is passed in rather than looked up here because the caller
+     * resolves it from its own index — nothing a renderer sends is trusted to
+     * describe what gets downloaded, and the digest in the manifest is what
+     * decides whether the bytes are the ones that were promised.
+     */
+    async installFromCatalogue(entry, { grant = null, config = null } = {}) {
+      const built = releaseSource(entry)
+      if (!built.ok) return built
 
-      return { ok: true, installation: installed.installation, ...started }
+      if (!entry?.ok) return fail(entry?.reason ?? 'That manifest could not be read.')
+      // `reasons` is never empty when `compatible` is false — `decorate` sets the
+      // two together from `checkCompatibility`, which pushes one before it can
+      // say no — so there is nothing to fall back to.
+      if (entry.compatible === false) return fail(entry.reasons.join(' '))
+
+      const name = entry.manifest?.name
+      if (!name) return fail('That catalogue entry names no extension.')
+
+      // The name is an address, so a reinstall replaces what is there rather
+      // than installing beside it. Stopping first means the old one is not still
+      // registered when the new one claims the same names.
+      if (host.list().some((installed) => installed.name === name)) host.stop(name)
+
+      const installed = await installer.install(built.source)
+      if (!installed.ok) return installed
+
+      // The manifest inside the downloaded package, not the catalogue's copy of
+      // it: the digest proves they are the same bytes, and the one that was
+      // actually unpacked is the one whose settings get saved.
+      return settle(installed, installed.installation.manifest ?? entry.manifest, { grant, config })
     },
 
     /**

--- a/desktop/src/main/index.js
+++ b/desktop/src/main/index.js
@@ -935,6 +935,22 @@ function registerIpc(getWindow) {
     return extensions.installLocal(path, { grant, config })
   })
 
+  ipcMain.handle('agentrq:extensions:install-catalogue', async (_event, { fullName, grant, config } = {}) => {
+    if (!extensions) return { ok: false, reason: 'Extensions are unavailable.' }
+    if (!fullName) return { ok: false, reason: 'No extension was chosen.' }
+
+    // Looked up here rather than taken from the renderer: the entry decides
+    // which release is downloaded and which digest it is checked against, and
+    // that is not a decision to accept from the page.
+    const index = (await discovery?.list()) ?? { entries: [] }
+    const entry = decorate(index, serverTools(app.getVersion())).entries.find(
+      (candidate) => candidate.fullName === fullName,
+    )
+    if (!entry) return { ok: false, reason: 'That extension is no longer in the catalogue.' }
+
+    return extensions.installFromCatalogue(entry, { grant, config })
+  })
+
   ipcMain.handle('agentrq:extensions:uninstall', async (_event, name) =>
     (await extensions?.remove(name)) ?? { ok: false, reason: 'Extensions are unavailable.' },
   )

--- a/desktop/src/preload/index.js
+++ b/desktop/src/preload/index.js
@@ -164,6 +164,16 @@ contextBridge.exposeInMainWorld('agentrq', {
     installLocal: (path, { grant = null, config = null } = {}) =>
       ipcRenderer.invoke('agentrq:extensions:install-local', { path, grant, config }),
 
+    /**
+     * Install a catalogue entry, named rather than described.
+     *
+     * Only the repository name crosses the bridge: the main process resolves it
+     * against its own index, so what gets downloaded is decided by what this app
+     * discovered, never by what the page says it discovered.
+     */
+    installFromCatalogue: (fullName, { grant = null, config = null } = {}) =>
+      ipcRenderer.invoke('agentrq:extensions:install-catalogue', { fullName, grant, config }),
+
     /** Remove it, its settings, its grant and anything it scheduled. */
     uninstall: (name) => ipcRenderer.invoke('agentrq:extensions:uninstall', name),
 

--- a/desktop/test/extensions/runtime.test.js
+++ b/desktop/test/extensions/runtime.test.js
@@ -407,6 +407,126 @@ describe('installLocal', () => {
   })
 })
 
+describe('installFromCatalogue', () => {
+  /** A catalogue entry, as the main process hands one over. */
+  const entry = (over = {}) => ({
+    fullName: 'owner/standup',
+    ok: true,
+    compatible: true,
+    reasons: [],
+    manifest: manifest(),
+    ...over,
+  })
+
+  it('installs the release the manifest names, and not as a linked folder', async () => {
+    const { runtime, installer, order } = build()
+    const grant = { scope: 'workspace', workspaces: ['ws1'], tools: { workspace: ['listTasks'], supervisor: [] } }
+
+    const result = await runtime.installFromCatalogue(entry(), { grant })
+
+    expect(result.ok).toBe(true)
+    // Not linked: a downloaded release is a copy this app owns, so removing the
+    // extension removes it. Only a folder is the author's own working copy.
+    expect(installer.install).toHaveBeenCalledWith({
+      kind: 'release',
+      name: 'standup',
+      repo: 'owner/standup',
+      release: 'v1.0.0',
+      asset: 'standup.tgz',
+      sha256: 'a'.repeat(64),
+    })
+    expect(order).toEqual(['install', 'setGrant', 'start', 'reconcile'])
+  })
+
+  it('refuses an entry with no release to install', async () => {
+    const { runtime, installer } = build()
+    const noRelease = entry({ manifest: manifest({ artifact: undefined }) })
+
+    expect((await runtime.installFromCatalogue(noRelease)).reason).toContain('no release to install')
+    expect(installer.install).not.toHaveBeenCalled()
+  })
+
+  it('refuses a manifest that never parsed, in the words it failed with', async () => {
+    const { runtime, installer } = build()
+
+    const result = await runtime.installFromCatalogue(entry({ ok: false, reason: '"license" is required.' }))
+
+    expect(result.reason).toBe('"license" is required.')
+    expect(installer.install).not.toHaveBeenCalled()
+  })
+
+  it('still says something when a broken entry carries no reason', async () => {
+    const { runtime } = build()
+
+    expect((await runtime.installFromCatalogue(entry({ ok: false }))).reason).toBe(
+      'That manifest could not be read.',
+    )
+  })
+
+  it('refuses one that cannot run here, before downloading anything', async () => {
+    const { runtime, installer } = build()
+    const wrong = entry({ compatible: false, reasons: ['Needs AgentRQ >=9.'] })
+
+    expect((await runtime.installFromCatalogue(wrong)).reason).toBe('Needs AgentRQ >=9.')
+    expect(installer.install).not.toHaveBeenCalled()
+  })
+
+  it('refuses an entry that names no extension', async () => {
+    const { runtime } = build()
+    const nameless = entry({ manifest: { ...manifest(), name: '' } })
+
+    expect((await runtime.installFromCatalogue(nameless)).reason).toBe(
+      'That catalogue entry names no extension.',
+    )
+  })
+
+  // The name is an address, so a reinstall replaces what is there rather than
+  // installing beside it — and the old one must not still be registered when the
+  // new one claims the same names.
+  it('stops what is already running under that name first', async () => {
+    const { runtime, host, order } = build()
+    await runtime.installLocal('/tmp/standup')
+    order.length = 0
+
+    await runtime.installFromCatalogue(entry())
+
+    expect(host.stop).toHaveBeenCalledWith('standup')
+    expect(order.indexOf('stop')).toBeLessThan(order.indexOf('install'))
+  })
+
+  it('carries a refused download through as it was given', async () => {
+    const { runtime } = build({
+      installer: { install: vi.fn(async () => ({ ok: false, reason: 'That checksum did not match.' })) },
+    })
+
+    expect((await runtime.installFromCatalogue(entry())).reason).toBe('That checksum did not match.')
+  })
+
+  // The manifest inside the downloaded package decides, not the catalogue's copy
+  // of it — the digest proves they are the same bytes, and the one unpacked is
+  // the one whose settings are saved.
+  it('saves settings against the manifest that was actually unpacked', async () => {
+    const { runtime, configStore } = build()
+
+    await runtime.installFromCatalogue(entry(), { config: { since: 8 } })
+
+    expect(configStore.save).toHaveBeenCalledWith('standup', manifest().config, { since: 8 })
+  })
+
+  it('falls back to the catalogue manifest when the install reports none', async () => {
+    const { runtime, configStore } = build({
+      installer: {
+        install: vi.fn(async () => ({ ok: true, installation: { name: 'standup', enabled: true, failures: 0 } })),
+      },
+    })
+
+    const result = await runtime.installFromCatalogue(entry(), { config: { since: 8 } })
+
+    expect(result.ok).toBe(true)
+    expect(configStore.save).toHaveBeenCalledWith('standup', manifest().config, { since: 8 })
+  })
+})
+
 describe('remove', () => {
   // The whole reason this function exists in one place.
   it('takes the standing work down while the grant still exists', async () => {

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -509,6 +509,36 @@ paths that deliberately say the status code and nothing else.
 The digest is what makes an install honest: a git tag can be moved under one that
 is already in place, and a hash cannot.
 
+### Step 3 is not optional, and the catalogue says so
+
+An extension is installed from the release asset its manifest names, fetched by
+name and checked against that digest. Until all three of `release`, `asset` and a
+real `sha256` are there, **there is nothing to install** — so the catalogue lists
+the extension under **Unavailable**, with the reason written on the row, and
+offers no Install button:
+
+| What the manifest says | What the row says |
+|---|---|
+| no `artifact` block, or no `release` / `asset` | This extension has not published a release yet, so there is nothing to install. |
+| an `artifact` whose `sha256` is absent, malformed, or all zeroes | This extension names a release but no checksum for it, so it cannot be verified. |
+
+A placeholder digest of zeroes is the common case, because it is what a manifest
+carries while the first release is still being prepared. It reads as *ready* to
+its author and as *not installable* to everybody else, which is exactly why the
+row says which it is rather than leaving somebody hunting for a button.
+
+Hash the asset you actually upload, and put that digest on the default branch —
+the catalogue reads `agentrq-extension.json` from the branch, not from inside the
+package, so the two are allowed to differ and only the branch copy decides:
+
+```bash
+npm pack                                   # or however the asset is built
+shasum -a 256 your-extension-1.0.0.tgz     # this goes in artifact.sha256
+```
+
+The asset must unpack to a **single top-level directory** — what `npm pack`
+produces — because the installer strips one level when it extracts.
+
 ### Installing without publishing
 
 **Extensions → Install from folder**, then pick the folder holding
@@ -528,9 +558,19 @@ Try it with the examples:
 Extensions → Install from folder → examples/extensions/task-stats
 ```
 
-The installer also supports **a release**, verified against the digest, and **a
-git URL** cloned at a commit for a private repository — those are how a published
-extension arrives.
+### Installing from the catalogue
+
+Anything listed under **Available** has a release to fetch, and its row carries
+an **Install** button. It asks the same permission-and-settings question the
+folder install asks, and for the same reason — an extension that asks for
+nothing installs without that step.
+
+A release install is **copied**, not linked: the app owns what it downloaded, so
+uninstalling removes it. Only a folder is left alone, because a folder is the
+author's own working copy.
+
+The installer also supports **a git URL** cloned at a commit, for a private
+repository.
 
 ### Managing what is installed
 

--- a/frontend/src/composables/useExtensionCatalogue.js
+++ b/frontend/src/composables/useExtensionCatalogue.js
@@ -42,7 +42,9 @@ const SCOPE_SUPERVISOR = 'supervisor';
 export function groupFor(entry, { installed = false } = {}) {
   if (installed) return 'installed';
   if (!entry.ok || !entry.compatible) return 'unavailable';
-  return 'available';
+  // Available means installable. An entry with no release to fetch belongs with
+  // the rest of what cannot be used, next to the sentence saying why.
+  return releaseProblem(entry) ? 'unavailable' : 'available';
 }
 
 /**
@@ -55,6 +57,36 @@ export function groupFor(entry, { installed = false } = {}) {
 export function blockedReason(entry) {
   if (!entry.ok) return entry.reason ?? 'This manifest could not be read.';
   if (!entry.compatible) return (entry.reasons ?? []).join(' ');
+  return releaseProblem(entry);
+}
+
+/** A digest of nothing: what a manifest carries before there is a release. */
+const PLACEHOLDER_DIGEST = /^0+$/;
+const SHA256 = /^[0-9a-f]{64}$/i;
+
+/**
+ * Why this entry has nothing to install, or '' when it has.
+ *
+ * An extension is installed from the release asset its manifest names, pinned
+ * by digest — the tag is mutable, so without the digest "install v1.2.0" is a
+ * promise nobody is keeping. An entry that names no asset, or names one with a
+ * placeholder digest, therefore cannot be installed at all.
+ *
+ * Said rather than discovered by pressing the button. The catalogue is
+ * uncurated, and an entry whose author has not cut a release yet looks exactly
+ * like one who has until you try — which leaves somebody hunting for a control
+ * that was never going to work.
+ */
+export function releaseProblem(entry) {
+  const artifact = entry?.manifest?.artifact;
+  if (!artifact?.release || !artifact?.asset) {
+    return 'This extension has not published a release yet, so there is nothing to install.';
+  }
+
+  const digest = String(artifact.sha256 ?? '');
+  if (!SHA256.test(digest) || PLACEHOLDER_DIGEST.test(digest)) {
+    return 'This extension names a release but no checksum for it, so it cannot be verified.';
+  }
   return '';
 }
 
@@ -155,6 +187,22 @@ export function toRows(index, { installed = [] } = {}) {
  */
 function byStarsThenName(a, b) {
   return (b.stars ?? 0) - (a.stars ?? 0) || String(a.fullName).localeCompare(String(b.fullName));
+}
+
+/**
+ * How much this extension has to ask a person before it can be installed.
+ *
+ * Settings count alongside permissions. They are entered on that same screen and
+ * on no other, so an extension declaring a config field but no permission would
+ * otherwise install straight past the only place its values could ever be given
+ * — and then run with every setting blank.
+ */
+export function asksFor(manifest) {
+  return (
+    (manifest?.mcp?.workspace ?? []).length +
+    (manifest?.mcp?.supervisor ?? []).length +
+    (manifest?.config ?? []).length
+  );
 }
 
 /** The install flow's states. A grant is a question, so there is a step for it. */
@@ -270,16 +318,36 @@ export function useExtensionCatalogue({ bridge = globalThis.window?.agentrq?.ext
       return;
     }
 
-    candidate.value = found;
-    const asks =
-      (found.manifest?.mcp?.workspace ?? []).length +
-      (found.manifest?.mcp?.supervisor ?? []).length +
-      // Settings count as something to ask about. They are entered on that same
-      // screen and on no other, so an extension declaring a config field but no
-      // permission would otherwise install straight past the only place its
-      // values could ever be given — and then run with every setting blank.
-      (found.manifest?.config ?? []).length;
-    if (asks === 0) {
+    candidate.value = { ...found, kind: 'folder' };
+    if (asksFor(found.manifest) === 0) {
+      await install({ grant: null, config: null });
+      return;
+    }
+    step.value = INSTALL_STEP.asking;
+  }
+
+  /**
+   * Install a catalogue row, asking about permissions if it asks for any.
+   *
+   * Only the repository name is sent. The main process resolves it against its
+   * own index, so the release that gets downloaded and the digest it is checked
+   * against are decided by what this app discovered, not by what this screen is
+   * holding.
+   */
+  async function beginInstall(row) {
+    if (!bridge || !row || row.installed) return;
+    error.value = '';
+    notice.value = '';
+
+    // Should not be reachable — a blocked row offers no button — but a row that
+    // says why it cannot be used must not install anyway if one is ever added.
+    if (row.blocked) {
+      error.value = row.blocked;
+      return;
+    }
+
+    candidate.value = { ...row, kind: 'catalogue' };
+    if (asksFor(row.manifest) === 0) {
       await install({ grant: null, config: null });
       return;
     }
@@ -293,7 +361,10 @@ export function useExtensionCatalogue({ bridge = globalThis.window?.agentrq?.ext
     error.value = '';
 
     try {
-      const result = await bridge.installLocal(candidate.value.path, { grant, config });
+      const result =
+        candidate.value.kind === 'catalogue'
+          ? await bridge.installFromCatalogue(candidate.value.fullName, { grant, config })
+          : await bridge.installLocal(candidate.value.path, { grant, config });
       if (!result?.ok) {
         error.value = result?.reason || 'That extension could not be installed.';
         return;
@@ -384,6 +455,7 @@ export function useExtensionCatalogue({ bridge = globalThis.window?.agentrq?.ext
     load,
     refresh,
     chooseFolder,
+    beginInstall,
     install,
     cancelInstall,
     uninstall,

--- a/frontend/src/desktop/ExtensionsView.vue
+++ b/frontend/src/desktop/ExtensionsView.vue
@@ -130,6 +130,13 @@
                 </span>
               </template>
               <template v-else>
+                <!-- Offered only where there is a release to fetch. A blocked
+                     row says why instead, which is the answer somebody actually
+                     needs — a button that fails on press is worse than none. -->
+                <button v-if="!row.blocked" type="button" @click="beginInstall(row)" :disabled="busy"
+                        class="text-[10px] font-bold uppercase tracking-wider text-black dark:text-white hover:opacity-70 disabled:opacity-40 transition-opacity">
+                  Install
+                </button>
                 <a :href="row.url" target="_blank" rel="noopener noreferrer"
                    class="text-[10px] font-bold uppercase tracking-wider text-gray-500 dark:text-zinc-400 hover:text-black dark:hover:text-white transition-colors">
                   View on GitHub
@@ -196,6 +203,7 @@ const {
   load,
   refresh,
   chooseFolder,
+  beginInstall,
   install,
   cancelInstall,
   uninstall,

--- a/frontend/test/extensionCatalogue.test.js
+++ b/frontend/test/extensionCatalogue.test.js
@@ -18,6 +18,16 @@ import {
  * itself" — every row that cannot be used says why, and nothing is hidden.
  */
 
+/**
+ * A published release, which is what makes an entry installable at all: the
+ * asset is fetched by name and pinned by digest.
+ */
+const RELEASE = {
+  release: 'v1.0.0',
+  asset: 'thing-1.0.0.tgz',
+  sha256: 'a'.repeat(64),
+};
+
 const entry = (over = {}) => ({
   fullName: 'owner/thing',
   owner: 'owner',
@@ -25,7 +35,7 @@ const entry = (over = {}) => ({
   ok: true,
   compatible: true,
   reasons: [],
-  manifest: { name: 'thing', displayName: 'Thing', license: 'MIT' },
+  manifest: { name: 'thing', displayName: 'Thing', license: 'MIT', artifact: { ...RELEASE } },
   ...over,
 });
 
@@ -55,6 +65,48 @@ describe('groupFor', () => {
 describe('blockedReason', () => {
   it('is empty for something that works', () => {
     expect(blockedReason(entry())).toBe('');
+  });
+
+  // The catalogue is uncurated, and an author who has not cut a release yet
+  // looks exactly like one who has — until you press a button that was never
+  // going to work. Saying so is the answer somebody actually needs.
+  it('says when there is no release to install', () => {
+    const noRelease = entry({ manifest: { name: 'thing', displayName: 'Thing', license: 'MIT' } });
+
+    expect(blockedReason(noRelease)).toBe(
+      'This extension has not published a release yet, so there is nothing to install.',
+    );
+    expect(groupFor(noRelease)).toBe('unavailable');
+  });
+
+  it('says when the release names no usable checksum', () => {
+    // A tag is mutable: an author can move v1.2.0 to different code after you
+    // installed it, so without a digest "install v1.2.0" promises nothing.
+    const placeholder = entry({
+      manifest: { name: 'thing', license: 'MIT', artifact: { ...RELEASE, sha256: '0'.repeat(64) } },
+    });
+    const nonsense = entry({
+      manifest: { name: 'thing', license: 'MIT', artifact: { ...RELEASE, sha256: 'not-a-digest' } },
+    });
+    const absent = entry({
+      manifest: { name: 'thing', license: 'MIT', artifact: { release: 'v1', asset: 'a.tgz' } },
+    });
+
+    for (const row of [placeholder, nonsense, absent]) {
+      expect(blockedReason(row)).toBe(
+        'This extension names a release but no checksum for it, so it cannot be verified.',
+      );
+      expect(groupFor(row)).toBe('unavailable');
+    }
+  });
+
+  // Half a release is not a release: an asset with no tag cannot be fetched.
+  it('says when the release is only half named', () => {
+    const noAsset = entry({
+      manifest: { name: 'thing', license: 'MIT', artifact: { release: 'v1', sha256: 'a'.repeat(64) } },
+    });
+
+    expect(blockedReason(noAsset)).toContain('has not published a release');
   });
 
   it('reports a manifest that could not be read', () => {
@@ -301,6 +353,7 @@ describe('useExtensionCatalogue', () => {
     refresh: vi.fn(async () => ({ ok: true, index: { entries: [entry(), entry({ fullName: 'b/x' })] } })),
     chooseFolder: vi.fn(async () => found()),
     installLocal: vi.fn(async () => ({ ok: true, installation: { name: 'standup' } })),
+    installFromCatalogue: vi.fn(async () => ({ ok: true, installation: { name: 'thing' } })),
     supervisor: vi.fn(async () => ({ authorized: false })),
     authorize: vi.fn(async () => ({ ok: true })),
     deauthorize: vi.fn(async () => ({ ok: true })),
@@ -308,6 +361,122 @@ describe('useExtensionCatalogue', () => {
     setEnabled: vi.fn(async () => ({ ok: true })),
     configure: vi.fn(async () => ({ ok: true })),
     ...over,
+  });
+
+  describe('installing from the catalogue', () => {
+    const rowFor = async (catalogue) => {
+      await catalogue.load();
+      return catalogue.sections.value.flatMap((section) => section.rows).find((row) => !row.installed);
+    };
+
+    // Only the repository name crosses the bridge. The main process resolves it
+    // against its own index, so the release that gets downloaded is decided by
+    // what the app discovered rather than by what this screen is holding.
+    it('sends the name, not the entry', async () => {
+      const bridge = fakeBridge();
+      const catalogue = useExtensionCatalogue({ bridge });
+      const row = await rowFor(catalogue);
+
+      await catalogue.beginInstall(row);
+
+      expect(bridge.installFromCatalogue).toHaveBeenCalledWith('owner/thing', { grant: null, config: null });
+      expect(catalogue.notice.value).toBe('Thing installed.');
+    });
+
+    // An extension that asks for nothing goes straight to installing.
+    // Interposing a permission screen with nothing on it would train people to
+    // click past the screen that does have something on it.
+    it('stops to ask when the extension asks for something', async () => {
+      const asking = entry({
+        manifest: {
+          name: 'thing',
+          displayName: 'Thing',
+          license: 'MIT',
+          artifact: { ...RELEASE },
+          mcp: { workspace: ['createTask'] },
+        },
+      });
+      const bridge = fakeBridge({ state: vi.fn(async () => ({ index: { entries: [asking] }, installed: [] })) });
+      const catalogue = useExtensionCatalogue({ bridge });
+      const row = await rowFor(catalogue);
+
+      await catalogue.beginInstall(row);
+
+      expect(catalogue.step.value).toBe('asking');
+      expect(bridge.installFromCatalogue).not.toHaveBeenCalled();
+
+      await catalogue.install({ grant: { workspace: ['createTask'] }, config: null });
+
+      expect(bridge.installFromCatalogue).toHaveBeenCalledWith('owner/thing', {
+        grant: { workspace: ['createTask'] },
+        config: null,
+      });
+    });
+
+    // Settings are entered on that same screen and on no other.
+    it('stops to ask for settings alone, with no permission asked for', async () => {
+      const configured = entry({
+        manifest: {
+          name: 'thing',
+          displayName: 'Thing',
+          license: 'MIT',
+          artifact: { ...RELEASE },
+          config: [{ key: 'token', type: 'string', label: 'Token' }],
+        },
+      });
+      const bridge = fakeBridge({ state: vi.fn(async () => ({ index: { entries: [configured] }, installed: [] })) });
+      const catalogue = useExtensionCatalogue({ bridge });
+
+      await catalogue.beginInstall(await rowFor(catalogue));
+
+      expect(catalogue.step.value).toBe('asking');
+    });
+
+    it('carries a refusal through as the sentence it was given', async () => {
+      const bridge = fakeBridge({
+        installFromCatalogue: vi.fn(async () => ({ ok: false, reason: 'That checksum did not match.' })),
+      });
+      const catalogue = useExtensionCatalogue({ bridge });
+
+      await catalogue.beginInstall(await rowFor(catalogue));
+
+      expect(catalogue.error.value).toBe('That checksum did not match.');
+    });
+
+    // Installed but not running is a real outcome and not an error.
+    it('says so when it installed but did not start', async () => {
+      const bridge = fakeBridge({
+        installFromCatalogue: vi.fn(async () => ({ ok: true, loadFailure: 'Cannot find module "x"' })),
+      });
+      const catalogue = useExtensionCatalogue({ bridge });
+
+      await catalogue.beginInstall(await rowFor(catalogue));
+
+      expect(catalogue.notice.value).toBe('Thing installed, but did not start: Cannot find module "x"');
+    });
+
+    // The button is not offered on a blocked row. This is the guard for the day
+    // somebody offers one anyway.
+    it('refuses a row that says why it cannot be used', async () => {
+      const bridge = fakeBridge();
+      const catalogue = useExtensionCatalogue({ bridge });
+
+      await catalogue.beginInstall({ blocked: 'No release.', manifest: {}, fullName: 'a/b' });
+
+      expect(catalogue.error.value).toBe('No release.');
+      expect(bridge.installFromCatalogue).not.toHaveBeenCalled();
+    });
+
+    it('has nothing to do without a bridge, a row, or with one already installed', async () => {
+      const bridge = fakeBridge();
+      const catalogue = useExtensionCatalogue({ bridge });
+
+      await useExtensionCatalogue({ bridge: undefined }).beginInstall({ fullName: 'a/b', manifest: {} });
+      await catalogue.beginInstall(undefined);
+      await catalogue.beginInstall({ installed: true, fullName: 'a/b', manifest: {} });
+
+      expect(bridge.installFromCatalogue).not.toHaveBeenCalled();
+    });
   });
 
   it('stays inert with no bridge, so the web build is absent rather than broken', async () => {


### PR DESCRIPTION
**What changed:** Extensions found on GitHub can now be installed straight from the list, and anything that cannot be installed says why on its row instead of appearing ready.

**Why changed:** The list offered no way to install anything it found. The installer had always supported fetching a release — nothing above it ever called that, so the only route was installing from a local folder.

**Test coverage report:** New lines introduced: 100%. Total coverage impact: none, both gates still 100% on every metric.

| Suite | Tests | Statements | Branches | Functions | Lines |
|---|---|---|---|---|---|
| frontend | 1341 (+10) | 100% | 100% | 100% | 100% |
| desktop | 1132 (+10) | 100% | 100% | 100% | 100% |

**Other reports:**

Two things were wrong, and the second is why a button alone would not have fixed it.

1. **Nothing connected the installer to the screen.** `install.js` has handled a release source since it was written, and `source.js` has `releaseSource(entry)` which builds one from a catalogue entry. No caller existed. Above that layer there was only the folder path — one bridge method, one IPC handler, one composable action — and the row rendered a GitHub link and a date.

2. **"Available" never meant "installable".** It meant the manifest parsed and the engine range matched; it never asked whether there was anything to fetch. An extension is installed from the release asset its manifest names, pinned by SHA-256 — a tag can be moved under one already in place, and a hash cannot — so an entry with no release, or with the placeholder digest of zeroes that a manifest carries before its first release, can never be installed. Those entries sat under Available looking ready. They now read as Unavailable with the reason on the row.

Design notes worth the review:

- **Only the repository name crosses the bridge.** The main process resolves it against its own index, so which release is downloaded and which digest it is checked against are decided by what the app discovered, never by what the page claims it discovered.
- **A release install is copied, not linked.** The app owns what it downloaded, so uninstalling removes it; only a folder is left alone, because that is the author's working copy.
- `installLocal` and the new path now share their tail — save settings, record the grant, start it — instead of stating it twice.
- `docs/EXTENSIONS.md` gains the requirement this exposed: what a publishable `artifact` block needs, how to hash the asset, that the catalogue reads the manifest from the default branch rather than from inside the package, and the two sentences a row shows when it cannot be installed.

Verified in the real app: `npm run verify:extensions` passes, including its check that the bridge exposes every method the renderer calls.

TaskID: 0ibR3HdR3Pl

🤖 Generated with [Claude Code](https://claude.com/claude-code)