### PR TITLE
fix(extensions): create the directory extensions live in

### DIFF
--- a/desktop/src/main/extensions/install.js
+++ b/desktop/src/main/extensions/install.js
@@ -1,3 +1,5 @@
+import { dirname } from 'node:path'
+
 import { parseManifest } from './manifest.js'
 import { checkShortcuts } from './shortcuts.js'
 import { describeSource, pinFor, verifyDigest } from './source.js'
@@ -124,6 +126,7 @@ export function createInstaller({
   fetchSource,
   readManifest,
   move,
+  makeDir,
   remove,
   makeTempDir,
   dirFor,
@@ -243,6 +246,12 @@ export function createInstaller({
 
       const target = dirFor(staged.manifest.name)
       try {
+        // The directory extensions live in need not exist yet. Nothing else
+        // creates it: installing a folder only *records* the path, so the first
+        // thing ever written there is a download — and `rename` reports a
+        // missing parent as ENOENT on the destination, which reads as "could
+        // not install into <target>" and sends you looking at the wrong path.
+        await makeDir(dirname(target))
         // Whatever was there is removed only once the replacement is staged and
         // verified, so a failed update cannot leave the machine with neither.
         await remove(target)
@@ -301,6 +310,7 @@ export function createInstaller({
 
       const target = dirFor(name)
       try {
+        await makeDir(dirname(target))
         await remove(target)
         await move(staged.dir, target)
       } catch (error) {

--- a/desktop/src/main/index.js
+++ b/desktop/src/main/index.js
@@ -1098,6 +1098,7 @@ function buildExtensionRuntime() {
     fetchSource: createFetchSource({ spawn }),
     readManifest,
     move: (from, to) => fsPromises.rename(from, to),
+    makeDir: (dir) => fsPromises.mkdir(dir, { recursive: true }),
     remove: (target) => fsPromises.rm(target, { recursive: true, force: true }),
     makeTempDir,
     dirFor: (name) => join(app.getPath('userData'), 'extensions', name),

--- a/desktop/test/extensions/install.test.js
+++ b/desktop/test/extensions/install.test.js
@@ -37,6 +37,7 @@ function build({ manifest = manifestFor('thing'), fetched = {}, ...over } = {}) 
   let saved = { installations: [] }
   // Mutable so a test can change what the *next* stage finds — which is how an
   // update that asks for more than the version already installed is set up.
+  const made = []
   const current = { manifest }
 
   const deps = {
@@ -48,6 +49,7 @@ function build({ manifest = manifestFor('thing'), fetched = {}, ...over } = {}) 
     })),
     readManifest: vi.fn(async () => current.manifest),
     move: vi.fn(async (from, to) => moved.push([from, to])),
+    makeDir: vi.fn(async (dir) => made.push(dir)),
     remove: vi.fn(async (dir) => removed.push(dir)),
     makeTempDir: vi.fn(async () => '/tmp/stage'),
     dirFor: (name) => `/ext/${name}`,
@@ -66,6 +68,7 @@ function build({ manifest = manifestFor('thing'), fetched = {}, ...over } = {}) 
     deps,
     removed,
     moved,
+    made,
     saved: () => saved,
     /** What the next fetch will find in the package. */
     setManifest: (next) => {
@@ -149,6 +152,36 @@ describe('install', () => {
     expect(installation.pin).toEqual({ kind: 'sha256', value: 'a'.repeat(64) })
     expect(installation.sourceLabel).toBe('acme/thing · v1.0.0')
     expect(saved().installations).toHaveLength(1)
+  })
+
+  // The bug this exists for: the extensions directory need not exist yet.
+  // Nothing else creates it — installing a folder only *records* the path, so
+  // the first thing ever written there is a download — and `rename` reports a
+  // missing parent as ENOENT against the destination, which reads as "could not
+  // install into <target>" and sends somebody looking at the wrong path.
+  it('creates the directory extensions live in before moving into it', async () => {
+    const { installer, made, moved, deps } = build()
+
+    await installer.install(releaseSource())
+
+    expect(made).toEqual(['/ext'])
+    // Before, not after: the move is what needs the parent to be there.
+    expect(deps.makeDir.mock.invocationCallOrder[0]).toBeLessThan(deps.move.mock.invocationCallOrder[0])
+    expect(moved).toEqual([['/tmp/stage/unpacked', '/ext/thing']])
+  })
+
+  it('reports a directory it could not create, rather than the rename that followed', async () => {
+    const { installer, moved } = build({
+      makeDir: vi.fn(async () => {
+        throw new Error('EACCES: permission denied')
+      }),
+    })
+
+    const result = await installer.install(releaseSource())
+
+    expect(result.ok).toBe(false)
+    expect(result.reason).toContain('EACCES')
+    expect(moved).toEqual([])
   })
 
   it('refuses a download that does not match its digest, and leaves nothing behind', async () => {


### PR DESCRIPTION
**What changed:** Installing an extension now creates the folder extensions are kept in, instead of assuming it is already there.

**Why changed:** The very first install on a machine failed. Nothing had ever created that folder — installing from a local folder only records its path, so until an extension is downloaded nothing is written there at all, and downloading is new.

**Test coverage report:** New lines introduced: 100%. Total coverage impact: none, the desktop gate stays at 100% on every metric — 1134 tests (+2), statements 100%, branches 100%, functions 100%, lines 100%.

**Other reports:**

The error named the wrong path, which is worth recording:

```
Could not install into …/agentrq-desktop/extensions/mermaid:
ENOENT: no such file or directory, rename '…/agentrq-ext-4XWZPZ/unpacked'
  -> '…/agentrq-desktop/extensions/mermaid'
```

`rename` reports a missing **parent** as ENOENT against the destination, so the message pointed at the extension's own directory while the thing actually missing was `extensions/` above it.

- The directory is created in the installer rather than in the Electron wiring, because `index.js` is excluded from coverage — a fix there is a fix nobody can test.
- `makeDir` is a **required** dependency with no default. A no-op default would let the same omission return silently; adding it failed 21 existing tests until the double was supplied, which is the check doing its job.
- Both move sites are covered — install and update — though update only runs against something already installed.
- Two tests added: that the directory is created **before** the move, and that a directory which cannot be created is reported as itself rather than as the rename that would have followed.

Confirmed against the reported machine: `extensions/` did not exist when the install failed, and nothing in the tree creates it — the only `mkdir` in the install path is the one `fetch-source` makes for its own temp directory.

TaskID: 0ibR3HdR3Pl

🤖 Generated with [Claude Code](https://claude.com/claude-code)