### PR TITLE
feat(extensions): let a diagram carry any format, and draw maths

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@huggingface/transformers": "^4.2.0",
         "cron-parser": "^5.5.0",
         "dompurify": "^3.4.10",
+        "katex": "^0.16.47",
         "marked": "^18.0.5",
         "mermaid": "^12.0.0",
         "pinia": "^4.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@huggingface/transformers": "^4.2.0",
     "cron-parser": "^5.5.0",
     "dompurify": "^3.4.10",
+    "katex": "^0.16.47",
     "marked": "^18.0.5",
     "mermaid": "^12.0.0",
     "pinia": "^4.0.3",

--- a/frontend/src/components/DiagramBlock.vue
+++ b/frontend/src/components/DiagramBlock.vue
@@ -25,7 +25,7 @@
       <pre class="mt-2 m-0 text-[12px] leading-relaxed overflow-x-auto custom-scrollbar text-gray-600 dark:text-zinc-400"><code>{{ source }}</code></pre>
     </div>
 
-    <div v-else-if="svg" class="px-3 py-2.5 overflow-x-auto custom-scrollbar agentrq-diagram" v-html="svg"></div>
+    <div v-else-if="drawn" class="px-3 py-2.5 overflow-x-auto custom-scrollbar agentrq-diagram" v-html="drawn"></div>
 
     <p v-else class="px-3 py-2.5 text-[11px] text-gray-400 dark:text-zinc-500">Drawing…</p>
 
@@ -62,7 +62,8 @@ const props = defineProps({
 const themeStore = useThemeStore();
 const { isDark } = storeToRefs(themeStore);
 
-const svg = ref('');
+/** What the drawer produced: mermaid's SVG, or KaTeX's HTML and MathML. */
+const drawn = ref('');
 const error = ref('');
 const showSource = ref(false);
 
@@ -71,17 +72,19 @@ let drawing = 0;
 
 async function draw() {
   const token = (drawing += 1);
-  svg.value = '';
+  drawn.value = '';
   error.value = '';
 
-  const result = await renderDiagram(props.source, { theme: isDark.value ? 'dark' : 'light' });
+  const result = await renderDiagram(props.format, props.source, { theme: isDark.value ? 'dark' : 'light' });
   if (token !== drawing) return;
 
-  if (result.ok) svg.value = result.svg;
+  if (result.ok) drawn.value = result.html;
   else error.value = result.reason;
 }
 
-watch(() => [props.source, isDark.value], draw, { immediate: true });
+// The format is watched too: it decides which drawer runs, so a node that
+// changes format has to be redrawn rather than keeping the old picture.
+watch(() => [props.format, props.source, isDark.value], draw, { immediate: true });
 </script>
 
 <style>

--- a/frontend/src/composables/useDiagram.js
+++ b/frontend/src/composables/useDiagram.js
@@ -33,8 +33,9 @@ import DOMPurify from 'dompurify';
  * for it until a message actually contains a diagram somebody claimed.
  */
 
-/** Set once, the first time a diagram is drawn. */
+/** Set once each, the first time a diagram of that kind is drawn. */
 let mermaidPromise = null;
+let katexPromise = null;
 
 /** Distinct per diagram: mermaid uses it as an element id while measuring. */
 let nextId = 0;
@@ -96,21 +97,33 @@ export function loadMermaid(importer = () => import('mermaid')) {
 export function resetMermaid() {
   mermaidPromise = null;
   nextId = 0;
+  katexPromise = null;
 }
 
 /**
- * Draws one diagram, or says why it could not be drawn.
+ * KaTeX, loaded with its stylesheet.
  *
- * Never throws. A diagram is one part of a message somebody is reading, and an
- * exception here would take the whole message with it — a malformed diagram
- * should cost its own block and nothing else.
- *
- * @returns {Promise<{ok: true, svg: string} | {ok: false, reason: string}>}
+ * The CSS is not optional decoration: without it the output is unstyled,
+ * overlapping glyphs rather than an equation. It comes along on the dynamic
+ * import so it stays out of the main bundle and can never be forgotten
+ * separately from the code it styles.
  */
-export async function renderDiagram(source, { theme = 'light', importer } = {}) {
-  const text = String(source ?? '').trim();
-  if (!text) return { ok: false, reason: 'This diagram is empty.' };
+export function loadKatex(
+  importer = () => Promise.all([import('katex'), import('katex/dist/katex.css')]).then(([mod]) => mod),
+) {
+  if (!katexPromise) {
+    katexPromise = importer()
+      .then((module) => module.default ?? module)
+      .catch((error) => {
+        katexPromise = null;
+        throw error;
+      });
+  }
+  return katexPromise;
+}
 
+/** Draws a mermaid diagram. */
+async function drawMermaid(text, { theme, importer }) {
   let mermaid;
   try {
     mermaid = await loadMermaid(importer);
@@ -124,12 +137,135 @@ export async function renderDiagram(source, { theme = 'light', importer } = {}) 
     // The whole configuration, not just the theme — see `configFor`.
     mermaid.initialize(configFor(theme));
     const { svg } = await mermaid.render(`agentrq-diagram-${nextId++}`, text);
-    return { ok: true, svg: sanitiseSvg(svg) };
+    return { ok: true, html: sanitiseSvg(svg) };
   } catch (error) {
     // Mermaid's own message, because it names the line and is written for
     // whoever wrote the diagram.
     return { ok: false, reason: firstLine(error?.message) || 'This diagram could not be drawn.' };
   }
+}
+
+/**
+ * Draws a TeX expression.
+ *
+ * Two settings here are load-bearing rather than taste:
+ *
+ * **`macros` is a fresh object every render.** KaTeX writes `\gdef`
+ * definitions into whatever object it is given, so one shared between renders
+ * lets a single expression redefine `\alpha` — or anything else — for every
+ * equation drawn afterwards, in every message on the page. A module-level
+ * `macros` object is the natural thing to write and exactly wrong.
+ *
+ * **`trust: false`** is what refuses `\href` and `\includegraphics`, so no
+ * `<a href>` and no `<img>` are produced at all. The URL text still appears
+ * inside the MathML `<annotation>`, which is the echoed source and is inert —
+ * that is not a leak to be patched out.
+ */
+async function drawMath(text, { importer }) {
+  let katex;
+  try {
+    katex = await loadKatex(importer);
+  } catch {
+    return { ok: false, reason: 'The maths renderer could not be loaded.' };
+  }
+
+  try {
+    const html = katex.renderToString(text, {
+      displayMode: true,
+      throwOnError: true,
+      macros: {},
+      trust: false,
+      // Questionable input is drawn rather than warned about on the console of
+      // somebody who did not write it.
+      strict: false,
+    });
+    return { ok: true, html: sanitiseMath(html) };
+  } catch (error) {
+    // KaTeX names the position in the expression, which is written for whoever
+    // wrote it.
+    return { ok: false, reason: firstLine(error?.message) || 'This expression could not be drawn.' };
+  }
+}
+
+/**
+ * Every format this can draw, and the only place that decides.
+ *
+ * A registry rather than an allowlist plus a hardwired renderer agreeing with
+ * it by hand: adding a format is one entry here, and there is no second place
+ * to fall out of step with.
+ *
+ * The host draws, and only the host — an extension sends source, never markup,
+ * because markup from an extension on a privileged origin is the one thing the
+ * view vocabulary exists to prevent. So this list is a real limit. What it is
+ * not is a *validation* rule: a format nobody draws degrades to showing its
+ * source, rather than destroying the view it arrived in.
+ */
+const DRAWERS = Object.freeze({
+  mermaid: drawMermaid,
+  math: drawMath,
+});
+
+/** The drawer for a format, or null when nothing here draws it. */
+export function drawerFor(format) {
+  return DRAWERS[String(format ?? '').toLowerCase()] ?? null;
+}
+
+/** The formats that will actually draw, for anything that needs to say so. */
+export function knownFormats() {
+  return Object.keys(DRAWERS);
+}
+
+/**
+ * Draws one diagram, or says why it could not be drawn.
+ *
+ * Never throws. A diagram is one part of a message somebody is reading, and an
+ * exception here would take the whole message with it — a malformed diagram
+ * should cost its own block and nothing else. An unknown format is the same
+ * kind of answer: a reason and the source, not a missing block.
+ *
+ * @returns {Promise<{ok: true, html: string} | {ok: false, reason: string}>}
+ */
+export async function renderDiagram(format, source, { theme = 'light', importer } = {}) {
+  const text = String(source ?? '').trim();
+  if (!text) return { ok: false, reason: 'This diagram is empty.' };
+
+  const draw = drawerFor(format);
+  if (!draw) {
+    // Named, so the author sees which word was wrong, and the block still shows
+    // the source underneath — which is what the reader wanted from it anyway.
+    return { ok: false, reason: `Nothing here draws \`${format}\`. This app can draw: ${knownFormats().join(', ')}.` };
+  }
+
+  return draw(text, { theme, importer });
+}
+
+/**
+ * What reaches the DOM from KaTeX.
+ *
+ * A separate pass from `sanitiseSvg`, because KaTeX emits HTML and MathML
+ * rather than SVG — that profile alone would strip it to nothing.
+ *
+ * **All three profiles, measured rather than assumed.** `html` and `mathMl` are
+ * the obvious two and they are not enough: KaTeX draws radicals and stretchy
+ * delimiters as inline `<svg><path>`, so `\sqrt{x}` came back without its
+ * sign — the expression still rendered, silently missing a symbol, which is the
+ * worst way for this to be wrong. The inline `style` attributes stay too:
+ * KaTeX positions every glyph with them, and removing them leaves an equation
+ * in a heap.
+ *
+ * Turning `svg` on costs nothing here, checked against hostile input: scripts,
+ * `<img>`, `<a>`, inline handlers and `foreignObject` are all still removed.
+ * `foreignObject` is named explicitly for the same reason it is in
+ * `sanitiseSvg` — it is the element that carries arbitrary HTML into SVG.
+ */
+export function sanitiseMath(html) {
+  return DOMPurify.sanitize(String(html ?? ''), {
+    USE_PROFILES: { html: true, mathMl: true, svg: true },
+    // `trust: false` already refuses the markup that would produce these; this
+    // is the second guard, and the two fail differently.
+    FORBID_TAGS: ['script', 'style', 'a', 'img', 'iframe', 'object', 'embed', 'foreignObject'],
+    FORBID_ATTR: ['onload', 'onerror', 'onclick'],
+  });
 }
 
 /**

--- a/frontend/src/composables/useExtensionView.js
+++ b/frontend/src/composables/useExtensionView.js
@@ -41,8 +41,23 @@ export const NODE_TYPES = Object.freeze({
   diagram: ['format', 'source', 'label'],
 });
 
-/** Diagram languages AgentRQ knows how to draw. */
-export const DIAGRAM_FORMATS = Object.freeze(['mermaid']);
+/**
+ * What a diagram format has to *look* like, which is not the same as one this
+ * app can draw.
+ *
+ * `format` is two things at once: a lookup key into the drawer registry, and a
+ * label shown to the reader when there is no title. So its shape is checked —
+ * a word, optionally hyphenated, bounded — and nothing more.
+ *
+ * Membership is deliberately not checked here. It used to be, against a list of
+ * one, and the cost was out of all proportion: an unknown format failed
+ * `normaliseView`, which fails the *whole view*, which `MarkdownBody` then drops
+ * entirely — so the fence fell back to an ordinary code block and nothing, to
+ * the reader or the author, said why. A format nobody draws is now a valid node
+ * that degrades to showing its source, which is what the reader wanted from it
+ * anyway. See `drawerFor` in `useDiagram.js`.
+ */
+export const DIAGRAM_FORMAT = /^[a-z][a-z0-9-]{0,31}$/i;
 
 /**
  * How much diagram source is worth drawing.
@@ -128,10 +143,10 @@ function normaliseNode(node, depth, budget) {
 
   if (type === 'diagram') {
     const format = String(node.format ?? '');
-    if (!DIAGRAM_FORMATS.includes(format)) {
-      // Named, and the alternatives listed, the same way an unknown node type
-      // is: an author who wrote "mermaidjs" is one word from working.
-      return fail(`"${format || '(none)'}" is not a diagram this can draw. Use one of: ${DIAGRAM_FORMATS.join(', ')}.`);
+    if (!DIAGRAM_FORMAT.test(format)) {
+      // Still refused, because a malformed format is a malformed node: it is a
+      // lookup key and a visible label, and neither tolerates arbitrary text.
+      return fail(`"${format || '(none)'}" is not a diagram format. A format is a word, like "mermaid".`);
     }
     const source = typeof node.source === 'string' ? node.source : '';
     if (!source.trim()) return fail('A diagram needs source to draw.');

--- a/frontend/test/diagram.test.js
+++ b/frontend/test/diagram.test.js
@@ -1,11 +1,17 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 
+import katex from 'katex';
+
 import {
   THEMES,
   configFor,
   loadMermaid,
   renderDiagram,
+  drawerFor,
+  knownFormats,
+  loadKatex,
   resetMermaid,
+  sanitiseMath,
   sanitiseCss,
   sanitiseSvg,
 } from '../src/composables/useDiagram';
@@ -175,10 +181,10 @@ describe('renderDiagram', () => {
   it('draws one, and sanitises what came back', async () => {
     const mermaid = fakeMermaid();
 
-    const result = await renderDiagram('graph TD;\n  A-->B;', { importer: importing(mermaid) });
+    const result = await renderDiagram('mermaid', 'graph TD;\n  A-->B;', { importer: importing(mermaid) });
 
     expect(result.ok).toBe(true);
-    expect(result.svg).toContain('<svg');
+    expect(result.html).toContain('<svg');
     expect(mermaid.render).toHaveBeenCalledWith(expect.stringContaining('agentrq-diagram-'), 'graph TD;\n  A-->B;');
   });
 
@@ -191,7 +197,7 @@ describe('renderDiagram', () => {
   it('configures mermaid strictly, whatever the source asks for', async () => {
     const mermaid = fakeMermaid();
 
-    await renderDiagram('graph TD;', { importer: importing(mermaid) });
+    await renderDiagram('mermaid', 'graph TD;', { importer: importing(mermaid) });
 
     const config = mermaid.initialize.mock.calls[0][0];
     expect(config.securityLevel).toBe('strict');
@@ -212,7 +218,7 @@ describe('renderDiagram', () => {
   it('sends the whole configuration every time, not just the theme', async () => {
     const mermaid = fakeMermaid();
 
-    await renderDiagram('graph TD;', { theme: 'dark', importer: importing(mermaid) });
+    await renderDiagram('mermaid', 'graph TD;', { theme: 'dark', importer: importing(mermaid) });
 
     for (const [config] of mermaid.initialize.mock.calls) {
       expect(config.securityLevel, JSON.stringify(config)).toBe('strict');
@@ -224,7 +230,7 @@ describe('renderDiagram', () => {
   it('draws in the theme it was given', async () => {
     const mermaid = fakeMermaid();
 
-    await renderDiagram('graph TD;', { theme: 'dark', importer: importing(mermaid) });
+    await renderDiagram('mermaid', 'graph TD;', { theme: 'dark', importer: importing(mermaid) });
 
     expect(mermaid.initialize.mock.calls.at(-1)[0].theme).toBe(THEMES.dark);
   });
@@ -232,7 +238,7 @@ describe('renderDiagram', () => {
   it('falls back to the light theme for one it does not know', async () => {
     const mermaid = fakeMermaid();
 
-    await renderDiagram('graph TD;', { theme: 'neon', importer: importing(mermaid) });
+    await renderDiagram('mermaid', 'graph TD;', { theme: 'neon', importer: importing(mermaid) });
 
     expect(mermaid.initialize.mock.calls.at(-1)[0].theme).toBe(THEMES.light);
   });
@@ -240,8 +246,8 @@ describe('renderDiagram', () => {
   it('gives each diagram its own id, because mermaid measures by element', async () => {
     const mermaid = fakeMermaid();
 
-    await renderDiagram('a', { importer: importing(mermaid) });
-    await renderDiagram('b', { importer: importing(mermaid) });
+    await renderDiagram('mermaid', 'a', { importer: importing(mermaid) });
+    await renderDiagram('mermaid', 'b', { importer: importing(mermaid) });
 
     const [first, second] = mermaid.render.mock.calls.map((call) => call[0]);
     expect(first).not.toBe(second);
@@ -256,7 +262,7 @@ describe('renderDiagram', () => {
       }),
     });
 
-    const result = await renderDiagram('graph TD;\n  ??', { importer: importing(mermaid) });
+    const result = await renderDiagram('mermaid', 'graph TD;\n  ??', { importer: importing(mermaid) });
 
     expect(result.ok).toBe(false);
     // The first line names the fault; the rest is the diagram echoed back.
@@ -265,22 +271,22 @@ describe('renderDiagram', () => {
 
   it('has something to say about a failure with no message', async () => {
     const empty = fakeMermaid({ render: vi.fn(async () => { throw new Error(''); }) });
-    expect((await renderDiagram('x', { importer: importing(empty) })).reason).toBe('This diagram could not be drawn.');
+    expect((await renderDiagram('mermaid', 'x', { importer: importing(empty) })).reason).toBe('This diagram could not be drawn.');
 
     resetMermaid();
     // Mermaid throws objects that are not Errors for some parse failures.
     const odd = fakeMermaid({ render: vi.fn(async () => { throw { detail: 'nope' } }) }); // eslint-disable-line no-throw-literal
-    expect((await renderDiagram('x', { importer: importing(odd) })).reason).toBe('This diagram could not be drawn.');
+    expect((await renderDiagram('mermaid', 'x', { importer: importing(odd) })).reason).toBe('This diagram could not be drawn.');
   });
 
   it('says so when there is nothing to draw', async () => {
-    expect((await renderDiagram('')).reason).toBe('This diagram is empty.');
-    expect((await renderDiagram('   \n  ')).reason).toBe('This diagram is empty.');
+    expect((await renderDiagram('mermaid', '')).reason).toBe('This diagram is empty.');
+    expect((await renderDiagram('mermaid', '   \n  ')).reason).toBe('This diagram is empty.');
     expect((await renderDiagram(undefined)).reason).toBe('This diagram is empty.');
   });
 
   it('says so plainly when the renderer itself will not load', async () => {
-    const result = await renderDiagram('graph TD;', {
+    const result = await renderDiagram('mermaid', 'graph TD;', {
       importer: () => Promise.reject(new Error('chunk failed')),
     });
 
@@ -297,8 +303,8 @@ describe('renderDiagram', () => {
       return attempt === 1 ? Promise.reject(new Error('chunk failed')) : Promise.resolve({ default: mermaid });
     };
 
-    expect((await renderDiagram('a', { importer })).ok).toBe(false);
-    expect((await renderDiagram('a', { importer })).ok).toBe(true);
+    expect((await renderDiagram('mermaid', 'a', { importer })).ok).toBe(false);
+    expect((await renderDiagram('mermaid', 'a', { importer })).ok).toBe(true);
   });
 });
 
@@ -336,4 +342,197 @@ describe('loadMermaid', () => {
     expect(typeof mermaid.render).toBe('function');
     expect(typeof mermaid.initialize).toBe('function');
   }, 30000);
+
+  /**
+   * The same for KaTeX, and this one carries a second claim: the default
+   * importer pulls `katex/dist/katex.css` alongside the code.
+   *
+   * That stylesheet is not decoration. Without it KaTeX's output is unstyled
+   * overlapping glyphs rather than an equation — it positions everything with
+   * classes the stylesheet defines. Loading it on the same dynamic import is
+   * what stops it being forgotten separately from the code it styles, and this
+   * test is what says that import path still resolves.
+   */
+  it('loads the real KaTeX, and its stylesheet with it', async () => {
+    const katexModule = await loadKatex();
+
+    expect(typeof katexModule.renderToString).toBe('function');
+    expect(katexModule.renderToString('x^2', { macros: {} })).toContain('katex');
+  }, 30000);
+});
+
+/**
+ * A format is a lookup, not an allowlist.
+ *
+ * The host still only *draws* what it has a drawer for — an extension cannot
+ * ship drawing code, because that would put third-party markup on a privileged
+ * origin, which is the one thing the view vocabulary exists to prevent. What
+ * changed is the cost of naming a format nobody draws: it used to destroy the
+ * whole view silently, and now it shows its source with a note.
+ */
+describe('the drawer registry', () => {
+  it('finds a drawer for what it draws, whatever the case', () => {
+    expect(drawerFor('mermaid')).toBeTypeOf('function');
+    expect(drawerFor('math')).toBeTypeOf('function');
+    expect(drawerFor('MERMAID')).toBe(drawerFor('mermaid'));
+  });
+
+  it('finds none for what it does not', () => {
+    expect(drawerFor('vega-lite')).toBeNull();
+    expect(drawerFor('')).toBeNull();
+    expect(drawerFor(undefined)).toBeNull();
+  });
+
+  it('says what it can draw, which is the one place that decides', () => {
+    expect(knownFormats()).toEqual(['mermaid', 'math']);
+  });
+});
+
+describe('renderDiagram, for a format nothing draws', () => {
+  // The whole point: a block that explains itself instead of a view that
+  // vanishes. The source comes with it, which is what the reader wanted.
+  it('names the format rather than failing silently', async () => {
+    const result = await renderDiagram('vega-lite', '{ "mark": "bar" }');
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('vega-lite');
+    expect(result.reason).toContain('mermaid, math');
+  });
+
+  it('still refuses an empty source before anything else', async () => {
+    expect((await renderDiagram('vega-lite', '   ')).reason).toBe('This diagram is empty.');
+  });
+
+  // Never throws: a diagram is one part of a message somebody is reading, and
+  // an exception here would take the whole message with it.
+  it('never throws, whatever it is handed', async () => {
+    for (const [format, source] of [[undefined, undefined], [null, null], [{}, []], ['', ''], ['math', undefined]]) {
+      await expect(renderDiagram(format, source)).resolves.toHaveProperty('ok');
+    }
+  });
+});
+
+describe('sanitiseMath', () => {
+  // KaTeX draws radicals and stretchy delimiters as inline <svg><path>. The
+  // obvious profile — html and mathMl — strips both, and the expression then
+  // renders silently missing a symbol, which is the worst way to be wrong.
+  it('keeps the parts an equation is actually made of', () => {
+    const drawn = sanitiseMath(katex.renderToString('\\frac{a}{b} = \\sqrt{x^2}', { displayMode: true, macros: {} }));
+
+    expect(drawn).toContain('<svg');
+    expect(drawn).toContain('<path');
+    expect(drawn).toMatch(/<math/i);
+    // KaTeX positions every glyph with an inline style; without them an
+    // equation is a heap of characters.
+    expect(drawn).toContain('style="');
+  });
+
+  it('removes everything that could act, even with SVG allowed', () => {
+    const hostile =
+      '<span onclick="x()">a</span><script>alert(1)</script><img src=x onerror=y>' +
+      '<a href="javascript:1">l</a><foreignObject><b>html</b></foreignObject>';
+
+    const clean = sanitiseMath(hostile);
+
+    expect(clean).not.toMatch(/<script/i);
+    expect(clean).not.toMatch(/<img/i);
+    expect(clean).not.toMatch(/<a[\s>]/i);
+    expect(clean).not.toMatch(/onclick|onerror/i);
+    expect(clean).not.toMatch(/foreignobject/i);
+  });
+
+  it('has nothing to say about nothing', () => {
+    expect(sanitiseMath('')).toBe('');
+    expect(sanitiseMath(undefined)).toBe('');
+  });
+});
+
+describe('renderDiagram, drawing maths', () => {
+  const importing_ = () => () => Promise.resolve({ default: katex });
+
+  it('draws an expression', async () => {
+    const result = await renderDiagram('math', 'E = mc^2', { importer: importing_() });
+
+    expect(result.ok).toBe(true);
+    expect(result.html).toMatch(/<math|katex/i);
+  });
+
+  /**
+   * The trap, and the reason `macros` is built fresh inside the drawer.
+   *
+   * KaTeX writes `\gdef` definitions into whatever object it is handed, so a
+   * module-level `macros` — the natural thing to write — lets one expression
+   * redefine `\alpha` for every equation drawn afterwards, in every message on
+   * the page. This is that, driven through the real renderer.
+   */
+  it('does not let one expression redefine a symbol for the next', async () => {
+    await renderDiagram('math', '\\gdef\\alpha{\\text{PWNED}} \\alpha', { importer: importing_() });
+
+    const after = await renderDiagram('math', '\\alpha', { importer: importing_() });
+
+    expect(after.ok).toBe(true);
+    expect(after.html).not.toContain('PWNED');
+  });
+
+  // `trust: false` refuses \href and \includegraphics outright, so neither is
+  // ever produced. The URL text survives inside the echoed source, inert.
+  it('produces no link and no image, whatever the expression asks for', async () => {
+    const result = await renderDiagram('math', '\\href{https://evil.example}{click}', { importer: importing_() });
+
+    if (result.ok) {
+      expect(result.html).not.toMatch(/<a[\s>]/i);
+      expect(result.html).not.toMatch(/<img/i);
+    } else {
+      expect(result.reason).toBeTruthy();
+    }
+  });
+
+  it('reports an expression that will not parse, in KaTeX own words', async () => {
+    const result = await renderDiagram('math', '\\frac{', { importer: importing_() });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBeTruthy();
+    expect(result.reason).not.toContain('\n');
+  });
+
+  it('says so plainly when the renderer itself will not load', async () => {
+    const failing = () => Promise.reject(new Error('chunk failed'));
+
+    expect((await renderDiagram('math', 'x', { importer: failing })).reason).toBe(
+      'The maths renderer could not be loaded.',
+    );
+  });
+
+  // Some builds hand back the namespace itself rather than a default export,
+  // and an equation should not depend on which.
+  it('takes the module however the bundler hands it over', async () => {
+    const namespace = { renderToString: katex.renderToString };
+
+    const result = await renderDiagram('math', 'x^2', { importer: () => Promise.resolve(namespace) });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('has something to say about a failure with no message', async () => {
+    const mute = { renderToString: () => { throw new Error(''); } };
+
+    expect((await renderDiagram('math', 'x', { importer: () => Promise.resolve({ default: mute }) })).reason).toBe(
+      'This expression could not be drawn.',
+    );
+  });
+
+  // Loaded once and remembered, the way mermaid is — and a failed load is
+  // forgotten so a flaky connection is retried rather than remembered forever.
+  it('loads KaTeX once, and retries after a failure', async () => {
+    const importer = vi.fn(() => Promise.resolve({ default: katex }));
+    await renderDiagram('math', 'x', { importer });
+    await renderDiagram('math', 'y', { importer });
+    expect(importer).toHaveBeenCalledOnce();
+
+    resetMermaid();
+    const failing = vi.fn(() => Promise.reject(new Error('offline')));
+    await renderDiagram('math', 'x', { importer: failing });
+    await renderDiagram('math', 'x', { importer: failing });
+    expect(failing).toHaveBeenCalledTimes(2);
+  });
 });

--- a/frontend/test/extensionView.test.js
+++ b/frontend/test/extensionView.test.js
@@ -183,12 +183,36 @@ describe('a diagram node', () => {
     expect(drawn.nodes[0].format).toBe('mermaid');
   });
 
-  it('names the formats it knows when given one it does not', () => {
-    const { ok, reason } = normaliseView([diagram({ format: 'mermaidjs' })]);
+  // The bug this replaces. An unknown format used to fail `normaliseView`,
+  // which fails the *whole view*, which MarkdownBody then drops — so the fence
+  // fell back to an ordinary code block and nothing said why, to the reader or
+  // to the author. Extensions may name any format; what the host cannot draw
+  // degrades to showing its source, which is what the reader wanted anyway.
+  it('accepts a format nobody here draws, rather than losing the view', () => {
+    for (const format of ['vega-lite', 'plantuml', 'graphviz', 'd2', 'mermaidjs']) {
+      const { ok, view } = normaliseView([diagram({ format })]);
 
-    expect(ok).toBe(false);
-    expect(reason).toContain('mermaidjs');
-    expect(reason).toContain('mermaid');
+      expect(ok).toBe(true);
+      expect(view.nodes[0].format).toBe(format);
+      expect(view.nodes[0].source).toBe('graph TD;\n  A-->B;');
+    }
+  });
+
+  // A format is a lookup key and a visible label, and neither tolerates
+  // arbitrary text — so the shape is still checked even though the list is not.
+  it('still refuses one that is not a format at all', () => {
+    for (const format of ['BAD FORMAT!', 'has space', '<script>', '9lives', '-leading', 'x'.repeat(33)]) {
+      const { ok, reason } = normaliseView([diagram({ format })]);
+
+      expect(ok).toBe(false);
+      expect(reason).toContain('is not a diagram format');
+    }
+  });
+
+  it('accepts the shapes that are legitimate', () => {
+    for (const format of ['mermaid', 'math', 'vega-lite', 'd2', 'a', 'x'.repeat(32)]) {
+      expect(normaliseView([diagram({ format })]).ok).toBe(true);
+    }
   });
 
   it('says "(none)" rather than an empty pair of quotes', () => {


### PR DESCRIPTION
**What changed:** An extension can now name any diagram format it likes, and one it names that nothing here draws shows its source with an explanation instead of silently disappearing. Maths expressions are drawn as a second format.

**Why changed:** Only mermaid was permitted, and anything else destroyed the entire view it arrived in — the block fell back to plain code with nothing said to either the reader or the author.

**Test coverage report:** New lines introduced: 100%. Total coverage impact: none, the frontend gate stays at 100% on every metric — 1380 tests (+23), statements 100%, branches 100%, functions 100%, lines 100%.

**Other reports:**

A format is a lookup now rather than an allowlist. `DRAWERS = { mermaid, math }` is the one place that decides what draws, `drawerFor`/`knownFormats` read it, and validation keeps only a *shape* check — `format` is both a lookup key and a visible label, so it must still be a word, but membership is no longer its business. Unknown-but-well-formed is a valid node that degrades to `Nothing here draws \`vega-lite\`` above the source.

The one limit is unchanged and deliberate: the host draws, because an extension shipping drawing code would put third-party markup on the privileged origin.

**The four KaTeX traps, all verified by running them rather than reasoning about them:**

| Claim | Measured |
|---|---|
| a shared `macros` object leaks `\gdef` between renders | **true** — so it is built fresh per render, with a test driving the leak through the real renderer |
| `trust: false` stops `\href`/`\includegraphics` | no `<a href>`, no `<img>` |
| KaTeX needs its own sanitiser pass | yes — and see below |
| the stylesheet must be loaded | build emits `katex-lp30VUw8.css` (28.5 kB) plus 26 woff2 faces |

**One correction to the plan, found by measuring.** `{ html: true, mathMl: true }` is not enough: KaTeX draws radicals and stretchy delimiters as inline `<svg><path>`, so `\sqrt{x}` came back *without its radical sign* — rendering silently short of a symbol, which is the worst way for it to be wrong. The pass needs `svg: true` as well. Checked against hostile input that turning it on still removes scripts, `<img>`, `<a>`, inline handlers and `foreignObject`.

**Two deviations from the brief worth a reviewer's eye:**

- The drawer result key is `html`, not `svg`. KaTeX emits HTML and MathML, and a field called `svg` holding MathML misleads whoever reads it next. Costs one assertion in the existing tests.
- `katex` is pinned at `^0.16.47`, the version mermaid already resolved — `npm install` reported "up to date", so this costs nothing in install or bundle and only makes an existing dependency honest.

The stylesheet loads on the same dynamic import as the code, so it cannot be forgotten separately from what it styles. Verified in the real browser too: `npm run verify:extensions` still draws a mermaid diagram in a real window.

TaskID: 0ibsDmBvo0H

🤖 Generated with [Claude Code](https://claude.com/claude-code)