### PR TITLE
docs: say that building an extension needs nothing from us

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,10 @@
 # Contributing to AgentRQ
 
-Contributions come in three forms. There is no fourth.
+Contributions to this repository come in three forms. There is no fourth.
+
+Building an **extension** is not a contribution to this repository and needs
+nothing from us — [skip to that](#extensions-need-none-of-this) if that is what
+you are here for.
 
 | Your intent | What to do |
 |---|---|
@@ -10,6 +14,44 @@ Contributions come in three forms. There is no fourth.
 
 Both kinds of proposal are submitted the same way: a pull request that adds one
 `.md` file to the relevant folder.
+
+## Extensions need none of this
+
+The three forms above are how you change *this* repository. Building an
+**extension** is not one of them, because it does not touch this repository at
+all — and that is the point. You need no permission, no proposal and no reply
+from us. There is no review, no approval queue, no registry to be admitted to
+and no fee.
+
+Publishing one is three things:
+
+1. Add the **`agentrq-extension`** topic to your GitHub repository. That is the
+   whole of discovery — the desktop app searches for that topic, and anything
+   carrying it shows up in everyone's Extensions screen.
+2. Put an `agentrq-extension.json` manifest at the root.
+3. Cut a release with your built asset attached, and put its SHA-256 in the
+   manifest.
+
+It is an ordinary Node module. It can add pages, context-menu actions, keyboard
+shortcuts, scheduled work, and renderers for fenced code blocks — and it can
+call the same MCP tools the app itself uses, with whatever permissions the
+person installing it agrees to.
+
+**[docs/EXTENSIONS.md](https://github.com/agentrq/agentrq/blob/main/docs/EXTENSIONS.md)**
+is the whole of it: what the manifest holds, what each surface can do, how
+permissions are asked for, and how to develop one against a running app without
+publishing anything.
+
+Three worked examples live in [`examples/extensions/`](examples/extensions) —
+`task-stats`, `standup` and `digest` — and
+[agentrq/mermaid-agentrq](https://github.com/agentrq/mermaid-agentrq) is a real
+published one, small enough to read in a sitting.
+
+The flip side of no gatekeeper is worth stating, since it is your users who
+carry it: nothing in the catalogue is reviewed and there is no sandbox, so an
+extension runs with full access to the machine of whoever installs it. The app
+says so on the screen and asks before installing anything. Write yours as though
+somebody is going to read it, because somebody should.
 
 ## Why we work this way
 


### PR DESCRIPTION
**What changed:** The contributing guide now explains that anyone can build and publish an extension without asking us, with the three steps to do it and a link to the full documentation.

**Why changed:** The guide opened by saying contributions come in three forms and then described three ways to change this repository. Somebody who wants to extend AgentRQ rather than change it found nothing — and the honest answer is that they need none of it.

**Test coverage report:** No lines of code introduced — documentation only. Total coverage impact: none.

**Other reports:**

This was written for #534 and pushed to that branch, but the merge took the branch as it stood a moment earlier, so the file never landed. Same commit, re-applied to main cleanly.

Two judgment calls worth a reviewer's eye:

- **"There is no fourth" is kept.** Rather than making extensions a fourth form of contribution and breaking that line, the opening now says an extension is *not* a contribution to this repository and links down to the section. The line stays true and the point lands harder — the answer to "how do I get my extension approved" is that there is nothing to approve.
- **The flip side is stated as well.** No gatekeeper means nothing is reviewed and there is no sandbox, and it is the author's *users* who carry that. The section ends by asking authors to write theirs as though somebody is going to read it. Advertising the freedom here while the app warns about it on screen would have been two documents disagreeing.

Links checked: `docs/EXTENSIONS.md` and `agentrq/mermaid-agentrq` both resolve, and the in-page anchor matches its heading.

TaskID: 0ibR3HdR3Pl

🤖 Generated with [Claude Code](https://claude.com/claude-code)