### PR TITLE
feat(extensions): say plainly that nothing here is reviewed, and that anyone may publish

### DIFF
--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -562,12 +562,30 @@ Extensions → Install from folder → examples/extensions/task-stats
 
 Anything listed under **Available** has a release to fetch, and its row carries
 an **Install** button. It asks the same permission-and-settings question the
-folder install asks, and for the same reason — an extension that asks for
-nothing installs without that step.
+folder install asks — and, unlike the folder install, **it asks every time**,
+even when the extension wants no permission at all.
+
+That difference is deliberate. Picking a folder is running code you already
+have; installing from the catalogue is downloading a stranger's and running it
+with full access to your machine. The screen is not empty in that case either —
+it names the author, the repository, the version and the licence, and carries
+the sentence about machine access — so there is something to read before
+agreeing to it.
 
 A release install is **copied**, not linked: the app owns what it downloaded, so
 uninstalling removes it. Only a folder is left alone, because a folder is the
 author's own working copy.
+
+### Nothing here is reviewed
+
+The catalogue is every repository carrying a topic. There is no review, no
+signing, and no sandbox — an installed extension runs as this app's own code,
+with the app's access to your files, your clipboard and your shell. The screen
+says so above the list, and the install question says so again.
+
+So the decision is about the author, which is why the row leads with who
+published it rather than with what it does. **Install only extensions you
+trust.**
 
 The installer also supports **a git URL** cloned at a commit, for a private
 repository.

--- a/frontend/src/composables/useExtensionCatalogue.js
+++ b/frontend/src/composables/useExtensionCatalogue.js
@@ -346,11 +346,18 @@ export function useExtensionCatalogue({ bridge = globalThis.window?.agentrq?.ext
       return;
     }
 
+    // Always asked, even when the extension wants no permission at all — which
+    // is the one place this differs from the folder install, deliberately.
+    //
+    // The rule there is that a permission screen with nothing on it teaches
+    // people to click past the screen that does have something on it, and that
+    // rule is right: you picked that folder, so you already have the code.
+    // Installing from the catalogue is the other thing. It downloads a
+    // stranger's code and runs it with full access to this machine, and the
+    // screen is not empty — it names the author, the repository, the version
+    // and the licence, and carries the sentence about machine access. That is
+    // the whole of the decision, and it is not one to make by single click.
     candidate.value = { ...row, kind: 'catalogue' };
-    if (asksFor(row.manifest) === 0) {
-      await install({ grant: null, config: null });
-      return;
-    }
     step.value = INSTALL_STEP.asking;
   }
 

--- a/frontend/src/desktop/ExtensionGrantDialog.vue
+++ b/frontend/src/desktop/ExtensionGrantDialog.vue
@@ -6,7 +6,12 @@
         <h2 class="text-lg font-black text-gray-900 dark:text-white">
           Install {{ candidate.manifest.displayName || candidate.manifest.name }}?
         </h2>
-        <p class="text-[11px] text-gray-500 dark:text-zinc-400 mt-1 font-mono truncate">{{ candidate.path }}</p>
+        <!-- Where it is about to come from. A folder shows its path; a
+             catalogue entry shows the repository, because "who published this"
+             is the question being answered by pressing Install. -->
+        <p class="text-[11px] text-gray-500 dark:text-zinc-400 mt-1 font-mono truncate">
+          {{ candidate.path || candidate.fullName }}
+        </p>
 
         <!-- The sentence that is true on every install, whatever else is on the
              screen. It carries the whole weight when the permission list below

--- a/frontend/src/desktop/ExtensionsView.vue
+++ b/frontend/src/desktop/ExtensionsView.vue
@@ -16,11 +16,21 @@
         </div>
       </div>
 
-      <p class="text-[11px] text-gray-500 dark:text-zinc-400 mb-6">
+      <p class="text-[11px] text-gray-500 dark:text-zinc-400 mb-3">
         {{ summary }} ·
         <span class="text-gray-400 dark:text-zinc-500">
           Published by anyone on GitHub under the <code class="font-mono">agentrq-extension</code> topic.
         </span>
+      </p>
+
+      <!-- Standing, not dismissible, and above the list rather than beside a
+           button: the catalogue is uncurated, nobody reviews what appears in it,
+           and an extension runs as this app's own code once installed. The row
+           says who published it because that is the whole of the decision. -->
+      <p class="mb-6 px-3 py-2 rounded-sm border border-amber-200 dark:border-amber-900/60 bg-amber-50 dark:bg-amber-950/30 text-[11px] leading-relaxed text-amber-900 dark:text-amber-200">
+        Install only extensions you trust. Anyone can publish one, nothing here is
+        reviewed, and an extension runs with full access to your computer — there
+        is no sandbox.
       </p>
 
       <div v-if="error"

--- a/frontend/test/extensionCatalogue.test.js
+++ b/frontend/test/extensionCatalogue.test.js
@@ -5,6 +5,7 @@ import {
   INSTALL_STEP,
   blockedReason,
   groupFor,
+  asksFor,
   installedRow,
   statusOf,
   summarise,
@@ -378,9 +379,40 @@ describe('useExtensionCatalogue', () => {
       const row = await rowFor(catalogue);
 
       await catalogue.beginInstall(row);
+      await catalogue.install({ grant: null, config: null });
 
       expect(bridge.installFromCatalogue).toHaveBeenCalledWith('owner/thing', { grant: null, config: null });
       expect(catalogue.notice.value).toBe('Thing installed.');
+    });
+
+    // The one place this differs from the folder install, deliberately. Picking
+    // a folder is running code you already have; installing from the catalogue
+    // downloads a stranger's and runs it with full access to the machine. The
+    // screen is not empty either — it names the author, the repository, the
+    // version and the licence — so there is something to read before agreeing.
+    it('asks before installing even when it wants no permission at all', async () => {
+      const bridge = fakeBridge();
+      const catalogue = useExtensionCatalogue({ bridge });
+      const row = await rowFor(catalogue);
+
+      expect(asksFor(row.manifest)).toBe(0);
+
+      await catalogue.beginInstall(row);
+
+      expect(catalogue.step.value).toBe('asking');
+      expect(bridge.installFromCatalogue).not.toHaveBeenCalled();
+    });
+
+    // Cancelling is a decision, and it must install nothing.
+    it('installs nothing when the question is declined', async () => {
+      const bridge = fakeBridge();
+      const catalogue = useExtensionCatalogue({ bridge });
+
+      await catalogue.beginInstall(await rowFor(catalogue));
+      catalogue.cancelInstall();
+
+      expect(catalogue.step.value).toBe('idle');
+      expect(bridge.installFromCatalogue).not.toHaveBeenCalled();
     });
 
     // An extension that asks for nothing goes straight to installing.
@@ -439,6 +471,7 @@ describe('useExtensionCatalogue', () => {
       const catalogue = useExtensionCatalogue({ bridge });
 
       await catalogue.beginInstall(await rowFor(catalogue));
+      await catalogue.install({ grant: null, config: null });
 
       expect(catalogue.error.value).toBe('That checksum did not match.');
     });
@@ -451,6 +484,7 @@ describe('useExtensionCatalogue', () => {
       const catalogue = useExtensionCatalogue({ bridge });
 
       await catalogue.beginInstall(await rowFor(catalogue));
+      await catalogue.install({ grant: null, config: null });
 
       expect(catalogue.notice.value).toBe('Thing installed, but did not start: Cannot find module "x"');
     });


### PR DESCRIPTION
**What changed:** The extensions screen now carries a standing warning that anyone can publish one and that they run with full access to your computer, installing one from the list always stops to ask first, and the contributing guide explains that building an extension needs no permission from us.

**Why changed:** Nothing on the screen said the catalogue is unreviewed, and an extension requesting no permissions installed on a single click with no confirmation at all — which is exactly the case for the one we just published. Separately, the contributing guide described three ways to change this repository and had nothing for somebody who wants to extend it instead.

**Test coverage report:** New lines introduced: 100%. Total coverage impact: none, the frontend gate stays at 100% on every metric — 1343 tests (+2), statements 100%, branches 100%, functions 100%, lines 100%.

**Other reports:**

Three parts.

**1. The notice is standing, not dismissible, and above the list** rather than beside a button, because it is true of every row rather than of a moment. It says the three things that were unsaid: anyone can publish, nothing is reviewed, and there is no sandbox.

**2. A catalogue install now always asks**, even when the extension wants no permission at all. This deliberately differs from the folder install, so it is worth saying why. The existing rule is that a permission screen with nothing on it teaches people to click past the screen that does have something on it — right where it was written, because picking a folder means running code you already have. Installing from the catalogue is a different act: it downloads a stranger's code and runs it with this app's access to files, clipboard and shell. The screen is not empty in that case either — it names the author, the repository, the version and the licence, and carries the machine-access sentence — so there is something to read before agreeing. The folder install is unchanged.

The dialog also now names where the install comes from. It showed `candidate.path`, blank for a catalogue entry; it shows the repository instead, since who published it is the question being answered.

**3. `CONTRIBUTING.md` gains "Extensions need none of this".** It opened with "contributions come in three forms, there is no fourth" and then described three ways of changing this repository — somebody wanting to extend AgentRQ found nothing, and the honest answer is that they need none of it. The section gives the three steps to publish, what an extension can reach, the link to `docs/EXTENSIONS.md`, and pointers to the three worked examples and to `agentrq/mermaid-agentrq` as a real published one. The "three forms" line keeps its word by naming what the section is not.

`docs/EXTENSIONS.md` gains a "Nothing here is reviewed" section, and the sentence saying an extension asking for nothing installs without the step is corrected — now true only of the folder path.

Verified in the real app: `npm run verify:extensions` passes.

TaskID: 0ibR3HdR3Pl

🤖 Generated with [Claude Code](https://claude.com/claude-code)