### PR TITLE
chore: bump patch version to v0.6.2

### DIFF
--- a/backend/internal/service/config/config.go
+++ b/backend/internal/service/config/config.go
@@ -18,7 +18,7 @@ const (
 	_envVar       = "ENV"
 	_appName      = "AgentRQ"
 	_appShortName = "agentrq"
-	_appVersion   = "v0.6.1"
+	_appVersion   = "v0.6.2"
 
 	// ErrMissingAppConfig error that shares the app configuration is not provided
 	ErrMissingAppConfig err = "[config] app configuration must be provided in " + _configPath + "/<>.yaml file"

--- a/backend/internal/service/config/config_test.go
+++ b/backend/internal/service/config/config_test.go
@@ -58,8 +58,8 @@ database:
 		if s.AppShortName() != "agentrq" {
 			t.Errorf("AppShortName mismatch: %s", s.AppShortName())
 		}
-		if s.Version() != "v0.6.1" {
-			t.Errorf("Expected version v0.6.1, got %s", s.Version())
+		if s.Version() != "v0.6.2" {
+			t.Errorf("Expected version v0.6.2, got %s", s.Version())
 		}
 		if s.Env() != "development" {
 			t.Errorf("Env mismatch: %s", s.Env())

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-desktop",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-desktop",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-desktop",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "AgentRQ desktop app \u2014 AI-powered task queue for autonomous agents",
   "type": "module",
   "main": "dist/main/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentrq-frontend",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentrq-frontend",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@huggingface/transformers": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrq-frontend",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --force",


### PR DESCRIPTION
**What changed:** The project version moves from 0.6.1 to 0.6.2 everywhere the release checks it.

**Why changed:** One change has landed since 0.6.1 — the copyright notice on every source file, with the checks that keep it there — and nothing a user can see is different, so it takes the patch segment.

**Test coverage report:** No lines of code introduced — version strings only. Total coverage impact: none; both gates remain at 100% and the backend config test, which asserts the version, passes.

**Other reports:**

One commit since v0.6.1:

- **chore**: the copyright notice on every source file, with a check that keeps it there (#541)

That is 430 Go, JavaScript, TypeScript and Vue files carrying:

```
Copyright 2026 Contextual, Inc. https://agentrq.com
This notice may not be modified or removed.
```

plus a CI workflow and a pre-push hook that refuse a tree where any of it has been removed or reworded — the same script in both, so the local check cannot disagree with the one that gates merging.

Verified before pushing:

```
node desktop/scripts/check-versions.mjs
  ✓ desktop, frontend and backend are all at 0.6.2

GITHUB_REF=refs/tags/v0.6.2 node desktop/scripts/check-versions.mjs
  ✓ desktop, frontend and backend are all at 0.6.2
  ✓ tag v0.6.2 matches version 0.6.2
```

Nine lines across six files. Lockfile versions were edited by hand rather than regenerated, so no dependency resolution shifted underneath a release, and `npm ci` still succeeds in both projects. Three lines matching `0.6.1` were deliberately left alone — `source-map`, `adm-zip` and a nested `source-map`, dependencies that happen to share the old version number. That is three in one bump, and the reason this is never a find-and-replace.

**Merging this publishes nothing.** The release is cut by tagging main afterwards:

```
git tag -a v0.6.2 -m "chore: bump patch version to v0.6.2"
git push origin v0.6.2
```

TaskID: 0ibycVv9Lur

🤖 Generated with [Claude Code](https://claude.com/claude-code)