### PR TITLE
chore: bump minor version to v0.6.0

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.5.21"
+	_appVersion   = "v0.6.0"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.5.21" {
-			t.Errorf("Expected version v0.5.21, got %s", s.Version())
+		if s.Version() != "v0.6.0" {
+			t.Errorf("Expected version v0.6.0, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.5.21",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.5.21",
+      "version": "0.6.0",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.5.21",
+  "version": "0.6.0",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.5.21",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.5.21",
+      "version": "0.6.0",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.5.21",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
**What changed:** The project version moves from 0.5.21 to 0.6.0 everywhere the release checks it.

**Why changed:** This release adds Extensions — a new capability rather than a fix to an existing one — so it takes the minor segment rather than the patch.

**Test coverage report:** No lines of code introduced — version strings only. Total coverage impact: none; both gates remain at 100% and the backend config test, which asserts the version, passes.

**Other reports:**

Ten commits since v0.5.21.

*Features*
- Extensions: install one from a folder, and manage it (#526) — the catalogue, manifest, host, broker, three UI surfaces, shortcuts, schedules and three worked examples
- Extensions: install one from the catalogue, and say when you cannot (#532)
- Extensions: say plainly that nothing here is reviewed (#534)

*Fixes*
- Notifications: tell people when the agent actually replies (#536), on both desktop and web — neither did
- Extensions: create the directory extensions live in (#533)
- Security: clear every advisory the repository could act on (#529) — 32 reachable Go standard-library vulnerabilities and 15 npm advisories, to zero
- Security: build the image on the new Go (#530), which is what actually ships
- UI: hide the model choice on a human task, and shrink it on mobile (#514)

*Chores*
- Dependencies: take the six majors that were held back (#531) — vitest 5, jsdom 30, pinia 4, vue-router 5, TypeScript 7, tsdown 0.23
- Docs: say that building an extension needs nothing from us (#535)

Verified before pushing:

```
node desktop/scripts/check-versions.mjs
  ✓ desktop, frontend and backend are all at 0.6.0

GITHUB_REF=refs/tags/v0.6.0 node desktop/scripts/check-versions.mjs
  ✓ desktop, frontend and backend are all at 0.6.0
  ✓ tag v0.6.0 matches version 0.6.0
```

The diff is nine lines across six files. Lockfile versions were edited by hand rather than regenerated, so no dependency resolution shifted underneath a release, and `npm ci` still succeeds in both projects. `source-map-support@0.5.21` is deliberately left alone — a dependency that happens to share the old version number, and the reason this was not a find-and-replace.

**Merging this publishes nothing.** The release is cut by tagging main afterwards:

```
git tag -a v0.6.0 -m "chore: bump minor version to v0.6.0"
git push origin v0.6.0
```

TaskID: 0ibfymaFeTJ

🤖 Generated with [Claude Code](https://claude.com/claude-code)