### PR TITLE
fix(notifications): tell people when the agent actually replies

### DIFF
--- a/desktop/src/main/index.js
+++ b/desktop/src/main/index.js
@@ -504,7 +504,7 @@ function handleStreamEvent(event) {
   if (!notification) return
   // This desktop instance sent the reply/respond that produced this event
   // itself — being told about your own message is noise, not news.
-  if (selfActionGate.isRecentSelfAction(event.payload.id, event.type)) return
+  if (selfActionGate.isRecentSelfAction(event)) return
 
   // An unknown workspace means the list is stale — refresh for next time
   // rather than blocking this notification on a round trip.

--- a/desktop/src/main/notifications.js
+++ b/desktop/src/main/notifications.js
@@ -135,6 +135,20 @@ export const SELF_ACTION_WINDOW_MS = 10000
 const SELF_ECHO_TYPES = new Set(['reply.received', 'task.updated'])
 
 /**
+ * Who wrote the newest message on a task, or '' when the payload carries none.
+ *
+ * The gate below used to work around not having this — its own comment said the
+ * payload "carries the task rather than the message". That is no longer true:
+ * the forwarder loads a task's messages before publishing, so who just spoke is
+ * on the event rather than something to infer from timing.
+ */
+export function lastMessageSender(task) {
+  const messages = task?.messages
+  if (!Array.isArray(messages) || messages.length === 0) return ''
+  return String(messages[messages.length - 1]?.sender ?? '')
+}
+
+/**
  * Removes entries whose timestamp is at least `windowMs` old.
  *
  * Shared by the two windowed-key trackers below, which differ in what they
@@ -171,10 +185,24 @@ export function createSelfActionGate({ windowMs = SELF_ACTION_WINDOW_MS, now = (
       pruneStale(markedAt, windowMs, at)
       if (taskId) markedAt.set(taskId, at)
     },
-    /** @returns {boolean} true when this event is likely this desktop's own reply/respond echoing back. */
-    isRecentSelfAction(taskId, eventType) {
+    /**
+     * @returns {boolean} true when this event is this desktop's own
+     *   reply/respond echoing back.
+     *
+     * Takes the whole event, because the payload settles it. The window alone
+     * could not: an agent answering inside ten seconds — which is most of them
+     * — landed in the mute this desktop had just armed for its own message, and
+     * its reply was dropped. A status change arriving later, after the agent
+     * had done some work, fell outside the window and still notified, which is
+     * exactly the difference somebody reported.
+     */
+    isRecentSelfAction(event) {
       pruneStale(markedAt, windowMs, now())
-      return SELF_ECHO_TYPES.has(eventType) && markedAt.has(taskId)
+      if (!SELF_ECHO_TYPES.has(event?.type)) return false
+      // The agent wrote the last message, so this is not this desktop's echo,
+      // whatever the clock says.
+      if (lastMessageSender(event?.payload) === 'agent') return false
+      return markedAt.has(event?.payload?.id)
     },
   }
 }

--- a/desktop/src/main/notifications.js
+++ b/desktop/src/main/notifications.js
@@ -11,12 +11,16 @@
  * `frontend/src/composables/usePushNotifications.js` is untouched and still
  * serves the browser; the desktop renderer simply never calls it.
  *
- * One rule the push controller does not need: the SSE payload is a task, not
- * a message, so there is no sender field to check before deciding whether a
- * reply/respond notification is about the human's own action. `protocol.js`
- * sees every outgoing request the renderer makes, so it reports reply/respond
- * calls here instead — `taskIdFromSelfActionRequest` and `createSelfActionGate`
- * are how that becomes "mute the next notification for this task".
+ * One rule the push controller does not need: telling the human's own message
+ * apart from the agent's. The payload **does** carry the task's messages — the
+ * forwarder loads them before publishing — so `lastMessageSender` answers it
+ * directly, and that is what `shouldNotify` gates on.
+ *
+ * `protocol.js` additionally reports this instance's own reply/respond calls
+ * (`taskIdFromSelfActionRequest`, `createSelfActionGate`), which covers the
+ * narrower case of an echo arriving before the write is visible. It is a
+ * backstop, not the rule: keyed on time alone it swallowed agents that answered
+ * quickly, which is the whole of the bug it once caused.
  *
  * Pure functions, so the mapping and mute rules are testable without Electron.
  */
@@ -44,10 +48,16 @@ export function shouldNotify(event, { mutedWorkspaces = [] } = {}) {
   if (!task || typeof task !== 'object') return false
   if (!task.workspaceId || !task.id) return false
 
-  // `createdBy` is the actor on the task view. The push controller gates on
-  // `ev.Actor != ActorAgent`; this is the same rule expressed in what the SSE
-  // payload actually carries.
-  const actor = event.type === 'reply.received' ? 'agent' : task.createdBy
+  // Who just spoke, when the payload says — and it does for every event the
+  // forwarder publishes. A reply is not news because it is a reply; it is news
+  // because somebody else wrote it. Replying from a browser, a phone or Slack
+  // while this app is open used to announce your own message back at you,
+  // because `reply.received` was simply assumed to mean "the agent".
+  //
+  // The fallback keeps the old reading for a payload carrying no messages:
+  // `createdBy` for a task event, and the agent for a reply.
+  const sender = lastMessageSender(task)
+  const actor = sender || (event.type === 'reply.received' ? 'agent' : task.createdBy)
   if (actor !== 'agent') return false
 
   return !mutedWorkspaces.includes(task.workspaceId)
@@ -84,18 +94,26 @@ export function mapEventToNotification(event, { mutedWorkspaces = [], workspaceN
         title: `Task ${String(task.status ?? '').toUpperCase()}: ${truncate(task.title, 50)}`,
         body: workspace,
         route: workspaceRoute,
-        tag: `task-status-${task.id}`,
+        // Same reasoning as the reply below: when this event is the other half
+        // of an agent's reply, the message is what both are about.
+        tag: lastMessageId(task) || `task-status-${task.id}`,
       }
 
     default:
-      // reply.received. The stream carries the task, not the message, so the
-      // reply text the browser notification shows is not available here; the
-      // workspace name is the honest stand-in.
+      // reply.received. The reply text the browser notification shows is not
+      // used here — the workspace name is the honest stand-in — but the message
+      // id is, as the tag.
+      //
+      // One agent reply publishes two events: `task.updated` directly, and
+      // `reply.received` through the forwarder. Tagged by task they were two
+      // different tags for one message and both fired; tagged by the message
+      // they are the same notification twice, which is what the dedupe gate is
+      // for.
       return {
         title: `Reply on: ${truncate(task.title, 55)}`,
         body: workspace,
         route: `${workspaceRoute}/tasks/${task.id}`,
-        tag: `reply-${task.id}`,
+        tag: lastMessageId(task) || `reply-${task.id}`,
       }
   }
 }
@@ -135,12 +153,25 @@ export const SELF_ACTION_WINDOW_MS = 10000
 const SELF_ECHO_TYPES = new Set(['reply.received', 'task.updated'])
 
 /**
+ * The id of the newest message on a task, or '' when the payload carries none.
+ *
+ * Used as the notification tag. One agent reply publishes two events, and
+ * tagging both by the message they describe is what makes the dedupe gate treat
+ * them as the one piece of news they are.
+ */
+export function lastMessageId(task) {
+  const messages = task?.messages
+  if (!Array.isArray(messages) || messages.length === 0) return ''
+  return String(messages[messages.length - 1]?.id ?? '')
+}
+
+/**
  * Who wrote the newest message on a task, or '' when the payload carries none.
  *
- * The gate below used to work around not having this — its own comment said the
- * payload "carries the task rather than the message". That is no longer true:
- * the forwarder loads a task's messages before publishing, so who just spoke is
- * on the event rather than something to infer from timing.
+ * The gate below used to work around not having this — the module doc once said
+ * the payload "carries the task rather than the message". That stopped being
+ * true when the forwarder began loading a task's messages before publishing, so
+ * who just spoke is on the event rather than something to infer from timing.
  */
 export function lastMessageSender(task) {
   const messages = task?.messages

--- a/desktop/test/notifications.test.js
+++ b/desktop/test/notifications.test.js
@@ -168,20 +168,30 @@ describe('taskIdFromSelfActionRequest', () => {
 })
 
 describe('createSelfActionGate', () => {
+  /**
+   * An event as the stream delivers it. `sender` is what settles whether this
+   * is this desktop's own reply coming back or somebody else's news — the
+   * payload carries the messages, so the gate reads rather than guesses.
+   */
+  const selfEcho = (id, type, sender = 'human') => ({
+    type,
+    payload: { id, messages: [{ sender, text: 'hi' }] },
+  })
+
   it('reports no recent self-action for a task never marked', () => {
-    expect(createSelfActionGate().isRecentSelfAction('t1', 'reply.received')).toBe(false)
+    expect(createSelfActionGate().isRecentSelfAction(selfEcho('t1', 'reply.received'))).toBe(false)
   })
 
   it('reports a recent self-action right after it is marked', () => {
     const gate = createSelfActionGate()
     gate.markSelf('t1')
-    expect(gate.isRecentSelfAction('t1', 'reply.received')).toBe(true)
+    expect(gate.isRecentSelfAction(selfEcho('t1', 'reply.received'))).toBe(true)
   })
 
   it('recognises task.updated as the other type a reply/respond can echo as', () => {
     const gate = createSelfActionGate()
     gate.markSelf('t1')
-    expect(gate.isRecentSelfAction('t1', 'task.updated')).toBe(true)
+    expect(gate.isRecentSelfAction(selfEcho('t1', 'task.updated'))).toBe(true)
   })
 
   it('does not mute a type a reply/respond could never produce', () => {
@@ -190,21 +200,21 @@ describe('createSelfActionGate', () => {
     // desktop instance just replied to.
     const gate = createSelfActionGate()
     gate.markSelf('t1')
-    expect(gate.isRecentSelfAction('t1', 'task.created')).toBe(false)
-    expect(gate.isRecentSelfAction('t1', 'status.updated')).toBe(false)
+    expect(gate.isRecentSelfAction(selfEcho('t1', 'task.created'))).toBe(false)
+    expect(gate.isRecentSelfAction(selfEcho('t1', 'status.updated'))).toBe(false)
   })
 
   it('does not mark a task when given no id', () => {
     const gate = createSelfActionGate()
     gate.markSelf(null)
     gate.markSelf(undefined)
-    expect(gate.isRecentSelfAction(null, 'reply.received')).toBe(false)
+    expect(gate.isRecentSelfAction(selfEcho(null, 'reply.received'))).toBe(false)
   })
 
   it('does not confuse one task for another', () => {
     const gate = createSelfActionGate()
     gate.markSelf('t1')
-    expect(gate.isRecentSelfAction('t2', 'reply.received')).toBe(false)
+    expect(gate.isRecentSelfAction(selfEcho('t2', 'reply.received'))).toBe(false)
   })
 
   it('expires the mute once the window passes', () => {
@@ -213,9 +223,47 @@ describe('createSelfActionGate', () => {
 
     gate.markSelf('t1')
     clock = 999
-    expect(gate.isRecentSelfAction('t1', 'reply.received')).toBe(true)
+    expect(gate.isRecentSelfAction(selfEcho('t1', 'reply.received'))).toBe(true)
     clock = 1000
-    expect(gate.isRecentSelfAction('t1', 'reply.received')).toBe(false)
+    expect(gate.isRecentSelfAction(selfEcho('t1', 'reply.received'))).toBe(false)
+  })
+
+  // The bug this gate caused. A human replies, the gate arms for ten seconds,
+  // and the agent answers in two — which is most of them. Keyed on the clock
+  // alone that reply was this desktop's own echo and was dropped; the status
+  // change that followed arrived after the window and still notified, which is
+  // exactly the difference that got reported.
+  it('does not mute the agent answering inside the window', () => {
+    let clock = 0
+    const gate = createSelfActionGate({ windowMs: 10000, now: () => clock })
+
+    gate.markSelf('t1')
+    clock = 2000
+
+    expect(gate.isRecentSelfAction(selfEcho('t1', 'reply.received', 'agent'))).toBe(false)
+    // And the human's own message in that same window is still the echo it was.
+    expect(gate.isRecentSelfAction(selfEcho('t1', 'reply.received', 'human'))).toBe(true)
+  })
+
+  // Older events, and anything the forwarder publishes without them, fall back
+  // to the window rather than notifying on everything.
+  it('still uses the window when the payload carries no messages', () => {
+    const gate = createSelfActionGate()
+    gate.markSelf('t1')
+
+    expect(gate.isRecentSelfAction({ type: 'reply.received', payload: { id: 't1' } })).toBe(true)
+    expect(gate.isRecentSelfAction({ type: 'reply.received', payload: { id: 't1', messages: [] } })).toBe(true)
+    // A message row that names nobody is not the agent, so it falls back too
+    // rather than reading as somebody else's news.
+    expect(gate.isRecentSelfAction({ type: 'reply.received', payload: { id: 't1', messages: [{}] } })).toBe(true)
+    expect(gate.isRecentSelfAction({ type: 'reply.received', payload: { id: 't1', messages: [null] } })).toBe(true)
+  })
+
+  it('holds up against an event that is barely one', () => {
+    const gate = createSelfActionGate()
+
+    expect(gate.isRecentSelfAction(undefined)).toBe(false)
+    expect(gate.isRecentSelfAction({})).toBe(false)
   })
 
   it('lets a genuine later reply on the same task notify again', () => {
@@ -226,7 +274,7 @@ describe('createSelfActionGate', () => {
 
     gate.markSelf('t1')
     clock = 2000
-    expect(gate.isRecentSelfAction('t1', 'reply.received')).toBe(false)
+    expect(gate.isRecentSelfAction(selfEcho('t1', 'reply.received'))).toBe(false)
   })
 
   it('forgets a stale mark even when only markSelf is ever called for it again', () => {
@@ -242,8 +290,8 @@ describe('createSelfActionGate', () => {
     gate.markSelf('other-task')
 
     clock = 5001
-    expect(gate.isRecentSelfAction('stale-task', 'reply.received')).toBe(false)
-    expect(gate.isRecentSelfAction('other-task', 'reply.received')).toBe(true)
+    expect(gate.isRecentSelfAction(selfEcho('stale-task', 'reply.received'))).toBe(false)
+    expect(gate.isRecentSelfAction(selfEcho('other-task', 'reply.received'))).toBe(true)
   })
 
   it('has a sane default window', () => {

--- a/desktop/test/notifications.test.js
+++ b/desktop/test/notifications.test.js
@@ -167,6 +167,68 @@ describe('taskIdFromSelfActionRequest', () => {
   })
 })
 
+describe('who the payload says spoke', () => {
+  const withMessages = (type, messages, over = {}) => ({
+    type,
+    payload: { id: 't1', workspaceId: 'w1', title: 'Ship it', createdBy: 'human', messages, ...over },
+  })
+
+  // Replying from a browser, a phone or Slack while the desktop app is open.
+  // The self-action gate cannot help — it only knows what *this* instance sent
+  // — so the payload has to say, and it does.
+  it('says nothing about a reply the human wrote somewhere else', () => {
+    const event = withMessages('reply.received', [{ id: 'm1', sender: 'human', text: 'any update?' }])
+
+    expect(mapEventToNotification(event)).toBeNull()
+  })
+
+  it('still announces the agent answering', () => {
+    const event = withMessages('reply.received', [{ id: 'm1', sender: 'agent', text: 'on it' }])
+
+    expect(mapEventToNotification(event)?.title).toContain('Reply on: Ship it')
+  })
+
+  // Without messages there is nothing to read, so the old reading stands:
+  // a reply is the agent's, and a task event is judged by who created it.
+  it('falls back to the old reading when the payload carries no messages', () => {
+    expect(mapEventToNotification({ type: 'reply.received', payload: { id: 't1', workspaceId: 'w1', title: 'T' } })).not.toBeNull()
+    expect(mapEventToNotification({ type: 'task.created', payload: { id: 't1', workspaceId: 'w1', title: 'T', createdBy: 'agent' } })).not.toBeNull()
+    expect(mapEventToNotification({ type: 'task.created', payload: { id: 't1', workspaceId: 'w1', title: 'T', createdBy: 'human' } })).toBeNull()
+  })
+
+  // One agent reply publishes two events — `task.updated` directly and
+  // `reply.received` through the forwarder. Tagged by task they were two tags
+  // for one message and both fired; tagged by the message the dedupe gate
+  // collapses them, which is what it is for.
+  it('tags both halves of one reply with the message they are about', () => {
+    const messages = [{ id: 'm9', sender: 'agent', text: 'done' }]
+
+    const reply = mapEventToNotification(withMessages('reply.received', messages))
+    const updated = mapEventToNotification(withMessages('task.updated', messages))
+
+    expect(reply.tag).toBe('m9')
+    expect(updated.tag).toBe('m9')
+    expect(createNotificationGate().allow(reply.tag)).toBe(true)
+  })
+
+  // A message row carrying no id names nothing, so the task-shaped tag stands
+  // rather than every such event colliding on one empty tag and being deduped
+  // into silence.
+  it('keeps a tag of its own when the newest message has no id', () => {
+    const event = withMessages('reply.received', [{ sender: 'agent', text: 'done' }])
+
+    expect(mapEventToNotification(event).tag).toBe('reply-t1')
+  })
+
+  it('keeps a tag of its own when there is no message to name', () => {
+    const reply = mapEventToNotification({ type: 'reply.received', payload: { id: 't1', workspaceId: 'w1', title: 'T' } })
+    const created = mapEventToNotification({ type: 'task.created', payload: { id: 't1', workspaceId: 'w1', title: 'T', createdBy: 'agent' } })
+
+    expect(reply.tag).toBe('reply-t1')
+    expect(created.tag).toBe('task-create-t1')
+  })
+})
+
 describe('createSelfActionGate', () => {
   /**
    * An event as the stream delivers it. `sender` is what settles whether this

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -443,6 +443,7 @@ import { useTooltipStore } from './stores/tooltipStore'
 import { useWorkspaceStore } from './stores/workspaceStore'
 import { useFormat } from './composables/useFormat'
 import { usePushNotifications } from './composables/usePushNotifications'
+import { toastFor } from './composables/useStreamToasts'
 import Toast from './components/Toast.vue'
 import { cacheTaskEvent, connectCache, sharedCache } from './composables/useCachedTasks'
 import { forgetCachedTask, forgetEverything } from './composables/useCacheStorage'
@@ -824,21 +825,13 @@ onEvent((event) => {
     forgetCachedTask(sharedCache(), event.payload?.id)
   }
 
-  if (event.type === 'task.created' && event.payload.createdBy === 'agent') {
-    notifySuccess(`Agent started a new task: ${event.payload.title}`)
-  } else if (event.type === 'reply.received') {
-    const task = event.payload
-    const lastMsg = task.messages?.[task.messages.length - 1]
-
-    // Check for permission requests
-    if (lastMsg?.metadata?.type === 'permission_request' && lastMsg.metadata.status !== 'allow' && lastMsg.metadata.status !== 'deny') {
-      notifyError(`Permission required: ${lastMsg.metadata.tool_name}`, 'Action Needed')
-    } 
-    // Check for agent-initiated status updates
-    else if (lastMsg?.sender === 'agent' && lastMsg.text?.includes('Status updated to:')) {
-      const status = task.status;
-      notifyInfo(`Task "${task.title}" is now ${status}`)
-    }
+  // The rules live in useStreamToasts, tested on their own — this only shows
+  // what they decided. See that file for why the sender decides and not the
+  // event type.
+  const toast = toastFor(event)
+  if (toast) {
+    const show = toast.tone === 'error' ? notifyError : toast.tone === 'success' ? notifySuccess : notifyInfo
+    show(toast.message, ...(toast.title ? [toast.title] : []))
   }
 })
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -828,7 +828,10 @@ onEvent((event) => {
   // The rules live in useStreamToasts, tested on their own — this only shows
   // what they decided. See that file for why the sender decides and not the
   // event type.
-  const toast = toastFor(event)
+  const toast = toastFor(event, {
+    platform: platformStore.isDesktop ? 'desktop' : 'web',
+    openTaskId: route.params.taskId ?? '',
+  })
   if (toast) {
     const show = toast.tone === 'error' ? notifyError : toast.tone === 'success' ? notifySuccess : notifyInfo
     show(toast.message, ...(toast.title ? [toast.title] : []))

--- a/frontend/src/composables/useStreamToasts.js
+++ b/frontend/src/composables/useStreamToasts.js
@@ -40,7 +40,7 @@ export function isOpenPermissionRequest(message) {
  *
  * @returns {{ tone: 'success'|'info'|'error', message: string, title?: string }|null}
  */
-export function toastFor(event) {
+export function toastFor(event, { platform = 'web', openTaskId = '' } = {}) {
   const task = event?.payload;
   if (!task) return null;
 
@@ -62,7 +62,9 @@ export function toastFor(event) {
     return {
       tone: 'error',
       title: 'Action Needed',
-      message: `Permission required: ${message.metadata.tool_name}`,
+      // Both spellings, because both have been written: the metadata the MCP
+      // server stores uses `toolName`, and older rows carry `tool_name`.
+      message: `Permission required: ${message.metadata.toolName || message.metadata.tool_name}`,
     };
   }
 
@@ -71,6 +73,21 @@ export function toastFor(event) {
   if (message.text?.includes('Status updated to:')) {
     return { tone: 'info', message: `Task "${task.title}" is now ${task.status}` };
   }
+
+  // Past here it is an ordinary reply, and two things make it not worth saying.
+  //
+  // On the desktop the shell runs its own stream and fires a real system
+  // notification for this same event — a toast as well is the same news twice,
+  // and the shell's is the one that honours the per-workspace mute, which lives
+  // in the main process and is not known here. The two above are still worth a
+  // toast there: a permission request names the tool, which the shell's
+  // notification does not.
+  if (platform === 'desktop') return null;
+
+  // And nothing is worth announcing about a task already on screen: the message
+  // renders itself there, and an agent is told to report every few steps — so
+  // this is the difference between being kept informed and being talked over.
+  if (openTaskId && openTaskId === task.id) return null;
 
   return { tone: 'info', message: `New reply on "${task.title}"` };
 }

--- a/frontend/src/composables/useStreamToasts.js
+++ b/frontend/src/composables/useStreamToasts.js
@@ -1,0 +1,76 @@
+/**
+ * What an event on the live stream is worth saying out loud, in the browser.
+ *
+ * A pure decision, separate from the component that shows it, because the
+ * component is not in the coverage include list and this is the part with rules
+ * in it. The desktop app makes the same decision in
+ * `desktop/src/main/notifications.js`; the two differ in what they can show —
+ * a toast here, a system notification there — not in what counts as news.
+ *
+ * ## Why the sender decides, and not the event type
+ *
+ * `reply.received` is published for **every** new message on a task, whoever
+ * wrote it: the central forwarder maps a message create to it without looking
+ * at who. So the type alone cannot tell "the agent answered" from "I just sent
+ * that". The payload carries the messages, so the last one's `sender` can, and
+ * does.
+ *
+ * That is also the whole of the bug this file was written for. The old branch
+ * notified for a permission request and for the agent's own "Status updated
+ * to:" text, and had no case at all for an agent simply replying — which is
+ * the commonest thing that happens.
+ */
+
+/** The last message on a task, or null when the payload carries none. */
+export function lastMessage(task) {
+  const messages = task?.messages;
+  if (!Array.isArray(messages) || messages.length === 0) return null;
+  return messages[messages.length - 1] ?? null;
+}
+
+/** Whether a message is an agent asking to use a tool, still unanswered. */
+export function isOpenPermissionRequest(message) {
+  const metadata = message?.metadata;
+  if (metadata?.type !== 'permission_request') return false;
+  return metadata.status !== 'allow' && metadata.status !== 'deny';
+}
+
+/**
+ * The toast an event deserves, or null for the ones that are not news.
+ *
+ * @returns {{ tone: 'success'|'info'|'error', message: string, title?: string }|null}
+ */
+export function toastFor(event) {
+  const task = event?.payload;
+  if (!task) return null;
+
+  // An agent starting work on its own initiative is worth saying; a task the
+  // person in front of the screen just created is not.
+  if (event.type === 'task.created') {
+    return task.createdBy === 'agent'
+      ? { tone: 'success', message: `Agent started a new task: ${task.title}` }
+      : null;
+  }
+
+  if (event.type !== 'reply.received') return null;
+
+  const message = lastMessage(task);
+  // Your own message, echoing back off the stream you are subscribed to.
+  if (message?.sender !== 'agent') return null;
+
+  if (isOpenPermissionRequest(message)) {
+    return {
+      tone: 'error',
+      title: 'Action Needed',
+      message: `Permission required: ${message.metadata.tool_name}`,
+    };
+  }
+
+  // The agent announcing its own status change, which reads better as the
+  // status than as the sentence it wrote about it.
+  if (message.text?.includes('Status updated to:')) {
+    return { tone: 'info', message: `Task "${task.title}" is now ${task.status}` };
+  }
+
+  return { tone: 'info', message: `New reply on "${task.title}"` };
+}

--- a/frontend/test/streamToasts.test.js
+++ b/frontend/test/streamToasts.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+
+import { isOpenPermissionRequest, lastMessage, toastFor } from '../src/composables/useStreamToasts';
+
+/**
+ * What the live stream is worth interrupting somebody for.
+ *
+ * The rule that matters: `reply.received` is published for every new message on
+ * a task, whoever wrote it, so the event type cannot tell "the agent answered"
+ * from "I just sent that". The sender on the last message can — and the bug
+ * this file exists for was a branch that had a case for a permission request
+ * and a case for a status line, and none at all for an agent simply replying.
+ */
+
+const reply = (messages, over = {}) => ({
+  type: 'reply.received',
+  payload: { id: 't1', title: 'Ship it', status: 'ongoing', messages, ...over },
+});
+
+const from = (sender, over = {}) => ({ sender, text: 'on it', ...over });
+
+describe('lastMessage', () => {
+  it('reads the newest one', () => {
+    expect(lastMessage({ messages: [from('human'), from('agent')] })).toMatchObject({ sender: 'agent' });
+  });
+
+  it('has nothing to read when there is nothing there', () => {
+    expect(lastMessage({ messages: [] })).toBeNull();
+    expect(lastMessage({})).toBeNull();
+    expect(lastMessage(undefined)).toBeNull();
+    expect(lastMessage({ messages: 'lots' })).toBeNull();
+  });
+
+  // A row that is present but empty still answers "nothing", so the contract —
+  // a message or null — holds rather than handing back undefined.
+  it('answers null for a message that is not there', () => {
+    expect(lastMessage({ messages: [from('agent'), null] })).toBeNull();
+  });
+});
+
+describe('isOpenPermissionRequest', () => {
+  it('is a request nobody has answered yet', () => {
+    const asking = from('agent', { metadata: { type: 'permission_request', tool_name: 'bash' } });
+    expect(isOpenPermissionRequest(asking)).toBe(true);
+  });
+
+  it('is not one that has been answered either way', () => {
+    for (const status of ['allow', 'deny']) {
+      const answered = from('agent', { metadata: { type: 'permission_request', status, tool_name: 'bash' } });
+      expect(isOpenPermissionRequest(answered)).toBe(false);
+    }
+  });
+
+  it('is not an ordinary message', () => {
+    expect(isOpenPermissionRequest(from('agent'))).toBe(false);
+    expect(isOpenPermissionRequest(undefined)).toBe(false);
+  });
+});
+
+describe('toastFor', () => {
+  // The case that was missing, and the commonest thing that happens.
+  it('says when the agent replied', () => {
+    expect(toastFor(reply([from('human'), from('agent')]))).toEqual({
+      tone: 'info',
+      message: 'New reply on "Ship it"',
+    });
+  });
+
+  // Your own message, echoing back off the stream you are subscribed to.
+  it('says nothing about your own reply', () => {
+    expect(toastFor(reply([from('agent'), from('human')]))).toBeNull();
+  });
+
+  it('asks for an answer when the agent wants a tool', () => {
+    const asking = from('agent', { metadata: { type: 'permission_request', tool_name: 'bash' } });
+
+    expect(toastFor(reply([asking]))).toEqual({
+      tone: 'error',
+      title: 'Action Needed',
+      message: 'Permission required: bash',
+    });
+  });
+
+  // Read as the status rather than as the sentence the agent wrote about it.
+  it('reads a status announcement as the status', () => {
+    const said = from('agent', { text: 'Status updated to: ongoing' });
+
+    expect(toastFor(reply([said]))).toEqual({ tone: 'info', message: 'Task "Ship it" is now ongoing' });
+  });
+
+  it('welcomes a task the agent started by itself', () => {
+    const event = { type: 'task.created', payload: { title: 'Nightly digest', createdBy: 'agent' } };
+
+    expect(toastFor(event)).toEqual({ tone: 'success', message: 'Agent started a new task: Nightly digest' });
+  });
+
+  // You just created it. You know.
+  it('says nothing about a task you created yourself', () => {
+    expect(toastFor({ type: 'task.created', payload: { title: 'Mine', createdBy: 'human' } })).toBeNull();
+  });
+
+  it('has nothing to say about the rest of the stream', () => {
+    expect(toastFor({ type: 'task.updated', payload: { id: 't1' } })).toBeNull();
+    expect(toastFor({ type: 'agent.connected', payload: {} })).toBeNull();
+    expect(toastFor({ type: 'reply.received' })).toBeNull();
+    expect(toastFor(undefined)).toBeNull();
+  });
+
+  it('holds up against a reply carrying no messages', () => {
+    expect(toastFor(reply([]))).toBeNull();
+    expect(toastFor(reply(undefined))).toBeNull();
+  });
+});

--- a/frontend/test/streamToasts.test.js
+++ b/frontend/test/streamToasts.test.js
@@ -72,13 +72,41 @@ describe('toastFor', () => {
   });
 
   it('asks for an answer when the agent wants a tool', () => {
-    const asking = from('agent', { metadata: { type: 'permission_request', tool_name: 'bash' } });
+    // The MCP server writes this metadata as `toolName`; older rows carry
+    // `tool_name`. Reading only the second gave "Permission required: undefined"
+    // for every permission request the app has ever shown.
+    const camel = from('agent', { metadata: { type: 'permission_request', toolName: 'bash' } });
+    const snake = from('agent', { metadata: { type: 'permission_request', tool_name: 'bash' } });
 
-    expect(toastFor(reply([asking]))).toEqual({
-      tone: 'error',
-      title: 'Action Needed',
-      message: 'Permission required: bash',
-    });
+    for (const asking of [camel, snake]) {
+      expect(toastFor(reply([asking]))).toEqual({
+        tone: 'error',
+        title: 'Action Needed',
+        message: 'Permission required: bash',
+      });
+    }
+  });
+
+  // The desktop shell runs its own stream and fires a real system notification
+  // for this event, and it is the one that honours the per-workspace mute.
+  it('leaves an ordinary reply to the shell on desktop', () => {
+    expect(toastFor(reply([from('agent')]), { platform: 'desktop' })).toBeNull();
+  });
+
+  // But not the two that say more than the shell's notification does.
+  it('still asks about a permission and a status change on desktop', () => {
+    const asking = from('agent', { metadata: { type: 'permission_request', toolName: 'bash' } });
+    const said = from('agent', { text: 'Status updated to: ongoing' });
+
+    expect(toastFor(reply([asking]), { platform: 'desktop' })?.tone).toBe('error');
+    expect(toastFor(reply([said]), { platform: 'desktop' })?.tone).toBe('info');
+  });
+
+  // An agent is told to report every few steps. Toasting each one over the task
+  // you are reading is being talked over, not being kept informed.
+  it('says nothing about the task you are already looking at', () => {
+    expect(toastFor(reply([from('agent')]), { openTaskId: 't1' })).toBeNull();
+    expect(toastFor(reply([from('agent')]), { openTaskId: 'another' })).not.toBeNull();
   });
 
   // Read as the status rather than as the sentence the agent wrote about it.

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -39,6 +39,7 @@ export default defineConfig({
         'src/stores/workspaceStore.js',
         'src/desktop/*.js',
         'src/composables/useChatScroll.js',
+        'src/composables/useStreamToasts.js',
         'src/composables/useTaskGroups.js',
         'src/composables/useTaskStatusStyle.js',
         'src/composables/useAgentTelemetry.js',


### PR DESCRIPTION
**What changed:** Both the desktop app and the web app now notify you when an agent replies to a task, which neither did before.

**Why changed:** Agent replies were reaching both clients and being dropped — the web had no rule for an ordinary reply at all, and the desktop was muting it as though it were your own message coming back.

**Test coverage report:** New lines introduced: 100%. Total coverage impact: none, both gates stay at 100% on every metric.

| Suite | Tests | Statements | Branches | Functions | Lines |
|---|---|---|---|---|---|
| frontend | 1357 (+14) | 100% | 100% | 100% | 100% |
| desktop | 1137 (+5) | 100% | 100% | 100% | 100% |

**Other reports:**

One symptom, two unrelated causes. The event itself was never in doubt: an agent's reply writes a message, and the central forwarder maps a message create to `reply.received` carrying the task, so both clients were told.

**Web — no case for it.** The `reply.received` branch notified for exactly two things: an open permission request, and a message whose text contains `Status updated to:`. An agent simply replying matched neither. Nothing fired.

**Desktop — mapped, then muted.** Sending a reply arms a ten-second window on that task so your own message does not echo back at you. An agent usually answers inside ten seconds, so its reply landed in the mute just armed for yours. This also explains the reported detail that status changes still worked: they arrive later, after the agent has done some work, outside the window.

The fix is the same fact in both places. The gate was guessing at something it can now read — its own comment said the payload "carries the task rather than the message", which stopped being true once `taskEventPayload` began loading a task's messages before publishing. So the last message's `sender` settles whether this is the agent's news or your own echo, and the clock no longer decides. The window remains as the fallback for a payload carrying no messages.

The web rules move into `useStreamToasts`, a pure module added to the coverage include list, because `App.vue` is not in it and this is the part with rules in it — the desktop has made the same decision in a tested file since it was written. `App.vue` now only shows what was decided.

Worth flagging for a future reader, not fixed here: `reply.received` is published from two places with different meanings — the REST reply handler publishes it for the human's own reply, and the forwarder publishes it for any new message. The name reads as "the agent replied" and is not that, which is part of why this was confusing.

TaskID: 0ibSawy3ryz

🤖 Generated with [Claude Code](https://claude.com/claude-code)