### PR TITLE
chore: bump patch version to v0.6.1

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -15,7 +15,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.6.0"
+	_appVersion   = "v0.6.1"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -55,8 +55,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.6.0" {
-			t.Errorf("Expected version v0.6.0, got %s", s.Version())
+		if s.Version() != "v0.6.1" {
+			t.Errorf("Expected version v0.6.1, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
**What changed:** The project version moves from 0.6.0 to 0.6.1 everywhere the release checks it.

**Why changed:** One change has landed since 0.6.0 — extensions now draw their own diagram formats — and it is a patch rather than a minor because nothing a user can see is new; what changed is where the drawing happens.

**Test coverage report:** No lines of code introduced — version strings only. Total coverage impact: none; both gates remain at 100% and the backend config test, which asserts the version, passes.

**Other reports:**

One commit since v0.6.0:

- **feat(extensions)**: an extension draws its own format in a sandboxed frame, and the host stops shipping renderers (#539)

That line carries more than it suggests. `mermaid` leaves `frontend/package.json` along with the `lodash-es` override that existed only to hold its chain back; `useDiagram.js` and its sanitisers are deleted; the frontend build drops from **2270 modules to 158**. Diagrams now draw inside a frame with an opaque origin — no bridge, no network, no reach into the page — so markup made from an extension's source never touches a privileged origin.

Worth knowing for anyone reading the version alone: **this is the build the mermaid extension's `engines.agentrq: ">=0.6"` actually needs.** On 0.6.0 that extension installs and then draws nothing, because that build has no frame to draw in.

Verified before pushing:

```
node desktop/scripts/check-versions.mjs
  ✓ desktop, frontend and backend are all at 0.6.1

GITHUB_REF=refs/tags/v0.6.1 node desktop/scripts/check-versions.mjs
  ✓ desktop, frontend and backend are all at 0.6.1
  ✓ tag v0.6.1 matches version 0.6.1
```

Nine lines across six files. Lockfile versions were edited by hand rather than regenerated, so no dependency resolution shifted underneath a release, and `npm ci` still succeeds in both projects. `tempy@0.6.0` in the frontend lockfile is deliberately left alone — a dependency that happens to share the old version number, and the reason this was not a find-and-replace.

**Merging this publishes nothing.** The release is cut by tagging main afterwards:

```
git tag -a v0.6.1 -m "chore: bump patch version to v0.6.1"
git push origin v0.6.1
```

TaskID: 0ibxsjyC5PV

🤖 Generated with [Claude Code](https://claude.com/claude-code)